### PR TITLE
fix(cors): Add GitHub Pages origin for interview demo hosting

### DIFF
--- a/src/lambdas/dashboard/handler.py
+++ b/src/lambdas/dashboard/handler.py
@@ -132,10 +132,12 @@ def get_cors_origins() -> list[str]:
     if ENVIRONMENT in ("dev", "test", "preprod"):
         # Allow localhost for local development, preprod testing, and file:// for interview demo
         # "null" origin is sent by browsers when opening HTML files via file:// protocol
+        # GitHub Pages hosts the interview demo for external access
         return [
             "http://localhost:3000",
             "http://127.0.0.1:3000",
             "http://localhost:8080",
+            "https://traylorre.github.io",
             "null",
         ]
     else:


### PR DESCRIPTION
## Summary
- Adds `https://traylorre.github.io` to CORS allowed origins in dev/test/preprod
- Enables hosting the interview demo on GitHub Pages for external access
- Proper separation of concerns: static demo content on Pages, API on Lambda

## Background
The interview demo kit (`interview/`) needs to make cross-origin requests to the preprod API. Rather than deploying the demo as a Lambda endpoint or S3 static site, GitHub Pages provides the cleanest separation of concerns for documentation/demo content.

## Test plan
- [ ] CI passes (linting, unit tests)
- [ ] After deploy, verify interview demo can call preprod API from `https://traylorre.github.io`

## Next steps for user
After this PR is merged and deployed:
1. Go to repo Settings → Pages
2. Set Source to "Deploy from a branch" 
3. Select `main` branch, `/ (root)` folder
4. Save - the interview demo will be accessible at `https://traylorre.github.io/sentiment-analyzer-gsk/interview/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)