### PR TITLE
fix(TD-010): Rename model_version to avoid Pydantic protected namespace

### DIFF
--- a/docs/TECH_DEBT_REGISTRY.md
+++ b/docs/TECH_DEBT_REGISTRY.md
@@ -125,15 +125,24 @@ filterwarnings = [
 **Root Cause**: moto 5.0 upgrade caused warning spam
 **Better Fix**: Address specific deprecations, not blanket ignore
 
-### TD-010: Protected Namespace Workaround
+### TD-010: Protected Namespace Workaround [RESOLVED]
 **Location**: `src/lambdas/shared/schemas.py`
 **Commit**: b90bc06
-```python
-class ConfigDict:
-    protected_namespaces = ()  # Suppress warning for model_version field
-```
-**Why**: Pydantic complains about `model_*` field names
-**Better Fix**: Rename `model_version` to `ml_model_version` or `version`
+
+**Status**: RESOLVED
+**Resolution**:
+- Renamed Python field `model_version` → `inference_version` in Pydantic models
+- Used `Field(alias="model_version")` for backward compatibility with:
+  - DynamoDB attribute names (no migration needed)
+  - API response JSON keys (no frontend breaking changes)
+  - SNS message payloads (no cross-Lambda changes needed)
+- Replaced `protected_namespaces=()` with `populate_by_name=True`
+- All existing tests pass (33 schema tests verified)
+
+**Files Changed**:
+- `src/lambdas/shared/schemas.py`
+- `src/lambdas/dashboard/sentiment.py`
+- `src/lambdas/shared/models/sentiment_result.py`
 
 ### TD-011: Metrics Lambda Not Implemented [RESOLVED]
 **Location**: `src/lambdas/metrics/handler.py`

--- a/src/lambdas/dashboard/sentiment.py
+++ b/src/lambdas/dashboard/sentiment.py
@@ -46,12 +46,14 @@ class ErrorResponse(BaseModel):
 class SourceSentiment(BaseModel):
     """Sentiment data from a single source."""
 
+    model_config = {"populate_by_name": True}
+
     score: float = Field(..., ge=-1.0, le=1.0)
     label: str = Field(..., pattern="^(positive|negative|neutral)$")
     confidence: float | None = None
     bullish_percent: float | None = None
     bearish_percent: float | None = None
-    model_version: str | None = None
+    inference_version: str | None = Field(default=None, alias="model_version")
     updated_at: str
 
 

--- a/src/lambdas/shared/models/sentiment_result.py
+++ b/src/lambdas/shared/models/sentiment_result.py
@@ -9,8 +9,10 @@ from pydantic import BaseModel, Field
 class SentimentSource(BaseModel):
     """Source metadata for sentiment."""
 
+    model_config = {"populate_by_name": True}
+
     source_type: Literal["tiingo", "finnhub", "our_model"]
-    model_version: str | None = None
+    inference_version: str | None = Field(default=None, alias="model_version")
     fetched_at: datetime
 
 
@@ -54,7 +56,7 @@ class SentimentResult(BaseModel):
             "sentiment_label": self.sentiment_label,
             "confidence": str(self.confidence),
             "source_type": self.source.source_type,
-            "model_version": self.source.model_version,
+            "model_version": self.source.inference_version,  # DynamoDB attr name
             "fetched_at": self.source.fetched_at.isoformat(),
             "news_article_ids": self.news_article_ids,
             "entity_type": "SENTIMENT_RESULT",
@@ -65,7 +67,7 @@ class SentimentResult(BaseModel):
         """Create SentimentResult from DynamoDB item."""
         source = SentimentSource(
             source_type=item["source_type"],
-            model_version=item.get("model_version"),
+            inference_version=item.get("model_version"),  # Read from DynamoDB attr
             fetched_at=datetime.fromisoformat(item["fetched_at"]),
         )
 

--- a/src/lambdas/shared/schemas.py
+++ b/src/lambdas/shared/schemas.py
@@ -147,7 +147,7 @@ class SentimentItemUpdate(BaseModel):
         score must be: 0.0 to 1.0
     """
 
-    model_config = ConfigDict(protected_namespaces=())
+    model_config = ConfigDict(populate_by_name=True)
 
     sentiment: Literal["positive", "neutral", "negative"] = Field(
         ...,
@@ -161,8 +161,9 @@ class SentimentItemUpdate(BaseModel):
         le=1.0,
     )
 
-    model_version: str = Field(
+    inference_version: str = Field(
         ...,
+        alias="model_version",  # Backward compatible with DynamoDB/API
         description="Version of sentiment model used",
         examples=["v1.0.0"],
         pattern=r"^v\d+\.\d+\.\d+$",
@@ -191,7 +192,7 @@ class SentimentItemResponse(BaseModel):
         that are safe to expose to dashboard users.
     """
 
-    model_config = ConfigDict(protected_namespaces=())
+    model_config = ConfigDict(populate_by_name=True)
 
     source_id: str = Field(
         ...,
@@ -241,8 +242,9 @@ class SentimentItemResponse(BaseModel):
         le=1.0,
     )
 
-    model_version: str | None = Field(
+    inference_version: str | None = Field(
         default=None,
+        alias="model_version",  # Backward compatible with DynamoDB/API
         description="Model version used for analysis",
     )
 


### PR DESCRIPTION
## Summary

Resolves TD-010 in the tech debt registry by using Pydantic Field aliases to avoid the protected namespace warning for `model_*` fields.

### Approach

Instead of renaming the field everywhere (which would require DynamoDB migration and API breaking changes), we:
1. Renamed the **Python field** from `model_version` → `inference_version`
2. Added `Field(alias="model_version")` for backward compatibility
3. Replaced `protected_namespaces=()` with `populate_by_name=True`

### Backward Compatibility

- DynamoDB attributes still use `"model_version"` (no data migration needed)
- API JSON responses still use `"model_version"` (no frontend changes needed)
- SNS message payloads still use `"model_version"` (no Lambda updates needed)

### Files Changed

- `src/lambdas/shared/schemas.py`
- `src/lambdas/dashboard/sentiment.py`
- `src/lambdas/shared/models/sentiment_result.py`
- `docs/TECH_DEBT_REGISTRY.md` (marked as RESOLVED)

## Test plan

- [x] All 1160 unit tests pass
- [x] Schema tests verify alias behavior works correctly
- [x] Black and ruff checks pass
- [ ] CI pipeline passes

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)