### PR TITLE
fix(alerts): Use ReturnValues=ALL_NEW to fix flaky E2E test

### DIFF
--- a/tests/unit/test_alerts.py
+++ b/tests/unit/test_alerts.py
@@ -374,15 +374,14 @@ class TestUpdateAlert:
     ):
         """Updates alert threshold value."""
         alert_id = sample_alert_item["alert_id"]
+        # get_item is called once to check existing alert
         mock_table.get_item.return_value = {"Item": sample_alert_item}
 
         request = AlertUpdateRequest(threshold_value=-0.5)
 
-        # First call for existing check, second for updated result
-        mock_table.get_item.side_effect = [
-            {"Item": sample_alert_item},
-            {"Item": {**sample_alert_item, "threshold_value": "-0.5"}},
-        ]
+        # update_item now returns the updated attributes with ReturnValues='ALL_NEW'
+        updated_item = {**sample_alert_item, "threshold_value": "-0.5"}
+        mock_table.update_item.return_value = {"Attributes": updated_item}
 
         result = update_alert(mock_table, user_id, alert_id, request)
 
@@ -395,16 +394,19 @@ class TestUpdateAlert:
     ):
         """Updates alert enabled status."""
         alert_id = sample_alert_item["alert_id"]
-        mock_table.get_item.side_effect = [
-            {"Item": sample_alert_item},
-            {"Item": {**sample_alert_item, "is_enabled": False}},
-        ]
+        # get_item is called once to check existing alert
+        mock_table.get_item.return_value = {"Item": sample_alert_item}
 
         request = AlertUpdateRequest(is_enabled=False)
+
+        # update_item now returns the updated attributes with ReturnValues='ALL_NEW'
+        updated_item = {**sample_alert_item, "is_enabled": False}
+        mock_table.update_item.return_value = {"Attributes": updated_item}
 
         result = update_alert(mock_table, user_id, alert_id, request)
 
         assert isinstance(result, AlertResponse)
+        assert result.is_enabled is False
         mock_table.update_item.assert_called_once()
 
     @patch("src.lambdas.dashboard.alerts.xray_recorder")


### PR DESCRIPTION
## Summary
- Fixed flaky `test_alert_toggle_off` E2E test caused by DynamoDB eventual consistency
- Modified `update_alert()` to use `ReturnValues='ALL_NEW'` instead of separate `get_alert()` call after update
- Updated unit tests to mock the new response format

## Root Cause
The `update_alert` function was calling `get_alert()` after `update_item()` to return the updated alert. This second read operation was subject to DynamoDB's eventual consistency, occasionally returning stale data where `is_enabled` was still `True` after being set to `False`.

Two E2E runs from the same commit at the same time demonstrated this:
- Run 19805990255: Test failed - `enabled: True` returned after update to `False`
- Run 19805990260: Test passed - correct value returned

## Fix
Use `ReturnValues='ALL_NEW'` in the `update_item` DynamoDB call, which returns the updated item directly from the write operation. This eliminates the read-after-write consistency window.

## Test plan
- [x] Unit tests updated and passing (33 tests)
- [ ] PR checks pass
- [ ] E2E test_alert_toggle_off consistently passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)