### PR TITLE
refactor: Remove deprecated v1 API endpoints and migrate tests to v2

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -27,7 +27,7 @@ If you're here during an incident:
 
 3. **Dashboard issues** → Check `lambdas/dashboard/handler.py`
    - API key validation: Look for `compare_digest` calls
-   - SSE timeouts: Check polling interval in `/api/stream`
+   - API v2 endpoints: Check `/api/v2/*` routes
 
 See `specs/001-interactive-dashboard-demo/ON_CALL_SOP.md` for full runbooks.
 

--- a/src/dashboard/README.md
+++ b/src/dashboard/README.md
@@ -18,20 +18,20 @@ Client-side UI for the sentiment analysis dashboard.
 If users report dashboard issues:
 
 1. **Charts not loading** → Check browser console for API errors
-2. **SSE not updating** → Check `/api/stream` endpoint in Network tab
+2. **Data not updating** → Check `/api/v2/sentiment` endpoint in Network tab
 3. **CORS errors** → Verify Function URL CORS configuration
 
 ### Browser Console Commands
 
 ```javascript
 // Check last API response
-console.log(window.lastMetricsResponse);
+console.log(window.lastSentimentResponse);
 
 // Force refresh
 window.location.reload(true);
 
 // Test API manually
-fetch('/api/metrics', {headers: {'X-API-Key': 'YOUR_KEY'}})
+fetch('/api/v2/sentiment?tags=AI', {headers: {'Authorization': 'Bearer YOUR_KEY'}})
   .then(r => r.json())
   .then(console.log);
 ```

--- a/src/dashboard/config.js
+++ b/src/dashboard/config.js
@@ -19,20 +19,15 @@ const CONFIG = {
     // Empty string means same origin (Lambda Function URL serves both static and API)
     API_BASE_URL: '',
 
-    // Endpoints
+    // Endpoints (API v2)
     ENDPOINTS: {
-        METRICS: '/api/metrics',
-        STREAM: '/api/stream',
-        ITEMS: '/api/items'
+        SENTIMENT: '/api/v2/sentiment',
+        TRENDS: '/api/v2/trends',
+        ARTICLES: '/api/v2/articles'
     },
 
-    // Polling interval for metrics (milliseconds)
-    // Used as fallback when SSE is not available
-    METRICS_POLL_INTERVAL: 30000, // 30 seconds
-
-    // SSE reconnection settings
-    SSE_RECONNECT_DELAY: 3000, // 3 seconds
-    SSE_MAX_RETRIES: 5,
+    // Polling interval for sentiment data (milliseconds)
+    SENTIMENT_POLL_INTERVAL: 30000, // 30 seconds
 
     // Chart colors (must match CSS custom properties)
     COLORS: {

--- a/src/lambdas/dashboard/README.md
+++ b/src/lambdas/dashboard/README.md
@@ -14,8 +14,9 @@ HTTP requests via Function URL (CORS enabled)
 |--------|------|---------|------|
 | GET | `/` | Serve index.html | None |
 | GET | `/health` | Health check + DynamoDB connectivity | None |
-| GET | `/api/metrics` | Aggregated sentiment metrics | API Key |
-| GET | `/api/stream` | SSE real-time updates | API Key |
+| GET | `/api/v2/sentiment` | Get sentiment data by tags | API Key |
+| GET | `/api/v2/trends` | Get sentiment trends | API Key |
+| GET | `/api/v2/articles` | Get news articles | API Key |
 
 ## For On-Call Engineers
 
@@ -47,20 +48,13 @@ aws secretsmanager get-secret-value \
 
 | Error Code | Cause | Fix |
 |------------|-------|-----|
-| 401 Unauthorized | Invalid API key | Check `X-API-Key` header matches secret |
+| 401 Unauthorized | Invalid API key | Check `Authorization` header matches secret |
 | `DATABASE_ERROR` | DynamoDB query failed | Check GSI `by_status` exists |
-| SSE timeout | Client disconnected | Normal behavior, client will reconnect |
 
 ## Authentication
 
-API key passed via `X-API-Key` header, validated with `secrets.compare_digest()`
+API key passed via `Authorization: Bearer <key>` header, validated with `secrets.compare_digest()`
 to prevent timing attacks.
 
 **Security Note**: The `/health` endpoint is unauthenticated intentionally for
 monitoring systems. It only returns connectivity status, no sensitive data.
-
-## SSE Behavior
-
-- Poll interval: 5 seconds
-- Sends `data: {metrics}` events
-- Client should handle reconnection on disconnect

--- a/src/lambdas/dashboard/handler.py
+++ b/src/lambdas/dashboard/handler.py
@@ -2,7 +2,7 @@
 Dashboard Lambda Handler
 ========================
 
-FastAPI application serving the sentiment analyzer dashboard with SSE updates.
+FastAPI application serving the sentiment analyzer dashboard API v2.
 
 For On-Call Engineers:
     If dashboard is not accessible:
@@ -11,16 +11,10 @@ For On-Call Engineers:
     3. Check API_KEY environment variable is set
     4. Verify DynamoDB table exists and Lambda has permissions
 
-    If SSE stream disconnects:
-    1. Check Lambda timeout (must be > 30s for SSE)
-    2. Verify client is reconnecting on disconnect
-    3. Check CloudWatch for Lambda errors
-
     See SC-05 in ON_CALL_SOP.md for dashboard-related incidents.
 
 For Developers:
     - Uses Mangum adapter for Lambda Function URL compatibility
-    - SSE endpoint polls DynamoDB every 5 seconds
     - API key validation uses constant-time comparison
     - Static files served from /static/ prefix
     - CORS enabled for all origins (demo configuration)
@@ -29,7 +23,6 @@ Security Notes:
     - API key required for all /api/* endpoints
     - Use secrets.compare_digest() to prevent timing attacks
     - Static files served without authentication
-    - No sensitive data in SSE stream (already sanitized by metrics module)
 
 X-Ray Tracing:
     X-Ray is enabled for distributed tracing across all Lambda invocations.
@@ -41,8 +34,6 @@ from aws_xray_sdk.core import patch_all  # noqa: E402
 
 patch_all()
 
-import asyncio
-import json
 import logging
 import os
 import secrets
@@ -55,7 +46,6 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, HTMLResponse, JSONResponse
 from fastapi.security import APIKeyHeader
 from mangum import Mangum
-from sse_starlette.sse import EventSourceResponse
 
 from src.lambdas.dashboard.api_v2 import (
     get_articles_by_tags,
@@ -73,11 +63,7 @@ from src.lambdas.dashboard.chaos import (
     start_experiment,
     stop_experiment,
 )
-from src.lambdas.dashboard.metrics import (
-    aggregate_dashboard_metrics,
-    get_recent_items,
-    sanitize_item_for_response,
-)
+from src.lambdas.dashboard.metrics import sanitize_item_for_response
 from src.lambdas.shared.dynamodb import get_table, parse_dynamodb_item
 from src.lambdas.shared.logging_utils import (
     get_safe_error_info,
@@ -94,92 +80,7 @@ logger.setLevel(logging.INFO)
 # Cloud-agnostic: Use DATABASE_TABLE, fallback to DYNAMODB_TABLE for backward compatibility
 DYNAMODB_TABLE = os.environ.get("DATABASE_TABLE") or os.environ["DYNAMODB_TABLE"]
 CHAOS_EXPERIMENTS_TABLE = os.environ.get("CHAOS_EXPERIMENTS_TABLE", "")
-SSE_POLL_INTERVAL = int(
-    os.environ.get("SSE_POLL_INTERVAL", "5")
-)  # Safe default: polling frequency
 ENVIRONMENT = os.environ["ENVIRONMENT"]
-
-# SSE connection tracking (P0-2 mitigation: prevent concurrency exhaustion)
-MAX_SSE_CONNECTIONS_PER_IP = int(os.environ.get("MAX_SSE_CONNECTIONS_PER_IP", "2"))
-sse_connections: dict[str, int] = {}  # ip_address -> active_connection_count
-
-# =============================================================================
-# DFA-001 FIX: Metrics Cache (reduces 72K queries/min to ~2 queries/30s)
-# =============================================================================
-# Cache dashboard metrics to avoid 6+ DynamoDB queries per SSE poll.
-# With 1000 concurrent clients polling every 5s, we'd have:
-#   - Before: 1000 * 12 queries/min * 6 queries/request = 72,000 queries/min
-#   - After: ~2 queries every 30 seconds = 4 queries/min (99.99% reduction)
-#
-# TTL is configurable via METRICS_CACHE_TTL_SECONDS (default: 30s)
-# For On-Call: If metrics appear stale, reduce TTL or restart Lambda container.
-import time
-
-METRICS_CACHE_TTL_SECONDS = int(os.environ.get("METRICS_CACHE_TTL_SECONDS", "30"))
-
-# Global cache state - survives across SSE poll cycles within same Lambda container
-_metrics_cache: dict[str, Any] = {}
-_metrics_cache_timestamp: float = 0.0
-_cached_table: Any = None  # Reuse table object across requests
-
-
-def _get_cached_table():
-    """Get or create cached DynamoDB table object."""
-    global _cached_table
-    if _cached_table is None:
-        _cached_table = get_table(DYNAMODB_TABLE)
-    return _cached_table
-
-
-def _get_cached_metrics(force_refresh: bool = False) -> dict[str, Any]:
-    """
-    Get cached dashboard metrics, refreshing if TTL expired.
-
-    This is the key optimization: instead of querying DynamoDB 6+ times per
-    SSE poll (every 5s per client), we cache for 30s and share across all clients.
-
-    Args:
-        force_refresh: If True, bypass cache and fetch fresh data
-
-    Returns:
-        Dashboard metrics dict (same format as aggregate_dashboard_metrics)
-    """
-    global _metrics_cache, _metrics_cache_timestamp
-
-    now = time.time()
-    cache_age = now - _metrics_cache_timestamp
-
-    # Check if cache is valid
-    if not force_refresh and _metrics_cache and cache_age < METRICS_CACHE_TTL_SECONDS:
-        logger.debug(
-            "Metrics cache hit",
-            extra={"cache_age_seconds": round(cache_age, 1)},
-        )
-        return _metrics_cache
-
-    # Cache miss or expired - fetch fresh data
-    logger.info(
-        "Metrics cache miss - fetching from DynamoDB",
-        extra={
-            "cache_age_seconds": round(cache_age, 1) if _metrics_cache else None,
-            "reason": "force_refresh" if force_refresh else "expired_or_empty",
-        },
-    )
-
-    table = _get_cached_table()
-    metrics = aggregate_dashboard_metrics(table, hours=24)
-
-    # Pre-parse and sanitize items once (avoid repeated parsing in SSE loop)
-    metrics["recent_items"] = [
-        sanitize_item_for_response(parse_dynamodb_item(item))
-        for item in metrics.get("recent_items", [])
-    ]
-
-    # Update cache
-    _metrics_cache = metrics
-    _metrics_cache_timestamp = now
-
-    return _metrics_cache
 
 
 def get_api_key() -> str:
@@ -519,11 +420,8 @@ async def api_index():
                 "health": {
                     "GET /health": "Health check with DynamoDB connectivity test",
                 },
-                "legacy": {
-                    "GET /api/metrics": "Get aggregated dashboard metrics",
-                    "GET /api/stream": "SSE stream for real-time updates",
-                    "GET /api/items": "List sentiment items",
-                    "GET /api/v2/sentiment": "Get sentiment data (legacy)",
+                "sentiment": {
+                    "GET /api/v2/sentiment": "Get sentiment data by tags",
                     "GET /api/v2/trends": "Get sentiment trends",
                     "GET /api/v2/articles": "Get news articles",
                 },
@@ -642,231 +540,6 @@ async def health_check():
                 "table": DYNAMODB_TABLE,
             },
         )
-
-
-@app.get("/api/metrics")
-async def get_metrics(
-    hours: int = 24,
-    _: bool = Depends(verify_api_key),
-):
-    """
-    Get aggregated dashboard metrics.
-
-    Args:
-        hours: Time window for metrics (default: 24)
-
-    Returns:
-        JSON with sentiment distribution, tag distribution, rates, recent items
-
-    On-Call Note:
-        If metrics are all zeros:
-        1. Check DynamoDB GSIs exist (by_sentiment, by_tag, by_status)
-        2. Verify items have been ingested and analyzed
-        3. Check time window covers expected data
-    """
-    if hours < 1 or hours > 168:  # Max 7 days
-        raise HTTPException(
-            status_code=400,
-            detail="Hours must be between 1 and 168",
-        )
-
-    try:
-        table = get_table(DYNAMODB_TABLE)
-        metrics = aggregate_dashboard_metrics(table, hours)
-
-        # Sanitize recent items
-        metrics["recent_items"] = [
-            sanitize_item_for_response(parse_dynamodb_item(item))
-            for item in metrics.get("recent_items", [])
-        ]
-
-        logger.info(
-            "Metrics retrieved",
-            extra={
-                "total": int(metrics.get("total", 0)),
-                "hours": int(hours),  # Explicit int cast for CodeQL py/log-injection
-            },
-        )
-
-        return JSONResponse(metrics)
-
-    except Exception as e:
-        logger.error(
-            "Failed to get metrics",
-            extra={"hours": sanitize_for_log(str(hours)), **get_safe_error_info(e)},
-        )
-        raise HTTPException(
-            status_code=500,
-            detail="Failed to retrieve metrics",
-        ) from e
-
-
-@app.get("/api/stream")
-async def stream_metrics(
-    request: Request,
-    _: bool = Depends(verify_api_key),
-):
-    """
-    Server-Sent Events endpoint for real-time dashboard updates.
-
-    Polls DynamoDB every SSE_POLL_INTERVAL seconds and sends metrics.
-
-    Returns:
-        EventSourceResponse with metrics updates
-
-    On-Call Note:
-        If SSE disconnects frequently:
-        1. Check Lambda timeout (should be > 30s)
-        2. Verify client reconnects on disconnect
-        3. Check for Lambda cold starts causing delays
-
-    Security Note (P0-2):
-        Connection limits enforced per IP to prevent concurrency exhaustion.
-        Max connections per IP: MAX_SSE_CONNECTIONS_PER_IP (default: 2)
-    """
-    # Get client IP from headers (behind Lambda Function URL / API Gateway)
-    client_ip = request.headers.get("X-Forwarded-For", "unknown").split(",")[0].strip()
-
-    # P0-2 mitigation: Enforce SSE connection limit per IP
-    current_connections = sse_connections.get(client_ip, 0)
-    if current_connections >= MAX_SSE_CONNECTIONS_PER_IP:
-        logger.warning(
-            "SSE connection limit exceeded",
-            extra={
-                "client_ip": client_ip,
-                "current_connections": current_connections,
-                "max_allowed": MAX_SSE_CONNECTIONS_PER_IP,
-            },
-        )
-        raise HTTPException(
-            status_code=429,
-            detail=f"Too many SSE connections from your IP. Max: {MAX_SSE_CONNECTIONS_PER_IP}",
-        )
-
-    # Increment connection count
-    sse_connections[client_ip] = current_connections + 1
-    logger.info(
-        "SSE connection established",
-        extra={
-            "client_ip": client_ip,
-            "total_connections": sse_connections[client_ip],
-        },
-    )
-
-    async def event_generator():
-        """
-        Generate SSE events with metrics updates.
-
-        DFA-001 OPTIMIZATION: Uses _get_cached_metrics() to avoid 6+ DynamoDB
-        queries per poll. All clients share a single cached metrics response
-        with 30-second TTL, reducing queries from 72K/min to ~4/min.
-        """
-        try:
-            while True:
-                # Check if client disconnected
-                if await request.is_disconnected():
-                    logger.info(
-                        "SSE client disconnected",
-                        extra={"client_ip": client_ip},
-                    )
-                    break
-
-                try:
-                    # DFA-001 FIX: Use cached metrics instead of querying DynamoDB
-                    # every 5 seconds. Metrics are already pre-parsed and sanitized.
-                    metrics = _get_cached_metrics()
-
-                    # Send metrics event
-                    yield {
-                        "event": "metrics",
-                        "data": json.dumps(metrics),
-                    }
-
-                except Exception as e:
-                    logger.error(
-                        "SSE metrics error",
-                        extra={**get_safe_error_info(e)},
-                    )
-                    # Send error event but keep connection alive
-                    yield {
-                        "event": "error",
-                        "data": json.dumps({"error": "Failed to retrieve metrics"}),
-                    }
-
-                # Wait before next poll
-                await asyncio.sleep(SSE_POLL_INTERVAL)
-
-        except asyncio.CancelledError:
-            logger.info(
-                "SSE stream cancelled",
-                extra={"client_ip": client_ip},
-            )
-            raise
-        finally:
-            # Decrement connection count when stream ends
-            if client_ip in sse_connections:
-                sse_connections[client_ip] -= 1
-                if sse_connections[client_ip] <= 0:
-                    del sse_connections[client_ip]
-                logger.info(
-                    "SSE connection closed",
-                    extra={
-                        "client_ip": client_ip,
-                        "remaining_connections": sse_connections.get(client_ip, 0),
-                    },
-                )
-
-    return EventSourceResponse(event_generator())
-
-
-@app.get("/api/items")
-async def get_items(
-    limit: int = 20,
-    status: str = "analyzed",
-    _: bool = Depends(verify_api_key),
-):
-    """
-    Get recent items with optional filtering.
-
-    Args:
-        limit: Maximum items to return (default: 20, max: 100)
-        status: Filter by status (default: analyzed)
-
-    Returns:
-        JSON array of recent items
-    """
-    if limit < 1 or limit > 100:
-        raise HTTPException(
-            status_code=400,
-            detail="Limit must be between 1 and 100",
-        )
-
-    if status not in ["pending", "analyzed", "failed"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Status must be: pending, analyzed, or failed",
-        )
-
-    try:
-        table = get_table(DYNAMODB_TABLE)
-        items = get_recent_items(table, limit=limit, status=status)
-
-        # Sanitize items
-        sanitized = [
-            sanitize_item_for_response(parse_dynamodb_item(item)) for item in items
-        ]
-
-        return JSONResponse(sanitized)
-
-    except Exception as e:
-        logger.error(
-            "Failed to get items",
-            extra={"limit": limit, "status": status, **get_safe_error_info(e)},
-        )
-        raise HTTPException(
-            status_code=500,
-            detail="Failed to retrieve items",
-        ) from e
 
 
 # ===================================================================

--- a/src/lambdas/shared/schemas.py
+++ b/src/lambdas/shared/schemas.py
@@ -184,7 +184,7 @@ class SentimentItemResponse(BaseModel):
     """
     Schema for sentiment item in API responses.
 
-    Used by dashboard Lambda for /api/metrics responses.
+    Used by dashboard Lambda for /api/v2/articles responses.
 
     For Developers:
         This is the public-facing schema. It includes all fields
@@ -282,7 +282,7 @@ class SNSAnalysisMessage(BaseModel):
 
 class MetricsResponse(BaseModel):
     """
-    Schema for dashboard /api/metrics response.
+    Schema for dashboard /api/v2/sentiment response.
 
     Aggregated metrics for the dashboard display.
     """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -277,13 +277,13 @@ def synthetic_data():
         - business_count: 2 (items with "business" tag)
 
     Example:
-        def test_metrics_returns_correct_counts(auth_headers, synthetic_data):
-            response = requests.get(f"{URL}/api/metrics", headers=auth_headers)
+        def test_sentiment_returns_data(auth_headers, synthetic_data):
+            response = requests.get(f"{URL}/api/v2/sentiment?tags=tech", headers=auth_headers)
             data = response.json()
 
             # Verify against known synthetic data
-            assert data["total"] >= synthetic_data["total_count"]
-            assert data["positive"] >= synthetic_data["positive_count"]
+            assert data["total_count"] >= 0
+            assert "tags" in data
     """
     # Only import and use for preprod tests (avoid import errors in unit tests)
     from tests.fixtures.synthetic_data import SyntheticDataGenerator


### PR DESCRIPTION
## Summary
- Remove all v1 API endpoints (`/api/metrics`, `/api/items`, `/api/stream`) from dashboard handler
- Remove SSE-related code (connection tracking, metrics cache)
- Update all tests to use v2 API endpoints (`/api/v2/sentiment`, `/api/v2/articles`, `/api/v2/trends`)
- Fix test isolation issues in CORS tests that reload the handler module
- Update documentation to reference v2 endpoints

## Test plan
- [x] Unit tests pass with v2 endpoints
- [x] Integration tests pass with v2 endpoints  
- [x] Test isolation fixed - all tests pass when run together
- [ ] CI pipeline passes
- [ ] Preprod E2E tests pass (requires real AWS)

## Breaking Changes
v1 endpoints are removed. All clients must use v2 API:
- `/api/metrics` → `/api/v2/sentiment?tags=<tag>`
- `/api/items` → `/api/v2/articles?tags=<tag>`
- `/api/stream` → Removed (SSE no longer supported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)