### PR TITLE
fix(ci): Properly fail deploy on unit test failures

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -500,6 +500,7 @@ jobs:
           pip install -r requirements-dev.txt
 
       - name: Run Unit Tests (Mocked AWS with moto)
+        id: unit-tests
         env:
           AWS_REGION: us-east-1
           ENVIRONMENT: dev
@@ -510,8 +511,26 @@ jobs:
         run: |
           # Dev environment uses mocked AWS resources (LOCAL mirrors DEV)
           # Fake AWS credentials prevent accidental real AWS access
-          pytest tests/unit/ -v --tb=short -m "not preprod" \
-            || echo "⚠️ Some unit tests failed - review before deploying"
+          set +e
+          pytest tests/unit/ -v --tb=short -m "not preprod"
+          TEST_EXIT_CODE=$?
+          set -e
+
+          if [ $TEST_EXIT_CODE -eq 0 ]; then
+            echo "✅ All unit tests passed"
+            echo "passed=true" >> $GITHUB_OUTPUT
+          else
+            echo "❌ Unit tests failed with exit code $TEST_EXIT_CODE"
+            echo "passed=false" >> $GITHUB_OUTPUT
+          fi
+          # Exit successfully to allow result check step
+          exit 0
+
+      - name: Check Unit Test Results
+        if: steps.unit-tests.outputs.passed != 'true'
+        run: |
+          echo "::error::Unit tests failed - cannot proceed with deployment"
+          exit 1
 
       - name: Validate Build Artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## Summary
- Fixed unit test step that was using `|| echo` to swallow failures
- Deploy could proceed even when unit tests failed
- Applies same pattern as integration tests (PR #140)

## Changes
- Track exit code with `$GITHUB_OUTPUT`
- Separate "Check Unit Test Results" step for proper failure handling
- Use `::error::` annotation for clear failure messages

## Test Plan
- [x] Verified workflow syntax is valid
- [x] Pattern matches working integration test fix

Part of test short-circuit audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)