### PR TITLE
fix: Add build job to test-dev needs for artifact access

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -396,7 +396,7 @@ jobs:
   # ========================================================================
   test-dev:
     name: Dev Tests (Mocked AWS)
-    needs: deploy-dev
+    needs: [build, deploy-dev]
     runs-on: ubuntu-latest
     environment: dev
 


### PR DESCRIPTION
## Summary
- Adds `build` to the `needs` array for `test-dev` job
- Fixes `packages/*.zip not found` error in Check Package Sizes step
- The download-artifact action needs `needs.build.outputs.artifact-name` to be available

## Root Cause
Without `build` in the `needs` array, `${{ needs.build.outputs.artifact-name }}` evaluates to empty string, causing download-artifact to download ALL artifacts (creating subdirectories) instead of just the specified one.

## Test plan
- [x] Pipeline should pass with this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)