### PR TITLE
fix: Dashboard Lambda pydantic binary compatibility (HTTP 502)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -176,27 +176,40 @@ jobs:
           echo "📦 Packaging Dashboard Lambda (FastAPI, Mangum, SSE, pydantic)..."
 
           # Install dashboard dependencies
-          # Build in Lambda-compatible Docker container for binary compatibility
-          # CRITICAL: pydantic has native C extensions that must match Lambda runtime
-          # Run container as current user to avoid permission issues (industry best practice)
-          docker run --rm \
-            --entrypoint /bin/bash \
-            --user $(id -u):$(id -g) \
-            -v $(pwd)/packages:/workspace \
-            public.ecr.aws/lambda/python:3.13 \
-            -c "
-              pip install \
-                fastapi==0.121.3 \
-                mangum==0.19.0 \
-                sse-starlette==3.0.3 \
-                pydantic==2.12.4 \
-                boto3==1.41.0 \
-                python-json-logger==4.0.0 \
-                -t /workspace/dashboard-deps/ \
-                --no-cache-dir \
-                --disable-pip-version-check \
-                --quiet
-            "
+          # CRITICAL: pydantic-core has Rust binaries that MUST match Lambda runtime
+          # Use explicit platform flags to ensure cp313 wheels are downloaded
+          # (Docker container approach was downloading cp311 wheels from cache)
+          pip install \
+            fastapi==0.121.3 \
+            mangum==0.19.0 \
+            sse-starlette==3.0.3 \
+            pydantic==2.12.4 \
+            boto3==1.41.0 \
+            python-json-logger==4.0.0 \
+            -t packages/dashboard-deps/ \
+            --platform manylinux2014_x86_64 \
+            --implementation cp \
+            --python-version 313 \
+            --only-binary=:all: \
+            --no-cache-dir \
+            --disable-pip-version-check \
+            --quiet
+
+          # Verify pydantic-core binary is for Python 3.13
+          echo "🔍 Verifying pydantic-core binary compatibility..."
+          PYDANTIC_SO=$(find packages/dashboard-deps -name "_pydantic_core*.so" | head -1)
+          if [ -z "$PYDANTIC_SO" ]; then
+            echo "❌ ERROR: pydantic-core .so file not found!"
+            exit 1
+          fi
+          echo "Found: $PYDANTIC_SO"
+          if echo "$PYDANTIC_SO" | grep -q "cpython-313"; then
+            echo "✅ pydantic-core binary is for Python 3.13"
+          else
+            echo "❌ ERROR: pydantic-core binary is NOT for Python 3.13!"
+            echo "File: $PYDANTIC_SO"
+            exit 1
+          fi
 
           # Build dashboard package
           # NOTE: handler.py must be at ROOT for Lambda handler config "handler.lambda_handler"
@@ -412,7 +425,11 @@ jobs:
 
       - name: Terraform Plan (Dev)
         run: |
-          terraform plan -var-file=dev.tfvars -out=dev.tfplan
+          SHA="${GITHUB_SHA::7}"
+          terraform plan \
+            -var-file=dev.tfvars \
+            -var="lambda_package_version=${SHA}" \
+            -out=dev.tfplan
 
       - name: Terraform Apply (Dev)
         run: |
@@ -651,6 +668,7 @@ jobs:
           terraform plan \
             -var-file=preprod.tfvars \
             -var="model_version=${{ needs.build.outputs.artifact-sha }}" \
+            -var="lambda_package_version=${{ needs.build.outputs.artifact-sha }}" \
             -no-color \
             -lock-timeout=5m \
             -out=preprod.tfplan | tee plan.txt
@@ -985,6 +1003,7 @@ jobs:
           terraform plan \
             -var-file=prod.tfvars \
             -var="model_version=${{ needs.build.outputs.artifact-sha }}" \
+            -var="lambda_package_version=${{ needs.build.outputs.artifact-sha }}" \
             -no-color \
             -lock-timeout=5m \
             -out=prod.tfplan | tee plan.txt

--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -124,6 +124,9 @@ module "ingestion_lambda" {
   s3_bucket     = "${var.environment}-sentiment-lambda-deployments"
   s3_key        = "ingestion/lambda.zip"
 
+  # Force update when package changes (git SHA triggers redeployment)
+  source_code_hash = var.lambda_package_version
+
   # Resource configuration per task spec
   memory_size          = 512
   timeout              = 60
@@ -167,6 +170,9 @@ module "analysis_lambda" {
   handler       = "handler.lambda_handler"
   s3_bucket     = "${var.environment}-sentiment-lambda-deployments"
   s3_key        = "analysis/lambda.zip"
+
+  # Force update when package changes (git SHA triggers redeployment)
+  source_code_hash = var.lambda_package_version
 
   # Resource configuration per task spec
   memory_size          = 1024
@@ -220,6 +226,9 @@ module "dashboard_lambda" {
   handler       = "handler.lambda_handler"
   s3_bucket     = "${var.environment}-sentiment-lambda-deployments"
   s3_key        = "dashboard/lambda.zip"
+
+  # Force update when package changes (git SHA triggers redeployment)
+  source_code_hash = var.lambda_package_version
 
   # Resource configuration per task spec
   memory_size          = 1024
@@ -280,6 +289,9 @@ module "metrics_lambda" {
   handler       = "handler.lambda_handler"
   s3_bucket     = "${var.environment}-sentiment-lambda-deployments"
   s3_key        = "metrics/lambda.zip"
+
+  # Force update when package changes (git SHA triggers redeployment)
+  source_code_hash = var.lambda_package_version
 
   # Lightweight Lambda - minimal resources needed
   memory_size          = 128

--- a/infrastructure/terraform/variables.tf
+++ b/infrastructure/terraform/variables.tf
@@ -62,3 +62,9 @@ variable "cors_allowed_origins" {
     error_message = "Wildcard '*' is not allowed in cors_allowed_origins. Use specific domain names."
   }
 }
+
+variable "lambda_package_version" {
+  description = "Version identifier for Lambda packages (git SHA). Used to force Lambda updates when packages change."
+  type        = string
+  default     = "initial"
+}


### PR DESCRIPTION
## Summary
- Fix Dashboard Lambda build to use explicit platform flags (`--platform manylinux2014_x86_64 --python-version 313 --only-binary=:all:`)
- Add build-time verification to ensure pydantic-core binary is cpython-313
- Add `lambda_package_version` variable to force Terraform Lambda updates when packages change

## Root Cause
The Dashboard Lambda was failing with HTTP 502 due to `No module named 'pydantic_core._pydantic_core'`. Investigation revealed:

1. **Build issue**: Docker container approach was downloading cpython-311 wheels instead of cpython-313
2. **Deploy issue**: Terraform wasn't detecting package changes because `source_code_hash` wasn't being passed (static S3 key)

The S3 bucket had the correct cpython-313 binary, but Terraform wasn't updating the Lambda.

## Changes

### `.github/workflows/deploy.yml`
- Replace Docker container pip install with explicit platform flags (consistent with Ingestion/Analysis Lambdas)
- Add verification step to ensure pydantic-core binary is for Python 3.13
- Pass `lambda_package_version` to all Terraform plan commands

### `infrastructure/terraform/main.tf`
- Add `source_code_hash = var.lambda_package_version` to all 4 Lambda modules

### `infrastructure/terraform/variables.tf`
- Add `lambda_package_version` variable with default value

## Test plan
- [ ] Verify CI builds pass
- [ ] Verify pydantic-core binary verification step passes
- [ ] After merge, verify Dashboard Lambda `/health` returns HTTP 200
- [ ] Check CloudWatch logs for no import errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)