### PR TITLE
feat(006): Add alert quota tracking with daily reset and API endpoint

### DIFF
--- a/src/lambdas/dashboard/quota.py
+++ b/src/lambdas/dashboard/quota.py
@@ -1,0 +1,207 @@
+"""Alert quota tracking for Feature 006.
+
+Tracks daily email sending quota per user. Uses DynamoDB with
+pattern PK=QUOTA#{user_id}, SK=DAILY#{date} for efficient
+daily reset without cleanup jobs.
+
+For On-Call Engineers:
+    - Quota resets at midnight UTC automatically (new date = new SK)
+    - TTL set for 30 days to auto-cleanup old quota records
+    - Uses atomic counters to prevent race conditions
+"""
+
+import logging
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from aws_xray_sdk.core import xray_recorder
+from pydantic import BaseModel
+
+from src.lambdas.shared.logging_utils import sanitize_for_log
+from src.lambdas.shared.models.alert_rule import ALERT_LIMITS
+
+logger = logging.getLogger(__name__)
+
+
+class QuotaStatus(BaseModel):
+    """Daily email quota status for a user."""
+
+    used: int
+    limit: int
+    remaining: int
+    resets_at: str  # ISO format datetime
+    is_exceeded: bool
+
+
+class QuotaExceededError(Exception):
+    """Raised when user exceeds their daily quota."""
+
+    def __init__(self, used: int, limit: int, resets_at: str):
+        self.used = used
+        self.limit = limit
+        self.resets_at = resets_at
+        super().__init__(f"Daily quota exceeded: {used}/{limit}")
+
+
+@xray_recorder.capture("get_daily_quota")
+def get_daily_quota(table: Any, user_id: str) -> QuotaStatus:
+    """Get user's daily email quota status.
+
+    Args:
+        table: DynamoDB Table resource
+        user_id: User ID
+
+    Returns:
+        QuotaStatus with current usage
+    """
+    today = datetime.now(UTC).date()
+    pk = f"QUOTA#{user_id}"
+    sk = f"DAILY#{today.isoformat()}"
+
+    try:
+        response = table.get_item(Key={"PK": pk, "SK": sk})
+        item = response.get("Item", {})
+        used = item.get("email_count", 0)
+    except Exception as e:
+        logger.warning(f"Failed to get quota, assuming 0: {e}")
+        used = 0
+
+    limit = ALERT_LIMITS["max_emails_per_day"]
+
+    # Calculate when quota resets (midnight UTC next day)
+    tomorrow = datetime.combine(
+        today + timedelta(days=1), datetime.min.time(), tzinfo=UTC
+    )
+
+    return QuotaStatus(
+        used=used,
+        limit=limit,
+        remaining=max(0, limit - used),
+        resets_at=tomorrow.isoformat(),
+        is_exceeded=used >= limit,
+    )
+
+
+@xray_recorder.capture("increment_email_quota")
+def increment_email_quota(table: Any, user_id: str) -> QuotaStatus:
+    """Increment user's daily email count atomically.
+
+    Uses DynamoDB atomic counter to safely increment.
+    Creates record if it doesn't exist.
+
+    Args:
+        table: DynamoDB Table resource
+        user_id: User ID
+
+    Returns:
+        Updated QuotaStatus
+
+    Raises:
+        QuotaExceededError: If quota would be exceeded
+    """
+    today = datetime.now(UTC).date()
+    pk = f"QUOTA#{user_id}"
+    sk = f"DAILY#{today.isoformat()}"
+
+    # Calculate TTL (30 days from now)
+    ttl = int((datetime.now(UTC) + timedelta(days=30)).timestamp())
+
+    # Calculate when quota resets
+    tomorrow = datetime.combine(
+        today + timedelta(days=1), datetime.min.time(), tzinfo=UTC
+    )
+    limit = ALERT_LIMITS["max_emails_per_day"]
+
+    try:
+        # Atomic increment with condition to prevent exceeding limit
+        response = table.update_item(
+            Key={"PK": pk, "SK": sk},
+            UpdateExpression="SET email_count = if_not_exists(email_count, :zero) + :inc, "
+            "entity_type = :entity, ttl = :ttl",
+            ConditionExpression="attribute_not_exists(email_count) OR email_count < :limit",
+            ExpressionAttributeValues={
+                ":zero": 0,
+                ":inc": 1,
+                ":entity": "QUOTA_TRACKER",
+                ":ttl": ttl,
+                ":limit": limit,
+            },
+            ReturnValues="ALL_NEW",
+        )
+
+        new_count = response["Attributes"].get("email_count", 1)
+
+        logger.info(
+            "Incremented email quota",
+            extra={
+                "user_id_prefix": sanitize_for_log(user_id[:8]),
+                "email_count": new_count,
+                "limit": limit,
+            },
+        )
+
+        return QuotaStatus(
+            used=new_count,
+            limit=limit,
+            remaining=max(0, limit - new_count),
+            resets_at=tomorrow.isoformat(),
+            is_exceeded=new_count >= limit,
+        )
+
+    except table.meta.client.exceptions.ConditionalCheckFailedException:
+        # Quota exceeded - get current count for error
+        current = get_daily_quota(table, user_id)
+        logger.warning(
+            "Quota exceeded",
+            extra={
+                "user_id_prefix": sanitize_for_log(user_id[:8]),
+                "used": current.used,
+                "limit": current.limit,
+            },
+        )
+        raise QuotaExceededError(
+            used=current.used,
+            limit=current.limit,
+            resets_at=current.resets_at,
+        ) from None
+
+
+@xray_recorder.capture("check_quota_available")
+def check_quota_available(table: Any, user_id: str, count: int = 1) -> bool:
+    """Check if user has quota available for sending emails.
+
+    Args:
+        table: DynamoDB Table resource
+        user_id: User ID
+        count: Number of emails to check (default 1)
+
+    Returns:
+        True if quota available, False otherwise
+    """
+    status = get_daily_quota(table, user_id)
+    return status.remaining >= count
+
+
+@xray_recorder.capture("get_user_total_alerts")
+def get_user_total_alerts(table: Any, user_id: str) -> int:
+    """Get total number of alerts across all configs for a user.
+
+    Args:
+        table: DynamoDB Table resource
+        user_id: User ID
+
+    Returns:
+        Total alert count
+    """
+    from boto3.dynamodb.conditions import Key
+
+    try:
+        response = table.query(
+            KeyConditionExpression=Key("PK").eq(f"USER#{user_id}")
+            & Key("SK").begins_with("ALERT#"),
+            Select="COUNT",
+        )
+        return response.get("Count", 0)
+    except Exception as e:
+        logger.warning(f"Failed to count alerts: {e}")
+        return 0

--- a/src/lambdas/dashboard/router_v2.py
+++ b/src/lambdas/dashboard/router_v2.py
@@ -32,6 +32,7 @@ from src.lambdas.dashboard import auth as auth_service
 from src.lambdas.dashboard import configurations as config_service
 from src.lambdas.dashboard import market as market_service
 from src.lambdas.dashboard import notifications as notification_service
+from src.lambdas.dashboard import quota as quota_service
 from src.lambdas.dashboard import sentiment as sentiment_service
 from src.lambdas.dashboard import tickers as ticker_service
 from src.lambdas.dashboard import volatility as volatility_service
@@ -795,6 +796,27 @@ async def toggle_alert(
     )
     if isinstance(result, alert_service.ErrorResponse):
         raise HTTPException(status_code=404, detail=result.error.message)
+    return JSONResponse(result.model_dump())
+
+
+@alert_router.get("/quota")
+async def get_alert_quota(
+    request: Request,
+    table=Depends(get_dynamodb_table),
+):
+    """Get alert email quota usage (T145).
+
+    Returns daily email quota status including:
+    - used: Number of emails sent today
+    - limit: Maximum emails per day
+    - remaining: Emails left today
+    - resets_at: When quota resets (ISO datetime)
+    """
+    user_id = get_authenticated_user_id(request)
+    result = quota_service.get_daily_quota(
+        table=table,
+        user_id=user_id,
+    )
     return JSONResponse(result.model_dump())
 
 

--- a/tests/unit/test_quota.py
+++ b/tests/unit/test_quota.py
@@ -1,0 +1,250 @@
+"""Unit tests for alert quota tracking."""
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.lambdas.dashboard.quota import (
+    QuotaExceededError,
+    QuotaStatus,
+    check_quota_available,
+    get_daily_quota,
+    get_user_total_alerts,
+    increment_email_quota,
+)
+
+
+class TestQuotaStatus:
+    """Tests for QuotaStatus model."""
+
+    def test_quota_status_creation(self):
+        """Test QuotaStatus model creation."""
+        status = QuotaStatus(
+            used=5,
+            limit=10,
+            remaining=5,
+            resets_at="2025-01-01T00:00:00+00:00",
+            is_exceeded=False,
+        )
+        assert status.used == 5
+        assert status.limit == 10
+        assert status.remaining == 5
+        assert status.is_exceeded is False
+
+    def test_quota_status_exceeded(self):
+        """Test QuotaStatus when quota is exceeded."""
+        status = QuotaStatus(
+            used=10,
+            limit=10,
+            remaining=0,
+            resets_at="2025-01-01T00:00:00+00:00",
+            is_exceeded=True,
+        )
+        assert status.is_exceeded is True
+        assert status.remaining == 0
+
+
+class TestGetDailyQuota:
+    """Tests for get_daily_quota function."""
+
+    def test_get_daily_quota_no_existing_record(self):
+        """Test getting quota when no record exists."""
+        mock_table = MagicMock()
+        mock_table.get_item.return_value = {}
+
+        result = get_daily_quota(mock_table, "user123")
+
+        assert result.used == 0
+        assert result.limit == 10
+        assert result.remaining == 10
+        assert result.is_exceeded is False
+
+    def test_get_daily_quota_with_existing_record(self):
+        """Test getting quota with existing usage."""
+        mock_table = MagicMock()
+        mock_table.get_item.return_value = {"Item": {"email_count": 7}}
+
+        result = get_daily_quota(mock_table, "user123")
+
+        assert result.used == 7
+        assert result.remaining == 3
+        assert result.is_exceeded is False
+
+    def test_get_daily_quota_exceeded(self):
+        """Test getting quota when exceeded."""
+        mock_table = MagicMock()
+        mock_table.get_item.return_value = {"Item": {"email_count": 10}}
+
+        result = get_daily_quota(mock_table, "user123")
+
+        assert result.used == 10
+        assert result.remaining == 0
+        assert result.is_exceeded is True
+
+    def test_get_daily_quota_resets_at_tomorrow(self):
+        """Test that resets_at is set to midnight UTC tomorrow."""
+        mock_table = MagicMock()
+        mock_table.get_item.return_value = {}
+
+        with patch("src.lambdas.dashboard.quota.datetime") as mock_dt:
+            # Mock current time to 2025-01-15 10:30:00 UTC
+            mock_now = datetime(2025, 1, 15, 10, 30, 0, tzinfo=UTC)
+            mock_dt.now.return_value = mock_now
+            mock_dt.combine = datetime.combine
+            mock_dt.min = datetime.min
+
+            result = get_daily_quota(mock_table, "user123")
+
+            # Should reset at 2025-01-16 00:00:00 UTC
+            assert "2025-01-16T00:00:00" in result.resets_at
+
+    def test_get_daily_quota_error_handling(self):
+        """Test graceful handling of DynamoDB errors."""
+        mock_table = MagicMock()
+        mock_table.get_item.side_effect = Exception("DynamoDB error")
+
+        result = get_daily_quota(mock_table, "user123")
+
+        # Should return 0 on error
+        assert result.used == 0
+        assert result.remaining == 10
+
+
+class TestIncrementEmailQuota:
+    """Tests for increment_email_quota function."""
+
+    def test_increment_quota_success(self):
+        """Test successful quota increment."""
+        mock_table = MagicMock()
+        mock_table.update_item.return_value = {"Attributes": {"email_count": 1}}
+
+        result = increment_email_quota(mock_table, "user123")
+
+        assert result.used == 1
+        mock_table.update_item.assert_called_once()
+
+    def test_increment_quota_to_limit(self):
+        """Test incrementing quota to the limit."""
+        mock_table = MagicMock()
+        mock_table.update_item.return_value = {"Attributes": {"email_count": 10}}
+
+        result = increment_email_quota(mock_table, "user123")
+
+        assert result.used == 10
+        assert result.is_exceeded is True
+
+    def test_increment_quota_exceeded_raises_error(self):
+        """Test that exceeding quota raises QuotaExceededError."""
+        mock_table = MagicMock()
+
+        # Create mock client with exception class
+        mock_client = MagicMock()
+        mock_client.exceptions.ConditionalCheckFailedException = type(
+            "ConditionalCheckFailedException", (Exception,), {}
+        )
+        mock_table.meta.client = mock_client
+        mock_table.update_item.side_effect = (
+            mock_client.exceptions.ConditionalCheckFailedException()
+        )
+
+        # Mock get_item for the error path
+        mock_table.get_item.return_value = {"Item": {"email_count": 10}}
+
+        with pytest.raises(QuotaExceededError) as exc_info:
+            increment_email_quota(mock_table, "user123")
+
+        assert exc_info.value.used == 10
+        assert exc_info.value.limit == 10
+
+    def test_increment_quota_uses_atomic_counter(self):
+        """Test that increment uses DynamoDB atomic counter."""
+        mock_table = MagicMock()
+        mock_table.update_item.return_value = {"Attributes": {"email_count": 5}}
+
+        increment_email_quota(mock_table, "user123")
+
+        call_args = mock_table.update_item.call_args
+        update_expr = call_args.kwargs["UpdateExpression"]
+        assert "if_not_exists" in update_expr
+        assert "+ :inc" in update_expr
+
+
+class TestCheckQuotaAvailable:
+    """Tests for check_quota_available function."""
+
+    def test_quota_available_when_under_limit(self):
+        """Test quota available when under limit."""
+        mock_table = MagicMock()
+        mock_table.get_item.return_value = {"Item": {"email_count": 5}}
+
+        result = check_quota_available(mock_table, "user123")
+
+        assert result is True
+
+    def test_quota_not_available_when_at_limit(self):
+        """Test quota not available when at limit."""
+        mock_table = MagicMock()
+        mock_table.get_item.return_value = {"Item": {"email_count": 10}}
+
+        result = check_quota_available(mock_table, "user123")
+
+        assert result is False
+
+    def test_quota_available_with_count_param(self):
+        """Test quota available with specific count."""
+        mock_table = MagicMock()
+        mock_table.get_item.return_value = {"Item": {"email_count": 7}}
+
+        # 3 remaining, asking for 3
+        result = check_quota_available(mock_table, "user123", count=3)
+        assert result is True
+
+        # 3 remaining, asking for 4
+        result = check_quota_available(mock_table, "user123", count=4)
+        assert result is False
+
+
+class TestGetUserTotalAlerts:
+    """Tests for get_user_total_alerts function."""
+
+    def test_get_total_alerts_success(self):
+        """Test getting total alert count."""
+        mock_table = MagicMock()
+        mock_table.query.return_value = {"Count": 15}
+
+        result = get_user_total_alerts(mock_table, "user123")
+
+        assert result == 15
+
+    def test_get_total_alerts_no_alerts(self):
+        """Test getting total when no alerts exist."""
+        mock_table = MagicMock()
+        mock_table.query.return_value = {"Count": 0}
+
+        result = get_user_total_alerts(mock_table, "user123")
+
+        assert result == 0
+
+    def test_get_total_alerts_error_returns_zero(self):
+        """Test error handling returns zero."""
+        mock_table = MagicMock()
+        mock_table.query.side_effect = Exception("DynamoDB error")
+
+        result = get_user_total_alerts(mock_table, "user123")
+
+        assert result == 0
+
+
+class TestQuotaExceededError:
+    """Tests for QuotaExceededError exception."""
+
+    def test_error_creation(self):
+        """Test QuotaExceededError creation."""
+        error = QuotaExceededError(
+            used=10, limit=10, resets_at="2025-01-01T00:00:00+00:00"
+        )
+        assert error.used == 10
+        assert error.limit == 10
+        assert "2025-01-01" in error.resets_at
+        assert "10/10" in str(error)


### PR DESCRIPTION
## Summary
- Adds `quota.py` service module with `QuotaStatus` model and `QuotaExceededError` exception
- Implements daily quota tracking using DynamoDB key pattern `PK=QUOTA#{user_id}, SK=DAILY#{date}` for automatic daily reset without cleanup jobs
- Uses atomic counters with condition checks to prevent race conditions
- Sets 30-day TTL for automatic cleanup of old quota records
- Wires quota service into existing `_get_daily_email_quota()` function
- Adds `GET /api/v2/alerts/quota` endpoint for quota status retrieval

## Test plan
- [x] All 18 new quota unit tests pass
- [x] All 33 alert unit tests pass (with updated mocks)
- [x] Full 1200 unit test suite passes
- [ ] CI pipeline passes

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)