### PR TITLE
fix: Place dashboard handler.py at package root for Lambda

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -199,9 +199,12 @@ jobs:
             "
 
           # Build dashboard package
+          # NOTE: handler.py must be at ROOT for Lambda handler config "handler.lambda_handler"
+          # The src/ directory structure is needed for internal imports (from src.lambdas.shared...)
           mkdir -p packages/dashboard-build/src/lambdas/dashboard packages/dashboard-build/src/lib packages/dashboard-build/src/dashboard
           cp -r packages/dashboard-deps/* packages/dashboard-build/
-          cp -r src/lambdas/dashboard/* packages/dashboard-build/src/lambdas/dashboard/
+          cp -r src/lambdas/dashboard/* packages/dashboard-build/          # handler.py at ROOT
+          cp -r src/lambdas/dashboard/* packages/dashboard-build/src/lambdas/dashboard/  # also in src/ for imports
           cp -r src/lambdas/shared packages/dashboard-build/src/lambdas/
           cp -r src/lib/* packages/dashboard-build/src/lib/
           cp -r src/dashboard/* packages/dashboard-build/src/dashboard/
@@ -211,7 +214,7 @@ jobs:
           cd ../..
 
           # Validate package structure before cleanup
-          validate_lambda_package "dashboard" "src/lambdas/dashboard/handler.py"
+          validate_lambda_package "dashboard" "handler.py"
 
           # Show size and cleanup
           DASHBOARD_SIZE=$(du -h packages/dashboard-${SHA}.zip | cut -f1)


### PR DESCRIPTION
## Summary
- Fix dashboard Lambda failing with "No module named 'fastapi'" error
- Root cause: handler.py was placed at `src/lambdas/dashboard/handler.py` but Lambda expects `handler.lambda_handler` to find `handler.py` at package root

## Changes
- Copy handler.py to package root (for Lambda handler config)
- Also copy to `src/lambdas/dashboard/` (for internal imports like `from src.lambdas.dashboard.chaos import ...`)
- Update validation to check for `handler.py` at root

## Test plan
- [ ] Deploy to dev and verify health endpoint works
- [ ] Check CloudWatch logs for no import errors
- [ ] Verify preprod smoke tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)