### PR TITLE
fix(cors): Add CloudFront domain to preprod CORS allowed origins

### DIFF
--- a/infrastructure/terraform/preprod.tfvars
+++ b/infrastructure/terraform/preprod.tfvars
@@ -33,6 +33,10 @@ ingestion_schedule = "rate(2 hours)"
 # Preprod has same alarms as prod but with higher thresholds
 # This prevents alert fatigue while still catching major issues
 
-# CORS: Preprod allows the Lambda Function URL domain itself (same-origin)
-# and localhost for testing. No wildcard allowed.
-cors_allowed_origins = ["http://localhost:3000", "http://localhost:8080"]
+# CORS: Preprod allows the CloudFront dashboard domain and localhost for testing.
+# No wildcard allowed per security policy.
+cors_allowed_origins = [
+  "https://d2z9uvoj5xlbd2.cloudfront.net", # CloudFront dashboard
+  "http://localhost:3000",                 # Local development
+  "http://localhost:8080"                  # Alternative local dev
+]


### PR DESCRIPTION
## Summary
Fix CORS misconfiguration in preprod that was causing cross-origin requests from the deployed CloudFront dashboard to fail.

## Problem
The preprod `cors_allowed_origins` only included localhost domains but **not the CloudFront domain** (`https://d2z9uvoj5xlbd2.cloudfront.net`). This meant that:
- API calls from the deployed dashboard failed with no `Access-Control-Allow-Origin` header
- Only local development worked correctly

## Solution
Add the CloudFront domain to the CORS allowed origins in `preprod.tfvars`:
```hcl
cors_allowed_origins = [
  "https://d2z9uvoj5xlbd2.cloudfront.net",  # CloudFront dashboard
  "http://localhost:3000",                   # Local development
  "http://localhost:8080"                    # Alternative local dev
]
```

## API Gateway Audit Findings

### ✅ Correctly Configured
| Setting | Value | Status |
|---------|-------|--------|
| Rate Limiting | 100 req/s | ✅ Configured |
| Burst Limit | 200 concurrent | ✅ Configured |
| X-Ray Tracing | Enabled | ✅ Configured |
| CloudWatch Logging | Enabled (30d retention) | ✅ Configured |
| 4XX Alarm | 100/5min threshold | ✅ Configured |
| 5XX Alarm | 10/5min threshold | ✅ Configured |
| Latency Alarm | 5000ms p90 threshold | ✅ Configured |

### ⚠️ Fixed in this PR
- CORS allowed origins missing CloudFront domain

## Test plan
- [ ] CI passes
- [ ] Deploy to preprod applies CORS update to Lambda env var
- [ ] Test CORS from CloudFront domain:
  ```bash
  curl -I -X OPTIONS https://API_URL/health -H "Origin: https://d2z9uvoj5xlbd2.cloudfront.net"
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)