### PR TITLE
fix: Also exclude ingestion preprod tests from PR checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,6 +78,7 @@ jobs:
           pytest --ignore=tests/integration/test_analysis_preprod.py \
             --ignore=tests/integration/test_dashboard_preprod.py \
             --ignore=tests/integration/test_canary_preprod.py \
+            --ignore=tests/integration/test_ingestion_preprod.py \
             --cov=src --cov-report=term-missing --cov-report=xml --junitxml=test-results.xml
         env:
           # Test environment variables


### PR DESCRIPTION
Follow-up to #18 and #19. Also exclude test_ingestion_preprod.py which requires real AWS preprod credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)