### PR TITLE
fix: Exclude all preprod integration tests from PR checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,6 +76,8 @@ jobs:
           # Exclude preprod tests (they require real AWS preprod credentials)
           # Preprod tests run in build-and-promote.yml workflow only
           pytest --ignore=tests/integration/test_analysis_preprod.py \
+            --ignore=tests/integration/test_dashboard_preprod.py \
+            --ignore=tests/integration/test_canary_preprod.py \
             --cov=src --cov-report=term-missing --cov-report=xml --junitxml=test-results.xml
         env:
           # Test environment variables


### PR DESCRIPTION
Follow-up to #18 - also exclude dashboard and canary preprod tests which require real AWS credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)