### PR TITLE
fix(interview): Send tickers as string array, not objects

### DIFF
--- a/interview/index.html
+++ b/interview/index.html
@@ -909,7 +909,8 @@ by_tag: tag → timestamp</div>
                     </button>
                 </div>
                 <div class="api-demo-body">
-                    <div id="config-create-response" class="response-box">Creates a watchlist with AAPL, MSFT, NVDA</div>
+                    <pre style="margin-bottom: 8px; padding: 8px; background: var(--bg-secondary); border-radius: 4px; font-size: 12px; color: var(--text-secondary);">{"name": "Tech Watchlist", "tickers": ["AAPL", "MSFT", "NVDA"]}</pre>
+                    <div id="config-create-response" class="response-box">Click "Create Tech Watchlist" to create a configuration</div>
                 </div>
             </div>
 
@@ -1713,11 +1714,7 @@ infrastructure/terraform/modules/<br>
                     },
                     body: JSON.stringify({
                         name: 'Tech Watchlist',
-                        tickers: [
-                            { symbol: 'AAPL', weight: 0.4 },
-                            { symbol: 'MSFT', weight: 0.35 },
-                            { symbol: 'NVDA', weight: 0.25 }
-                        ]
+                        tickers: ['AAPL', 'MSFT', 'NVDA']
                     })
                 });
                 const data = await response.json();


### PR DESCRIPTION
## Summary
Fix configuration creation API call to use correct payload format.

## Problem
Creating configuration failed with validation error:
```json
{
  "detail": [
    {
      "type": "string_type",
      "msg": "Input should be a valid string",
      "input": {"symbol": "AAPL", "weight": 0.4}
    }
  ]
}
```

## Root Cause
The `ConfigurationCreate` API expects `tickers` as `list[str]`:
```python
class ConfigurationCreate(BaseModel):
    name: str = Field(..., max_length=50)
    tickers: list[str] = Field(..., max_length=5)  # <-- strings!
```

But interview page was sending objects:
```json
{"tickers": [{"symbol": "AAPL", "weight": 0.4}, ...]}
```

## Fix
Changed to correct format:
```json
{"name": "Tech Watchlist", "tickers": ["AAPL", "MSFT", "NVDA"]}
```

## Test plan
- [ ] Click "Create Anonymous Session" → success
- [ ] Click "Create Tech Watchlist" → config created (returns config_id)
- [ ] Click "Get Sentiment" → returns sentiment data for tickers

🤖 Generated with [Claude Code](https://claude.com/claude-code)