### PR TITLE
fix: Add json={} body to anonymous auth POST requests in E2E tests

### DIFF
--- a/tests/e2e/test_alerts.py
+++ b/tests/e2e/test_alerts.py
@@ -24,7 +24,7 @@ async def create_config_and_session(
 
     Returns (token, config_id).
     """
-    session_response = await api_client.post("/api/v2/auth/anonymous")
+    session_response = await api_client.post("/api/v2/auth/anonymous", json={})
     assert session_response.status_code == 200
     token = session_response.json()["token"]
 

--- a/tests/e2e/test_anonymous_restrictions.py
+++ b/tests/e2e/test_anonymous_restrictions.py
@@ -24,7 +24,7 @@ async def create_anonymous_session(
     Returns:
         Access token for the anonymous session
     """
-    response = await api_client.post("/api/v2/auth/anonymous")
+    response = await api_client.post("/api/v2/auth/anonymous", json={})
     assert response.status_code == 200, f"Anonymous session failed: {response.text}"
     return response.json()["token"]
 

--- a/tests/e2e/test_auth_anonymous.py
+++ b/tests/e2e/test_auth_anonymous.py
@@ -22,7 +22,7 @@ async def test_anonymous_session_creation(api_client: PreprodAPIClient) -> None:
     When: POST /api/v2/auth/anonymous is called
     Then: Response contains session_id, token, and expires_at
     """
-    response = await api_client.post("/api/v2/auth/anonymous")
+    response = await api_client.post("/api/v2/auth/anonymous", json={})
 
     assert response.status_code == 200, f"Expected 200, got {response.status_code}"
 
@@ -49,7 +49,7 @@ async def test_anonymous_session_validation(api_client: PreprodAPIClient) -> Non
     Then: Response confirms the session is anonymous and returns session info
     """
     # Create anonymous session
-    create_response = await api_client.post("/api/v2/auth/anonymous")
+    create_response = await api_client.post("/api/v2/auth/anonymous", json={})
     assert create_response.status_code == 200
 
     data = create_response.json()
@@ -87,7 +87,7 @@ async def test_anonymous_config_creation(
     Then: Configuration is created and returns config_id
     """
     # Create anonymous session
-    session_response = await api_client.post("/api/v2/auth/anonymous")
+    session_response = await api_client.post("/api/v2/auth/anonymous", json={})
     assert session_response.status_code == 200
 
     session_data = session_response.json()
@@ -143,7 +143,7 @@ async def test_anonymous_session_expires_header(api_client: PreprodAPIClient) ->
     """
     from datetime import UTC, datetime
 
-    response = await api_client.post("/api/v2/auth/anonymous")
+    response = await api_client.post("/api/v2/auth/anonymous", json={})
     assert response.status_code == 200
 
     data = response.json()
@@ -178,12 +178,12 @@ async def test_anonymous_multiple_sessions_isolated(
     Then: One session cannot access the other's data
     """
     # Create first anonymous session
-    response1 = await api_client.post("/api/v2/auth/anonymous")
+    response1 = await api_client.post("/api/v2/auth/anonymous", json={})
     assert response1.status_code == 200
     token1 = response1.json()["token"]
 
     # Create second anonymous session
-    response2 = await api_client.post("/api/v2/auth/anonymous")
+    response2 = await api_client.post("/api/v2/auth/anonymous", json={})
     assert response2.status_code == 200
     token2 = response2.json()["token"]
 

--- a/tests/e2e/test_auth_magic_link.py
+++ b/tests/e2e/test_auth_magic_link.py
@@ -171,7 +171,7 @@ async def test_anonymous_data_merge(
     Then: The anonymous configuration is accessible in the authenticated session
     """
     # Step 1: Create anonymous session
-    anon_response = await api_client.post("/api/v2/auth/anonymous")
+    anon_response = await api_client.post("/api/v2/auth/anonymous", json={})
     assert anon_response.status_code == 200
 
     anon_data = anon_response.json()
@@ -268,7 +268,7 @@ async def test_full_anonymous_to_authenticated_journey(
     config_name = f"Journey Config {test_run_id}"
 
     # === Phase 1: Anonymous Session ===
-    anon_response = await api_client.post("/api/v2/auth/anonymous")
+    anon_response = await api_client.post("/api/v2/auth/anonymous", json={})
     assert anon_response.status_code == 200, "Failed to create anonymous session"
 
     anon_data = anon_response.json()

--- a/tests/e2e/test_auth_oauth.py
+++ b/tests/e2e/test_auth_oauth.py
@@ -153,7 +153,7 @@ async def test_session_validation(
     Then: Response contains user/session information
     """
     # Create anonymous session for testing
-    anon_response = await api_client.post("/api/v2/auth/anonymous")
+    anon_response = await api_client.post("/api/v2/auth/anonymous", json={})
     assert anon_response.status_code == 200
 
     token = anon_response.json()["token"]
@@ -190,7 +190,7 @@ async def test_signout_invalidates_session(
     Then: Session token is invalidated
     """
     # Create anonymous session
-    anon_response = await api_client.post("/api/v2/auth/anonymous")
+    anon_response = await api_client.post("/api/v2/auth/anonymous", json={})
     assert anon_response.status_code == 200
 
     token = anon_response.json()["token"]

--- a/tests/e2e/test_circuit_breaker.py
+++ b/tests/e2e/test_circuit_breaker.py
@@ -19,7 +19,7 @@ async def create_session_and_config(
     test_run_id: str,
 ) -> tuple[str, str]:
     """Helper to create session and config."""
-    session_response = await api_client.post("/api/v2/auth/anonymous")
+    session_response = await api_client.post("/api/v2/auth/anonymous", json={})
     assert session_response.status_code == 200
     token = session_response.json()["token"]
 

--- a/tests/e2e/test_config_crud.py
+++ b/tests/e2e/test_config_crud.py
@@ -19,7 +19,7 @@ async def create_auth_session(api_client: PreprodAPIClient) -> str:
 
     Returns the access token.
     """
-    response = await api_client.post("/api/v2/auth/anonymous")
+    response = await api_client.post("/api/v2/auth/anonymous", json={})
     assert response.status_code == 200
     return response.json()["token"]
 

--- a/tests/e2e/test_market_status.py
+++ b/tests/e2e/test_market_status.py
@@ -142,7 +142,7 @@ async def test_premarket_estimates_returned(
     Note: This validates the API supports pre-market data.
     """
     # Create session and config
-    session_response = await api_client.post("/api/v2/auth/anonymous")
+    session_response = await api_client.post("/api/v2/auth/anonymous", json={})
     assert session_response.status_code == 200
     token = session_response.json()["token"]
 

--- a/tests/e2e/test_notification_preferences.py
+++ b/tests/e2e/test_notification_preferences.py
@@ -24,7 +24,7 @@ async def create_anonymous_session(
     Returns:
         Access token for the anonymous session
     """
-    response = await api_client.post("/api/v2/auth/anonymous")
+    response = await api_client.post("/api/v2/auth/anonymous", json={})
     assert response.status_code == 200, f"Anonymous session failed: {response.text}"
     return response.json()["token"]
 

--- a/tests/e2e/test_notifications.py
+++ b/tests/e2e/test_notifications.py
@@ -18,7 +18,7 @@ async def create_session_with_config(
     test_run_id: str,
 ) -> tuple[str, str]:
     """Helper to create session and config."""
-    session_response = await api_client.post("/api/v2/auth/anonymous")
+    session_response = await api_client.post("/api/v2/auth/anonymous", json={})
     assert session_response.status_code == 200
     token = session_response.json()["token"]
 

--- a/tests/e2e/test_observability.py
+++ b/tests/e2e/test_observability.py
@@ -29,7 +29,7 @@ async def test_cloudwatch_logs_created(
     Then: CloudWatch log entry exists with request details
     """
     # Make a request that should generate logs
-    session_response = await api_client.post("/api/v2/auth/anonymous")
+    session_response = await api_client.post("/api/v2/auth/anonymous", json={})
     assert session_response.status_code == 200
 
     # Query CloudWatch Logs for evidence of the request
@@ -68,7 +68,7 @@ async def test_cloudwatch_metrics_incremented(
     """
     # Make a few requests
     for _ in range(3):
-        await api_client.post("/api/v2/auth/anonymous")
+        await api_client.post("/api/v2/auth/anonymous", json={})
 
     # Query metrics
     try:
@@ -100,7 +100,7 @@ async def test_xray_trace_exists(
     Then: Trace exists with correct service name
     """
     # Make a request
-    session_response = await api_client.post("/api/v2/auth/anonymous")
+    session_response = await api_client.post("/api/v2/auth/anonymous", json={})
     assert session_response.status_code == 200
 
     # Get trace ID from response header
@@ -143,7 +143,7 @@ async def test_xray_cross_lambda_trace(
     Then: Trace shows connected subsegments across Lambdas
     """
     # Create session and config to trigger multiple Lambda calls
-    session_response = await api_client.post("/api/v2/auth/anonymous")
+    session_response = await api_client.post("/api/v2/auth/anonymous", json={})
     if session_response.status_code != 200:
         pytest.skip("Cannot create session for cross-lambda test")
 

--- a/tests/e2e/test_quota.py
+++ b/tests/e2e/test_quota.py
@@ -24,7 +24,7 @@ async def create_anonymous_session(
     Returns:
         Access token for the anonymous session
     """
-    response = await api_client.post("/api/v2/auth/anonymous")
+    response = await api_client.post("/api/v2/auth/anonymous", json={})
     assert response.status_code == 200, f"Anonymous session failed: {response.text}"
     return response.json()["token"]
 

--- a/tests/e2e/test_rate_limiting.py
+++ b/tests/e2e/test_rate_limiting.py
@@ -27,7 +27,7 @@ async def test_requests_within_limit_succeed(
     Then: All requests succeed with 200
     """
     # Create session
-    session_response = await api_client.post("/api/v2/auth/anonymous")
+    session_response = await api_client.post("/api/v2/auth/anonymous", json={})
     assert session_response.status_code == 200
     token = session_response.json()["token"]
 
@@ -58,7 +58,7 @@ async def test_rate_limit_triggers_429(
     Then: Some requests return 429 Too Many Requests
     """
     # Create session
-    session_response = await api_client.post("/api/v2/auth/anonymous")
+    session_response = await api_client.post("/api/v2/auth/anonymous", json={})
     assert session_response.status_code == 200
     token = session_response.json()["token"]
 
@@ -98,7 +98,7 @@ async def test_retry_after_header_present(
     Then: Retry-After header indicates when to retry
     """
     # Create session
-    session_response = await api_client.post("/api/v2/auth/anonymous")
+    session_response = await api_client.post("/api/v2/auth/anonymous", json={})
     assert session_response.status_code == 200
     token = session_response.json()["token"]
 
@@ -154,7 +154,7 @@ async def test_rate_limit_recovery(
     Then: Subsequent requests succeed
     """
     # Create session
-    session_response = await api_client.post("/api/v2/auth/anonymous")
+    session_response = await api_client.post("/api/v2/auth/anonymous", json={})
     assert session_response.status_code == 200
     token = session_response.json()["token"]
 
@@ -244,7 +244,7 @@ async def test_rate_limit_per_endpoint(
     When: Accessing a different endpoint
     Then: Second endpoint may not be rate limited
     """
-    session_response = await api_client.post("/api/v2/auth/anonymous")
+    session_response = await api_client.post("/api/v2/auth/anonymous", json={})
     assert session_response.status_code == 200
     token = session_response.json()["token"]
 

--- a/tests/e2e/test_sentiment.py
+++ b/tests/e2e/test_sentiment.py
@@ -25,7 +25,7 @@ async def create_config_with_tickers(
     Returns (token, config_id).
     """
     # Create anonymous session
-    session_response = await api_client.post("/api/v2/auth/anonymous")
+    session_response = await api_client.post("/api/v2/auth/anonymous", json={})
     assert session_response.status_code == 200
     token = session_response.json()["token"]
 

--- a/tests/e2e/test_sse.py
+++ b/tests/e2e/test_sse.py
@@ -19,7 +19,7 @@ async def create_session_and_config(
     test_run_id: str,
 ) -> tuple[str, str]:
     """Helper to create session and config."""
-    session_response = await api_client.post("/api/v2/auth/anonymous")
+    session_response = await api_client.post("/api/v2/auth/anonymous", json={})
     assert session_response.status_code == 200
     token = session_response.json()["token"]
 
@@ -212,7 +212,7 @@ async def test_sse_invalid_config_rejected(
     Then: Response is 404 Not Found
     """
     # Create session
-    session_response = await api_client.post("/api/v2/auth/anonymous")
+    session_response = await api_client.post("/api/v2/auth/anonymous", json={})
     assert session_response.status_code == 200
     token = session_response.json()["token"]
 


### PR DESCRIPTION
## Summary
- Fixed E2E tests failing with 422 Unprocessable Entity
- The anonymous auth endpoint (`POST /api/v2/auth/anonymous`) requires a request body due to Pydantic validation
- Updated all 15 E2E test files to include `json={}` when creating anonymous sessions

## Root Cause
Tests were calling `api_client.post("/api/v2/auth/anonymous")` without a body, but the API endpoint expects at least an empty JSON object `{}` because the `AnonymousSessionRequest` Pydantic model validates the request body.

## Files Changed
- tests/e2e/test_alerts.py
- tests/e2e/test_anonymous_restrictions.py
- tests/e2e/test_auth_anonymous.py
- tests/e2e/test_auth_magic_link.py
- tests/e2e/test_auth_oauth.py
- tests/e2e/test_circuit_breaker.py
- tests/e2e/test_config_crud.py
- tests/e2e/test_market_status.py
- tests/e2e/test_notification_preferences.py
- tests/e2e/test_notifications.py
- tests/e2e/test_observability.py
- tests/e2e/test_quota.py
- tests/e2e/test_rate_limiting.py
- tests/e2e/test_sentiment.py
- tests/e2e/test_sse.py

## Test plan
- [ ] E2E Tests (Preprod) workflow passes
- [ ] Unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)