### PR TITLE
fix(dashboard): Fix ticker cache validate() tuple unpacking

### DIFF
--- a/src/lambdas/dashboard/configurations.py
+++ b/src/lambdas/dashboard/configurations.py
@@ -608,14 +608,14 @@ def _validate_ticker(symbol: str, ticker_cache: Any | None) -> Ticker | None:
 
     # If we have a ticker cache, validate against it
     if ticker_cache:
-        validation = ticker_cache.validate(symbol)
-        if validation.get("status") != "valid":
+        status, ticker_info = ticker_cache.validate(symbol)
+        if status != "valid":
             return None
 
         return Ticker(
             symbol=symbol,
-            name=validation.get("name"),
-            exchange=validation.get("exchange", "NASDAQ"),
+            name=ticker_info.name if ticker_info else f"{symbol} Inc",
+            exchange=ticker_info.exchange if ticker_info else "NASDAQ",
             added_at=datetime.now(UTC),
         )
 


### PR DESCRIPTION
## Summary
- Fixes the `ticker_cache.validate()` return value handling
- The method returns a tuple `(status, ticker_info)`, not a dict
- The code was calling `.get()` on a tuple, causing `AttributeError`

## Context
Preprod integration tests were failing because config creation was returning 500 errors.

CloudWatch logs showed:
```
AttributeError: 'tuple' object has no attribute 'get'
```

The bug was in `_validate_ticker()` which expected `ticker_cache.validate()` to return a dict, but it returns a tuple.

## Test plan
- [x] All 16 configuration unit tests pass locally
- [ ] Unit tests pass in CI
- [ ] Preprod integration tests pass (config creation no longer returns 500)

🤖 Generated with [Claude Code](https://claude.com/claude-code)