### PR TITLE
fix: Exclude preprod tests from PR checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,7 +73,10 @@ jobs:
 
       - name: Run tests with coverage
         run: |
-          pytest --cov=src --cov-report=term-missing --cov-report=xml --junitxml=test-results.xml
+          # Exclude preprod tests (they require real AWS preprod credentials)
+          # Preprod tests run in build-and-promote.yml workflow only
+          pytest --ignore=tests/integration/test_analysis_preprod.py \
+            --cov=src --cov-report=term-missing --cov-report=xml --junitxml=test-results.xml
         env:
           # Test environment variables
           AWS_DEFAULT_REGION: us-east-1


### PR DESCRIPTION
## Problem
PR test workflow was failing because it tried to run preprod integration tests, which require real AWS preprod credentials that aren't available during PR checks.

## Solution
Exclude `tests/integration/test_analysis_preprod.py` from the PR test workflow. These tests only run in `build-and-promote.yml` where preprod environment secrets are available.

## Testing
- [x] PR tests should now pass
- [x] Preprod tests still run during promotion pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)