### PR TITLE
fix: Disable Lambda FIS chaos testing (Terraform provider bug)

### DIFF
--- a/docs/TECH_DEBT_REGISTRY.md
+++ b/docs/TECH_DEBT_REGISTRY.md
@@ -332,6 +332,30 @@ class CloudDatabase(ComponentResource):
 **Effort**: 4-6 weeks
 **Risk**: High (complete infrastructure rewrite)
 
+### TD-021: Lambda FIS Chaos Testing Blocked by Terraform Provider
+**Status**: Blocked - Waiting for upstream fix
+**Location**: `infrastructure/terraform/main.tf:442-445`, `modules/chaos/main.tf`
+**Issue**: [hashicorp/terraform-provider-aws#41208](https://github.com/hashicorp/terraform-provider-aws/issues/41208)
+
+**Current State**: AWS FIS added Lambda fault injection actions in October 2024:
+- `aws:lambda:invocation-add-delay` - Inject latency
+- `aws:lambda:invocation-error` - Force errors
+
+However, the Terraform AWS provider validation doesn't recognize `"Functions"` as a valid
+target key. The provider only allows: `AutoScalingGroups`, `Buckets`, `Cluster`, `Clusters`,
+`DBInstances`, `Instances`, `Nodegroups`, `Pods`, `ReplicationGroups`, `Roles`, `SpotInstances`,
+`Subnets`, `Tables`, `Tasks`, `TransitGateways`, `Volumes`.
+
+**Workaround**: Set `enable_chaos_testing = false` in main.tf until provider is updated.
+
+**Resolution**: Monitor the GitHub issue. Once resolved:
+1. Update AWS provider version in `versions.tf`
+2. Change `enable_chaos_testing = false` back to `var.environment == "preprod"`
+3. Test chaos experiments in preprod
+
+**Effort**: 30 minutes once provider is updated
+**Risk**: None (feature disabled, not broken)
+
 ---
 
 ## Cloud Portability Action Plan

--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -438,8 +438,11 @@ module "monitoring" {
 module "chaos" {
   source = "./modules/chaos"
 
-  environment          = var.environment
-  enable_chaos_testing = var.environment == "preprod" # Only enabled in preprod
+  environment = var.environment
+  # DISABLED: Terraform AWS provider doesn't support Lambda FIS target key "Functions" yet
+  # See: https://github.com/hashicorp/terraform-provider-aws/issues/41208
+  # Re-enable when provider version supports aws:lambda:invocation-add-delay targets
+  enable_chaos_testing = false # var.environment == "preprod"
 
   # Lambda targets for chaos experiments
   lambda_arns = [


### PR DESCRIPTION
## Summary
Disable Lambda FIS chaos testing due to Terraform AWS provider bug.

## Root Cause
The Terraform AWS provider doesn't support `"Functions"` as a valid target key for FIS experiment templates.

**Error:**
```
expected action.0.target.0.key to be one of ["AutoScalingGroups" "Buckets" "Cluster" ...], got Functions
```

**Issue:** [hashicorp/terraform-provider-aws#41208](https://github.com/hashicorp/terraform-provider-aws/issues/41208)

## Fix
- Set `enable_chaos_testing = false` in main.tf
- Added TD-021 to tech debt registry to track when to re-enable

## When to re-enable
Once the Terraform provider is updated to support Lambda FIS targets:
1. Update AWS provider version
2. Change `enable_chaos_testing = false` back to `var.environment == "preprod"`
3. Test chaos experiments in preprod

## Test plan
- [x] Terraform plan passes (no cycle error, no validation error)
- [ ] Deploy pipeline completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)