### PR TITLE
fix: Make backup outputs conditional to match resource count

### DIFF
--- a/infrastructure/terraform/modules/dynamodb/outputs.tf
+++ b/infrastructure/terraform/modules/dynamodb/outputs.tf
@@ -31,13 +31,13 @@ output "gsi_by_status_name" {
 }
 
 output "backup_vault_arn" {
-  description = "ARN of the backup vault"
-  value       = aws_backup_vault.dynamodb.arn
+  description = "ARN of the backup vault (empty if backups disabled)"
+  value       = var.enable_backup ? aws_backup_vault.dynamodb[0].arn : ""
 }
 
 output "backup_plan_id" {
-  description = "ID of the backup plan"
-  value       = aws_backup_plan.dynamodb_daily.id
+  description = "ID of the backup plan (empty if backups disabled)"
+  value       = var.enable_backup ? aws_backup_plan.dynamodb_daily[0].id : ""
 }
 
 output "cloudwatch_alarm_user_errors_arn" {


### PR DESCRIPTION
## Summary

Fix Terraform plan error when `enable_backup=false` by making backup outputs reference conditional resources properly.

## Problem

Workflow 19567240319 failed with:
```
Error: Missing resource instance key
  on modules/dynamodb/outputs.tf line 35
  Because aws_backup_vault.dynamodb has "count" set, its attributes must be accessed on specific instances.
```

## Solution

Make backup-related outputs conditional:
```hcl
output "backup_vault_arn" {
  value = var.enable_backup ? aws_backup_vault.dynamodb[0].arn : ""
}
```

## Test Plan

- ✅ Terraform fmt passes
- [ ] PR checks pass
- [ ] Merge to main
- [ ] Re-run promotion pipeline from main

## Related

- Follows up PR #25 (enable_backup variable)
- Unblocks workflow 19567240319

🤖 Generated with [Claude Code](https://claude.com/claude-code)