### PR TITLE
fix(iam): Add lambda:GetFunctionCodeSigningConfig permission for CI deployer

### DIFF
--- a/infrastructure/terraform/ci-user-policy.tf
+++ b/infrastructure/terraform/ci-user-policy.tf
@@ -69,7 +69,9 @@ data "aws_iam_policy_document" "ci_deploy_core" {
       "lambda:DeleteLayerVersion",
       "lambda:GetLayerVersion",
       "lambda:ListLayerVersions",
-      "lambda:ListLayers"
+      "lambda:ListLayers",
+      "lambda:GetFunctionCodeSigningConfig",
+      "lambda:ListFunctionUrlConfigs"
     ]
     resources = ["*"]
   }


### PR DESCRIPTION
## Summary
- Add missing Lambda permissions required for Terraform refresh:
  - `lambda:GetFunctionCodeSigningConfig` - needed to read function code signing configuration
  - `lambda:ListFunctionUrlConfigs` - needed to list all function URL configurations

## Problem
Terraform plan fails with:
```
Error: reading Lambda Function code signing config: AccessDeniedException: User is not authorized to perform: lambda:GetFunctionCodeSigningConfig
```

This causes "Cannot apply incomplete plan" error in CI deploys.

## Test plan
- [x] Terraform fmt and validate pass
- [ ] CI unit tests pass
- [ ] Deploy pipeline succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)