### PR TITLE
chore(interview): Use python3 in traffic generator commands

### DIFF
--- a/interview/README.md
+++ b/interview/README.md
@@ -15,7 +15,7 @@ Interactive tools for demonstrating the Sentiment Analyzer architecture during t
 2. **Run Traffic Generator**
    ```bash
    cd interview
-   python traffic_generator.py --env preprod --scenario all
+   python3 traffic_generator.py --env preprod --scenario all
    ```
 
 ## Components
@@ -48,10 +48,10 @@ Generates realistic traffic patterns to demonstrate system behavior.
 **Example:**
 ```bash
 # Run all scenarios with verbose output
-python traffic_generator.py --env preprod --scenario all
+python3 traffic_generator.py --env preprod --scenario all
 
 # Custom load test
-python traffic_generator.py --env preprod --scenario load --users 10 --requests 20
+python3 traffic_generator.py --env preprod --scenario load --users 10 --requests 20
 ```
 
 ## Interview Flow (90 minutes)

--- a/interview/index.html
+++ b/interview/index.html
@@ -1198,29 +1198,29 @@ by_tag: tag → timestamp</div>
 
                 <div class="code-block" style="margin-bottom: 16px;">
 <span class="comment"># Basic flow: session → config → sentiment</span>
-python traffic_generator.py --env preprod --scenario basic
+python3 traffic_generator.py --env preprod --scenario basic
 
 <span class="comment"># Cache warmup: show latency improvement</span>
-python traffic_generator.py --env preprod --scenario cache
+python3 traffic_generator.py --env preprod --scenario cache
 
 <span class="comment"># Load test: 5 users, 10 requests each</span>
-python traffic_generator.py --env preprod --scenario load --users 5 --requests 10
+python3 traffic_generator.py --env preprod --scenario load --users 5 --requests 10
 
 <span class="comment"># Rate limit test: burst 50 requests</span>
-python traffic_generator.py --env preprod --scenario rate-limit
+python3 traffic_generator.py --env preprod --scenario rate-limit
 
 <span class="comment"># Run ALL scenarios</span>
-python traffic_generator.py --env preprod --scenario all
+python3 traffic_generator.py --env preprod --scenario all
                 </div>
 
                 <div style="display: flex; gap: 12px; flex-wrap: wrap;">
-                    <button class="btn btn-primary" onclick="copyCommand('python traffic_generator.py --env preprod --scenario all')">
+                    <button class="btn btn-primary" onclick="copyCommand('python3 traffic_generator.py --env preprod --scenario all')">
                         Copy "Run All"
                     </button>
-                    <button class="btn btn-secondary" onclick="copyCommand('python traffic_generator.py --env preprod --scenario basic')">
+                    <button class="btn btn-secondary" onclick="copyCommand('python3 traffic_generator.py --env preprod --scenario basic')">
                         Copy "Basic Flow"
                     </button>
-                    <button class="btn btn-secondary" onclick="copyCommand('python traffic_generator.py --env preprod --scenario cache')">
+                    <button class="btn btn-secondary" onclick="copyCommand('python3 traffic_generator.py --env preprod --scenario cache')">
                         Copy "Cache Test"
                     </button>
                 </div>

--- a/interview/traffic_generator.py
+++ b/interview/traffic_generator.py
@@ -11,9 +11,9 @@ Generates realistic traffic patterns to demonstrate:
 - Quota tracking
 
 Usage:
-    python traffic_generator.py --env preprod --scenario all
-    python traffic_generator.py --env preprod --scenario circuit-breaker
-    python traffic_generator.py --env preprod --scenario rate-limit
+    python3 traffic_generator.py --env preprod --scenario all
+    python3 traffic_generator.py --env preprod --scenario circuit-breaker
+    python3 traffic_generator.py --env preprod --scenario rate-limit
 """
 
 import argparse


### PR DESCRIPTION
## Summary
- Fix traffic generator commands to use `python3` instead of `python`

## Test plan
- [ ] Verify traffic generator commands work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)