### PR TITLE
fix: Strip 'v' prefix from artifact_sha inputs in pipeline workflows

### DIFF
--- a/.github/workflows/pipeline-2-deploy-preprod.yml
+++ b/.github/workflows/pipeline-2-deploy-preprod.yml
@@ -68,6 +68,10 @@ jobs:
             SHA="${{ github.event.workflow_run.head_sha }}"
             SHA="${SHA:0:7}"
           fi
+
+          # Strip 'v' prefix if present (GitHub UI may add it)
+          SHA="${SHA#v}"
+
           echo "sha=${SHA}" >> $GITHUB_OUTPUT
           echo "artifact_name=lambda-packages-${SHA}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/pipeline-3-test-preprod.yml
+++ b/.github/workflows/pipeline-3-test-preprod.yml
@@ -61,6 +61,10 @@ jobs:
             SHA="${{ github.event.workflow_run.head_sha }}"
             SHA="${SHA:0:7}"
           fi
+
+          # Strip 'v' prefix if present (GitHub UI may add it)
+          SHA="${SHA#v}"
+
           echo "sha=${SHA}" >> $GITHUB_OUTPUT
 
       - name: Setup Python

--- a/.github/workflows/pipeline-4-deploy-prod.yml
+++ b/.github/workflows/pipeline-4-deploy-prod.yml
@@ -133,6 +133,9 @@ jobs:
             SHA="${{ needs.check-preprod-validation.outputs.artifact_sha }}"
           fi
 
+          # Strip 'v' prefix if present (GitHub UI may add it)
+          SHA="${SHA#v}"
+
           echo "sha=${SHA}" >> $GITHUB_OUTPUT
           echo "Deploying SHA: ${SHA}"
 


### PR DESCRIPTION
## Summary
Fix artifact lookup failures in manual deployments caused by GitHub UI validation requiring 'v' prefix for artifact_sha input.

## Problem
When manually triggering pipelines 2/3/4 via GitHub UI or gh CLI, the artifact_sha input may have a 'v' prefix (e.g., `ve655a00`) due to UI validation rules. However, Lambda package artifacts are created WITHOUT the 'v' prefix (e.g., `lambda-packages-e655a00`), causing "Artifact not found" errors.

**Error example:**
```
Unable to download artifact(s): Artifact not found for name: lambda-packages-ve655a00
```

## Solution
Add `SHA="${SHA#v}"` to strip any leading 'v' prefix in all three deployment workflows:
- `pipeline-2-deploy-preprod.yml`
- `pipeline-3-test-preprod.yml`
- `pipeline-4-deploy-prod.yml`

This normalization happens in the "Determine Artifact SHA" step, ensuring artifact names match regardless of input format.

## Testing
Now supports both input formats:
- ✅ With 'v': `ve655a00` → normalized to `e655a00`
- ✅ Without 'v': `e655a00` → remains `e655a00`

Both resolve to the correct artifact: `lambda-packages-e655a00`

## Impact
- **Pipelines 2/3/4**: Manual triggers now work correctly
- **Automatic triggers**: No change (already working)
- **Backwards compatible**: Works with or without 'v' prefix

## Related
- Fixes failed preprod deployments from earlier today (runs #19592878886, #19592873334)
- Enables proper testing of preprod deployment pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)