### PR TITLE
fix: Preserve src/lambdas/dashboard directory structure in Lambda package

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -146,9 +146,9 @@ jobs:
             --quiet
 
           # Build dashboard package
-          mkdir -p packages/dashboard-build/src/lambdas packages/dashboard-build/src/lib packages/dashboard-build/src/dashboard
+          mkdir -p packages/dashboard-build/src/lambdas/dashboard packages/dashboard-build/src/lib packages/dashboard-build/src/dashboard
           cp -r packages/dashboard-deps/* packages/dashboard-build/
-          cp -r src/lambdas/dashboard/* packages/dashboard-build/
+          cp -r src/lambdas/dashboard/* packages/dashboard-build/src/lambdas/dashboard/
           cp -r src/lambdas/shared packages/dashboard-build/src/lambdas/
           cp -r src/lib/* packages/dashboard-build/src/lib/
           cp -r src/dashboard/* packages/dashboard-build/src/dashboard/


### PR DESCRIPTION
## Problem
Dashboard Lambda failing with `Runtime.ImportModuleError: No module named 'src.lambdas.dashboard'`

## Root Cause  
Deployment workflow was flattening the directory structure when packaging dashboard Lambda:
- **Before**: `cp -r src/lambdas/dashboard/* packages/dashboard-build/`
- **After**: `cp -r src/lambdas/dashboard/* packages/dashboard-build/src/lambdas/dashboard/`

This caused handler.py imports like `from src.lambdas.dashboard.metrics` to fail.

## Changes
- Updated `.github/workflows/deploy.yml` to preserve `src/lambdas/dashboard/` structure
- Created missing `src/lambdas/dashboard` directory in package build

## Testing
- [x] Pre-commit hooks pass
- [ ] CI will verify package structure
- [ ] Deployment to preprod will test import resolution

Fixes preprod dashboard 502 errors