### PR TITLE
fix(lambda): Add email-validator to Dashboard Lambda package

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -185,6 +185,7 @@ jobs:
             mangum==0.19.0 \
             sse-starlette==3.0.3 \
             pydantic==2.12.4 \
+            email-validator==2.2.0 \
             boto3==1.41.0 \
             python-json-logger==4.0.0 \
             aws-xray-sdk==2.14.0 \


### PR DESCRIPTION
## Summary
- Fixes HTTP 502 error in Dashboard Lambda caused by missing `email-validator` dependency
- Error was: `ImportModuleError: email-validator is not installed, run pip install 'pydantic[email]'`
- Required because shared models use `EmailStr` from Pydantic

## Root Cause
The Dashboard Lambda packaging in `deploy.yml` included `pydantic` but not `email-validator`, which is needed for `EmailStr` type validation at runtime.

## Test plan
- [ ] PR checks pass
- [ ] After merge, verify deploy pipeline succeeds
- [ ] Smoke test returns HTTP 200 instead of 502

🤖 Generated with [Claude Code](https://claude.com/claude-code)