### PR TITLE
fix(iam): Add dynamodb:UpdateItem permission for CI deployer

### DIFF
--- a/.claude/commands/iam-audit.md
+++ b/.claude/commands/iam-audit.md
@@ -134,7 +134,7 @@ dynamodb:DescribeContinuousBackups, dynamodb:UpdateContinuousBackups,
 dynamodb:TagResource, dynamodb:UntagResource, dynamodb:ListTagsOfResource,
 
 # Data operations (needed for integration tests)
-dynamodb:PutItem, dynamodb:GetItem, dynamodb:Query, dynamodb:Scan, dynamodb:DeleteItem
+dynamodb:PutItem, dynamodb:GetItem, dynamodb:UpdateItem, dynamodb:Query, dynamodb:Scan, dynamodb:DeleteItem
 ```
 
 #### S3

--- a/infrastructure/terraform/ci-user-policy.tf
+++ b/infrastructure/terraform/ci-user-policy.tf
@@ -96,6 +96,7 @@ data "aws_iam_policy_document" "ci_deploy_core" {
       # Data operations needed for integration tests
       "dynamodb:PutItem",
       "dynamodb:GetItem",
+      "dynamodb:UpdateItem",
       "dynamodb:Query",
       "dynamodb:Scan",
       "dynamodb:DeleteItem"


### PR DESCRIPTION
## Summary
- Adds missing `dynamodb:UpdateItem` permission to CI deployer IAM policy
- Updates IAM audit checklist to include UpdateItem in data operations

## Context
Integration tests were failing with `AccessDeniedException` because the CI deployer policy was missing `dynamodb:UpdateItem`. PR #222 added `PutItem`, `GetItem`, `Query`, `Scan`, and `DeleteItem` but forgot `UpdateItem`.

Error observed:
```
AccessDeniedException: User: arn:aws:iam::218795110243:user/sentiment-analyzer-preprod-deployer 
is not authorized to perform: dynamodb:UpdateItem on resource: 
arn:aws:dynamodb:us-east-1:218795110243:table/preprod-sentiment-items
```

## Test plan
- [ ] Unit tests pass
- [ ] Deploy to preprod succeeds
- [ ] Integration tests pass (no more UpdateItem AccessDeniedException)

🤖 Generated with [Claude Code](https://claude.com/claude-code)