### PR TITLE
fix: Add build job to deploy-preprod needs for artifact access

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -463,7 +463,7 @@ jobs:
   # ========================================================================
   deploy-preprod:
     name: Deploy to Preprod
-    needs: test-dev
+    needs: [build, test-dev]
     runs-on: ubuntu-latest
     environment:
       name: preprod


### PR DESCRIPTION
## Summary
- Adds `build` to the `needs` array for `deploy-preprod` job
- Same fix as PR #90 for test-dev - deploy-preprod uses `needs.build.outputs.artifact-name` and `artifact-sha`

## Test plan
- [x] Pipeline should pass with this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)