### PR TITLE
fix: Add PREPROD_API_URL env var for E2E tests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -833,6 +833,8 @@ jobs:
           # Required for canary tests (test_canary_preprod.py)
           PREPROD_DASHBOARD_URL: ${{ needs.deploy-preprod.outputs.dashboard_url }}
           PREPROD_DASHBOARD_API_KEY: ${{ secrets.DASHBOARD_API_KEY }}
+          # Required for E2E tests (tests/e2e/helpers/api_client.py uses PREPROD_API_URL)
+          PREPROD_API_URL: ${{ needs.deploy-preprod.outputs.dashboard_url }}
           # Required for E2E Lambda invocation tests (test_e2e_lambda_invocation_preprod.py)
           DASHBOARD_FUNCTION_URL: ${{ needs.deploy-preprod.outputs.dashboard_url }}
         id: integration-tests


### PR DESCRIPTION
## Summary
- Adds `PREPROD_API_URL` environment variable to the Preprod Integration Tests job

## Problem
The E2E tests in `tests/e2e/` use `PreprodAPIClient` which reads from `PREPROD_API_URL` environment variable. The workflow was setting `PREPROD_DASHBOARD_URL` but not `PREPROD_API_URL`, causing tests to fall back to the non-existent default domain `api.preprod.sentiment-analyzer.com`.

## Test plan
- [x] All E2E tests should connect to the actual Lambda Function URL
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)