### PR TITLE
fix: Add Terraform setup to pipeline-3 integration tests

### DIFF
--- a/.github/workflows/pipeline-3-test-preprod.yml
+++ b/.github/workflows/pipeline-3-test-preprod.yml
@@ -83,8 +83,13 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.PREPROD_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.PREPROD_AWS_SECRET_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.PREPROD_AWS_SECRET_ACCESS_KEY}}
           aws-region: us-east-1
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.6.0
 
       - name: Get Preprod Infrastructure Outputs
         id: infra


### PR DESCRIPTION
## Summary

Fixes the `terraform: command not found` error in pipeline-3 preprod integration tests.

## Changes

- Added "Setup Terraform" step to `.github/workflows/pipeline-3-test-preprod.yml`
- Uses `hashicorp/setup-terraform@v3` with version 1.6.0 (matching pipeline-2)

## Context

The workflow was attempting to run terraform commands to get preprod infrastructure outputs without first installing terraform. This caused the integration tests to fail immediately with exit code 127.

## Test Plan

- Pipeline-3 should now successfully run `terraform init` and `terraform output` commands
- Integration tests should progress past the infrastructure setup phase

Fixes: "the preprod integration tests failed (could not find a command)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)