### PR TITLE
fix: Patch get_api_key in handler namespace for preprod tests

### DIFF
--- a/tests/integration/test_ingestion_preprod.py
+++ b/tests/integration/test_ingestion_preprod.py
@@ -172,7 +172,7 @@ class TestIngestionE2E:
                 patch("src.lib.metrics.emit_metric"),
                 patch("src.lib.metrics.emit_metrics_batch"),
                 patch(
-                    "src.lambdas.shared.secrets.get_api_key",
+                    "src.lambdas.ingestion.handler.get_api_key",
                     return_value="mock-newsapi-key-for-testing",
                 ),
             ):
@@ -267,7 +267,7 @@ class TestIngestionE2E:
                 patch("src.lib.metrics.emit_metric"),
                 patch("src.lib.metrics.emit_metrics_batch"),
                 patch(
-                    "src.lambdas.shared.secrets.get_api_key",
+                    "src.lambdas.ingestion.handler.get_api_key",
                     return_value="mock-newsapi-key-for-testing",
                 ),
             ):
@@ -293,7 +293,7 @@ class TestIngestionE2E:
                 patch("src.lib.metrics.emit_metric"),
                 patch("src.lib.metrics.emit_metrics_batch"),
                 patch(
-                    "src.lambdas.shared.secrets.get_api_key",
+                    "src.lambdas.ingestion.handler.get_api_key",
                     return_value="mock-newsapi-key-for-testing",
                 ),
             ):
@@ -363,7 +363,7 @@ class TestIngestionE2E:
                 patch("src.lib.metrics.emit_metric"),
                 patch("src.lib.metrics.emit_metrics_batch"),
                 patch(
-                    "src.lambdas.shared.secrets.get_api_key",
+                    "src.lambdas.ingestion.handler.get_api_key",
                     return_value="mock-newsapi-key-for-testing",
                 ),
             ):
@@ -440,7 +440,7 @@ class TestIngestionE2E:
                 patch("src.lib.metrics.emit_metric"),
                 patch("src.lib.metrics.emit_metrics_batch"),
                 patch(
-                    "src.lambdas.shared.secrets.get_api_key",
+                    "src.lambdas.ingestion.handler.get_api_key",
                     return_value="mock-newsapi-key-for-testing",
                 ),
             ):
@@ -521,7 +521,7 @@ class TestIngestionE2E:
                 patch("src.lib.metrics.emit_metric"),
                 patch("src.lib.metrics.emit_metrics_batch"),
                 patch(
-                    "src.lambdas.shared.secrets.get_api_key",
+                    "src.lambdas.ingestion.handler.get_api_key",
                     return_value="mock-newsapi-key-for-testing",
                 ),
             ):


### PR DESCRIPTION
## Summary
- Fixed preprod integration tests failing with `Secret not found` error
- Changed mock patch location from definition site to usage site

## Root Cause
The test was patching `src.lambdas.shared.secrets.get_api_key`, but the handler imports it with:
```python
from src.lambdas.shared.secrets import get_api_key
```

This binds the function to the handler's namespace. Per Python's `mock.patch` documentation, we must patch where the object is **used**, not where it's **defined**.

## Changes
Changed patch target in all 6 test methods:
- Before: `patch("src.lambdas.shared.secrets.get_api_key", ...)`
- After: `patch("src.lambdas.ingestion.handler.get_api_key", ...)`

## Test Plan
- [x] PR checks will verify preprod integration tests now pass
- [x] All 6 test methods updated with correct patch path

## Impact
Fixes preprod integration test suite blocking pipeline deployments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)