### PR TITLE
fix: Add concurrency controls to prevent deployment race conditions

### DIFF
--- a/.github/workflows/build-and-promote.yml
+++ b/.github/workflows/build-and-promote.yml
@@ -49,6 +49,11 @@ permissions:
   id-token: write  # For OIDC if configured
   actions: write   # For artifact management
 
+# Prevent concurrent preprod deployments to avoid Terraform state conflicts
+concurrency:
+  group: deploy-preprod
+  cancel-in-progress: false  # Wait for current deployment to finish
+
 jobs:
   # ========================================================================
   # JOB 1: Build Lambda Packages (Build Once, Deploy Everywhere)

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -49,6 +49,12 @@ permissions:
   id-token: write
   actions: read
 
+# Prevent concurrent production deployments to avoid Terraform state conflicts
+# Both production and production-auto use the same concurrency group
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false  # Wait for current deployment to finish
+
 jobs:
   # ========================================================================
   # JOB 0: Check if Preprod Validation Passed


### PR DESCRIPTION
## Problem
Without concurrency controls, multiple deployments could run simultaneously:
- Dependabot auto-deploy + manual deploy → both hit production
- Multiple preprod deploys → Terraform state conflicts

## Solution
Added concurrency groups to serialize deployments:
- `deploy-preprod`: Only one preprod deployment at a time
- `deploy-production`: Only one prod deployment at a time (covers both `production` and `production-auto` environments)

## How It Works
```yaml
concurrency:
  group: deploy-production
  cancel-in-progress: false  # Queue subsequent runs, don't cancel
```

If a deployment is running and another is triggered:
1. New deployment enters "pending" state
2. Waits for current deployment to finish
3. Then runs (with fresh state)

## Testing
To prove no race condition:
1. Trigger deploy manually
2. While running, trigger again
3. Second deploy should queue (not run concurrently)

🤖 Generated with [Claude Code](https://claude.com/claude-code)