### PR TITLE
fix: Use correct secret names for E2E preprod workflow

### DIFF
--- a/.github/workflows/e2e-preprod.yml
+++ b/.github/workflows/e2e-preprod.yml
@@ -76,8 +76,8 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v5
         with:
-          aws-access-key-id: ${{ secrets.PREPROD_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.PREPROD_AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Create reports directory


### PR DESCRIPTION
## Summary
- Fixed secret name mismatch in E2E preprod workflow
- Changed from `PREPROD_AWS_ACCESS_KEY_ID` to `AWS_ACCESS_KEY_ID`
- Changed from `PREPROD_AWS_SECRET_ACCESS_KEY` to `AWS_SECRET_ACCESS_KEY`

The preprod GitHub environment has secrets named `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` (without PREPROD_ prefix), matching the pattern documented in `docs/GITHUB_SECRETS_SETUP.md`.

## Test plan
- [ ] PR checks pass
- [ ] After merge, E2E Tests (Preprod) workflow should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)