### PR TITLE
fix: Complete preprod test fixes - mock path and parameter validation

### DIFF
--- a/tests/integration/test_dashboard_preprod.py
+++ b/tests/integration/test_dashboard_preprod.py
@@ -300,8 +300,8 @@ class TestDashboardE2E:
 
         Tests with time window that likely has no data.
         """
-        # Query with very restrictive time window (minimum valid: 0.01 hours = 36 seconds)
-        response = client.get("/api/metrics?hours=0.01", headers=auth_headers)
+        # Query with very restrictive time window (minimum valid: 1 hour)
+        response = client.get("/api/metrics?hours=1", headers=auth_headers)
 
         assert response.status_code == 200
         data = response.json()

--- a/tests/integration/test_ingestion_preprod.py
+++ b/tests/integration/test_ingestion_preprod.py
@@ -588,7 +588,7 @@ class TestIngestionEdgeCases:
             patch("src.lib.metrics.emit_metric"),
             patch("src.lib.metrics.emit_metrics_batch"),
             patch(
-                "src.lambdas.shared.secrets.get_api_key",
+                "src.lambdas.ingestion.handler.get_api_key",
                 return_value="mock-newsapi-key-for-testing",
             ),
         ):


### PR DESCRIPTION
## Summary
- Fixed remaining mock path issue in `test_empty_newsapi_response`
- Fixed invalid float parameter in `test_empty_table_or_no_matches_returns_zeros`

## Problem 1: Incomplete Mock Path Fix
**Test**: `test_empty_newsapi_response`

The previous PR #46 replaced 6 occurrences but missed one due to different indentation in the pattern match.

**Change**:
```python
# Before (wrong namespace - doesn't intercept call)
patch("src.lambdas.shared.secrets.get_api_key", ...)

# After (correct namespace - intercepts call)
patch("src.lambdas.ingestion.handler.get_api_key", ...)
```

## Problem 2: Invalid Parameter Type
**Test**: `test_empty_table_or_no_matches_returns_zeros`

The test was passing `hours=0.01` (float), but the API endpoint expects `hours: int` with minimum value 1.

**Error**: FastAPI returned 422 Unprocessable Entity (type validation failure)

**Change**:
```python
# Before (invalid - float parameter for int type)
response = client.get("/api/metrics?hours=0.01", headers=auth_headers)

# After (valid - meets minimum int constraint)
response = client.get("/api/metrics?hours=1", headers=auth_headers)
```

## Test Plan
- [x] PR checks will verify all preprod integration tests pass
- [x] Both failing tests now corrected

## Impact
Unblocks preprod deployment pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)