### PR TITLE
feat(interview): Add price-sentiment overlay scenario to traffic generator

### DIFF
--- a/interview/README.md
+++ b/interview/README.md
@@ -39,7 +39,8 @@ Generates realistic traffic patterns to demonstrate system behavior.
 
 | Scenario | Command | What It Shows |
 |----------|---------|---------------|
-| Basic Flow | `--scenario basic` | Happy path: session → config → sentiment |
+| Basic Flow | `--scenario basic` | Happy path: session → config → sentiment + OHLC |
+| Price-Sentiment | `--scenario price-sentiment` | OHLC + historical sentiment with shape validation |
 | Cache Warmup | `--scenario cache` | Cold vs warm latency (~200ms → ~50ms) |
 | Load Test | `--scenario load` | Concurrent users, horizontal scaling |
 | Rate Limit | `--scenario rate-limit` | Burst traffic, 429 responses |

--- a/interview/index.html
+++ b/interview/index.html
@@ -1197,8 +1197,11 @@ by_tag: tag → timestamp</div>
                 <p style="color: var(--text-secondary); margin-bottom: 16px;">Run these commands from the <code style="background: var(--bg-primary); padding: 2px 6px; border-radius: 4px;">interview/</code> directory:</p>
 
                 <div class="code-block" style="margin-bottom: 16px;">
-<span class="comment"># Basic flow: session → config → sentiment</span>
+<span class="comment"># Basic flow: session → config → sentiment + OHLC</span>
 python3 traffic_generator.py --env preprod --scenario basic
+
+<span class="comment"># Price-Sentiment Overlay: OHLC + historical sentiment</span>
+python3 traffic_generator.py --env preprod --scenario price-sentiment
 
 <span class="comment"># Cache warmup: show latency improvement</span>
 python3 traffic_generator.py --env preprod --scenario cache
@@ -1220,6 +1223,9 @@ python3 traffic_generator.py --env preprod --scenario all
                     <button class="btn btn-secondary" onclick="copyCommand('python3 traffic_generator.py --env preprod --scenario basic')">
                         Copy "Basic Flow"
                     </button>
+                    <button class="btn btn-secondary" onclick="copyCommand('python3 traffic_generator.py --env preprod --scenario price-sentiment')">
+                        Copy "Price-Sentiment"
+                    </button>
                     <button class="btn btn-secondary" onclick="copyCommand('python3 traffic_generator.py --env preprod --scenario cache')">
                         Copy "Cache Test"
                     </button>
@@ -1233,7 +1239,16 @@ python3 traffic_generator.py --env preprod --scenario all
                         <div class="card-title">Basic Flow</div>
                     </div>
                     <div class="card-body">
-                        Creates session → Creates config with sample tickers → Lists configs → Fetches sentiment. Great for walking through the happy path.
+                        Creates session → Creates config → Lists configs → Fetches sentiment + OHLC + sentiment history. Great for walking through the happy path.
+                    </div>
+                </div>
+                <div class="card">
+                    <div class="card-header">
+                        <div class="card-icon purple">📈</div>
+                        <div class="card-title">Price-Sentiment Overlay</div>
+                    </div>
+                    <div class="card-body">
+                        Tests OHLC and sentiment history endpoints with multiple tickers (AAPL, MSFT, NVDA) and time ranges (1W, 1M, 3M). Validates response shapes.
                     </div>
                 </div>
                 <div class="card">


### PR DESCRIPTION
## Summary

- Add `get_ohlc()` and `get_sentiment_history()` methods for OHLC/sentiment API testing
- Add `price-sentiment` scenario that validates response shapes across multiple tickers
- Update basic flow to include OHLC and sentiment history calls
- Update dashboard and README with new scenario documentation

## Test plan

- [ ] Run `python3 interview/traffic_generator.py --env preprod --scenario price-sentiment` to validate OHLC/sentiment endpoint integration
- [ ] Verify dashboard shows new scenario in Traffic Generator section
- [ ] Confirm README documents the new scenario

🤖 Generated with [Claude Code](https://claude.com/claude-code)