### PR TITLE
fix: Use setdefault for test env vars to prevent CI overwrites

### DIFF
--- a/tests/unit/test_dashboard_handler.py
+++ b/tests/unit/test_dashboard_handler.py
@@ -28,10 +28,11 @@ from moto import mock_aws
 
 from src.lambdas.dashboard.handler import app
 
-# Set env vars for tests (handler now reads lazily via get_api_key())
-os.environ["API_KEY"] = "test-api-key-12345"
-os.environ["DYNAMODB_TABLE"] = "test-sentiment-items"
-os.environ["ENVIRONMENT"] = "test"
+# Set default env vars for tests (only if not already set by CI)
+# IMPORTANT: Use setdefault to avoid overwriting CI-provided preprod values
+os.environ.setdefault("API_KEY", "test-api-key-12345")
+os.environ.setdefault("DYNAMODB_TABLE", "test-sentiment-items")
+os.environ.setdefault("ENVIRONMENT", "test")
 
 
 def create_test_table():


### PR DESCRIPTION
## Summary
- Fix module-level `os.environ["DYNAMODB_TABLE"]` in `test_dashboard_handler.py` that was unconditionally overwriting CI-provided preprod values (`preprod-sentiment-items`) with test defaults (`test-sentiment-items`)
- Changed to `os.environ.setdefault()` so CI values take precedence during preprod test runs
- Also updated preprod dashboard-api-key secret to JSON format (`{"api_key": "..."}`) to match the expected schema in `secrets.py`

## Root Cause
When pytest runs with `-m "preprod"`, it still imports ALL test files during collection. The module-level assignment `os.environ["DYNAMODB_TABLE"] = "test-sentiment-items"` in `test_dashboard_handler.py` was executing before preprod tests ran, overwriting the CI-provided `preprod-sentiment-items` value.

## Test plan
- [x] Local unit tests pass (87 passed in test_dashboard_handler.py)
- [ ] CI PR checks pass
- [ ] After merge, deploy workflow runs preprod integration tests successfully
- [ ] All 14 previously failing preprod tests should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)