### PR TITLE
fix(e2e): Add session validation and fix DynamoDB key case

### DIFF
--- a/tests/e2e/test_failure_injection.py
+++ b/tests/e2e/test_failure_injection.py
@@ -159,11 +159,11 @@ async def test_circuit_breaker_opens_on_failures(
     """
     try:
         # Query DynamoDB for circuit breaker state
-        # Circuit breaker items have pk="CB#{service}" sk="STATE"
+        # Circuit breaker items have PK="CB#{service}" SK="STATE"
         response = dynamodb_table.get_item(
             Key={
-                "pk": "CB#tiingo",
-                "sk": "STATE",
+                "PK": "CB#tiingo",
+                "SK": "STATE",
             }
         )
 


### PR DESCRIPTION
## Summary
- Add session validation to `get_user_id_from_request` in router_v2.py to check `session_expires_at` before allowing access to protected endpoints
- Fix test_failure_injection.py to use uppercase `PK`/`SK` keys matching DynamoDB single-table design convention

## Problem
The preprod E2E tests were failing with:
1. **test_signout_invalidates_session**: Token not invalidated after signout (200 instead of 401)
2. **test_circuit_breaker_opens_on_failures**: DynamoDB ValidationException due to key case mismatch

## Root Cause
1. `get_user_id_from_request()` extracted the user ID from headers but did not validate that the session was still active (not expired/signed out)
2. E2E test used lowercase `pk`/`sk` but DynamoDB schema uses uppercase `PK`/`SK`

## Solution
1. Enhanced `get_user_id_from_request()` to optionally validate session by calling `auth_service.validate_session()` which checks `session_expires_at`
2. Updated `list_configurations` endpoint to pass the DynamoDB table for session validation
3. Fixed DynamoDB key case in test_failure_injection.py

## Test plan
- [x] All unit tests pass (1303 passed)
- [ ] CI pipeline passes
- [ ] Preprod E2E tests pass for `test_signout_invalidates_session`
- [ ] Preprod E2E tests pass for `test_circuit_breaker_opens_on_failures`

🤖 Generated with [Claude Code](https://claude.com/claude-code)