### PR TITLE
fix(interview): Use X-User-ID header for authenticated API calls

### DIFF
--- a/interview/index.html
+++ b/interview/index.html
@@ -1660,7 +1660,7 @@ infrastructure/terraform/modules/<br>
                 const response = await fetch(url, {
                     method,
                     headers: {
-                        'Authorization': `Bearer ${authToken}`,
+                        'X-User-ID': authToken,
                         'Content-Type': 'application/json'
                     }
                 });


### PR DESCRIPTION
## Summary
- Fix interview page to use `X-User-ID` header instead of `Authorization: Bearer` for v2 API calls
- The v2 endpoints expect user identification via `X-User-ID` header, not Bearer token

## Problem
After creating an anonymous session, calling `GET /api/v2/configurations` returned:
```json
{"detail": "Missing user identification"}
```

## Root Cause
The `callAuthenticatedAPI()` function was sending:
```js
headers: {
    'Authorization': `Bearer ${authToken}`,
    ...
}
```

But the v2 router expects:
```js
headers: {
    'X-User-ID': authToken,
    ...
}
```

## Test plan
- [ ] Create anonymous session on interview page
- [ ] Click "Execute" on configurations endpoint
- [ ] Verify it returns configurations list (not "Missing user identification")

🤖 Generated with [Claude Code](https://claude.com/claude-code)