### PR TITLE
fix: Add DescribeTable permission for dashboard health check

### DIFF
--- a/infrastructure/terraform/modules/iam/main.tf
+++ b/infrastructure/terraform/modules/iam/main.tf
@@ -257,7 +257,7 @@ resource "aws_iam_role" "dashboard_lambda" {
   }
 }
 
-# Dashboard Lambda policy (DynamoDB Query + GetItem - READ ONLY)
+# Dashboard Lambda policy (DynamoDB Query + GetItem + DescribeTable - READ ONLY)
 resource "aws_iam_role_policy" "dashboard_dynamodb" {
   name = "${var.environment}-dashboard-dynamodb-policy"
   role = aws_iam_role.dashboard_lambda.id
@@ -269,7 +269,8 @@ resource "aws_iam_role_policy" "dashboard_dynamodb" {
         Effect = "Allow"
         Action = [
           "dynamodb:Query",
-          "dynamodb:GetItem"
+          "dynamodb:GetItem",
+          "dynamodb:DescribeTable"
         ]
         Resource = [
           var.dynamodb_table_arn,


### PR DESCRIPTION
## Summary
Add `dynamodb:DescribeTable` permission to dashboard Lambda IAM role.

## Root Cause  
The health check endpoint calls `table.table_status` which triggers a `DescribeTable` API call. Without this permission, health check returns HTTP 503 "unhealthy" even though the Lambda is working.

## Test plan
- [ ] Verify CI passes
- [ ] After deploy, `/health` returns HTTP 200 with `{"status": "healthy"}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)