### PR TITLE
fix(terraform): Remove undeclared variables from tfvars files

### DIFF
--- a/infrastructure/terraform/preprod.tfvars
+++ b/infrastructure/terraform/preprod.tfvars
@@ -15,23 +15,9 @@ tags = {
   CostCenter  = "testing"
 }
 
-# Lambda Configuration
-# Note: Same settings as prod to ensure accurate testing
-lambda_memory_mb       = 512
-lambda_timeout_seconds = 60
-
-# DynamoDB Configuration
-# Note: On-demand billing, no reserved capacity (cost optimization)
-# Prod will use provisioned capacity or on-demand based on traffic
-
-# EventBridge Schedule
-# Run ingestion every 2 hours (less frequent than prod)
-# Prod runs every 15 minutes
-ingestion_schedule = "rate(2 hours)"
-
-# Monitoring and Alerting
-# Preprod has same alarms as prod but with higher thresholds
-# This prevents alert fatigue while still catching major issues
+# Note: Lambda memory/timeout and EventBridge schedule are configured
+# in the Terraform modules with environment-appropriate defaults.
+# DynamoDB uses on-demand billing (no reserved capacity).
 
 # CORS: Preprod allows the CloudFront dashboard domain and localhost for testing.
 # No wildcard allowed per security policy.

--- a/infrastructure/terraform/prod.tfvars
+++ b/infrastructure/terraform/prod.tfvars
@@ -23,10 +23,6 @@ watch_tags = "AI,climate,economy,health,sports"
 # Model Configuration
 model_version = "v1.0.0"
 
-# EventBridge Schedule
-# Run ingestion every 15 minutes for near-real-time analysis
-ingestion_schedule = "rate(15 minutes)"
-
 # Monitoring and Alerting
 alarm_email = "" # Set to production email or PagerDuty endpoint
 


### PR DESCRIPTION
## Summary
- Remove `lambda_memory_mb`, `lambda_timeout_seconds`, and `ingestion_schedule` from preprod.tfvars
- Remove `ingestion_schedule` from prod.tfvars
- These variables were set but never declared in the Terraform configuration, causing warnings

## Test plan
- [ ] Verify `terraform validate` passes
- [ ] Verify `terraform plan` shows no changes (variables had no effect)

🤖 Generated with [Claude Code](https://claude.com/claude-code)