### PR TITLE
fix: Eliminate test fallbacks that hide failures

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -856,6 +856,11 @@ jobs:
           API_KEY: ${{ secrets.DASHBOARD_API_KEY }}
           WATCH_TAGS: AI,climate,economy
           MODEL_VERSION: v${{ needs.build.outputs.artifact-sha }}
+          # Required for canary tests (test_canary_preprod.py)
+          PREPROD_DASHBOARD_URL: ${{ needs.deploy-preprod.outputs.dashboard_url }}
+          PREPROD_DASHBOARD_API_KEY: ${{ secrets.DASHBOARD_API_KEY }}
+          # Required for E2E Lambda invocation tests (test_e2e_lambda_invocation_preprod.py)
+          DASHBOARD_FUNCTION_URL: ${{ needs.deploy-preprod.outputs.dashboard_url }}
         run: |
           # Run tests marked as "preprod" (auto-marked by conftest.py for *_preprod.py files)
           # These tests use REAL AWS resources, not moto mocks

--- a/tests/integration/test_e2e_lambda_invocation_preprod.py
+++ b/tests/integration/test_e2e_lambda_invocation_preprod.py
@@ -51,9 +51,16 @@ REQUEST_TIMEOUT = 65
 
 @pytest.fixture
 def auth_headers() -> dict[str, str]:
-    """Return valid authorization headers for E2E tests."""
+    """Return valid authorization headers for E2E tests.
+
+    API_KEY MUST be set in CI - this is not optional.
+    """
     if not API_KEY:
-        pytest.skip("API_KEY not set - cannot test authenticated endpoints")
+        pytest.fail(
+            "API_KEY not set! "
+            "This is required for E2E Lambda invocation tests. "
+            "Check deploy.yml test-preprod job env vars."
+        )
     return {"Authorization": API_KEY}
 
 


### PR DESCRIPTION
## Summary
- Remove multi-status assertions (e.g., `in [200, 404]`) that auto-pass tests
- Change pytest.skip to pytest.fail for missing env vars in preprod tests  
- Fix static file tests to expect 200 (files exist at src/dashboard/)
- Add explicit assertion for SSE streaming test timeout handling
- Add CloudWatch observability tests for Lambda metrics validation
- Add required env vars (PREPROD_DASHBOARD_URL, DASHBOARD_FUNCTION_URL) to deploy.yml

## Changes by File

### .github/workflows/deploy.yml
- Add PREPROD_DASHBOARD_URL and PREPROD_DASHBOARD_API_KEY for canary tests
- Add DASHBOARD_FUNCTION_URL for E2E Lambda invocation tests

### tests/unit/test_dashboard_handler.py
- Fix TestStaticFiles to expect 200 (files exist at src/dashboard/)
- Fix TestStaticFilePackaging to verify files exist and are served correctly

### tests/integration/test_canary_preprod.py
- Change pytest.skip to pytest.fail for missing PREPROD_DASHBOARD_URL
- Change pytest.skip to pytest.fail for missing PREPROD_DASHBOARD_API_KEY

### tests/integration/test_e2e_lambda_invocation_preprod.py
- Change pytest.skip to pytest.fail for missing API_KEY

### tests/integration/test_dashboard_preprod.py
- Add explicit assertion for SSE streaming test (was using `pass` on timeout)

### tests/integration/test_observability_preprod.py (NEW)
- CloudWatch metric validation tests
- Tests Lambda invocation count, error rate, average duration
- Tests CloudWatch Logs existence and recent log events

## Test plan
- [x] All 569 unit tests pass locally
- [ ] CI lint/test passes
- [ ] Preprod integration tests pass (validates env vars are correctly set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)