### PR TITLE
fix(e2e): Change api_client fixture from session to function scope

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -466,11 +466,12 @@ def generate_test_email(test_email_domain: str, username: str = "user") -> str:
     return f"{username}@{test_email_domain}"
 
 
-@pytest_asyncio.fixture(scope="session")
+@pytest_asyncio.fixture
 async def api_client() -> AsyncGenerator[PreprodAPIClient, None]:
     """Preprod API client for making HTTP requests.
 
-    Session-scoped to reuse connections across tests.
+    Function-scoped due to pytest-asyncio's asyncio_default_fixture_loop_scope=function.
+    httpx.AsyncClient is lightweight, so per-test creation is acceptable.
     """
     async with PreprodAPIClient() as client:
         yield client


### PR DESCRIPTION
## Summary
- Changed `api_client` async fixture from session-scoped to function-scoped
- The fixture was causing `ScopeMismatch` errors on 140+ E2E tests
- `asyncio_default_fixture_loop_scope=function` in pyproject.toml requires function-scoped async fixtures
- httpx.AsyncClient is lightweight, so per-test creation is acceptable

## Root Cause
Same issue as PR #270 - pytest-asyncio scope mismatch between session-scoped async fixtures and function-scoped event loop.

## Test plan
- [x] All 1411 unit tests pass locally
- [ ] CI pipeline E2E tests pass after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)