### PR TITLE
fix(iam): Add missing SNS and API Gateway permissions for CI deployer

### DIFF
--- a/infrastructure/terraform/ci-user-policy.tf
+++ b/infrastructure/terraform/ci-user-policy.tf
@@ -107,6 +107,7 @@ data "aws_iam_policy_document" "ci_deploy_core" {
       "sns:Subscribe",
       "sns:Unsubscribe",
       "sns:ListSubscriptionsByTopic",
+      "sns:GetSubscriptionAttributes",
       "sns:TagResource",
       "sns:UntagResource",
       "sns:ListTagsForResource"
@@ -168,6 +169,8 @@ data "aws_iam_policy_document" "ci_deploy_core" {
     resources = [
       "arn:aws:apigateway:*::/restapis",
       "arn:aws:apigateway:*::/restapis/*",
+      "arn:aws:apigateway:*::/usageplans",
+      "arn:aws:apigateway:*::/usageplans/*",
       "arn:aws:apigateway:*::/tags/*"
     ]
   }


### PR DESCRIPTION
## Summary

Add permissions required for Terraform to read SNS subscriptions and API Gateway usage plans:

- `sns:GetSubscriptionAttributes` - needed for refreshing SNS subscription state
- `apigateway:GET` on `/usageplans/*` - needed for usage plan state management

## Root Cause

During preprod deployment, Terraform failed with authorization errors:
```
Error: reading SNS Topic Subscription: AuthorizationError: SNS:GetSubscriptionAttributes action not allowed
Error: reading API Gateway Usage Plan: AccessDeniedException: apigateway:GET on /usageplans/* not allowed
```

## Test plan

- [ ] PR CI passes
- [ ] Merge to main triggers successful preprod deployment
- [ ] E2E preprod tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)