### PR TITLE
fix(e2e): Add X-Auth-Type header support for authenticated tests

### DIFF
--- a/tests/e2e/helpers/api_client.py
+++ b/tests/e2e/helpers/api_client.py
@@ -36,6 +36,7 @@ class PreprodAPIClient:
         self.timeout = timeout
         self._client: httpx.AsyncClient | None = None
         self._access_token: str | None = None
+        self._auth_type: str | None = None
         self._last_trace_id: str | None = None
         self._last_request_id: str | None = None
 
@@ -57,9 +58,18 @@ class PreprodAPIClient:
         """Set the access token for authenticated requests."""
         self._access_token = token
 
+    def set_auth_type(self, auth_type: str) -> None:
+        """Set the auth type for authenticated requests.
+
+        Args:
+            auth_type: Authentication type (e.g., 'email', 'oauth', 'anonymous')
+        """
+        self._auth_type = auth_type
+
     def clear_access_token(self) -> None:
         """Clear the access token (for testing unauthenticated endpoints)."""
         self._access_token = None
+        self._auth_type = None
 
     @property
     def last_trace_id(self) -> str | None:
@@ -79,11 +89,17 @@ class PreprodAPIClient:
         The API v2 router uses X-User-ID header for user identification,
         not Authorization: Bearer. The access_token is the user_id returned
         from the anonymous session creation endpoint.
+
+        X-Auth-Type header indicates the authentication method used
+        (e.g., 'email', 'oauth', 'anonymous').
         """
         headers: dict[str, str] = {}
         if self._access_token:
             # API v2 uses X-User-ID header for authentication
             headers["X-User-ID"] = self._access_token
+        if self._auth_type:
+            # API v2 uses X-Auth-Type to distinguish auth methods
+            headers["X-Auth-Type"] = self._auth_type
         if extra_headers:
             headers.update(extra_headers)
         return headers

--- a/tests/e2e/test_notifications.py
+++ b/tests/e2e/test_notifications.py
@@ -18,13 +18,20 @@ async def create_session_with_config(
     api_client: PreprodAPIClient,
     synthetic_config: SyntheticConfiguration,
 ) -> tuple[str, str]:
-    """Helper to create session and config."""
+    """Helper to create session and config.
+
+    Sets auth_type to 'email' to simulate authenticated user for
+    endpoints that require non-anonymous authentication.
+    """
     session_response = await api_client.post("/api/v2/auth/anonymous", json={})
     # API returns 201 Created for new sessions (correct HTTP semantics)
     assert session_response.status_code in (200, 201)
     token = session_response.json()["token"]
 
     api_client.set_access_token(token)
+    # Set auth_type to simulate authenticated user
+    api_client.set_auth_type("email")
+
     config_response = await api_client.post(
         "/api/v2/configurations",
         json=synthetic_config.to_api_payload(),


### PR DESCRIPTION
## Summary
- Add `set_auth_type()` method to `PreprodAPIClient` for setting authentication type header
- Update `_build_headers()` to include `X-Auth-Type` header when set
- Update alert and notification tests to simulate authenticated users by setting auth_type='email'

## Problem
The API v2 router's `get_authenticated_user_id()` function checks the `X-Auth-Type` header and rejects anonymous users (403 Forbidden) for operations like alerts and notifications. The E2E tests were failing because the API client wasn't sending this header.

## Changes
- `tests/e2e/helpers/api_client.py`: Add `_auth_type` field, `set_auth_type()` method, update `_build_headers()` and `clear_access_token()`
- `tests/e2e/test_alerts.py`: Add `authenticated` parameter to helper, set to True by default for authenticated operations
- `tests/e2e/test_notifications.py`: Set `auth_type='email'` in session helper

## Test plan
- [ ] PR checks pass (formatting, linting, unit tests)
- [ ] Deploy to Preprod workflow succeeds
- [ ] Preprod Integration Tests pass without 403 errors on alert/notification endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)