### PR TITLE
fix(iam): Add S3 object tagging and CloudWatch Logs tagging permissions

### DIFF
--- a/.claude/commands/iam-audit.md
+++ b/.claude/commands/iam-audit.md
@@ -159,7 +159,8 @@ s3:GetBucketOwnershipControls,
 
 # Object operations
 s3:PutObject, s3:GetObject, s3:DeleteObject, s3:ListBucket,
-s3:GetObjectAcl, s3:PutObjectAcl
+s3:GetObjectAcl, s3:PutObjectAcl,
+s3:GetObjectTagging, s3:PutObjectTagging
 ```
 
 #### Cognito User Pools
@@ -196,7 +197,7 @@ cloudwatch:TagResource, cloudwatch:UntagResource
 logs:CreateLogGroup, logs:DeleteLogGroup, logs:DescribeLogGroups,
 logs:PutRetentionPolicy, logs:DeleteRetentionPolicy,
 logs:PutMetricFilter, logs:DeleteMetricFilter, logs:DescribeMetricFilters,
-logs:TagLogGroup, logs:UntagLogGroup
+logs:TagLogGroup, logs:UntagLogGroup, logs:ListTagsForResource
 ```
 
 #### CloudFront

--- a/infrastructure/terraform/ci-user-policy.tf
+++ b/infrastructure/terraform/ci-user-policy.tf
@@ -227,6 +227,7 @@ data "aws_iam_policy_document" "ci_deploy_monitoring" {
       "logs:TagLogGroup",
       "logs:UntagLogGroup",
       "logs:ListTagsLogGroup",
+      "logs:ListTagsForResource",
       "logs:PutMetricFilter",
       "logs:DeleteMetricFilter",
       "logs:DescribeMetricFilters"
@@ -524,7 +525,9 @@ data "aws_iam_policy_document" "ci_deploy_storage" {
       "s3:DeleteObject",
       "s3:ListBucket",
       "s3:GetObjectAcl",
-      "s3:PutObjectAcl"
+      "s3:PutObjectAcl",
+      "s3:GetObjectTagging",
+      "s3:PutObjectTagging"
     ]
     resources = [
       "arn:aws:s3:::sentiment-analyzer-*",


### PR DESCRIPTION
## Summary
- Add `s3:GetObjectTagging`, `s3:PutObjectTagging` for S3 object tagging
- Add `logs:ListTagsForResource` for CloudWatch Logs tagging
- Update `/iam-audit` checklist with these permissions

## Context
Deploy pipeline failed with errors:
```
s3:GetObjectTagging on resource: ".../ticker-cache/us-symbols.json"
logs:ListTagsForResource on resource: ".../log-group:/aws/lambda/preprod-sentiment-metrics"
```

These permissions are required by Terraform AWS provider during state refresh.

**IAM policies already bootstrapped via AWS CLI** - This PR syncs Terraform code with the live AWS policies.

## Test plan
- [x] AWS policies updated via CLI (CIDeployStorage v9, CIDeployMonitoring v5)
- [ ] Deploy pipeline passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)