### PR TITLE
fix(api): Fix notification list parameter name mismatch

### DIFF
--- a/src/lambdas/dashboard/router_v2.py
+++ b/src/lambdas/dashboard/router_v2.py
@@ -1027,7 +1027,7 @@ async def list_notifications(
         user_id=user_id,
         limit=limit,
         offset=offset,
-        status_filter=status,
+        status=status,
         alert_id=alert_id,
     )
     return JSONResponse(result.model_dump())


### PR DESCRIPTION
## Summary

- Fixed `status_filter=status` -> `status=status` in notification list endpoint

## Problem

The router was passing an unexpected keyword argument to the service:
```python
# Router was calling:
notification_service.list_notifications(..., status_filter=status, ...)

# But service expects:
def list_notifications(..., status=None, ...):
```

This caused TypeError -> 500 errors on `GET /api/v2/notifications`.

## Test plan

- [ ] `test_notification_list` passes
- [ ] `test_alert_trigger_creates_notification` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)