### PR TITLE
fix: Use correct env var name PREPROD_API_URL in e2e workflow

### DIFF
--- a/.github/workflows/e2e-preprod.yml
+++ b/.github/workflows/e2e-preprod.yml
@@ -104,7 +104,7 @@ jobs:
 
           pytest $PYTEST_ARGS
         env:
-          PREPROD_API_BASE_URL: ${{ secrets.PREPROD_API_BASE_URL }}
+          PREPROD_API_URL: ${{ secrets.PREPROD_API_URL }}
           PREPROD_DYNAMODB_TABLE: ${{ secrets.PREPROD_DYNAMODB_TABLE }}
           TEST_EMAIL_DOMAIN: ${{ secrets.TEST_EMAIL_DOMAIN }}
 


### PR DESCRIPTION
## Summary
- Fixed environment variable naming mismatch between workflow and test code
- Workflow was passing `PREPROD_API_BASE_URL` but tests read from `PREPROD_API_URL`
- Added `PREPROD_API_URL` secret to preprod environment

## Test plan
- [ ] E2E Tests (Preprod) workflow should now connect to the correct API endpoint
- [ ] Tests should no longer fail with DNS resolution errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)