### PR TITLE
feat: Migrate chaos testing to Lambda FIS actions

### DIFF
--- a/docs/TECH_DEBT_REGISTRY.md
+++ b/docs/TECH_DEBT_REGISTRY.md
@@ -534,4 +534,43 @@ class ChaosTest:
 
 ---
 
+### TD-015: Performance Tuning and Load Testing
+
+**Status**: Tech Debt - Future Enhancement
+**Priority**: Medium
+**Created**: 2024-11-24
+
+**Context**: System needs performance baseline and tuning to understand capacity limits.
+
+**What's Missing**:
+1. **Load Testing**: No baseline metrics for max throughput
+2. **CPU/Memory Profiling**: Unknown at what traffic level CPU hits 60%
+3. **Cost Optimization**: No analysis of Lambda right-sizing
+4. **DynamoDB Capacity**: Using on-demand, no cost modeling for provisioned
+
+**Acceptance Criteria**:
+- [ ] Establish baseline: requests/sec for each Lambda
+- [ ] Determine breaking point: traffic level causing 60% CPU load
+- [ ] Document p50/p95/p99 latencies under normal load
+- [ ] Model cost: on-demand vs provisioned DynamoDB at expected scale
+- [ ] Create runbook: scaling procedures for traffic spikes
+
+**Approach**:
+1. Use AWS X-Ray for distributed tracing (already configured)
+2. Use CloudWatch Contributor Insights for DynamoDB hot keys
+3. Consider Artillery or k6 for load testing
+4. FIS Lambda latency injection can validate timeout handling
+
+**Business Value**:
+- Medium: Prevents surprise cost overruns
+- Validates: System meets SLA requirements
+- Enables: Capacity planning for growth
+
+**Notes**:
+- DynamoDB is highly durable; FIS doesn't support API-level throttle simulation
+- Focus on Lambda-layer chaos testing (latency/error injection)
+- Current FIS experiments: `aws:lambda:invocation-add-delay`, `aws:lambda:invocation-error`
+
+---
+
 *This registry should be reviewed before any production deployment. Items marked as "acceptable for demo" must be addressed for production.*

--- a/infrastructure/terraform/modules/chaos/outputs.tf
+++ b/infrastructure/terraform/modules/chaos/outputs.tf
@@ -1,8 +1,14 @@
 # Chaos Testing Module Outputs
+# ============================
 
-output "fis_dynamodb_throttle_template_id" {
-  description = "ID of the FIS experiment template for DynamoDB throttling"
-  value       = var.enable_chaos_testing ? aws_fis_experiment_template.dynamodb_throttle[0].id : ""
+output "fis_lambda_latency_template_id" {
+  description = "ID of the FIS experiment template for Lambda latency injection"
+  value       = var.enable_chaos_testing ? aws_fis_experiment_template.lambda_latency[0].id : ""
+}
+
+output "fis_lambda_error_template_id" {
+  description = "ID of the FIS experiment template for Lambda error injection"
+  value       = var.enable_chaos_testing ? aws_fis_experiment_template.lambda_error[0].id : ""
 }
 
 output "fis_execution_role_arn" {
@@ -15,8 +21,11 @@ output "fis_log_group_name" {
   value       = var.enable_chaos_testing ? aws_cloudwatch_log_group.fis_experiments[0].name : ""
 }
 
-# Phase 4 outputs (commented out for now)
-# output "fis_lambda_delay_template_id" {
-#   description = "ID of the FIS experiment template for Lambda delay injection"
-#   value       = var.enable_chaos_testing ? aws_fis_experiment_template.lambda_delay[0].id : ""
-# }
+# ============================================================================
+# Deprecated Outputs (kept for backwards compatibility)
+# ============================================================================
+
+output "fis_dynamodb_throttle_template_id" {
+  description = "DEPRECATED: Use fis_lambda_latency_template_id instead"
+  value       = ""
+}

--- a/infrastructure/terraform/modules/chaos/variables.tf
+++ b/infrastructure/terraform/modules/chaos/variables.tf
@@ -1,4 +1,5 @@
 # Chaos Testing Module Variables
+# ===============================
 
 variable "environment" {
   description = "Environment name (dev, preprod, prod)"
@@ -11,25 +12,28 @@ variable "enable_chaos_testing" {
   default     = false
 }
 
-variable "dynamodb_table_arn" {
-  description = "ARN of the DynamoDB table to target for chaos experiments"
+variable "lambda_arns" {
+  description = "List of Lambda ARNs to target for chaos experiments"
+  type        = list(string)
+}
+
+variable "lambda_error_alarm_arn" {
+  description = "ARN of the CloudWatch alarm for Lambda errors (kill switch for experiments)"
   type        = string
+}
+
+# ============================================================================
+# Deprecated Variables (kept for backwards compatibility during migration)
+# ============================================================================
+
+variable "dynamodb_table_arn" {
+  description = "DEPRECATED: DynamoDB ARN - FIS doesn't support DynamoDB API fault injection"
+  type        = string
+  default     = ""
 }
 
 variable "write_throttle_alarm_arn" {
-  description = "ARN of the CloudWatch alarm for write throttles (kill switch)"
+  description = "DEPRECATED: Was used for DynamoDB throttle alarm"
   type        = string
+  default     = ""
 }
-
-# Phase 4 variables (commented out for now)
-# variable "analysis_lambda_arn" {
-#   description = "ARN of the Analysis Lambda to target for latency injection"
-#   type        = string
-#   default     = ""
-# }
-#
-# variable "lambda_error_alarm_arn" {
-#   description = "ARN of the CloudWatch alarm for Lambda errors (kill switch)"
-#   type        = string
-#   default     = ""
-# }

--- a/infrastructure/terraform/modules/monitoring/outputs.tf
+++ b/infrastructure/terraform/modules/monitoring/outputs.tf
@@ -24,3 +24,8 @@ output "budget_name" {
   description = "Name of the monthly budget"
   value       = aws_budgets_budget.monthly.name
 }
+
+output "analysis_errors_alarm_arn" {
+  description = "ARN of the Analysis Lambda errors alarm (used as FIS kill switch)"
+  value       = aws_cloudwatch_metric_alarm.analysis_errors.arn
+}


### PR DESCRIPTION
## Summary

Fixes chaos testing infrastructure by migrating from non-existent DynamoDB FIS actions to working Lambda FIS actions.

### The Problem

AWS FIS does **NOT** support DynamoDB API-level fault injection. The previous implementation used `aws:dynamodb:api-error` which doesn't exist. FIS only supports:
- `aws:dynamodb:global-table-pause-replication` (requires global tables - we don't have)
- `aws:network:disrupt-connectivity` (requires VPC - our Lambdas aren't VPC-attached)

### The Solution

Use Lambda fault injection actions (released October 2024):
- **`aws:lambda:invocation-add-delay`** - Injects latency into Lambda invocations
- **`aws:lambda:invocation-error`** - Forces Lambda invocations to fail

## Changes

- **`modules/chaos/main.tf`**: Complete rewrite using valid Lambda FIS actions
- **`modules/chaos/variables.tf`**: New `lambda_arns` and `lambda_error_alarm_arn` variables
- **`modules/chaos/outputs.tf`**: New outputs for Lambda latency/error templates
- **`modules/monitoring/outputs.tf`**: Export `analysis_errors_alarm_arn` for kill switch
- **`main.tf`**: 
  - Enable chaos testing in preprod only
  - Pass Lambda ARNs to chaos module
  - Update dashboard env vars for new FIS templates
- **`docs/TECH_DEBT_REGISTRY.md`**: Add TD-015 for performance tuning

## Test plan

- [ ] Terraform validates successfully
- [ ] FIS templates created in preprod after merge
- [ ] Can manually start experiment from AWS Console
- [ ] Kill switch (analysis_errors_alarm) stops experiment when triggered

## References

- [AWS FIS Lambda Actions (Oct 2024)](https://aws.amazon.com/blogs/mt/introducing-aws-fault-injection-service-actions-to-inject-chaos-in-lambda-functions/)
- [AWS FIS Actions Reference](https://docs.aws.amazon.com/fis/latest/userguide/fis-actions-reference.html)

🤖 Generated with [Claude Code](https://claude.com/claude-code)