### PR TITLE
fix(iam): Add secretsmanager:GetResourcePolicy permission for CI deployer

### DIFF
--- a/infrastructure/terraform/ci-user-policy.tf
+++ b/infrastructure/terraform/ci-user-policy.tf
@@ -183,6 +183,7 @@ data "aws_iam_policy_document" "ci_deploy_core" {
       "secretsmanager:CreateSecret",
       "secretsmanager:DeleteSecret",
       "secretsmanager:DescribeSecret",
+      "secretsmanager:GetResourcePolicy",
       "secretsmanager:UpdateSecret",
       "secretsmanager:PutSecretValue",
       "secretsmanager:TagResource",


### PR DESCRIPTION
## Summary

Add `secretsmanager:GetResourcePolicy` permission to CI deployer IAM policy.

Terraform needs this to read secret resource policies during plan/refresh.

## Root Cause

Deploy pipeline failed with:
```
AccessDeniedException: User is not authorized to perform:
secretsmanager:GetResourcePolicy
```

## Test plan

- [x] IAM policy manually applied
- [ ] PR CI passes
- [ ] Deploy pipeline succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)