### PR TITLE
fix(e2e): Update config generator to match API v2 ticker schema

### DIFF
--- a/tests/fixtures/synthetic/config_generator.py
+++ b/tests/fixtures/synthetic/config_generator.py
@@ -32,10 +32,14 @@ class SyntheticConfiguration:
     user_id: str
 
     def to_api_payload(self) -> dict:
-        """Convert to API request payload."""
+        """Convert to API request payload.
+
+        Note: API v2 expects tickers as simple string list, not objects.
+        The weight field is only used for internal test calculations.
+        """
         return {
             "name": self.name,
-            "tickers": [t.to_dict() for t in self.tickers],
+            "tickers": [t.symbol for t in self.tickers],
         }
 
 

--- a/tests/unit/fixtures/test_synthetic_generators.py
+++ b/tests/unit/fixtures/test_synthetic_generators.py
@@ -545,7 +545,10 @@ class TestConfigGenerator:
         assert name.startswith("My-Custom-Prefix-")
 
     def test_to_api_payload(self):
-        """Test SyntheticConfiguration.to_api_payload()."""
+        """Test SyntheticConfiguration.to_api_payload().
+
+        API v2 expects tickers as simple string list (not objects with weight).
+        """
         gen = create_config_generator()
         config = gen.generate_config("test-run-1", ticker_count=2)
         payload = config.to_api_payload()
@@ -553,7 +556,10 @@ class TestConfigGenerator:
         assert "name" in payload
         assert "tickers" in payload
         assert len(payload["tickers"]) == 2
-        assert all("symbol" in t and "weight" in t for t in payload["tickers"])
+        # API v2 expects simple strings, not objects
+        assert all(isinstance(t, str) for t in payload["tickers"])
+        # Verify tickers match the symbols from the config
+        assert payload["tickers"] == [t.symbol for t in config.tickers]
 
 
 class TestOracleApiSentiment:


### PR DESCRIPTION
## Summary
- Fix E2E test config generator to send tickers as simple strings instead of objects
- Update unit test to verify new payload format
- This fixes 5 failing E2E tests in preprod

## Root Cause
The API v2 `ConfigurationCreate` model expects:
```python
tickers: list[str] = Field(..., max_length=5)  # ["GOOGL", "NVDA"]
```

But the test generator was sending:
```python
tickers: [{"symbol": "GOOGL", "weight": 0.47}, ...]  # objects
```

## Test plan
- [x] Unit tests pass locally (1303 passed)
- [x] Black formatting verified
- [ ] CI pipeline passes
- [ ] E2E tests in preprod pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)