### PR TITLE
fix(ci): Use peter-evans/enable-pull-request-automerge for fine-grained PAT

### DIFF
--- a/.github/workflows/pr-auto-merge-enable.yml
+++ b/.github/workflows/pr-auto-merge-enable.yml
@@ -18,20 +18,23 @@
 #   - To disable auto-merge: gh pr merge --disable-auto <PR_NUMBER>
 #
 # IMPORTANT: Workflow Trigger Token
-#   This workflow uses REPO_PAT (Personal Access Token) instead of GITHUB_TOKEN.
-#   When GITHUB_TOKEN merges a PR, the resulting push to main does NOT trigger
-#   other workflows (GitHub security feature to prevent infinite loops).
+#   This workflow uses REPO_PAT (fine-grained Personal Access Token) to enable
+#   auto-merge. When GITHUB_TOKEN merges a PR, the resulting push to main does
+#   NOT trigger other workflows (GitHub security feature to prevent infinite loops).
 #   Using a PAT ensures the Deploy Pipeline triggers on merge.
 #
-#   To set up REPO_PAT:
-#   1. Create a PAT at https://github.com/settings/tokens with 'repo' scope
-#   2. Add it as a repository secret named REPO_PAT
-#   3. If REPO_PAT is not set, falls back to GITHUB_TOKEN (deploy won't auto-trigger)
+#   To set up REPO_PAT (fine-grained token):
+#   1. Go to https://github.com/settings/personal-access-tokens/new
+#   2. Select repository: sentiment-analyzer-gsk
+#   3. Permissions needed:
+#      - Contents: Read and write
+#      - Pull requests: Read and write
+#   4. Add as repository secret named REPO_PAT
 #
 # Security Notes:
 #   - All branch protection rules still apply
 #   - Status checks must pass before merge
-#   - PAT should have minimal required permissions (repo scope only)
+#   - Uses peter-evans/enable-pull-request-automerge action for fine-grained PAT support
 
 name: Enable Auto-Merge
 
@@ -51,27 +54,21 @@ jobs:
 
     steps:
       - name: Enable auto-merge
-        run: gh pr merge --auto --squash "$PR_URL"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          # Use REPO_PAT to trigger Deploy Pipeline on merge, fallback to GITHUB_TOKEN
-          GH_TOKEN: ${{ secrets.REPO_PAT || secrets.GITHUB_TOKEN }}
+        uses: peter-evans/enable-pull-request-automerge@v3
+        with:
+          token: ${{ secrets.REPO_PAT }}
+          pull-request-number: ${{ github.event.pull_request.number }}
+          merge-method: squash
 
       - name: Comment on PR
         run: |
-          if [ -n "${{ secrets.REPO_PAT }}" ]; then
-            DEPLOY_MSG="Deploy Pipeline will trigger automatically on merge."
-          else
-            DEPLOY_MSG="⚠️ REPO_PAT not configured - Deploy Pipeline will NOT auto-trigger. Run manually after merge."
-          fi
-
           gh pr comment "$PR_URL" --body "🤖 Auto-merge enabled. This PR will automatically merge once all required checks pass:
           - ✅ Run Tests
           - ✅ Code Quality
           - ✅ Dependency Vulnerability Scan
           - ✅ Analyze (CodeQL)
 
-          ${DEPLOY_MSG}
+          Deploy Pipeline will trigger automatically on merge.
 
           To disable auto-merge: \`gh pr merge --disable-auto ${{ github.event.pull_request.number }}\`"
         env:


### PR DESCRIPTION
## Problem

The `gh pr merge --auto` command uses a GraphQL mutation (`enablePullRequestAutoMerge`) that fine-grained PATs don't support:

```
GraphQL: Resource not accessible by personal access token (enablePullRequestAutoMerge)
```

## Solution

Use the `peter-evans/enable-pull-request-automerge@v3` action which properly supports fine-grained tokens.

## Changes

- Replace `gh pr merge --auto` with `peter-evans/enable-pull-request-automerge@v3`
- Update REPO_PAT setup instructions for fine-grained tokens
- Simplify PR comment

## REPO_PAT Permissions (fine-grained token)

- **Contents**: Read and write
- **Pull requests**: Read and write

## Test Plan

- [ ] Enable Auto-Merge workflow succeeds on this PR
- [ ] Auto-merge triggers after checks pass
- [ ] Deploy Pipeline triggers after merge

Generated with Claude Code