### PR TITLE
fix(iam): Add missing API Gateway permissions to CI policy

### DIFF
--- a/.claude/commands/iam-audit.md
+++ b/.claude/commands/iam-audit.md
@@ -76,6 +76,7 @@ grep -rh "^resource\s" infrastructure/terraform/ | sort | uniq
 
 Group resources by AWS service:
 - **Lambda**: `aws_lambda_function`, `aws_lambda_alias`, `aws_lambda_layer_version`, `aws_lambda_event_source_mapping`, `aws_lambda_function_url`, `aws_lambda_permission`
+- **API Gateway**: `aws_api_gateway_rest_api`, `aws_api_gateway_resource`, `aws_api_gateway_method`, `aws_api_gateway_integration`, `aws_api_gateway_deployment`, `aws_api_gateway_stage`, `aws_api_gateway_usage_plan`
 - **DynamoDB**: `aws_dynamodb_table`
 - **S3**: `aws_s3_bucket`, `aws_s3_bucket_*`, `aws_s3_object`
 - **SNS**: `aws_sns_topic`, `aws_sns_topic_subscription`
@@ -109,6 +110,18 @@ lambda:CreateEventSourceMapping, lambda:UpdateEventSourceMapping,
 lambda:DeleteEventSourceMapping, lambda:GetEventSourceMapping,
 lambda:PublishLayerVersion, lambda:DeleteLayerVersion, lambda:GetLayerVersion,
 lambda:TagResource, lambda:UntagResource, lambda:ListTags
+```
+
+#### API Gateway
+```
+# API Gateway uses HTTP-verb-style permissions on resource ARNs
+apigateway:GET, apigateway:POST, apigateway:PUT, apigateway:DELETE, apigateway:PATCH,
+apigateway:TagResource, apigateway:UntagResource
+
+# Resource ARN patterns:
+# - arn:aws:apigateway:REGION::/restapis
+# - arn:aws:apigateway:REGION::/restapis/*
+# - arn:aws:apigateway:REGION::/tags/*
 ```
 
 #### DynamoDB

--- a/infrastructure/terraform/ci-user-policy.tf
+++ b/infrastructure/terraform/ci-user-policy.tf
@@ -156,6 +156,26 @@ data "aws_iam_policy_document" "ci_deploy_core" {
     resources = ["*"]
   }
 
+  # API Gateway Management
+  statement {
+    sid    = "APIGateway"
+    effect = "Allow"
+    actions = [
+      "apigateway:GET",
+      "apigateway:POST",
+      "apigateway:PUT",
+      "apigateway:DELETE",
+      "apigateway:PATCH",
+      "apigateway:TagResource",
+      "apigateway:UntagResource"
+    ]
+    resources = [
+      "arn:aws:apigateway:*::/restapis",
+      "arn:aws:apigateway:*::/restapis/*",
+      "arn:aws:apigateway:*::/tags/*"
+    ]
+  }
+
   # Secrets Manager
   statement {
     sid    = "SecretsManager"


### PR DESCRIPTION
## Summary
Add missing API Gateway permissions to the CI deployment policy. The policy was completely missing all `apigateway:*` permissions despite having `aws_api_gateway_*` resources in the Terraform configuration.

## Root Cause
The `/iam-audit` command identified that API Gateway resources exist but no corresponding permissions were in the CI policy.

## Changes

### CI Policy (`ci-user-policy.tf`)
Added to `CIDeployCore` policy:
```hcl
statement {
  sid    = "APIGateway"
  effect = "Allow"
  actions = [
    "apigateway:GET",
    "apigateway:POST",
    "apigateway:PUT",
    "apigateway:DELETE",
    "apigateway:PATCH",
    "apigateway:TagResource",
    "apigateway:UntagResource"
  ]
  resources = [
    "arn:aws:apigateway:*::/restapis",
    "arn:aws:apigateway:*::/restapis/*",
    "arn:aws:apigateway:*::/tags/*"
  ]
}
```

### iam-audit Command (`.claude/commands/iam-audit.md`)
- Added API Gateway to resource checklist
- Added API Gateway permissions section with ARN patterns

## Bootstrap Required
An admin must apply this policy update:
```bash
cd infrastructure/terraform
terraform apply -var="environment=dev" -var="aws_region=us-east-1" \
  -target=aws_iam_policy.ci_deploy_core
```

## Test plan
- [ ] Admin applies bootstrap command
- [ ] Re-run deploy pipeline
- [ ] Verify API Gateway resources create successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)