### PR TITLE
fix: Auto-trigger deploy pipeline on integration test changes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ on:
     paths:
       - 'src/**'
       - 'infrastructure/terraform/**'
-      - 'tests/integration/test_*_preprod.py'
+      - 'tests/integration/**'
       - '.github/workflows/deploy.yml'
 
   # Manual trigger for testing/rollbacks


### PR DESCRIPTION
## Problem
Deploy pipeline was not auto-triggering when only integration test files changed, requiring manual `workflow_dispatch` for every test fix.

## Root Cause
Path filter pattern `tests/integration/test_*_preprod.py` was too specific and GitHub Actions was not matching it.

**Evidence**:
- Commit 89fc72d: Changed `test_ingestion_preprod.py` → manual trigger only
- Commit 5fd2020: Changed `test_ingestion_preprod.py` → manual trigger only  
- Commit 42f75da: Changed `test_ingestion_preprod.py` + `test_dashboard_preprod.py` → manual trigger only
- Commit c6073e0: Changed `infrastructure/terraform/**` → **auto-triggered** ✓

All test-only commits showed `event: workflow_dispatch` (manual), never `event: push` (automatic).

## Solution
Changed path filter from specific pattern to broader match:

```yaml
# Before (didn't match)
- 'tests/integration/test_*_preprod.py'

# After (matches all integration tests)
- 'tests/integration/**'
```

## Why This Is Better
1. Simpler glob pattern that GitHub Actions handles correctly
2. Any integration test change should trigger deployment validation
3. Catches all test files, not just preprod ones
4. Aligns with existing patterns like `src/**` and `infrastructure/terraform/**`

## Impact
Future commits that only change integration tests will automatically trigger the deployment pipeline instead of requiring manual workflow_dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)