### PR TITLE
fix(cloudfront): Extract domain only from API Gateway endpoint

### DIFF
--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -80,7 +80,8 @@ module "cloudfront" {
   account_suffix = data.aws_caller_identity.current.account_id
 
   # API Gateway integration
-  api_gateway_domain = replace(module.api_gateway.api_endpoint, "https://", "")
+  # Extract just the domain from API Gateway endpoint (strip https:// and path like /v1)
+  api_gateway_domain = split("/", replace(module.api_gateway.api_endpoint, "https://", ""))[0]
 
   # Custom domain (optional)
   custom_domain       = var.cloudfront_custom_domain


### PR DESCRIPTION
## Summary
- Fix CloudFront distribution creation failure caused by API Gateway endpoint including stage path (`/v1`)
- Use `split("/", ...)[0]` to extract only the domain portion, removing the stage path
- Audited codebase for similar issues - none found

## Root Cause
The API Gateway endpoint is `https://xxx.execute-api.us-east-1.amazonaws.com/v1`. After stripping `https://`, the result `xxx.execute-api.us-east-1.amazonaws.com/v1` still contains the `/v1` path, which CloudFront rejects as invalid for an origin domain name.

## Test plan
- [x] `terraform validate` passes
- [ ] CI deploy to dev succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)