### PR TITLE
fix(security): Sanitize view parameter to prevent log injection (CWE-117)

### DIFF
--- a/src/lambdas/dashboard/sentiment.py
+++ b/src/lambdas/dashboard/sentiment.py
@@ -439,13 +439,14 @@ def get_heatmap_data(
 
         legend = None  # Legend optional for timeperiods view
 
-    # Pre-sanitize config_id to prevent log injection (CodeQL py/log-injection)
+    # Pre-sanitize user inputs to prevent log injection (CodeQL py/log-injection)
     safe_config_id = sanitize_for_log(config_id[:8] if config_id else "")
+    safe_view = sanitize_for_log(view)
     logger.debug(
         "Generated heatmap data",
         extra={
             "config_id": safe_config_id,
-            "view": view,
+            "view": safe_view,
             "ticker_count": len(tickers),
         },
     )


### PR DESCRIPTION
## Summary
Fix CodeQL security alert #73: `py/log-injection` in `get_heatmap_data` function.

## Problem
The `view` parameter in `get_heatmap_data()` was being logged without sanitization. Although Pydantic constrains this parameter to `Literal["sources", "timeperiods"]`, CodeQL cannot infer this type safety and correctly flags it as a potential log injection vulnerability (CWE-117).

A malicious actor could potentially inject false log entries via CRLF characters, allowing them to:
- Create misleading audit trails
- Hide malicious activity by injecting benign-looking log entries
- Confuse log analysis tools

## Solution
Wrap the `view` parameter with `sanitize_for_log()` before logging, following the same pattern already used for `config_id` in the same function.

## Security References
- [OWASP Log Injection](https://owasp.org/www-community/attacks/Log_Injection)
- [CWE-117: Improper Output Neutralization for Logs](https://cwe.mitre.org/data/definitions/117.html)
- [CodeQL py/log-injection](https://codeql.github.com/codeql-query-help/python/py-log-injection/)

## Test plan
- [x] Code passes black formatting
- [x] Code passes ruff linting
- [ ] CI unit tests pass
- [ ] CodeQL security scan passes (should close alert #73)

🤖 Generated with [Claude Code](https://claude.com/claude-code)