### PR TITLE
perf: Add k6 load testing and scaling runbook

### DIFF
--- a/docs/runbooks/scaling.md
+++ b/docs/runbooks/scaling.md
@@ -1,0 +1,208 @@
+# Scaling Runbook
+
+This document provides procedures for scaling the Sentiment Analyzer system in response to traffic changes.
+
+## Architecture Overview
+
+The system uses AWS serverless architecture:
+
+| Component | Service | Scaling Mode | Default Capacity |
+|-----------|---------|--------------|------------------|
+| API | Lambda | Auto (concurrent) | 1000 concurrent |
+| Database | DynamoDB | On-demand | Auto |
+| CDN | CloudFront | Auto | Global |
+| Ingestion | Lambda + EventBridge | Scheduled | Every 15 min |
+
+## Monitoring Dashboards
+
+- **CloudWatch Dashboard**: `sentiment-analyzer-{env}-dashboard`
+- **X-Ray Service Map**: AWS X-Ray console
+- **Lambda Insights**: CloudWatch Lambda Insights
+
+## Key Metrics to Monitor
+
+### Lambda Metrics
+| Metric | Warning Threshold | Critical Threshold | Action |
+|--------|-------------------|-------------------|--------|
+| ConcurrentExecutions | >70% of limit | >90% of limit | Request limit increase |
+| Duration p95 | >5s | >10s | Profile for bottlenecks |
+| Errors | >1% | >5% | Investigate logs |
+| Throttles | Any | Sustained | Increase reserved concurrency |
+
+### DynamoDB Metrics
+| Metric | Warning Threshold | Critical Threshold | Action |
+|--------|-------------------|-------------------|--------|
+| ConsumedReadCapacity | >70% of provisioned | >90% | Scale up or switch to on-demand |
+| ConsumedWriteCapacity | >70% of provisioned | >90% | Scale up or switch to on-demand |
+| ThrottledRequests | Any | Sustained | Review GSI design, add capacity |
+| SystemErrors | Any | Any | AWS issue - check status page |
+
+### API Gateway (Lambda Function URL)
+| Metric | Warning Threshold | Critical Threshold | Action |
+|--------|-------------------|-------------------|--------|
+| Latency p95 | >1s | >3s | Check downstream services |
+| 5xx Errors | >1% | >5% | Check Lambda errors |
+| 429 Rate Limit | >10/min | >100/min | Review rate limit config |
+
+## Scaling Procedures
+
+### 1. Increase Lambda Concurrency
+
+**When to use**: Throttling observed, or preparing for traffic spike
+
+```bash
+# Check current concurrency
+aws lambda get-function-configuration \
+  --function-name sentiment-analyzer-{env}-dashboard \
+  --query 'ReservedConcurrentExecutions'
+
+# Increase reserved concurrency
+aws lambda put-function-concurrency \
+  --function-name sentiment-analyzer-{env}-dashboard \
+  --reserved-concurrent-executions 500
+
+# Verify
+aws lambda get-function-configuration \
+  --function-name sentiment-analyzer-{env}-dashboard \
+  --query 'ReservedConcurrentExecutions'
+```
+
+**Rollback**:
+```bash
+aws lambda delete-function-concurrency \
+  --function-name sentiment-analyzer-{env}-dashboard
+```
+
+### 2. Switch DynamoDB to Provisioned Capacity
+
+**When to use**: Predictable traffic patterns, cost optimization at scale
+
+```bash
+# First, analyze current usage (last 7 days)
+aws cloudwatch get-metric-statistics \
+  --namespace AWS/DynamoDB \
+  --metric-name ConsumedReadCapacityUnits \
+  --dimensions Name=TableName,Value=sentiment-analyzer-{env} \
+  --start-time $(date -d '7 days ago' --iso-8601=seconds) \
+  --end-time $(date --iso-8601=seconds) \
+  --period 3600 \
+  --statistics Maximum
+
+# Update via Terraform (recommended)
+cd infrastructure/terraform
+terraform plan -var-file={env}.tfvars -target=module.dynamodb
+terraform apply -var-file={env}.tfvars -target=module.dynamodb
+```
+
+### 3. Enable Lambda Provisioned Concurrency
+
+**When to use**: Reduce cold starts for critical paths
+
+```bash
+# Publish new version
+VERSION=$(aws lambda publish-version \
+  --function-name sentiment-analyzer-{env}-dashboard \
+  --query 'Version' --output text)
+
+# Create alias with provisioned concurrency
+aws lambda create-alias \
+  --function-name sentiment-analyzer-{env}-dashboard \
+  --name prod-warm \
+  --function-version $VERSION
+
+aws lambda put-provisioned-concurrency-config \
+  --function-name sentiment-analyzer-{env}-dashboard \
+  --qualifier prod-warm \
+  --provisioned-concurrent-executions 10
+```
+
+### 4. Scale Ingestion Frequency
+
+**When to use**: Need more real-time data during market events
+
+```bash
+# Current schedule in Terraform
+# ingestion_schedule = "rate(15 minutes)"
+
+# To change, update preprod.tfvars or prod.tfvars:
+# ingestion_schedule = "rate(5 minutes)"
+
+cd infrastructure/terraform
+terraform apply -var-file={env}.tfvars -target=module.eventbridge
+```
+
+## Emergency Procedures
+
+### High Error Rate (>5%)
+
+1. Check Lambda logs for errors:
+   ```bash
+   aws logs filter-log-events \
+     --log-group-name /aws/lambda/sentiment-analyzer-{env}-dashboard \
+     --filter-pattern "ERROR" \
+     --start-time $(date -d '1 hour ago' +%s000)
+   ```
+
+2. Check X-Ray for failed traces:
+   ```bash
+   aws xray get-trace-summaries \
+     --start-time $(date -d '1 hour ago' --iso-8601=seconds) \
+     --end-time $(date --iso-8601=seconds) \
+     --filter-expression 'responsetime > 5 AND error = true'
+   ```
+
+3. If external API (Tiingo/Finnhub) issue:
+   - Circuit breaker should activate automatically
+   - Check quota tracker: `DynamoDB scan for QUOTA# keys`
+
+### Sustained Throttling
+
+1. Request AWS limit increase:
+   - Go to AWS Service Quotas
+   - Request increase for Lambda concurrent executions
+
+2. Temporarily reduce traffic:
+   - Update rate limits in `src/lambdas/shared/middleware/rate_limit.py`
+   - Deploy via CI/CD
+
+### DynamoDB Hot Key
+
+1. Identify hot key using Contributor Insights:
+   ```bash
+   aws dynamodb describe-contributor-insights \
+     --table-name sentiment-analyzer-{env}
+   ```
+
+2. Review access patterns in X-Ray
+3. Consider adding GSI or caching layer
+
+## Load Testing Before Scaling
+
+Before any major scaling change, run load tests:
+
+```bash
+# Smoke test (quick validation)
+k6 run --env API_URL=$PREPROD_API_URL --env STAGE=smoke tests/load/api-load-test.js
+
+# Load test (normal traffic)
+k6 run --env API_URL=$PREPROD_API_URL --env STAGE=load tests/load/api-load-test.js
+
+# Stress test (find breaking point)
+k6 run --env API_URL=$PREPROD_API_URL --env STAGE=stress tests/load/api-load-test.js
+```
+
+## Cost Considerations
+
+| Action | Cost Impact | When to Use |
+|--------|-------------|-------------|
+| Increase Lambda memory | +$$ | CPU-bound operations |
+| Provisioned concurrency | +$$$ | Cold start sensitive |
+| DynamoDB provisioned | -$ at scale | Predictable traffic |
+| CloudFront caching | -$ | Static content |
+| Reserved capacity | -30% | Long-term commitment |
+
+## Contacts
+
+- **On-call**: Check PagerDuty rotation
+- **AWS Support**: Support ticket (if Business/Enterprise support)
+- **Escalation**: See incident response runbook

--- a/tests/load/.gitignore
+++ b/tests/load/.gitignore
@@ -1,0 +1,3 @@
+# k6 load test outputs
+load-test-results.json
+*.html

--- a/tests/load/api-load-test.js
+++ b/tests/load/api-load-test.js
@@ -1,0 +1,349 @@
+// k6 Load Test Script for Sentiment Analyzer API
+//
+// Usage:
+//   k6 run --env API_URL=https://your-api-url.com tests/load/api-load-test.js
+//
+// Environment variables:
+//   API_URL - Base URL of the API (required)
+//   STAGE   - Test stage: smoke, load, stress, soak (default: load)
+//
+// Stages:
+//   smoke  - Quick validation (1 VU, 30s)
+//   load   - Normal load test (ramp to 50 VUs over 5 minutes)
+//   stress - Find breaking point (ramp to 200 VUs)
+//   soak   - Extended duration (50 VUs for 30 minutes)
+
+import http from "k6/http";
+import { check, group, sleep } from "k6";
+import { Rate, Trend } from "k6/metrics";
+
+// Custom metrics
+const errorRate = new Rate("errors");
+const authLatency = new Trend("auth_latency", true);
+const configLatency = new Trend("config_latency", true);
+const sentimentLatency = new Trend("sentiment_latency", true);
+
+// Test configuration based on STAGE
+const stages = {
+  smoke: {
+    stages: [{ duration: "30s", target: 1 }],
+    thresholds: {
+      http_req_duration: ["p(95)<2000"],
+      errors: ["rate<0.1"],
+    },
+  },
+  load: {
+    stages: [
+      { duration: "1m", target: 10 }, // Ramp up
+      { duration: "3m", target: 50 }, // Stay at 50 VUs
+      { duration: "1m", target: 0 }, // Ramp down
+    ],
+    thresholds: {
+      http_req_duration: ["p(95)<1500", "p(99)<3000"],
+      errors: ["rate<0.05"],
+    },
+  },
+  stress: {
+    stages: [
+      { duration: "2m", target: 50 },
+      { duration: "2m", target: 100 },
+      { duration: "2m", target: 150 },
+      { duration: "2m", target: 200 },
+      { duration: "2m", target: 0 },
+    ],
+    thresholds: {
+      http_req_duration: ["p(95)<5000"],
+      errors: ["rate<0.2"],
+    },
+  },
+  soak: {
+    stages: [
+      { duration: "2m", target: 50 },
+      { duration: "30m", target: 50 },
+      { duration: "2m", target: 0 },
+    ],
+    thresholds: {
+      http_req_duration: ["p(95)<2000"],
+      errors: ["rate<0.05"],
+    },
+  },
+};
+
+const stage = __ENV.STAGE || "load";
+const config = stages[stage];
+
+export const options = {
+  stages: config.stages,
+  thresholds: {
+    ...config.thresholds,
+    auth_latency: ["p(95)<1000"],
+    config_latency: ["p(95)<1500"],
+    sentiment_latency: ["p(95)<2000"],
+  },
+};
+
+const BASE_URL = __ENV.API_URL;
+
+if (!BASE_URL) {
+  throw new Error("API_URL environment variable is required");
+}
+
+// Helper to build headers
+function buildHeaders(userId = null) {
+  const headers = {
+    "Content-Type": "application/json",
+  };
+  if (userId) {
+    headers["X-User-ID"] = userId;
+  }
+  return headers;
+}
+
+// Create anonymous session
+function createSession() {
+  const start = Date.now();
+  const response = http.post(
+    `${BASE_URL}/api/v2/auth/anonymous`,
+    JSON.stringify({}),
+    { headers: buildHeaders() }
+  );
+  authLatency.add(Date.now() - start);
+
+  const success = check(response, {
+    "auth status is 200 or 201": (r) => r.status === 200 || r.status === 201,
+    "auth returns token": (r) => {
+      try {
+        const body = JSON.parse(r.body);
+        return body.token || body.user_id;
+      } catch {
+        return false;
+      }
+    },
+  });
+
+  errorRate.add(!success);
+
+  if (success) {
+    try {
+      const body = JSON.parse(response.body);
+      return body.token || body.user_id;
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+// Get configurations
+function getConfigurations(userId) {
+  const start = Date.now();
+  const response = http.get(`${BASE_URL}/api/v2/configurations`, {
+    headers: buildHeaders(userId),
+  });
+  configLatency.add(Date.now() - start);
+
+  const success = check(response, {
+    "configs status is 200": (r) => r.status === 200,
+    "configs returns array or object": (r) => {
+      try {
+        const body = JSON.parse(r.body);
+        return Array.isArray(body) || typeof body === "object";
+      } catch {
+        return false;
+      }
+    },
+  });
+
+  errorRate.add(!success);
+  return response;
+}
+
+// Create configuration
+function createConfiguration(userId) {
+  const start = Date.now();
+  const payload = {
+    name: `Load Test Config ${Date.now()}`,
+    tickers: [{ symbol: "AAPL", weight: 1.0 }],
+  };
+
+  const response = http.post(
+    `${BASE_URL}/api/v2/configurations`,
+    JSON.stringify(payload),
+    { headers: buildHeaders(userId) }
+  );
+  configLatency.add(Date.now() - start);
+
+  const success = check(response, {
+    "create config status is 200 or 201": (r) =>
+      r.status === 200 || r.status === 201,
+    "create config returns id": (r) => {
+      try {
+        const body = JSON.parse(r.body);
+        return body.config_id || body.id;
+      } catch {
+        return false;
+      }
+    },
+  });
+
+  errorRate.add(!success);
+
+  if (success) {
+    try {
+      const body = JSON.parse(response.body);
+      return body.config_id || body.id;
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+// Get sentiment data
+function getSentiment(userId, configId) {
+  const start = Date.now();
+  const response = http.get(
+    `${BASE_URL}/api/v2/configurations/${configId}/sentiment`,
+    { headers: buildHeaders(userId) }
+  );
+  sentimentLatency.add(Date.now() - start);
+
+  const success = check(response, {
+    "sentiment status is 200 or 404": (r) =>
+      r.status === 200 || r.status === 404,
+  });
+
+  errorRate.add(!success && response.status !== 404);
+  return response;
+}
+
+// Delete configuration (cleanup)
+function deleteConfiguration(userId, configId) {
+  const response = http.del(
+    `${BASE_URL}/api/v2/configurations/${configId}`,
+    null,
+    { headers: buildHeaders(userId) }
+  );
+
+  check(response, {
+    "delete config status is 200 or 204": (r) =>
+      r.status === 200 || r.status === 204,
+  });
+
+  return response;
+}
+
+// Health check
+function healthCheck() {
+  const response = http.get(`${BASE_URL}/health`);
+  check(response, {
+    "health check status is 200": (r) => r.status === 200,
+  });
+  return response;
+}
+
+// Main test scenario
+export default function () {
+  // Simulate user journey
+  group("User Journey", function () {
+    // 1. Health check (10% of iterations)
+    if (Math.random() < 0.1) {
+      group("Health Check", function () {
+        healthCheck();
+      });
+    }
+
+    // 2. Create session
+    let userId = null;
+    group("Authentication", function () {
+      userId = createSession();
+    });
+
+    if (!userId) {
+      console.log("Failed to create session, skipping rest of iteration");
+      return;
+    }
+
+    // 3. List configurations (most common operation)
+    group("List Configurations", function () {
+      getConfigurations(userId);
+    });
+
+    // 4. Create and query configuration (30% of iterations)
+    if (Math.random() < 0.3) {
+      let configId = null;
+      group("Create Configuration", function () {
+        configId = createConfiguration(userId);
+      });
+
+      if (configId) {
+        // Query sentiment
+        group("Get Sentiment", function () {
+          getSentiment(userId, configId);
+        });
+
+        // Cleanup (50% of time to simulate retained configs)
+        if (Math.random() < 0.5) {
+          group("Delete Configuration", function () {
+            deleteConfiguration(userId, configId);
+          });
+        }
+      }
+    }
+
+    // Think time between iterations (1-3 seconds)
+    sleep(1 + Math.random() * 2);
+  });
+}
+
+// Setup function - runs once before the test
+export function setup() {
+  console.log(`Starting ${stage} test against ${BASE_URL}`);
+
+  // Verify API is reachable
+  const response = http.get(`${BASE_URL}/health`);
+  if (response.status !== 200) {
+    throw new Error(`API health check failed: ${response.status}`);
+  }
+
+  console.log("API health check passed");
+  return { startTime: Date.now() };
+}
+
+// Teardown function - runs once after the test
+export function teardown(data) {
+  const duration = (Date.now() - data.startTime) / 1000;
+  console.log(`Test completed in ${duration.toFixed(2)} seconds`);
+}
+
+// Handle test summary
+export function handleSummary(data) {
+  const summary = {
+    timestamp: new Date().toISOString(),
+    stage: stage,
+    api_url: BASE_URL,
+    duration_seconds: data.state.testRunDurationMs / 1000,
+    metrics: {
+      http_reqs: data.metrics.http_reqs?.values?.count || 0,
+      http_req_duration_p50:
+        data.metrics.http_req_duration?.values?.["p(50)"] || 0,
+      http_req_duration_p95:
+        data.metrics.http_req_duration?.values?.["p(95)"] || 0,
+      http_req_duration_p99:
+        data.metrics.http_req_duration?.values?.["p(99)"] || 0,
+      error_rate: data.metrics.errors?.values?.rate || 0,
+      auth_latency_p95: data.metrics.auth_latency?.values?.["p(95)"] || 0,
+      config_latency_p95: data.metrics.config_latency?.values?.["p(95)"] || 0,
+      sentiment_latency_p95:
+        data.metrics.sentiment_latency?.values?.["p(95)"] || 0,
+    },
+    thresholds_passed: Object.values(data.thresholds || {}).every(
+      (t) => t.ok
+    ),
+  };
+
+  return {
+    stdout: JSON.stringify(summary, null, 2) + "\n",
+    "load-test-results.json": JSON.stringify(summary, null, 2),
+  };
+}


### PR DESCRIPTION
## Summary

- Add k6 load test script with multiple test stages (smoke, load, stress, soak)
- Add scaling runbook with procedures for Lambda, DynamoDB, and emergency scenarios
- Include custom metrics for auth, config, and sentiment latency tracking

## Files Added

- `tests/load/api-load-test.js` - k6 load testing script with:
  - Smoke testing (1 VU, 30s)
  - Load testing (ramp to 50 VUs over 5 minutes)
  - Stress testing (ramp to 200 VUs)
  - Soak testing (50 VUs for 30 minutes)
  - Custom metrics for auth, config, and sentiment latency

- `docs/runbooks/scaling.md` - Scaling runbook with:
  - Architecture overview
  - Key metrics and thresholds
  - Scaling procedures (Lambda concurrency, DynamoDB capacity, provisioned concurrency)
  - Emergency procedures
  - Cost considerations

## Usage

```bash
# Smoke test
k6 run --env API_URL=https://your-api.com --env STAGE=smoke tests/load/api-load-test.js

# Load test
k6 run --env API_URL=https://your-api.com --env STAGE=load tests/load/api-load-test.js
```

## Test Plan

- [x] k6 script syntax validated
- [x] Runbook procedures documented
- [ ] Run smoke test against preprod (manual after merge)

Partial work on #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)