### PR TITLE
feat(frontend): Connect settings page to notification preferences API

### DIFF
--- a/frontend/src/app/(dashboard)/settings/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/page.tsx
@@ -12,6 +12,7 @@ import { SignOutDialog } from '@/components/auth/sign-out-dialog';
 import { useAnimationStore } from '@/stores/animation-store';
 import { useAuth } from '@/hooks/use-auth';
 import { cn } from '@/lib/utils';
+import { notificationsApi } from '@/lib/api';
 
 interface SettingItemProps {
   icon: typeof User;
@@ -42,10 +43,10 @@ export default function SettingsPage() {
   const { user, isAuthenticated, isAnonymous, signOut, isLoading } = useAuth();
   const [signOutOpen, setSignOutOpen] = useState(false);
 
-  const handleNotificationSave = useCallback(async (settings: unknown) => {
-    // TODO: Save to backend
-    console.log('Saving notification settings:', settings);
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+  const handleNotificationSave = useCallback(async (settings: { emailEnabled: boolean }) => {
+    await notificationsApi.updatePreferences({
+      email_enabled: settings.emailEnabled,
+    });
   }, []);
 
   const authTypeLabel: Record<string, string> = {

--- a/frontend/src/lib/api/index.ts
+++ b/frontend/src/lib/api/index.ts
@@ -6,3 +6,4 @@ export { configsApi } from './configs';
 export { sentimentApi } from './sentiment';
 export { alertsApi } from './alerts';
 export { tickersApi } from './tickers';
+export { notificationsApi } from './notifications';

--- a/frontend/src/lib/api/notifications.ts
+++ b/frontend/src/lib/api/notifications.ts
@@ -1,0 +1,74 @@
+import { api } from './client';
+
+export interface NotificationPreferences {
+  emailEnabled: boolean;
+  digestEnabled: boolean;
+  digestTime: string;
+  timezone: string;
+}
+
+export interface UpdateNotificationPreferencesRequest {
+  email_enabled?: boolean;
+  digest_enabled?: boolean;
+  digest_time?: string;
+}
+
+export interface DigestSettings {
+  enabled: boolean;
+  time: string;
+  timezone: string;
+  includeAllConfigs: boolean;
+  configIds: string[];
+}
+
+export interface UpdateDigestSettingsRequest {
+  enabled?: boolean;
+  time?: string;
+  timezone?: string;
+  include_all_configs?: boolean;
+  config_ids?: string[];
+}
+
+export const notificationsApi = {
+  /**
+   * Get notification preferences
+   */
+  getPreferences: () =>
+    api.get<NotificationPreferences>('/api/v2/notifications/preferences'),
+
+  /**
+   * Update notification preferences
+   */
+  updatePreferences: (updates: UpdateNotificationPreferencesRequest) =>
+    api.patch<NotificationPreferences>('/api/v2/notifications/preferences', updates),
+
+  /**
+   * Disable all notifications
+   */
+  disableAll: () =>
+    api.post<void>('/api/v2/notifications/disable-all'),
+
+  /**
+   * Resubscribe to notifications
+   */
+  resubscribe: () =>
+    api.post<void>('/api/v2/notifications/resubscribe'),
+
+  /**
+   * Get digest settings
+   */
+  getDigestSettings: () =>
+    api.get<DigestSettings>('/api/v2/notifications/digest'),
+
+  /**
+   * Update digest settings
+   */
+  updateDigestSettings: (updates: UpdateDigestSettingsRequest) =>
+    api.patch<DigestSettings>('/api/v2/notifications/digest', updates),
+
+  /**
+   * Trigger test digest email
+   */
+  triggerTestDigest: () =>
+    api.post<void>('/api/v2/notifications/digest/test'),
+};


### PR DESCRIPTION
## Summary
- Adds `notifications.ts` API client module with endpoints for preferences, digest settings, and notification management
- Exports `notificationsApi` from `lib/api/index.ts`
- Updates settings page `handleNotificationSave` to call `PATCH /api/v2/notifications/preferences` instead of logging to console
- Removes TODO comment and mock delay from settings page

## Test plan
- [x] TypeScript type check passes
- [x] All 365 frontend unit tests pass
- [x] All 1182 backend unit tests pass
- [ ] CI pipeline passes

The backend API endpoint (`PATCH /api/v2/notifications/preferences`) already exists (T139/T140). This change wires the frontend settings page to persist changes to the backend.

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)