### PR TITLE
docs: Add test debt burndown report and specifications

### DIFF
--- a/docs/TEST-DEBT.md
+++ b/docs/TEST-DEBT.md
@@ -1,0 +1,147 @@
+# Test Debt Burndown Report
+
+**Generated:** 2025-11-25
+**Overall Coverage:** 85.99% (target: 80%)
+**Total Tests:** 569 unit tests + integration/e2e suites
+
+## Executive Summary
+
+The test suite meets coverage thresholds but has structural weaknesses that reduce confidence in preprod validation. This document tracks test debt items to be burned down over time.
+
+## Coverage by Module
+
+| Module | Coverage | Risk Level | Notes |
+|--------|----------|------------|-------|
+| `dashboard/handler.py` | 72% | HIGH | SSE streaming, WebSocket, static file paths untested |
+| `analysis/sentiment.py` | 74% | MEDIUM | S3 model loading path untested |
+| `dashboard/chaos.py` | 75% | MEDIUM | FIS experiment execution paths |
+| `dashboard/api_v2.py` | 86% | LOW | Some edge cases missing |
+| `ingestion/handler.py` | 87% | LOW | Error handling paths |
+| `shared/secrets.py` | 88% | LOW | Edge cases |
+| `ingestion/adapters/newsapi.py` | 87% | LOW | Error paths |
+| `shared/dynamodb.py` | 91% | LOW | Good coverage |
+| `dashboard/metrics.py` | 92% | LOW | Good coverage |
+| `shared/logging_utils.py` | 100% | NONE | Fully covered |
+| `shared/errors.py` | 100% | NONE | Fully covered |
+| `shared/schemas.py` | 100% | NONE | Fully covered |
+| `shared/chaos_injection.py` | 100% | NONE | Fully covered |
+
+## Tests With Skips/Fallbacks
+
+### TD-001: Observability Tests Skip on Missing Metrics
+**File:** `tests/integration/test_observability_preprod.py`
+**Status:** OPEN
+**Lines:** 72, 122, 130, 165, 200, 261, 281
+
+**Problem:** Tests skip when CloudWatch metrics don't exist, hiding the fact that metrics SHOULD exist if the system is running correctly.
+
+**Root Cause:** No guaranteed metric generation during preprod deployment.
+
+**Solution:** See spec `003-preprod-metrics-generation`
+
+---
+
+### TD-002: E2E Lambda Tests Have Empty Placeholders
+**File:** `tests/integration/test_e2e_lambda_invocation_preprod.py`
+**Status:** OPEN
+**Lines:** 373, 556
+
+**Problem:** Tests have `pass` placeholders that do nothing, giving false confidence.
+
+**Root Cause:** Tests were scaffolded but never implemented.
+
+**Solution:** See spec `004-remove-test-placeholders`
+
+---
+
+### TD-003: Ingestion Preprod Tests Have Empty Exception Handlers
+**File:** `tests/integration/test_ingestion_preprod.py`
+**Status:** OPEN
+**Lines:** 328, 405, 480
+
+**Problem:** Exception handlers with `pass` silently swallow failures.
+
+**Root Cause:** Defensive coding that hides real issues.
+
+**Solution:** See spec `004-remove-test-placeholders`
+
+---
+
+### TD-004: No Synthetic Data for E2E Validation
+**File:** Multiple preprod test files
+**Status:** OPEN
+
+**Problem:** E2E tests depend on real data existing in preprod. If table is empty or stale, tests give false positives.
+
+**Root Cause:** No on-demand test data generation.
+
+**Solution:** See spec `005-synthetic-test-data`
+
+---
+
+### TD-005: Dashboard Handler Low Coverage
+**File:** `src/lambdas/dashboard/handler.py`
+**Status:** OPEN
+**Coverage:** 72%
+
+**Problem:** SSE streaming, WebSocket, and static file error paths are untested.
+
+**Uncovered Lines:**
+- 115-129: Static file serving initialization
+- 557-628: SSE streaming implementation
+- 746-760: WebSocket handling
+- 939-953: Error response formatting
+- 1079-1093: Request validation edge cases
+
+**Solution:** Add unit tests mocking SSE/WebSocket connections.
+
+---
+
+### TD-006: Sentiment Model S3 Loading Untested
+**File:** `src/lambdas/analysis/sentiment.py`
+**Status:** OPEN
+**Coverage:** 74%
+
+**Problem:** Lines 81-139 (S3 model download and loading) are never executed in unit tests.
+
+**Root Cause:** Unit tests mock the model directly.
+
+**Solution:** Add integration test that loads model from real S3 in preprod.
+
+## Burndown Specifications
+
+| Spec ID | Title | Status | Resolves |
+|---------|-------|--------|----------|
+| 003-preprod-metrics-generation | Generate Metrics During Preprod Deploy | PLANNED | TD-001 |
+| 004-remove-test-placeholders | Remove Empty Test Placeholders | PLANNED | TD-002, TD-003 |
+| 005-synthetic-test-data | On-Demand Synthetic Test Data | PLANNED | TD-004 |
+
+## Progress Tracking
+
+### Week of 2025-11-25
+- [x] Identified all test debt items
+- [x] Created TEST-DEBT.md tracking document
+- [x] Created spec placeholders for burndown work
+- [ ] TD-001: Implement preprod metrics generation
+- [ ] TD-002: Remove test placeholders
+- [ ] TD-003: Add synthetic data generation
+
+### Acceptance Criteria for Closing Items
+
+- **TD-001:** Zero `pytest.skip` calls in observability tests
+- **TD-002:** Zero `pass` statements in test files (except `__init__.py`)
+- **TD-003:** Same as TD-002
+- **TD-004:** E2E tests create/verify their own data
+- **TD-005:** Dashboard handler coverage >= 85%
+- **TD-006:** Sentiment model coverage >= 85%
+
+## Metrics
+
+Track these metrics weekly:
+
+```
+Overall Coverage: 85.99%
+Skip Count: 7
+Pass Placeholder Count: 6
+Modules Below 80%: 3 (handler.py, sentiment.py, chaos.py)
+```

--- a/specs/003-preprod-metrics-generation/spec.md
+++ b/specs/003-preprod-metrics-generation/spec.md
@@ -1,0 +1,114 @@
+# 003: Preprod Metrics Generation
+
+## Problem Statement
+
+Observability tests in `test_observability_preprod.py` skip when CloudWatch metrics don't exist. This hides real issues because if the system is running correctly, metrics SHOULD exist. Currently, 6 `pytest.skip()` calls mask potential problems:
+
+- Line 72: Skip when metrics namespace not found
+- Line 122: Skip when no invocation metrics in last hour
+- Line 130: Skip when no invocations in last hour
+- Line 165: Skip when no duration metrics in last hour
+- Line 200: Skip when no error metrics found
+- Line 261, 281: Skip when log groups not found
+
+## Goal
+
+Guarantee that preprod deployment generates CloudWatch metrics so observability tests can validate real data instead of skipping.
+
+## Requirements
+
+### Functional Requirements
+
+1. **FR-001:** During preprod deployment, invoke each Lambda at least once to generate metrics
+2. **FR-002:** Wait for CloudWatch metrics to be queryable (up to 2 minutes)
+3. **FR-003:** Verify metrics exist before running observability tests
+4. **FR-004:** Convert all `pytest.skip()` calls to `pytest.fail()` after metrics are guaranteed
+
+### Non-Functional Requirements
+
+1. **NFR-001:** Metric generation adds < 3 minutes to deployment pipeline
+2. **NFR-002:** No manual intervention required
+3. **NFR-003:** Metrics must be from current deployment (not stale historical data)
+
+## Technical Approach
+
+### Phase 1: Add Warmup Step to CI Pipeline
+
+Add a new CI step after preprod deployment but before integration tests:
+
+```yaml
+- name: Warm Up Lambdas for Metrics
+  run: |
+    # Invoke dashboard Lambda
+    curl -H "X-API-Key: $API_KEY" "$DASHBOARD_URL/health"
+    curl -H "X-API-Key: $API_KEY" "$DASHBOARD_URL/api/metrics"
+
+    # Invoke ingestion Lambda (trigger SNS)
+    aws lambda invoke --function-name preprod-sentiment-ingestion \
+      --payload '{"source": "test"}' /dev/null
+
+    # Invoke analysis Lambda
+    aws lambda invoke --function-name preprod-sentiment-analysis \
+      --payload '{"test": true}' /dev/null
+
+    # Wait for metrics to propagate
+    echo "Waiting 60s for CloudWatch metrics to be available..."
+    sleep 60
+```
+
+### Phase 2: Update Observability Tests
+
+Convert skips to failures:
+
+```python
+# BEFORE
+if not metrics:
+    pytest.skip("No invocation metrics in last hour")
+
+# AFTER
+assert metrics, (
+    "No invocation metrics found. "
+    "Warmup step should have generated metrics. "
+    "Check CI logs for warmup failures."
+)
+```
+
+### Phase 3: Add Metric Validation Step
+
+Add explicit metric existence check before running tests:
+
+```python
+@pytest.fixture(scope="session")
+def verify_metrics_exist(cloudwatch_client):
+    """Verify warmup step generated metrics."""
+    response = cloudwatch_client.list_metrics(
+        Namespace="AWS/Lambda",
+        Dimensions=[{"Name": "FunctionName", "Value": "preprod-sentiment-dashboard"}]
+    )
+    assert response["Metrics"], "No metrics found - warmup step may have failed"
+```
+
+## Files to Modify
+
+1. `.github/workflows/deploy.yml` - Add warmup step
+2. `tests/integration/test_observability_preprod.py` - Convert skips to assertions
+3. `tests/conftest.py` - Add metric verification fixture
+
+## Test Debt Resolution
+
+This spec resolves:
+- **TD-001:** Observability Tests Skip on Missing Metrics
+
+## Acceptance Criteria
+
+1. [ ] Warmup step invokes all Lambdas during preprod deploy
+2. [ ] CloudWatch metrics are queryable within 2 minutes of warmup
+3. [ ] Zero `pytest.skip()` calls remain in `test_observability_preprod.py`
+4. [ ] Observability tests pass with real metric data
+5. [ ] Pipeline time increase < 3 minutes
+
+## Dependencies
+
+- AWS Lambda invoke permissions in CI
+- CloudWatch read permissions in CI
+- API key available in CI environment

--- a/specs/004-remove-test-placeholders/spec.md
+++ b/specs/004-remove-test-placeholders/spec.md
@@ -1,0 +1,170 @@
+# 004: Remove Test Placeholders
+
+## Problem Statement
+
+Multiple preprod integration tests contain empty `pass` statements that do nothing, providing false confidence that tests are comprehensive. These placeholders were scaffolded but never implemented:
+
+### Affected Files
+
+**test_e2e_lambda_invocation_preprod.py:**
+- Line 373: `test_malformed_json_handled_gracefully` - Empty pass, no actual test
+- Line 556: `test_benchmark_cold_start_time` - Empty pass, no actual benchmark
+
+**test_ingestion_preprod.py:**
+- Line 328: Exception handler with empty pass
+- Line 405: Exception handler with empty pass
+- Line 480: Exception handler with empty pass
+
+**test_newsapi_adapter.py:**
+- Line 289: Empty pass in exception handler
+- Line 334: Empty pass in test body
+
+**test_metrics.py:**
+- Line 307: Empty pass in exception handler
+
+## Goal
+
+Remove all empty `pass` placeholders from test files. Either implement the test or delete it entirely.
+
+## Requirements
+
+### Functional Requirements
+
+1. **FR-001:** No `pass` statements in test methods (except `__init__.py`)
+2. **FR-002:** Exception handlers must either re-raise, log, or assert
+3. **FR-003:** Placeholder tests must be implemented or removed
+4. **FR-004:** Each test must have at least one assertion
+
+### Non-Functional Requirements
+
+1. **NFR-001:** No reduction in actual test coverage
+2. **NFR-002:** Clear error messages when tests fail
+3. **NFR-003:** Tests must be deterministic
+
+## Technical Approach
+
+### For Empty Test Methods
+
+**Option A: Implement the test**
+```python
+# BEFORE
+def test_malformed_json_handled_gracefully(self):
+    """E2E: Malformed requests are handled gracefully."""
+    pass
+
+# AFTER
+def test_malformed_json_handled_gracefully(self, auth_headers):
+    """E2E: Malformed requests are handled gracefully."""
+    response = requests.post(
+        f"{DASHBOARD_URL}/api/analyze",
+        headers=auth_headers,
+        data="not valid json",
+        timeout=REQUEST_TIMEOUT,
+    )
+    assert response.status_code in [400, 422], (
+        f"Expected 400/422 for malformed JSON, got {response.status_code}"
+    )
+```
+
+**Option B: Delete with explanation**
+```python
+# DELETE the test entirely and add to TEST-DEBT.md if needed
+```
+
+### For Empty Exception Handlers
+
+**Option A: Re-raise the exception**
+```python
+# BEFORE
+except Exception:
+    pass
+
+# AFTER
+except Exception as e:
+    pytest.fail(f"Unexpected exception: {e}")
+```
+
+**Option B: Explicit assertion on exception**
+```python
+# AFTER
+except SpecificException as e:
+    assert "expected message" in str(e)
+except Exception as e:
+    pytest.fail(f"Wrong exception type: {type(e).__name__}: {e}")
+```
+
+### Specific Fixes
+
+#### test_e2e_lambda_invocation_preprod.py:373
+```python
+def test_malformed_json_handled_gracefully(self, auth_headers):
+    """E2E: POST endpoints handle malformed JSON gracefully."""
+    # Skip if no POST endpoints exist
+    # Otherwise test with invalid JSON body
+    response = requests.post(
+        f"{DASHBOARD_URL}/api/chaos/experiments",
+        headers={**auth_headers, "Content-Type": "application/json"},
+        data="{{invalid json",
+        timeout=REQUEST_TIMEOUT,
+    )
+    assert response.status_code == 422, (
+        f"Expected 422 Unprocessable Entity, got {response.status_code}"
+    )
+```
+
+#### test_e2e_lambda_invocation_preprod.py:556
+```python
+def test_benchmark_cold_start_time(self):
+    """BENCHMARK: Measure cold start time by forcing new Lambda instance."""
+    # Force cold start by updating function config
+    # This test is complex - defer to spec 003 warmup implementation
+    pytest.skip("Cold start benchmark requires Lambda config update - implement in spec 003")
+```
+
+#### test_ingestion_preprod.py exception handlers
+```python
+# Replace all:
+except Exception:
+    pass
+
+# With:
+except requests.Timeout:
+    pytest.fail("Request timed out - Lambda may be throttled")
+except requests.ConnectionError as e:
+    pytest.fail(f"Connection failed: {e}")
+except Exception as e:
+    pytest.fail(f"Unexpected error: {type(e).__name__}: {e}")
+```
+
+## Files to Modify
+
+1. `tests/integration/test_e2e_lambda_invocation_preprod.py`
+2. `tests/integration/test_ingestion_preprod.py`
+3. `tests/unit/test_newsapi_adapter.py`
+4. `tests/unit/test_metrics.py`
+
+## Test Debt Resolution
+
+This spec resolves:
+- **TD-002:** E2E Lambda Tests Have Empty Placeholders
+- **TD-003:** Ingestion Preprod Tests Have Empty Exception Handlers
+
+## Acceptance Criteria
+
+1. [ ] Zero `pass` statements in test methods (grep confirms)
+2. [ ] All exception handlers either re-raise, assert, or call pytest.fail
+3. [ ] No reduction in test count (tests replaced, not deleted)
+4. [ ] All tests have at least one assertion
+5. [ ] CI passes after changes
+
+## Verification Script
+
+```bash
+# Should return 0 matches (excluding __init__.py)
+grep -r "^\s*pass$" tests/ --include="*.py" | grep -v "__init__"
+```
+
+## Risks
+
+- **Risk:** Implementing placeholder tests may reveal real bugs
+- **Mitigation:** Run tests locally first, fix issues before merging

--- a/specs/005-synthetic-test-data/spec.md
+++ b/specs/005-synthetic-test-data/spec.md
@@ -1,0 +1,248 @@
+# 005: On-Demand Synthetic Test Data Generation
+
+## Problem Statement
+
+E2E and integration tests in preprod depend on real data existing in DynamoDB. When the table is empty or contains stale data, tests may:
+
+1. Return empty results and pass (false positive)
+2. Verify against outdated data (incorrect validation)
+3. Miss edge cases not present in real data
+
+Tests should create their own data to ensure deterministic, comprehensive validation.
+
+## Goal
+
+Implement on-demand synthetic data generation that:
+- Creates known test data before E2E tests run
+- Cleans up test data after tests complete
+- Ensures tests validate against deterministic data
+
+## Requirements
+
+### Functional Requirements
+
+1. **FR-001:** Create synthetic sentiment items with known properties
+2. **FR-002:** Support all sentiment values (positive, neutral, negative)
+3. **FR-003:** Support tagged items for tag-based query testing
+4. **FR-004:** Clean up synthetic data after tests complete
+5. **FR-005:** Synthetic data must be identifiable (tagged with test marker)
+6. **FR-006:** Data generation must use the same code paths as production
+
+### Non-Functional Requirements
+
+1. **NFR-001:** Data generation adds < 30 seconds to test runtime
+2. **NFR-002:** Test data does not interfere with real preprod data
+3. **NFR-003:** Data cleanup is automatic, even on test failure
+4. **NFR-004:** Works in CI/CD without manual intervention
+
+## Technical Approach
+
+### Phase 1: Create Test Data Generator
+
+Create a utility module for generating synthetic test data:
+
+```python
+# tests/fixtures/synthetic_data.py
+
+import uuid
+from datetime import datetime, timezone
+from typing import Literal
+import boto3
+
+TEST_DATA_PREFIX = "TEST_E2E_"
+
+class SyntheticDataGenerator:
+    """Generate synthetic sentiment items for E2E testing."""
+
+    def __init__(self, table_name: str, region: str = "us-east-1"):
+        self.dynamodb = boto3.resource("dynamodb", region_name=region)
+        self.table = self.dynamodb.Table(table_name)
+        self.created_items: list[str] = []
+
+    def create_sentiment_item(
+        self,
+        sentiment: Literal["positive", "neutral", "negative"] = "neutral",
+        score: float = 0.75,
+        tags: list[str] | None = None,
+        source: str = "test-source",
+    ) -> dict:
+        """Create a synthetic sentiment item in DynamoDB."""
+        item_id = f"{TEST_DATA_PREFIX}{uuid.uuid4().hex[:12]}"
+        timestamp = datetime.now(timezone.utc).isoformat()
+
+        item = {
+            "item_id": item_id,
+            "source_id": f"newsapi:{uuid.uuid4().hex[:8]}",
+            "title": f"Test Article - {sentiment.upper()} sentiment",
+            "url": f"https://test.example.com/article/{item_id}",
+            "snippet": f"This is a synthetic test article with {sentiment} sentiment.",
+            "timestamp": timestamp,
+            "status": "analyzed",
+            "sentiment": sentiment,
+            "score": score,
+            "model_version": "test-model-v1",
+            "analyzed_at": timestamp,
+            "tags": tags or ["test", "synthetic"],
+        }
+
+        self.table.put_item(Item=item)
+        self.created_items.append(item_id)
+        return item
+
+    def create_test_dataset(self) -> list[dict]:
+        """Create a standard test dataset with known properties."""
+        items = []
+
+        # Create items for each sentiment
+        items.append(self.create_sentiment_item(
+            sentiment="positive", score=0.95, tags=["tech", "ai"]
+        ))
+        items.append(self.create_sentiment_item(
+            sentiment="positive", score=0.75, tags=["business"]
+        ))
+        items.append(self.create_sentiment_item(
+            sentiment="neutral", score=0.55, tags=["tech"]
+        ))
+        items.append(self.create_sentiment_item(
+            sentiment="neutral", score=0.50, tags=["politics"]
+        ))
+        items.append(self.create_sentiment_item(
+            sentiment="negative", score=0.85, tags=["business", "economy"]
+        ))
+        items.append(self.create_sentiment_item(
+            sentiment="negative", score=0.65, tags=["tech"]
+        ))
+
+        return items
+
+    def cleanup(self):
+        """Delete all synthetic test items."""
+        for item_id in self.created_items:
+            try:
+                self.table.delete_item(Key={"item_id": item_id})
+            except Exception:
+                pass  # Best effort cleanup
+        self.created_items.clear()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.cleanup()
+        return False
+```
+
+### Phase 2: Create pytest Fixtures
+
+Add fixtures to preprod conftest:
+
+```python
+# tests/integration/conftest.py
+
+import os
+import pytest
+from tests.fixtures.synthetic_data import SyntheticDataGenerator
+
+@pytest.fixture(scope="session")
+def synthetic_data():
+    """Generate synthetic test data for E2E tests."""
+    table_name = os.environ.get("DYNAMODB_TABLE", "preprod-sentiment-items")
+
+    with SyntheticDataGenerator(table_name) as generator:
+        items = generator.create_test_dataset()
+        yield {
+            "items": items,
+            "generator": generator,
+            "positive_count": 2,
+            "neutral_count": 2,
+            "negative_count": 2,
+            "total_count": 6,
+        }
+        # Cleanup happens automatically via context manager
+```
+
+### Phase 3: Update E2E Tests
+
+Update tests to use synthetic data:
+
+```python
+# BEFORE
+def test_metrics_returns_correct_counts(self, auth_headers):
+    response = requests.get(f"{URL}/api/metrics", headers=auth_headers)
+    data = response.json()
+    # Hope real data exists
+    assert data["total"] >= 0
+
+# AFTER
+def test_metrics_returns_correct_counts(self, auth_headers, synthetic_data):
+    response = requests.get(f"{URL}/api/metrics", headers=auth_headers)
+    data = response.json()
+
+    # Verify against known synthetic data
+    assert data["total"] >= synthetic_data["total_count"]
+    assert data["positive"] >= synthetic_data["positive_count"]
+    assert data["neutral"] >= synthetic_data["neutral_count"]
+    assert data["negative"] >= synthetic_data["negative_count"]
+```
+
+### Phase 4: Add Tag-Based Query Tests
+
+```python
+def test_items_filtered_by_tag(self, auth_headers, synthetic_data):
+    """Verify tag filtering works with known data."""
+    response = requests.get(
+        f"{URL}/api/items?tag=tech",
+        headers=auth_headers,
+    )
+    data = response.json()
+
+    # We created 3 items with "tech" tag
+    tech_items = [i for i in synthetic_data["items"] if "tech" in i.get("tags", [])]
+    assert len(data) >= len(tech_items)
+```
+
+## Files to Create/Modify
+
+1. `tests/fixtures/synthetic_data.py` - New data generator
+2. `tests/integration/conftest.py` - Add fixtures
+3. `tests/integration/test_e2e_lambda_invocation_preprod.py` - Use fixtures
+4. `tests/integration/test_dashboard_preprod.py` - Use fixtures
+
+## Test Debt Resolution
+
+This spec resolves:
+- **TD-004:** No Synthetic Data for E2E Validation
+
+## Acceptance Criteria
+
+1. [ ] Synthetic data generator creates items in DynamoDB
+2. [ ] Test data is automatically cleaned up after tests
+3. [ ] E2E tests verify against known synthetic data
+4. [ ] Tests detect when data is missing (not false positive)
+5. [ ] Tag-based queries tested with synthetic data
+6. [ ] No interference with real preprod data
+
+## Data Safety
+
+To prevent synthetic data from polluting production:
+
+1. All synthetic items have `item_id` starting with `TEST_E2E_`
+2. Cleanup runs in fixture teardown
+3. Items include `"source": "test-synthetic"` marker
+4. Production can filter out test data by prefix
+
+## IAM Requirements
+
+CI role needs:
+- `dynamodb:PutItem` on preprod table
+- `dynamodb:DeleteItem` on preprod table
+
+These permissions are already in place for existing test infrastructure.
+
+## Risks
+
+- **Risk:** Cleanup fails, leaving test data in table
+- **Mitigation:** Daily cleanup job removes items with `TEST_E2E_` prefix
+
+- **Risk:** Test data affects metrics/dashboards
+- **Mitigation:** Filter by source or prefix in dashboard queries


### PR DESCRIPTION
## Summary
- Add comprehensive test debt tracking documentation
- Create specifications for burning down test debt over time
- Establish clear acceptance criteria and metrics

## Files Added

### docs/TEST-DEBT.md
Test debt burndown report including:
- Coverage analysis (85.99% overall)
- 6 identified test debt items (TD-001 through TD-006)
- Weekly tracking metrics
- Acceptance criteria for closing items

### specs/003-preprod-metrics-generation/spec.md
Specification to guarantee CloudWatch metrics exist before running observability tests:
- Add Lambda warmup step to CI pipeline
- Convert pytest.skip to pytest.fail
- Resolves **TD-001**

### specs/004-remove-test-placeholders/spec.md  
Specification to eliminate empty `pass` statements in tests:
- Replace placeholders with actual assertions
- Implement tests or delete them
- Resolves **TD-002**, **TD-003**

### specs/005-synthetic-test-data/spec.md
Specification for on-demand synthetic test data:
- Create deterministic test data in DynamoDB
- Auto-cleanup after tests
- Resolves **TD-004**

## Test Debt Summary

| ID | Issue | Risk | Spec |
|----|-------|------|------|
| TD-001 | Observability tests skip on missing metrics | HIGH | 003 |
| TD-002 | E2E tests have empty placeholders | MEDIUM | 004 |
| TD-003 | Ingestion tests have empty exception handlers | MEDIUM | 004 |
| TD-004 | No synthetic data for E2E validation | MEDIUM | 005 |
| TD-005 | Dashboard handler 72% coverage | HIGH | - |
| TD-006 | Sentiment model S3 loading untested | MEDIUM | - |

## Test plan
- [x] Documentation only - no code changes
- [x] Specs are complete with acceptance criteria

🤖 Generated with [Claude Code](https://claude.com/claude-code)