### PR TITLE
fix(security): Remove CORS wildcard fallback in Terraform

### DIFF
--- a/infrastructure/terraform/prod.tfvars
+++ b/infrastructure/terraform/prod.tfvars
@@ -38,6 +38,8 @@ monthly_budget_limit = 100
 model_layer_arns = []
 
 # CORS: Production requires explicit origins - NO WILDCARDS
-# Add your production domain(s) here before deploying to production
-# Example: ["https://dashboard.example.com", "https://example.com"]
+# IMPORTANT: Set this to your CloudFront domain before deploying to production
+# The CloudFront domain is output after first deployment as cloudfront_domain_name
+# Example: ["https://d1234567890.cloudfront.net"]
+# You can also add custom domains: ["https://dashboard.example.com", "https://d1234567890.cloudfront.net"]
 cors_allowed_origins = []

--- a/infrastructure/terraform/variables.tf
+++ b/infrastructure/terraform/variables.tf
@@ -54,7 +54,13 @@ variable "model_layer_arns" {
 }
 
 variable "cors_allowed_origins" {
-  description = "List of allowed CORS origins for the dashboard Lambda. Use specific domains in production."
+  description = <<-EOT
+    List of allowed CORS origins for the dashboard Lambda.
+    SECURITY: Wildcards are NOT allowed - specify exact origins.
+    For production: Include your CloudFront domain (output as cloudfront_domain_name after first deploy).
+    For preprod: localhost origins are auto-added if this is empty.
+    Example: ["https://d1234567890.cloudfront.net", "https://mydomain.com"]
+  EOT
   type        = list(string)
   default     = []
   validation {


### PR DESCRIPTION
## Summary

- Removes dangerous CORS wildcard `["*"]` fallback in Lambda Function URL configuration
- For non-prod environments, defaults to localhost origins for local development
- For production, requires explicit origin configuration (empty list = no CORS = secure default)
- Adds comprehensive security documentation to `variables.tf`
- Updates `prod.tfvars` with instructions for configuring CloudFront domain

## Security Issue

The Lambda Function URL CORS was configured with:
```terraform
allow_origins = length(var.cors_allowed_origins) > 0 ? var.cors_allowed_origins : ["*"]
```

This meant that if `cors_allowed_origins` was empty (as in prod.tfvars), it would fall back to allowing **any domain** to make cross-origin requests.

## Test plan

- [x] Terraform validates: `terraform validate` passes
- [x] All 15 CORS-related unit tests pass
- [x] No change to Python handler behavior (already secure at app level)

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)