### PR TITLE
fix(cors): Enable interview demo from local file:// protocol

### DIFF
--- a/src/lambdas/dashboard/handler.py
+++ b/src/lambdas/dashboard/handler.py
@@ -130,8 +130,14 @@ def get_cors_origins() -> list[str]:
 
     # Default: environment-based CORS (dev/test only)
     if ENVIRONMENT in ("dev", "test", "preprod"):
-        # Allow localhost for local development and preprod testing
-        return ["http://localhost:3000", "http://127.0.0.1:3000"]
+        # Allow localhost for local development, preprod testing, and file:// for interview demo
+        # "null" origin is sent by browsers when opening HTML files via file:// protocol
+        return [
+            "http://localhost:3000",
+            "http://127.0.0.1:3000",
+            "http://localhost:8080",
+            "null",
+        ]
     else:
         # Production: no defaults, must be explicitly configured via CORS_ORIGINS
         logger.error(
@@ -198,8 +204,8 @@ if cors_origins:
         CORSMiddleware,
         allow_origins=cors_origins,
         allow_credentials=False,  # Not needed for Bearer token auth
-        allow_methods=["GET", "OPTIONS"],
-        allow_headers=["Authorization", "Content-Type"],
+        allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
+        allow_headers=["Authorization", "Content-Type", "X-User-ID", "X-Auth-Type"],
     )
     logger.info(
         "CORS configured",


### PR DESCRIPTION
## Summary
- Fixed CORS configuration to allow the interview demo kit to work when opened as a local file
- Added `null` origin support for `file://` protocol
- Expanded allowed HTTP methods and headers for full API access

## Problem
The interview demo (`interview/index.html`) shows "Error: Failed to fetch" when trying to execute API calls because:
1. Browsers send `null` as the Origin header for `file://` URLs
2. CORS only allowed `GET` and `OPTIONS` methods, but POST is needed for anonymous session creation
3. Required headers `X-User-ID` and `X-Auth-Type` were not in the allowed list

## Fix
Updated `get_cors_origins()` and CORS middleware configuration:
- Added `"null"` to allowed origins for file:// access
- Added `http://localhost:8080` for local HTTP server option
- Expanded methods: `GET, POST, PUT, PATCH, DELETE, OPTIONS`
- Added headers: `X-User-ID, X-Auth-Type`

## Test plan
- [ ] PR checks pass
- [ ] Open `interview/index.html` directly in browser after deploy
- [ ] Click "Execute" on anonymous session - should work

🤖 Generated with [Claude Code](https://claude.com/claude-code)