### PR TITLE
fix: Temporarily disable FIS chaos testing to unblock deploy

### DIFF
--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -389,7 +389,7 @@ module "chaos" {
   source = "./modules/chaos"
 
   environment              = var.environment
-  enable_chaos_testing     = var.environment != "prod" # Only in preprod/dev
+  enable_chaos_testing     = false # Temporarily disabled - FIS template needs fix (TD-XXX)
   dynamodb_table_arn       = module.dynamodb.table_arn
   write_throttle_alarm_arn = module.dynamodb.cloudwatch_alarm_write_throttles_arn
 }


### PR DESCRIPTION
## Summary
- Temporarily disables AWS FIS chaos testing to unblock the CI/CD deploy pipeline
- The `aws:dynamodb:api-error` action with `aws:dynamodb:table` target type is not supported by AWS FIS
- Terraform apply fails with: `ValidationException: TargetResourceType with ID aws:dynamodb:table not found`

## Root Cause
AWS FIS doesn't have native DynamoDB throttling fault injection using the approach in our current config. The correct approach requires either:
1. SSM-based API throttling using `aws:ssm:send-command`
2. Using FIS SDK fault injection at the application level
3. Alternative chaos engineering tools like Chaos Monkey or custom Lambda-based injection

## Test plan
- [ ] CI pipeline should pass after this change
- [ ] Dev deployment should succeed

## Follow-up
Create a tech debt ticket to properly implement FIS chaos testing using a supported approach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)