### PR TITLE
fix(iam): Add additional S3 bucket read permissions for Terraform state refresh

### DIFF
--- a/infrastructure/terraform/ci-user-policy.tf
+++ b/infrastructure/terraform/ci-user-policy.tf
@@ -500,7 +500,13 @@ data "aws_iam_policy_document" "ci_deploy_storage" {
       "s3:GetBucketAcl",
       "s3:PutBucketAcl",
       "s3:GetAccelerateConfiguration",
-      "s3:PutAccelerateConfiguration"
+      "s3:PutAccelerateConfiguration",
+      "s3:GetBucketRequestPayment",
+      "s3:GetBucketLogging",
+      "s3:GetBucketNotification",
+      "s3:GetReplicationConfiguration",
+      "s3:GetBucketObjectLockConfiguration",
+      "s3:GetBucketOwnershipControls"
     ]
     resources = [
       "arn:aws:s3:::sentiment-analyzer-*",


### PR DESCRIPTION
## Summary
- Add additional S3 bucket read permissions for Terraform AWS provider state refresh

## Permissions Added
- `s3:GetBucketRequestPayment`
- `s3:GetBucketLogging`
- `s3:GetBucketNotification`
- `s3:GetReplicationConfiguration`
- `s3:GetBucketObjectLockConfiguration`
- `s3:GetBucketOwnershipControls`

## Root Cause
Terraform AWS provider reads all S3 bucket attributes during state refresh, not just the ones explicitly configured. When any Get* permission is missing, `terraform plan` fails with AccessDenied.

## Notes
- AWS policy has already been manually updated to v8 via AWS CLI
- This PR keeps Terraform code in sync with AWS state

🤖 Generated with [Claude Code](https://claude.com/claude-code)