### PR TITLE
fix(iam): Add DescribeTable permission to Dashboard Lambda role

### DIFF
--- a/infrastructure/terraform/modules/iam/main.tf
+++ b/infrastructure/terraform/modules/iam/main.tf
@@ -417,7 +417,8 @@ resource "aws_iam_role_policy" "dashboard_feature_006_users" {
           "dynamodb:DeleteItem",
           "dynamodb:Query",
           "dynamodb:BatchGetItem",
-          "dynamodb:BatchWriteItem"
+          "dynamodb:BatchWriteItem",
+          "dynamodb:DescribeTable"
         ]
         Resource = [
           var.feature_006_users_table_arn,


### PR DESCRIPTION
## Summary

- Adds `dynamodb:DescribeTable` permission to the `dashboard_feature_006_users` IAM policy
- Updates `/iam-audit` command to detect Lambda execution role permission gaps (specifically missing DescribeTable for health checks)

## Root Cause

The Dashboard Lambda health check calls `table.table_status` which triggers a `DescribeTable` API call. This permission was missing from the Lambda's IAM role policy, causing the health check endpoint to return "unhealthy" status even though the Lambda loaded successfully.

**Error Pattern:**
```json
{"status": "unhealthy", "error": "An error occurred processing your request", "table": "preprod-sentiment-users"}
```

## Test Plan

- [ ] PR deploys to preprod via pipeline
- [ ] Smoke test passes (`/health` returns 200)
- [ ] Pipeline completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)