### PR TITLE
fix(e2e): Update API client to use X-User-ID header and accept FastAPI error format

### DIFF
--- a/tests/e2e/helpers/api_client.py
+++ b/tests/e2e/helpers/api_client.py
@@ -74,10 +74,16 @@ class PreprodAPIClient:
     def _build_headers(
         self, extra_headers: dict[str, str] | None = None
     ) -> dict[str, str]:
-        """Build request headers including auth if set."""
+        """Build request headers including auth if set.
+
+        The API v2 router uses X-User-ID header for user identification,
+        not Authorization: Bearer. The access_token is the user_id returned
+        from the anonymous session creation endpoint.
+        """
         headers: dict[str, str] = {}
         if self._access_token:
-            headers["Authorization"] = f"Bearer {self._access_token}"
+            # API v2 uses X-User-ID header for authentication
+            headers["X-User-ID"] = self._access_token
         if extra_headers:
             headers.update(extra_headers)
         return headers

--- a/tests/e2e/test_alerts.py
+++ b/tests/e2e/test_alerts.py
@@ -317,7 +317,10 @@ async def test_alert_max_limit_enforced(
                 # Limit reached
                 data = response.json()
                 assert (
-                    "error" in data or "message" in data or "limit" in str(data).lower()
+                    "error" in data
+                    or "message" in data
+                    or "detail" in data
+                    or "limit" in str(data).lower()
                 ), f"Limit error should have message: {data}"
                 break
         # If no limit hit, that's also acceptable
@@ -364,7 +367,7 @@ async def test_alert_anonymous_forbidden(
         if response.status_code == 403:
             data = response.json()
             # Should indicate authentication required
-            assert "error" in data or "message" in data
+            assert "error" in data or "message" in data or "detail" in data
         elif response.status_code in (200, 201):
             # Anonymous alerts allowed - that's fine too
             pass

--- a/tests/e2e/test_anonymous_restrictions.py
+++ b/tests/e2e/test_anonymous_restrictions.py
@@ -480,8 +480,9 @@ async def test_anonymous_test_digest_may_be_restricted(
 
         if response.status_code in (401, 403):
             data = response.json()
+            # FastAPI uses "detail" for error messages, other APIs may use "error" or "message"
             assert (
-                "error" in data or "message" in data
+                "error" in data or "message" in data or "detail" in data
             ), "401/403 response should have error message"
 
     finally:

--- a/tests/e2e/test_auth_magic_link.py
+++ b/tests/e2e/test_auth_magic_link.py
@@ -172,7 +172,9 @@ async def test_magic_link_invalid_token(api_client: PreprodAPIClient) -> None:
     ), f"Invalid token should be rejected: {response.status_code}"
 
     data = response.json()
-    assert "error" in data or "message" in data, "Error response missing message"
+    assert (
+        "error" in data or "message" in data or "detail" in data
+    ), "Error response missing message"
 
 
 @pytest.mark.asyncio

--- a/tests/e2e/test_auth_oauth.py
+++ b/tests/e2e/test_auth_oauth.py
@@ -185,7 +185,7 @@ async def test_oauth_callback_tokens_returned(
     if response.status_code == 200:
         # If 200, should have error indicator or tokens
         data = response.json()
-        has_error = "error" in data or "message" in data
+        has_error = "error" in data or "message" in data or "detail" in data
         has_tokens = "access_token" in data
         assert has_error or has_tokens, f"Unexpected 200 response: {data}"
 
@@ -302,7 +302,9 @@ async def test_token_refresh(
     # Handle empty response body gracefully
     if response.text:
         data = response.json()
-        assert "error" in data or "message" in data, "Error response missing message"
+        assert (
+            "error" in data or "message" in data or "detail" in data
+        ), "Error response missing message"
 
 
 @pytest.mark.asyncio

--- a/tests/e2e/test_ticker_validation.py
+++ b/tests/e2e/test_ticker_validation.py
@@ -109,7 +109,7 @@ async def test_invalid_ticker_returns_invalid(
     elif response.status_code == 400:
         # Bad request for invalid ticker is acceptable
         data = response.json()
-        assert "error" in data or "message" in data
+        assert "error" in data or "message" in data or "detail" in data
     elif response.status_code == 200:
         # Some APIs return 200 with is_valid=false
         data = response.json()


### PR DESCRIPTION
## Summary
- Changed API client auth header from `Authorization: Bearer` to `X-User-ID` to match the API v2 router's expected authentication mechanism
- Updated all E2E tests to accept `detail` key in error responses (FastAPI standard) in addition to `error` and `message` keys

## Root Cause Analysis
The API v2 router expects user identification via the `X-User-ID` header, but the test API client was incorrectly using `Authorization: Bearer {token}`. This caused all authenticated API calls to fail with 401 "Missing user identification".

## Test plan
- [ ] CI passes unit tests
- [ ] CI passes preprod integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)