### PR TITLE
fix: Add cache paths and permissions to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,6 +66,7 @@ jobs:
         with:
           python-version: '3.13'
           cache: 'pip'
+          cache-dependency-path: 'requirements.txt'
 
       - name: Install dependencies
         run: |
@@ -301,6 +302,10 @@ jobs:
     runs-on: ubuntu-latest
     environment: dev
 
+    permissions:
+      contents: read
+      actions: read
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -310,6 +315,7 @@ jobs:
         with:
           python-version: '3.13'
           cache: 'pip'
+          cache-dependency-path: 'requirements-dev.txt'
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Summary

Fixes two issues in the Deploy Pipeline workflow identified in run #19637926307.

## Issues Fixed

### 1. Pip Cache Warning
**Error**: `Cache folder path is retrieved for pip but doesn't exist on disk: /home/runner/.cache/pip`

**Fix**: Add `cache-dependency-path` to both jobs:
- Build job → `requirements.txt`
- Test-dev job → `requirements-dev.txt`

This tells GitHub Actions which requirements file to use for cache key generation.

### 2. Artifact Download Permission Error
**Error**: Permission denied when test-dev job attempts to download build artifacts

**Fix**: Add `permissions` block to test-dev job:
```yaml
permissions:
  contents: read
  actions: read
```

The `actions: read` permission is required for `actions/download-artifact@v4`.

## Testing

- ✅ Pre-commit hooks passed
- ⏳ Will verify in next deploy run

## Files Changed

- `.github/workflows/deploy.yml` - Added cache-dependency-path and permissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>