### PR TITLE
fix(ci): Add missing IAM permissions and notification Lambda build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -317,14 +317,55 @@ jobs:
           rm -rf packages/metrics-deps packages/metrics-build
 
           # ============================================================
+          # Notification Lambda - SendGrid email notifications (Feature 006)
+          # ============================================================
+          echo ""
+          echo "📦 Packaging Notification Lambda (boto3, sendgrid, pydantic)..."
+
+          # Install notification dependencies
+          pip install \
+            boto3==1.41.0 \
+            sendgrid==6.11.0 \
+            pydantic==2.12.4 \
+            python-json-logger==4.0.0 \
+            -t packages/notification-deps/ \
+            --platform manylinux2014_x86_64 \
+            --implementation cp \
+            --python-version 313 \
+            --only-binary=:all: \
+            --no-cache-dir \
+            --disable-pip-version-check \
+            --quiet
+
+          # Build notification package
+          mkdir -p packages/notification-build/src/lambdas packages/notification-build/src/lib
+          cp -r packages/notification-deps/* packages/notification-build/
+          cp -r src/lambdas/notification/* packages/notification-build/
+          cp -r src/lambdas/shared packages/notification-build/src/lambdas/
+          cp -r src/lib/* packages/notification-build/src/lib/
+          cd packages/notification-build
+          zip -r ../notification-${SHA}.zip . \
+            -x "*.pyc" "__pycache__/*" "*.pytest_cache/*" "tests/*" -q
+          cd ../..
+
+          # Validate package structure before cleanup
+          validate_lambda_package "notification" "handler.py"
+
+          # Show size and cleanup
+          NOTIFICATION_SIZE=$(du -h packages/notification-${SHA}.zip | cut -f1)
+          echo "✅ Notification Lambda: ${NOTIFICATION_SIZE}"
+          rm -rf packages/notification-deps packages/notification-build
+
+          # ============================================================
           # Summary
           # ============================================================
           echo ""
           echo "📊 Package Summary:"
-          echo "  Ingestion:  ${INGESTION_SIZE}"
-          echo "  Dashboard:  ${DASHBOARD_SIZE}"
-          echo "  Analysis:   ${ANALYSIS_SIZE}"
-          echo "  Metrics:    ${METRICS_SIZE}"
+          echo "  Ingestion:     ${INGESTION_SIZE}"
+          echo "  Dashboard:     ${DASHBOARD_SIZE}"
+          echo "  Analysis:      ${ANALYSIS_SIZE}"
+          echo "  Metrics:       ${METRICS_SIZE}"
+          echo "  Notification:  ${NOTIFICATION_SIZE}"
           echo ""
           ls -lh packages/*.zip
           echo ""
@@ -410,6 +451,7 @@ jobs:
           aws s3 cp ../../packages/analysis-${SHA}.zip s3://${BUCKET}/analysis/lambda.zip
           aws s3 cp ../../packages/dashboard-${SHA}.zip s3://${BUCKET}/dashboard/lambda.zip
           aws s3 cp ../../packages/metrics-${SHA}.zip s3://${BUCKET}/metrics/lambda.zip
+          aws s3 cp ../../packages/notification-${SHA}.zip s3://${BUCKET}/notification/lambda.zip
 
           echo "Lambda packages uploaded successfully"
 
@@ -612,6 +654,10 @@ jobs:
 
           aws s3 cp ../../packages/metrics-${SHA}.zip \
             s3://${BUCKET}/metrics/lambda.zip \
+            --metadata "git-sha=${GITHUB_SHA},build-timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+          aws s3 cp ../../packages/notification-${SHA}.zip \
+            s3://${BUCKET}/notification/lambda.zip \
             --metadata "git-sha=${GITHUB_SHA},build-timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
           echo "✅ Lambda packages uploaded to S3"
@@ -1015,6 +1061,10 @@ jobs:
 
           aws s3 cp ../../packages/metrics-${SHA}.zip \
             s3://${BUCKET}/metrics/lambda.zip \
+            --metadata "git-sha=${GITHUB_SHA},build-timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ),validated-in=preprod"
+
+          aws s3 cp ../../packages/notification-${SHA}.zip \
+            s3://${BUCKET}/notification/lambda.zip \
             --metadata "git-sha=${GITHUB_SHA},build-timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ),validated-in=preprod"
 
           echo "✅ Lambda packages uploaded to S3"

--- a/infrastructure/terraform/ci-user-policy.tf
+++ b/infrastructure/terraform/ci-user-policy.tf
@@ -334,8 +334,26 @@ data "aws_iam_policy_document" "ci_deploy_monitoring" {
       "arn:aws:iam::*:role/*-lambda-role",
       "arn:aws:iam::*:role/*-fis-execution-role",
       "arn:aws:iam::*:role/*-backup-role",
-      "arn:aws:iam::*:role/*-cognito-*"
+      "arn:aws:iam::*:role/*-cognito-*",
+      "arn:aws:iam::*:role/*-rum-*"
     ]
+  }
+
+  # Service-Linked Roles (needed for services like RUM)
+  statement {
+    sid    = "ServiceLinkedRoles"
+    effect = "Allow"
+    actions = [
+      "iam:CreateServiceLinkedRole"
+    ]
+    resources = [
+      "arn:aws:iam::*:role/aws-service-role/rum.amazonaws.com/*"
+    ]
+    condition {
+      test     = "StringEquals"
+      variable = "iam:AWSServiceName"
+      values   = ["rum.amazonaws.com"]
+    }
   }
 
   # IAM Policy Management
@@ -366,7 +384,8 @@ data "aws_iam_policy_document" "ci_deploy_monitoring" {
       "arn:aws:iam::*:role/*-lambda-role",
       "arn:aws:iam::*:role/*-fis-execution-role",
       "arn:aws:iam::*:role/*-backup-role",
-      "arn:aws:iam::*:role/*-cognito-*"
+      "arn:aws:iam::*:role/*-cognito-*",
+      "arn:aws:iam::*:role/*-rum-*"
     ]
   }
 


### PR DESCRIPTION
## Summary
Fixes the Deploy to Dev pipeline failure by addressing three issues:

1. **CloudFront origin domain fix** - API Gateway endpoint includes stage path (`/v1`) which CloudFront rejects. Fixed by extracting only domain portion.

2. **IAM CreateServiceLinkedRole permission** - CloudWatch RUM requires a service-linked role on first creation. Added `iam:CreateServiceLinkedRole` with proper conditions for `rum.amazonaws.com`.

3. **Missing notification Lambda build** - The notification Lambda was defined in Terraform but not built/uploaded by CI. Added to:
   - Build step (with sendgrid dependency)
   - Dev S3 upload
   - Preprod S3 upload  
   - Prod S3 upload

4. **IAM role patterns** - Added `*-rum-*` to IAM role and PassRole patterns for RUM guest roles.

## Also includes
- Updated `/iam-audit` slash command to detect missing service-linked role permissions
- Added SLR documentation section with common services requiring SLRs

## Root Cause Analysis
The pipeline failed with two errors:
```
Error: creating CloudWatch RUM App Monitor: AccessDeniedException: User is not authorized 
to perform: iam:CreateServiceLinkedRole on resource: 
arn:aws:iam::*:role/aws-service-role/rum.amazonaws.com/AWSServiceRoleForCloudWatchRUM

Error: creating Lambda Function (dev-sentiment-notification): S3 Error Code: NoSuchKey
```

## Test plan
- [x] `terraform validate` passes
- [x] `terraform fmt` passes
- [ ] CI deploy to dev succeeds (requires bootstrap for IAM policy update)

## Bootstrap Required
An admin must manually apply the IAM policy changes before CI can succeed:
```bash
cd infrastructure/terraform
terraform init -backend-config=backend-dev.hcl
terraform apply -var-file=dev.tfvars \
  -target=aws_iam_policy.ci_deploy_monitoring
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)