### PR TITLE
fix(cors): Let Lambda Function URL handle CORS (remove app-level CORS)

### DIFF
--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -390,7 +390,8 @@ module "dashboard_lambda" {
   # Function URL with CORS
   # SECURITY: No wildcard fallback - require explicit origins
   # The Lambda Function URL CORS is for browser preflight checks
-  # The Python code handles actual CORS header validation
+  # Lambda Function URL handles ALL CORS - no app-level CORS headers needed
+  # This prevents duplicate Access-Control-Allow-Origin headers
   create_function_url    = true
   function_url_auth_type = "NONE"
   function_url_cors = {
@@ -403,7 +404,8 @@ module "dashboard_lambda" {
       # Only allow localhost in non-prod if no origins specified (for local development)
       var.environment != "prod" ? ["http://localhost:3000", "http://localhost:8080"] : []
     )
-    expose_headers = []
+    # Expose rate-limit and request tracking headers to frontend
+    expose_headers = ["x-ratelimit-limit", "x-ratelimit-remaining", "x-ratelimit-reset", "x-request-id", "retry-after"]
     max_age        = 86400
   }
 


### PR DESCRIPTION
## Summary

Fixes "Failed to fetch" error in interview dashboard by removing duplicate CORS headers.

## Root Cause

Lambda Function URL and the application code were both adding CORS headers, causing:
```
access-control-allow-origin: https://traylorre.github.io
access-control-allow-origin: https://traylorre.github.io
```

Browsers reject responses with duplicate `Access-Control-Allow-Origin` headers.

## Solution (Industry Best Practice)

Let Lambda Function URL handle ALL CORS:
- Preflight (OPTIONS) requests handled automatically by AWS (no Lambda invocation = cost savings)
- CORS headers added by AWS before Lambda code runs
- Single source of truth for CORS config (Terraform)

## Changes

| File | Change |
|------|--------|
| `infrastructure/terraform/main.tf` | Add `expose_headers` for rate-limit headers |
| `src/lambdas/shared/middleware/security_headers.py` | Remove CORS header generation (deprecated `get_cors_headers`) |
| `tests/unit/shared/middleware/test_security_headers.py` | Update tests to verify CORS headers NOT added |

## Test plan

- [x] All 36 security headers unit tests pass
- [x] Terraform validates successfully
- [ ] After deploy: Test anonymous auth from interview dashboard
- [ ] Verify no duplicate CORS headers in response

🤖 Generated with [Claude Code](https://claude.com/claude-code)