### PR TITLE
fix(cors): Add GitHub Pages to Lambda Function URL CORS config

### DIFF
--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -395,8 +395,8 @@ module "dashboard_lambda" {
   function_url_auth_type = "NONE"
   function_url_cors = {
     allow_credentials = false
-    allow_headers     = ["content-type", "authorization", "x-api-key"]
-    allow_methods     = ["GET"] # AWS handles OPTIONS preflight automatically; not in allowed values
+    allow_headers     = ["content-type", "authorization", "x-api-key", "x-user-id", "x-auth-type"]
+    allow_methods     = ["GET", "POST", "PUT", "PATCH", "DELETE"] # AWS handles OPTIONS preflight automatically
     # SECURITY: Require explicit origins - no wildcard fallback
     # For new deployments, cors_allowed_origins MUST be set in tfvars
     allow_origins = length(var.cors_allowed_origins) > 0 ? var.cors_allowed_origins : (

--- a/infrastructure/terraform/preprod.tfvars
+++ b/infrastructure/terraform/preprod.tfvars
@@ -19,10 +19,11 @@ tags = {
 # in the Terraform modules with environment-appropriate defaults.
 # DynamoDB uses on-demand billing (no reserved capacity).
 
-# CORS: Preprod allows the CloudFront dashboard domain and localhost for testing.
+# CORS: Preprod allows the CloudFront dashboard domain, GitHub Pages, and localhost for testing.
 # No wildcard allowed per security policy.
 cors_allowed_origins = [
   "https://d2z9uvoj5xlbd2.cloudfront.net", # CloudFront dashboard
+  "https://traylorre.github.io",           # GitHub Pages interview demo
   "http://localhost:3000",                 # Local development
   "http://localhost:8080"                  # Alternative local dev
 ]


### PR DESCRIPTION
## Summary
Fixes the interview demo "Failed to fetch" error when calling the API from GitHub Pages.

## Root Cause
The **Lambda Function URL** has its own CORS configuration at the AWS level (Terraform), separate from the FastAPI CORS middleware in Python code. The AWS-level CORS was:
1. **Missing POST method** - only `GET` was in `allow_methods`
2. **Missing GitHub Pages origin** - `https://traylorre.github.io` not in `allow_origins`

## Changes
- **main.tf**: Add all HTTP methods (`GET`, `POST`, `PUT`, `PATCH`, `DELETE`) to `allow_methods`
- **main.tf**: Add `x-user-id` and `x-auth-type` to `allow_headers`  
- **preprod.tfvars**: Add `https://traylorre.github.io` to `cors_allowed_origins`

## Why Two CORS Configs?
1. **Lambda Function URL CORS** (AWS/Terraform) - Handles browser preflight (OPTIONS) at the infrastructure level
2. **FastAPI CORSMiddleware** (Python) - Adds CORS headers to actual responses

Both need to be configured for cross-origin requests to work.

## Test plan
- [ ] CI passes
- [ ] After deploy, interview demo Execute button works from https://traylorre.github.io/sentiment-analyzer-gsk/interview/

🤖 Generated with [Claude Code](https://claude.com/claude-code)