### PR TITLE
fix(api): Return 404 instead of 500 for non-existent configs

### DIFF
--- a/src/lambdas/dashboard/router_v2.py
+++ b/src/lambdas/dashboard/router_v2.py
@@ -434,6 +434,8 @@ async def get_configuration(
         user_id=user_id,
         config_id=config_id,
     )
+    if result is None:
+        raise HTTPException(status_code=404, detail="Configuration not found")
     if isinstance(result, config_service.ErrorResponse):
         raise HTTPException(status_code=404, detail=result.error.message)
     return JSONResponse(result.model_dump())
@@ -456,6 +458,8 @@ async def update_configuration(
         request=body,
         ticker_cache=ticker_cache,
     )
+    if result is None:
+        raise HTTPException(status_code=404, detail="Configuration not found")
     if isinstance(result, config_service.ErrorResponse):
         raise HTTPException(status_code=400, detail=result.error.message)
     return JSONResponse(result.model_dump())
@@ -474,8 +478,9 @@ async def delete_configuration(
         user_id=user_id,
         config_id=config_id,
     )
-    if isinstance(result, config_service.ErrorResponse):
-        raise HTTPException(status_code=404, detail=result.error.message)
+    # delete_configuration returns bool: True if deleted, False if not found
+    if not result:
+        raise HTTPException(status_code=404, detail="Configuration not found")
     return JSONResponse({"message": "Configuration deleted"})
 
 


### PR DESCRIPTION
## Summary
- Fix configuration endpoints that were returning 500 errors when accessing non-existent configurations
- The issue was that service functions return `None` for not-found cases, but the router only checked for `ErrorResponse`, causing `AttributeError` on `.model_dump()`
- Fixed `get_configuration`, `update_configuration`, and `delete_configuration` endpoints

## Test plan
- [ ] Verify unit tests pass
- [ ] Verify E2E tests for invalid config lookup now pass (tests/e2e/test_config_crud.py)
- [ ] Manual testing of config endpoints with invalid IDs returns 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)