### PR TITLE
fix(lambda): Add httpx to Dashboard Lambda package

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -186,6 +186,7 @@ jobs:
             sse-starlette==3.0.3 \
             pydantic==2.12.4 \
             email-validator==2.2.0 \
+            httpx==0.28.1 \
             boto3==1.41.0 \
             python-json-logger==4.0.0 \
             aws-xray-sdk==2.14.0 \


### PR DESCRIPTION
## Summary
- Fixes HTTP 502 error in Dashboard Lambda caused by missing `httpx` dependency
- Error was: `ImportModuleError: No module named 'httpx'`
- httpx is used by shared adapters (Tiingo, Finnhub) and middleware (hCaptcha, Cognito auth)

## Root Cause
The Dashboard Lambda packaging includes shared modules that depend on httpx for HTTP requests, but httpx wasn't included in the pip install list.

## Test plan
- [ ] PR checks pass
- [ ] After merge, verify deploy pipeline succeeds
- [ ] Smoke test returns HTTP 200 instead of 502

🤖 Generated with [Claude Code](https://claude.com/claude-code)