### PR TITLE
fix(terraform): Use boolean for Feature 006 IAM policy count

### DIFF
--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -602,6 +602,7 @@ module "iam" {
   ticker_cache_bucket_arn      = aws_s3_bucket.ticker_cache.arn
   sendgrid_secret_arn          = module.secrets.sendgrid_secret_arn
   feature_006_users_table_arn  = module.dynamodb.feature_006_users_table_arn
+  enable_feature_006           = true
 }
 
 # ===================================================================

--- a/infrastructure/terraform/modules/iam/main.tf
+++ b/infrastructure/terraform/modules/iam/main.tf
@@ -381,7 +381,7 @@ resource "aws_iam_role_policy" "dashboard_chaos" {
 
 # Dashboard Lambda: Ticker Cache S3 Read Access (Feature 006)
 resource "aws_iam_role_policy" "dashboard_ticker_cache" {
-  count = var.ticker_cache_bucket_arn != "" ? 1 : 0
+  count = var.enable_feature_006 ? 1 : 0
   name  = "${var.environment}-dashboard-ticker-cache-policy"
   role  = aws_iam_role.dashboard_lambda.id
 
@@ -401,7 +401,7 @@ resource "aws_iam_role_policy" "dashboard_ticker_cache" {
 
 # Dashboard Lambda: Feature 006 Users Table Access (full CRUD for configs, alerts, users)
 resource "aws_iam_role_policy" "dashboard_feature_006_users" {
-  count = var.feature_006_users_table_arn != "" ? 1 : 0
+  count = var.enable_feature_006 ? 1 : 0
   name  = "${var.environment}-dashboard-feature-006-users-policy"
   role  = aws_iam_role.dashboard_lambda.id
 

--- a/infrastructure/terraform/modules/iam/variables.tf
+++ b/infrastructure/terraform/modules/iam/variables.tf
@@ -58,3 +58,9 @@ variable "feature_006_users_table_arn" {
   type        = string
   default     = ""
 }
+
+variable "enable_feature_006" {
+  description = "Whether Feature 006 resources should be created (ticker cache, users table policies)"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
## Problem

Deploy Pipeline failed with Terraform error:

```
Error: Invalid count argument

on modules/iam/main.tf line 384
The "count" value depends on resource attributes that cannot be
determined until apply
```

## Root Cause

Terraform cannot use computed resource attributes (like ARNs from resources being created) in `count` expressions during plan phase. The `ticker_cache_bucket_arn` and `feature_006_users_table_arn` values come from resources being created in the same apply.

## Fix

Add `enable_feature_006` boolean variable instead of checking if ARN strings are empty. The boolean is known at plan time, allowing Terraform to determine the count.

## Changes

- `modules/iam/variables.tf`: Add `enable_feature_006` boolean variable
- `modules/iam/main.tf`: Use `var.enable_feature_006` in count expressions
- `main.tf`: Pass `enable_feature_006 = true` to IAM module

## Test Plan

- [ ] Deploy Pipeline completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)