### PR TITLE
fix: Replace paths with paths-ignore in deploy.yml to ensure CI/CD triggers

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,11 +23,14 @@ on:
   push:
     branches:
       - main
-    paths:
-      - 'src/**'
-      - 'infrastructure/terraform/**'
-      - 'tests/integration/**'
-      - '.github/workflows/deploy.yml'
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+      - 'specs/**'
+      - '.vscode/**'
+      - '.github/workflows/test.yml'
+      - '.github/workflows/lint.yml'
+      - '.github/workflows/codeql.yml'
 
   # Manual trigger for testing/rollbacks
   workflow_dispatch:


### PR DESCRIPTION
## Summary

Fixes deploy pipeline not triggering on merge commits by replacing restrictive `paths` filter with `paths-ignore` pattern.

## Problem

The deploy workflow used a `paths` allowlist that had two issues:
1. **GitHub Actions limitation**: Merge commits don't always trigger workflows with `paths` filters (known bug)
2. **Too restrictive**: Required changes to specific paths, causing valid code changes to not trigger deploys

Example: PR #72 changed `src/lambdas/dashboard/metrics.py` and `tests/integration/*_preprod.py`, which should have triggered deploy, but didn't.

## Solution

Use `paths-ignore` instead of `paths`:
- **Before**: Only trigger if changes match specific paths
- **After**: Trigger for ALL changes EXCEPT docs-only commits

```yaml
paths-ignore:
  - 'docs/**'
  - '*.md'
  - 'specs/**'
  - '.vscode/**'
  - '.github/workflows/test.yml'
  - '.github/workflows/lint.yml'
  - '.github/workflows/codeql.yml'
```

## Benefits

✅ Deploy triggers on ANY code change (src, infrastructure, tests, etc.)  
✅ Avoids GitHub Actions merge commit bug  
✅ Prevents docs-only commits from triggering expensive deploys  
✅ More intuitive: "deploy everything except docs"

## Testing

- Current deploy was manually triggered: https://github.com/traylorre/sentiment-analyzer-gsk/actions/runs/19635666907
- After merge, next code push to main will auto-trigger deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>