### PR TITLE
fix(iam): Add DynamoDB data ops and DescribeLogStreams for integration tests

### DIFF
--- a/.claude/commands/iam-audit.md
+++ b/.claude/commands/iam-audit.md
@@ -126,11 +126,15 @@ apigateway:TagResource, apigateway:UntagResource
 
 #### DynamoDB
 ```
+# Table management
 dynamodb:CreateTable, dynamodb:UpdateTable, dynamodb:DeleteTable,
 dynamodb:DescribeTable, dynamodb:ListTables,
 dynamodb:DescribeTimeToLive, dynamodb:UpdateTimeToLive,
 dynamodb:DescribeContinuousBackups, dynamodb:UpdateContinuousBackups,
-dynamodb:TagResource, dynamodb:UntagResource, dynamodb:ListTagsOfResource
+dynamodb:TagResource, dynamodb:UntagResource, dynamodb:ListTagsOfResource,
+
+# Data operations (needed for integration tests)
+dynamodb:PutItem, dynamodb:GetItem, dynamodb:Query, dynamodb:Scan, dynamodb:DeleteItem
 ```
 
 #### S3
@@ -194,7 +198,7 @@ cloudwatch:PutMetricAlarm, cloudwatch:DeleteAlarms, cloudwatch:DescribeAlarms,
 cloudwatch:PutDashboard, cloudwatch:DeleteDashboards, cloudwatch:GetDashboard,
 cloudwatch:ListDashboards, cloudwatch:ListMetrics, cloudwatch:GetMetricStatistics,
 cloudwatch:TagResource, cloudwatch:UntagResource
-logs:CreateLogGroup, logs:DeleteLogGroup, logs:DescribeLogGroups,
+logs:CreateLogGroup, logs:DeleteLogGroup, logs:DescribeLogGroups, logs:DescribeLogStreams,
 logs:PutRetentionPolicy, logs:DeleteRetentionPolicy,
 logs:PutMetricFilter, logs:DeleteMetricFilter, logs:DescribeMetricFilters,
 logs:TagLogGroup, logs:UntagLogGroup, logs:ListTagsForResource

--- a/infrastructure/terraform/ci-user-policy.tf
+++ b/infrastructure/terraform/ci-user-policy.tf
@@ -92,7 +92,13 @@ data "aws_iam_policy_document" "ci_deploy_core" {
       "dynamodb:UpdateContinuousBackups",
       "dynamodb:TagResource",
       "dynamodb:UntagResource",
-      "dynamodb:ListTagsOfResource"
+      "dynamodb:ListTagsOfResource",
+      # Data operations needed for integration tests
+      "dynamodb:PutItem",
+      "dynamodb:GetItem",
+      "dynamodb:Query",
+      "dynamodb:Scan",
+      "dynamodb:DeleteItem"
     ]
     resources = ["*"]
   }
@@ -222,6 +228,7 @@ data "aws_iam_policy_document" "ci_deploy_monitoring" {
       "logs:CreateLogGroup",
       "logs:DeleteLogGroup",
       "logs:DescribeLogGroups",
+      "logs:DescribeLogStreams",
       "logs:PutRetentionPolicy",
       "logs:DeleteRetentionPolicy",
       "logs:TagLogGroup",


### PR DESCRIPTION
## Summary
- Adds missing DynamoDB data operations (PutItem, GetItem, Query, Scan, DeleteItem) to CI deployer policy
- Adds logs:DescribeLogStreams permission for CloudWatch log verification
- Updates iam-audit.md checklist with these permissions

## Root Cause
Terraform was overwriting AWS CLI policy changes during deploy, removing the DynamoDB data operations and DescribeLogStreams permissions that were added manually. This caused integration tests to fail with AccessDenied errors.

## Test plan
- [ ] Deploy pipeline passes (no IAM permission errors)
- [ ] Integration tests pass (can write/read DynamoDB, can describe log streams)

🤖 Generated with [Claude Code](https://claude.com/claude-code)