### PR TITLE
fix: Remove empty test placeholders and improve exception handlers (TD-002, TD-003)

### DIFF
--- a/tests/integration/test_e2e_lambda_invocation_preprod.py
+++ b/tests/integration/test_e2e_lambda_invocation_preprod.py
@@ -355,15 +355,24 @@ class TestLambdaErrorHandling:
         assert response.status_code == 400
         assert "Hours must be between" in response.text
 
-    def test_malformed_json_handled_gracefully(self):
+    def test_malformed_json_handled_gracefully(self, auth_headers):
         """
         E2E: Malformed requests are handled gracefully.
 
-        Verifies Lambda doesn't crash on bad input.
+        Verifies Lambda doesn't crash on bad input and returns proper error.
+        Tests POST endpoint with invalid JSON body.
         """
-        # This test doesn't apply to GET endpoints
-        # Keeping it here as placeholder for future POST endpoint tests
-        pass
+        response = requests.post(
+            f"{DASHBOARD_URL}/api/chaos/experiments",
+            headers={**auth_headers, "Content-Type": "application/json"},
+            data="{{invalid json syntax",
+            timeout=REQUEST_TIMEOUT,
+        )
+        # Should return 422 Unprocessable Entity for invalid JSON
+        assert response.status_code == 422, (
+            f"Expected 422 for malformed JSON, got {response.status_code}. "
+            f"Response: {response.text[:200]}"
+        )
 
 
 class TestLambdaConcurrency:
@@ -543,10 +552,15 @@ class TestPerformanceBenchmarks:
     """
 
     def test_benchmark_cold_start_time(self):
-        """BENCHMARK: Measure cold start time."""
-        # This would require forcing a cold start, which is complex
-        # Keeping as placeholder for future work
-        pass
+        """BENCHMARK: Measure cold start time.
+
+        Requires updating Lambda config to force new execution environment.
+        Deferred until cold start optimization becomes a priority.
+        """
+        pytest.skip(
+            "Cold start benchmark requires Lambda config update to force new instance. "
+            "See Spec 003 for future implementation."
+        )
 
     def test_benchmark_metrics_query_time(self, auth_headers):
         """BENCHMARK: Measure metrics endpoint response time."""

--- a/tests/integration/test_ingestion_preprod.py
+++ b/tests/integration/test_ingestion_preprod.py
@@ -30,6 +30,7 @@ For Developers:
     - Validates schema compliance
 """
 
+import logging
 import os
 from datetime import UTC, datetime
 from unittest.mock import MagicMock, patch
@@ -40,6 +41,8 @@ import responses
 
 from src.lambdas.ingestion.adapters.newsapi import NEWSAPI_BASE_URL
 from src.lambdas.ingestion.handler import lambda_handler
+
+logger = logging.getLogger(__name__)
 
 # Environment variables should be set by CI (do NOT override here)
 # CI sets: DYNAMODB_TABLE=dev-sentiment-items, SNS_TOPIC_ARN=..., etc.
@@ -226,8 +229,8 @@ class TestIngestionE2E:
                             "timestamp": item["timestamp"],
                         }
                     )
-            except Exception:  # noqa: S110
-                pass  # Cleanup is best-effort, exceptions during cleanup don't fail test
+            except Exception as e:  # noqa: S110
+                logger.warning("Cleanup failed (best-effort): %s", e)
 
     @responses.activate
     def test_deduplication_across_invocations(
@@ -324,8 +327,8 @@ class TestIngestionE2E:
                             "timestamp": item["timestamp"],
                         }
                     )
-            except Exception:  # noqa: S110
-                pass
+            except Exception as e:  # noqa: S110
+                logger.warning("Cleanup failed (best-effort): %s", e)
 
     @responses.activate
     def test_item_ttl_set_correctly(
@@ -401,8 +404,8 @@ class TestIngestionE2E:
                             "timestamp": item["timestamp"],
                         }
                     )
-            except Exception:  # noqa: S110
-                pass
+            except Exception as e:  # noqa: S110
+                logger.warning("Cleanup failed (best-effort): %s", e)
 
     @responses.activate
     def test_metadata_preserved(
@@ -476,8 +479,8 @@ class TestIngestionE2E:
                             "timestamp": item["timestamp"],
                         }
                     )
-            except Exception:  # noqa: S110
-                pass
+            except Exception as e:  # noqa: S110
+                logger.warning("Cleanup failed (best-effort): %s", e)
 
     @responses.activate
     def test_text_for_analysis_extraction(
@@ -554,8 +557,8 @@ class TestIngestionE2E:
                             "timestamp": item["timestamp"],
                         }
                     )
-            except Exception:  # noqa: S110
-                pass  # Cleanup is best-effort
+            except Exception as e:  # noqa: S110
+                logger.warning("Cleanup failed (best-effort): %s", e)
 
 
 class TestIngestionEdgeCases:


### PR DESCRIPTION
## Summary

Implements **Spec 004 - Remove Test Placeholders** to resolve test debt items TD-002 and TD-003.

### Test placeholders fixed:
- `test_malformed_json_handled_gracefully`: Now tests POST endpoint with invalid JSON body, expects 422
- `test_benchmark_cold_start_time`: Now has explicit `pytest.skip` with reason instead of empty `pass`

### Exception handlers improved:
- All 5 cleanup exception handlers in `test_ingestion_preprod.py` now log warnings instead of silently passing

### Valid `pass` statements retained:
- `test_dashboard_preprod.py:466` - `asyncio.TimeoutError` is success case for SSE streaming test
- `test_metrics.py:307` - Timer context manager needs no-op body for testing
- `test_newsapi_adapter.py:289,334` - Circuit breaker tests expect failures

## Changes

1. **`tests/integration/test_e2e_lambda_invocation_preprod.py`**
   - Implemented malformed JSON test with actual assertions
   - Added proper skip with reason for cold start benchmark

2. **`tests/integration/test_ingestion_preprod.py`**
   - Added logging import
   - Changed 5 silent `except: pass` blocks to log warnings

## Test Plan

- [ ] CI lint/format passes
- [ ] Unit tests pass
- [ ] No new empty placeholders introduced

## Related

- Spec: `specs/004-remove-test-placeholders/spec.md`
- Test Debt Items: TD-002, TD-003

🤖 Generated with [Claude Code](https://claude.com/claude-code)