### PR TITLE
fix(e2e): Convert cleanup_test_data fixture from async to sync

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -634,8 +634,8 @@ def calculate_ttl_timestamp(days: int = E2E_TEST_TTL_DAYS) -> int:
     return int((datetime.now(UTC) + timedelta(days=days)).timestamp())
 
 
-@pytest_asyncio.fixture(scope="session", autouse=True)
-async def cleanup_test_data(test_run_id: str) -> AsyncGenerator[None, None]:
+@pytest.fixture(scope="session", autouse=True)
+def cleanup_test_data(test_run_id: str) -> Generator[None, None, None]:
     """Log test run ID for reference (no auto-cleanup).
 
     Test data uses TTL-based expiration (7 days) instead of immediate cleanup.


### PR DESCRIPTION
## Summary
- Converted `cleanup_test_data` fixture from async to sync generator in `tests/e2e/conftest.py`
- The fixture was session-scoped async, but pytest-asyncio's `asyncio_default_fixture_loop_scope` is set to "function" in pyproject.toml
- This caused `ScopeMismatch` errors on ALL E2E tests (50+ failures)
- Since the fixture only prints and yields (no async operations), converting to sync fixes the scope mismatch

## Test plan
- [x] All 1411 unit tests pass locally
- [ ] CI pipeline E2E tests pass after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)