### PR TITLE
fix(iam): Add S3 accelerate and budgets tagging permissions for CI deployer

### DIFF
--- a/infrastructure/terraform/ci-user-policy.tf
+++ b/infrastructure/terraform/ci-user-policy.tf
@@ -498,7 +498,9 @@ data "aws_iam_policy_document" "ci_deploy_storage" {
       "s3:GetLifecycleConfiguration",
       "s3:PutLifecycleConfiguration",
       "s3:GetBucketAcl",
-      "s3:PutBucketAcl"
+      "s3:PutBucketAcl",
+      "s3:GetAccelerateConfiguration",
+      "s3:PutAccelerateConfiguration"
     ]
     resources = [
       "arn:aws:s3:::sentiment-analyzer-*",
@@ -626,7 +628,10 @@ data "aws_iam_policy_document" "ci_deploy_storage" {
       "budgets:DeleteBudget",
       "budgets:ViewBudget",
       "budgets:DescribeBudgets",
-      "budgets:DescribeBudgetActionsForBudget"
+      "budgets:DescribeBudgetActionsForBudget",
+      "budgets:TagResource",
+      "budgets:UntagResource",
+      "budgets:ListTagsForResource"
     ]
     resources = ["*"]
   }


### PR DESCRIPTION
## Summary
- Add `s3:GetAccelerateConfiguration` and `s3:PutAccelerateConfiguration` to CI deployer S3 permissions
- Add `budgets:TagResource`, `budgets:UntagResource`, and `budgets:ListTagsForResource` to CI deployer budgets permissions

## Root Cause
Deploy to Preprod failed with:
```
Error: reading S3 Bucket accelerate configuration: AccessDenied
Error: listing tags for Budgets Budget: AccessDeniedException
```

Terraform requires these permissions during state refresh.

## Test plan
- [ ] CI pipeline passes
- [ ] Deploy to Preprod succeeds
- [ ] E2E tests run

🤖 Generated with [Claude Code](https://claude.com/claude-code)