### PR TITLE
fix: Address CodeQL security alerts #62 and #11

### DIFF
--- a/tests/unit/test_dashboard_handler.py
+++ b/tests/unit/test_dashboard_handler.py
@@ -204,10 +204,11 @@ class TestStaticFiles:
         assert response.status_code in [400, 404]
 
     def test_dotdot_in_filename_blocked(self, client):
-        """Test .. in filename is blocked."""
+        """Test .. in filename is blocked (returns 404 since not in whitelist)."""
         response = client.get("/static/..styles.css")
-        assert response.status_code == 400
-        assert "Invalid filename" in response.json()["detail"]
+        # With whitelist approach, non-whitelisted files return 404
+        assert response.status_code == 404
+        assert "Static file not found" in response.json()["detail"]
 
 
 class TestHealthCheck:


### PR DESCRIPTION
## Summary
- Fixes CodeQL path injection alert #62 (py/path-injection)
- Fixes CodeQL log injection alert #11 (py/log-injection)

## Changes

### Path Injection Fix (Alert #62)
Replaced the sanitization-based approach with a **strict whitelist**:
- Added `ALLOWED_STATIC_FILES` dict that defines exactly which files can be served
- User input is checked against whitelist before any filesystem operation
- Non-whitelisted requests return 404 immediately
- This completely eliminates path injection risk since tainted data never reaches Path operations

### Log Injection Fix (Alert #11)
- Added explicit `int()` cast to `hours` parameter before logging
- The parameter was already validated as int 1-168, but CodeQL flagged the taint flow
- Explicit cast breaks the taint tracking chain

## Test plan
- [x] `test_dotdot_in_filename_blocked` updated to expect 404 (whitelist behavior)
- [x] All static file tests pass
- [x] Full test suite passes locally

## Security Impact
These changes close 2 open CodeQL alerts and strengthen the security posture of the dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)