### PR TITLE
fix(e2e): Update ticker pool to use valid preprod symbols

### DIFF
--- a/tests/fixtures/synthetic/config_generator.py
+++ b/tests/fixtures/synthetic/config_generator.py
@@ -51,6 +51,8 @@ class ConfigGenerator:
     weights, and user ID.
     """
 
+    # Tickers validated against preprod ticker cache (S3)
+    # Removed: UNH (not in preprod cache), V (single-char may have issues)
     TICKER_POOL: ClassVar[list[str]] = [
         "AAPL",
         "MSFT",
@@ -60,13 +62,13 @@ class ConfigGenerator:
         "NVDA",
         "TSLA",
         "JPM",
-        "V",
         "JNJ",
         "WMT",
         "PG",
-        "UNH",
         "HD",
         "DIS",
+        "NFLX",
+        "INTC",
     ]
 
     def __init__(self, seed: int = 42) -> None:


### PR DESCRIPTION
## Summary
- Remove UNH and V from synthetic test TICKER_POOL
- Add NFLX and INTC as replacements to maintain pool size

## Problem
`test_config_create_success` and `test_config_update_name_and_tickers` fail with 400 errors because UNH is not recognized by the preprod ticker cache loaded from S3.

## Test plan
- [ ] PR checks pass
- [ ] E2E tests pass without "Invalid ticker symbol: UNH" errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)