### PR TITLE
fix(ci): Split notification Lambda pip install for starkbank-ecdsa

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -322,17 +322,27 @@ jobs:
           echo ""
           echo "📦 Packaging Notification Lambda (boto3, sendgrid, pydantic)..."
 
-          # Install notification dependencies
+          # Install notification dependencies in two steps:
+          # 1. Binary packages with platform-specific flags (pydantic-core needs correct binary)
+          # 2. SendGrid separately (starkbank-ecdsa is pure Python, no binary available for py313)
           pip install \
             boto3==1.41.0 \
-            sendgrid==6.11.0 \
             pydantic==2.12.4 \
             python-json-logger==4.0.0 \
+            aws-xray-sdk==2.14.0 \
             -t packages/notification-deps/ \
             --platform manylinux2014_x86_64 \
             --implementation cp \
             --python-version 313 \
             --only-binary=:all: \
+            --no-cache-dir \
+            --disable-pip-version-check \
+            --quiet
+
+          # Install sendgrid without binary restriction (starkbank-ecdsa is pure Python)
+          pip install \
+            sendgrid==6.11.0 \
+            -t packages/notification-deps/ \
             --no-cache-dir \
             --disable-pip-version-check \
             --quiet


### PR DESCRIPTION
## Summary
Fixes the notification Lambda build failure in the deploy pipeline.

## Root Cause
The `sendgrid` package depends on `starkbank-ecdsa`, which is a pure Python package without pre-built wheels for Python 3.13. The `--only-binary=:all:` flag was blocking pip from building it from source.

Error:
```
ERROR: Could not find a version that satisfies the requirement starkbank-ecdsa>=2.0.1 (from sendgrid)
ERROR: No matching distribution found for starkbank-ecdsa>=2.0.1
```

## Solution
Split the pip install into two steps:
1. Binary packages (boto3, pydantic, aws-xray-sdk) with platform-specific flags for Lambda compatibility
2. SendGrid separately without the binary restriction (pure Python deps can safely build from source)

## Test plan
- [ ] CI deploy to dev succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)