### PR TITLE
fix(e2e): Reduce ticker pool to only preprod-validated symbols

### DIFF
--- a/tests/fixtures/synthetic/config_generator.py
+++ b/tests/fixtures/synthetic/config_generator.py
@@ -52,7 +52,10 @@ class ConfigGenerator:
     """
 
     # Tickers validated against preprod ticker cache (S3)
-    # Removed: UNH (not in preprod cache), V (single-char may have issues)
+    # Only includes tickers confirmed to work in preprod E2E tests:
+    # - AAPL, MSFT, GOOGL confirmed via test_valid_ticker_returns_metadata
+    # - AMZN, NVDA, META, TSLA used in traffic_generator.py
+    # Removed: UNH, V, INTC, DIS, JPM, JNJ, WMT, PG, HD, NFLX (not in preprod cache)
     TICKER_POOL: ClassVar[list[str]] = [
         "AAPL",
         "MSFT",
@@ -61,14 +64,6 @@ class ConfigGenerator:
         "META",
         "NVDA",
         "TSLA",
-        "JPM",
-        "JNJ",
-        "WMT",
-        "PG",
-        "HD",
-        "DIS",
-        "NFLX",
-        "INTC",
     ]
 
     def __init__(self, seed: int = 42) -> None:


### PR DESCRIPTION
## Summary

- Reduced ConfigGenerator TICKER_POOL from 15 to 7 symbols
- Removed: JPM, JNJ, WMT, PG, HD, DIS, NFLX, INTC (not in preprod cache)
- Kept: AAPL, MSFT, GOOGL, AMZN, META, NVDA, TSLA (validated in preprod E2E)

## Problem

E2E tests were failing with errors like:
```
AssertionError: Config create failed: 400 - {"detail":"Invalid ticker symbol: INTC"}
```

The ConfigGenerator was producing configurations with tickers that don't exist in preprod's ticker cache.

## Test plan

- [ ] Verify `test_config_create_success` passes
- [ ] Verify `test_config_update_name_and_tickers` passes
- [ ] Verify `test_config_max_limit_enforced` passes
- [ ] Full E2E test suite runs without ticker validation errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)