### PR TITLE
feat(iam): Add X-Ray permissions to CI deployer policy

### DIFF
--- a/infrastructure/terraform/ci-user-policy.tf
+++ b/infrastructure/terraform/ci-user-policy.tf
@@ -423,6 +423,40 @@ data "aws_iam_policy_document" "ci_deploy_monitoring" {
     ]
     resources = ["*"]
   }
+
+  # X-Ray Tracing
+  statement {
+    sid    = "XRay"
+    effect = "Allow"
+    actions = [
+      "xray:PutTraceSegments",
+      "xray:PutTelemetryRecords",
+      "xray:GetSamplingRules",
+      "xray:GetSamplingTargets",
+      "xray:GetSamplingStatisticSummaries",
+      "xray:GetServiceGraph",
+      "xray:GetTraceGraph",
+      "xray:GetTraceSummaries",
+      "xray:GetGroups",
+      "xray:GetGroup",
+      "xray:CreateGroup",
+      "xray:UpdateGroup",
+      "xray:DeleteGroup",
+      "xray:GetEncryptionConfig",
+      "xray:PutEncryptionConfig",
+      "xray:GetInsight",
+      "xray:GetInsightEvents",
+      "xray:GetInsightImpactGraph",
+      "xray:GetInsightSummaries",
+      "xray:CreateSamplingRule",
+      "xray:UpdateSamplingRule",
+      "xray:DeleteSamplingRule",
+      "xray:TagResource",
+      "xray:UntagResource",
+      "xray:ListTagsForResource"
+    ]
+    resources = ["*"]
+  }
 }
 
 # ==================================================================


### PR DESCRIPTION
## Summary
- Add AWS X-Ray permissions to the CIDeployMonitoring policy
- Enables CI/CD pipeline to deploy Lambda functions with X-Ray tracing
- The infrastructure uses X-Ray tracing but deployer was missing permissions

## Permissions Added
- `xray:PutTraceSegments`, `PutTelemetryRecords` (write traces)
- `xray:GetSamplingRules/Targets/StatisticSummaries` (sampling config)
- `xray:GetServiceGraph`, `GetTraceGraph`, `GetTraceSummaries` (read traces)
- `xray:CreateGroup/UpdateGroup/DeleteGroup/GetGroup/GetGroups` (groups)
- `xray:CreateSamplingRule/UpdateSamplingRule/DeleteSamplingRule` (rules)
- `xray:GetEncryptionConfig/PutEncryptionConfig` (encryption)
- `xray:GetInsight*` (insights)
- `xray:TagResource/UntagResource/ListTagsForResource` (tagging)

## Test plan
- [ ] Verify Terraform validates successfully
- [ ] Verify CI/CD deploy runs without X-Ray permission errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)