### PR TITLE
fix(api): Add alert response field mapping and fix GET 404 handling

### DIFF
--- a/src/lambdas/dashboard/router_v2.py
+++ b/src/lambdas/dashboard/router_v2.py
@@ -778,6 +778,10 @@ async def update_config_alert(
     response_data = result.model_dump()
     if "is_enabled" in response_data:
         response_data["enabled"] = response_data["is_enabled"]
+    if "threshold_value" in response_data:
+        response_data["threshold"] = response_data["threshold_value"]
+    if "threshold_direction" in response_data:
+        response_data["condition"] = response_data["threshold_direction"]
     return JSONResponse(response_data)
 
 
@@ -918,6 +922,8 @@ async def get_alert(
         user_id=user_id,
         alert_id=alert_id,
     )
+    if result is None:
+        raise HTTPException(status_code=404, detail="Alert not found")
     if isinstance(result, alert_service.ErrorResponse):
         raise HTTPException(status_code=404, detail=result.error.message)
     return JSONResponse(result.model_dump())
@@ -946,6 +952,10 @@ async def update_alert(
     response_data = result.model_dump()
     if "is_enabled" in response_data:
         response_data["enabled"] = response_data["is_enabled"]
+    if "threshold_value" in response_data:
+        response_data["threshold"] = response_data["threshold_value"]
+    if "threshold_direction" in response_data:
+        response_data["condition"] = response_data["threshold_direction"]
     return JSONResponse(response_data)
 
 


### PR DESCRIPTION
## Summary
- Add `threshold_value` -> `threshold` mapping in update_alert responses
- Add `threshold_direction` -> `condition` mapping in update_alert responses
- Fix `get_alert` to return 404 (not 500) when alert not found
- Apply same fixes to both standalone and config-scoped alert endpoints

## Test plan
- [ ] Run preprod E2E tests
- [ ] Verify `test_alert_update_threshold` passes
- [ ] Verify `test_alert_delete` passes (GET returns 404 after deletion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)