### PR TITLE
fix(e2e): Assert 201 status code across all E2E tests

### DIFF
--- a/tests/e2e/test_alerts.py
+++ b/tests/e2e/test_alerts.py
@@ -36,7 +36,7 @@ async def create_config_and_session(
     """
     session_response = await api_client.post("/api/v2/auth/anonymous", json={})
     # API returns 201 Created for new sessions (correct HTTP semantics)
-    assert session_response.status_code in (200, 201)
+    assert session_response.status_code == 201
     token = session_response.json()["token"]
 
     api_client.set_access_token(token)
@@ -52,7 +52,7 @@ async def create_config_and_session(
     if config_response.status_code == 500:
         api_client.clear_access_token()
         pytest.skip("Config creation endpoint returning 500 - API issue")
-    if config_response.status_code not in (200, 201):
+    if config_response.status_code != 201:
         api_client.clear_access_token()
         pytest.skip("Config creation not available")
 
@@ -179,7 +179,7 @@ async def test_alert_toggle_off(
         if create_response.status_code == 404:
             pytest.skip("Alerts endpoint not implemented")
 
-        assert create_response.status_code in (200, 201)
+        assert create_response.status_code == 201
         alert_id = create_response.json()["alert_id"]
 
         # Toggle off
@@ -230,7 +230,7 @@ async def test_alert_update_threshold(
         if create_response.status_code == 404:
             pytest.skip("Alerts endpoint not implemented")
 
-        assert create_response.status_code in (200, 201)
+        assert create_response.status_code == 201
         alert_id = create_response.json()["alert_id"]
 
         # Update threshold
@@ -279,7 +279,7 @@ async def test_alert_delete(
         if create_response.status_code == 404:
             pytest.skip("Alerts endpoint not implemented")
 
-        assert create_response.status_code in (200, 201)
+        assert create_response.status_code == 201
         alert_id = create_response.json()["alert_id"]
 
         # Delete alert
@@ -331,7 +331,7 @@ async def test_alert_max_limit_enforced(
             if response.status_code == 404:
                 pytest.skip("Alerts endpoint not implemented")
 
-            if response.status_code in (200, 201):
+            if response.status_code == 201:
                 created_alerts.append(response.json()["alert_id"])
             elif response.status_code in (400, 403, 429):
                 # Limit reached
@@ -392,7 +392,7 @@ async def test_alert_anonymous_forbidden(
             data = response.json()
             # Should indicate authentication required
             assert "error" in data or "message" in data or "detail" in data
-        elif response.status_code in (200, 201):
+        elif response.status_code == 201:
             # Anonymous alerts allowed - that's fine too
             pass
 

--- a/tests/e2e/test_anonymous_restrictions.py
+++ b/tests/e2e/test_anonymous_restrictions.py
@@ -130,7 +130,7 @@ async def test_anonymous_cannot_access_other_users_config(
 
     if config_response.status_code == 500:
         pytest.skip("Config creation endpoint returning 500 - API issue")
-    if config_response.status_code not in (200, 201):
+    if config_response.status_code != 201:
         pytest.skip("Config creation not available")
 
     config_id = config_response.json()["config_id"]
@@ -179,7 +179,7 @@ async def test_anonymous_cannot_modify_other_users_config(
 
     if config_response.status_code == 500:
         pytest.skip("Config creation endpoint returning 500 - API issue")
-    if config_response.status_code not in (200, 201):
+    if config_response.status_code != 201:
         pytest.skip("Config creation not available")
 
     config_id = config_response.json()["config_id"]
@@ -231,7 +231,7 @@ async def test_anonymous_cannot_delete_other_users_config(
 
     if config_response.status_code == 500:
         pytest.skip("Config creation endpoint returning 500 - API issue")
-    if config_response.status_code not in (200, 201):
+    if config_response.status_code != 201:
         pytest.skip("Config creation not available")
 
     config_id = config_response.json()["config_id"]
@@ -294,7 +294,7 @@ async def test_anonymous_config_limit_enforced(
 
             if response.status_code == 500:
                 pytest.skip("Config creation endpoint returning 500 - API issue")
-            if response.status_code in (200, 201):
+            if response.status_code == 201:
                 created_count += 1
             elif response.status_code in (400, 403, 422, 429):
                 # Limit reached or validation error - this is expected
@@ -343,7 +343,7 @@ async def test_anonymous_alert_limit_enforced(
 
         if config_response.status_code == 500:
             pytest.skip("Config creation endpoint returning 500 - API issue")
-        if config_response.status_code not in (200, 201):
+        if config_response.status_code != 201:
             pytest.skip("Config creation not available")
 
         config_id = config_response.json()["config_id"]
@@ -367,7 +367,7 @@ async def test_anonymous_alert_limit_enforced(
             if response.status_code == 404:
                 pytest.skip("Alerts endpoint not implemented")
 
-            if response.status_code in (200, 201):
+            if response.status_code == 201:
                 created_count += 1
             elif response.status_code in (400, 403, 429):
                 # Limit reached

--- a/tests/e2e/test_auth_anonymous.py
+++ b/tests/e2e/test_auth_anonymous.py
@@ -24,11 +24,8 @@ async def test_anonymous_session_creation(api_client: PreprodAPIClient) -> None:
     """
     response = await api_client.post("/api/v2/auth/anonymous", json={})
 
-    # API returns 201 Created for new sessions (correct HTTP semantics)
-    assert response.status_code in (
-        200,
-        201,
-    ), f"Expected 200/201, got {response.status_code}"
+    # 201 Created is the correct status for resource creation
+    assert response.status_code == 201, f"Expected 201, got {response.status_code}"
 
     data = response.json()
     # Response may use user_id or session_id depending on implementation
@@ -62,7 +59,7 @@ async def test_anonymous_session_validation(api_client: PreprodAPIClient) -> Non
     """
     # Create anonymous session
     create_response = await api_client.post("/api/v2/auth/anonymous", json={})
-    assert create_response.status_code in (200, 201)
+    assert create_response.status_code == 201
 
     data = create_response.json()
     token = data["token"]
@@ -100,7 +97,7 @@ async def test_anonymous_config_creation(
     """
     # Create anonymous session
     session_response = await api_client.post("/api/v2/auth/anonymous", json={})
-    assert session_response.status_code in (200, 201)
+    assert session_response.status_code == 201
 
     session_data = session_response.json()
     token = session_data["token"]
@@ -124,10 +121,10 @@ async def test_anonymous_config_creation(
         if config_response.status_code == 500:
             pytest.skip("Config creation endpoint returning 500 - API issue")
 
-        assert config_response.status_code in (
-            200,
-            201,
-        ), f"Expected 200/201, got {config_response.status_code}"
+        # 201 Created is the correct status for resource creation
+        assert (
+            config_response.status_code == 201
+        ), f"Expected 201, got {config_response.status_code}"
 
         config_data = config_response.json()
         assert "config_id" in config_data, "Response missing config_id"
@@ -158,7 +155,7 @@ async def test_anonymous_session_expires_header(api_client: PreprodAPIClient) ->
 
     response = await api_client.post("/api/v2/auth/anonymous", json={})
     # API returns 201 Created for new sessions (correct HTTP semantics)
-    assert response.status_code in (200, 201)
+    assert response.status_code == 201
 
     data = response.json()
     # Response may use session_expires_at or expires_at
@@ -195,13 +192,13 @@ async def test_anonymous_multiple_sessions_isolated(
     # Create first anonymous session
     response1 = await api_client.post("/api/v2/auth/anonymous", json={})
     # API returns 201 Created for new sessions (correct HTTP semantics)
-    assert response1.status_code in (200, 201)
+    assert response1.status_code == 201
     token1 = response1.json()["token"]
 
     # Create second anonymous session
     response2 = await api_client.post("/api/v2/auth/anonymous", json={})
     # API returns 201 Created for new sessions (correct HTTP semantics)
-    assert response2.status_code in (200, 201)
+    assert response2.status_code == 201
     token2 = response2.json()["token"]
 
     # Tokens should be different
@@ -216,7 +213,7 @@ async def test_anonymous_multiple_sessions_isolated(
         )
         if config_response.status_code == 500:
             pytest.skip("Config creation endpoint returning 500 - API issue")
-        if config_response.status_code in (200, 201):
+        if config_response.status_code == 201:
             config_id = config_response.json()["config_id"]
 
             # Try to access with second session - should fail

--- a/tests/e2e/test_auth_magic_link.py
+++ b/tests/e2e/test_auth_magic_link.py
@@ -203,7 +203,7 @@ async def test_anonymous_data_merge(
     # Step 1: Create anonymous session
     anon_response = await api_client.post("/api/v2/auth/anonymous", json={})
     # API returns 201 Created for new sessions (correct HTTP semantics)
-    assert anon_response.status_code in (200, 201)
+    assert anon_response.status_code == 201
 
     anon_data = anon_response.json()
     anon_token = anon_data["token"]
@@ -222,7 +222,7 @@ async def test_anonymous_data_merge(
             },
         )
 
-        if config_response.status_code not in (200, 201):
+        if config_response.status_code != 201:
             pytest.skip("Anonymous config creation not supported")
 
         # Config ID not used directly - we verify by listing configs with auth token
@@ -307,7 +307,7 @@ async def test_full_anonymous_to_authenticated_journey(
     # === Phase 1: Anonymous Session ===
     anon_response = await api_client.post("/api/v2/auth/anonymous", json={})
     # API returns 201 Created for new sessions (correct HTTP semantics)
-    assert anon_response.status_code in (200, 201), "Failed to create anonymous session"
+    assert anon_response.status_code == 201, "Failed to create anonymous session"
 
     anon_data = anon_response.json()
     anon_token = anon_data["token"]
@@ -325,7 +325,7 @@ async def test_full_anonymous_to_authenticated_journey(
             },
         )
 
-        if config_response.status_code not in (200, 201):
+        if config_response.status_code != 201:
             api_client.clear_access_token()
             pytest.skip("Anonymous configuration not supported")
 

--- a/tests/e2e/test_auth_oauth.py
+++ b/tests/e2e/test_auth_oauth.py
@@ -207,7 +207,7 @@ async def test_session_validation(
     # Create anonymous session for testing
     anon_response = await api_client.post("/api/v2/auth/anonymous", json={})
     # API returns 201 Created for new sessions (correct HTTP semantics)
-    assert anon_response.status_code in (200, 201)
+    assert anon_response.status_code == 201
 
     token = anon_response.json()["token"]
     api_client.set_access_token(token)
@@ -248,7 +248,7 @@ async def test_signout_invalidates_session(
     # Create anonymous session
     anon_response = await api_client.post("/api/v2/auth/anonymous", json={})
     # API returns 201 Created for new sessions (correct HTTP semantics)
-    assert anon_response.status_code in (200, 201)
+    assert anon_response.status_code == 201
 
     token = anon_response.json()["token"]
     api_client.set_access_token(token)

--- a/tests/e2e/test_circuit_breaker.py
+++ b/tests/e2e/test_circuit_breaker.py
@@ -21,7 +21,7 @@ async def create_session_and_config(
     """Helper to create session and config."""
     session_response = await api_client.post("/api/v2/auth/anonymous", json={})
     # API returns 201 Created for new sessions (correct HTTP semantics)
-    assert session_response.status_code in (200, 201)
+    assert session_response.status_code == 201
     token = session_response.json()["token"]
 
     api_client.set_access_token(token)
@@ -33,7 +33,7 @@ async def create_session_and_config(
         },
     )
 
-    if config_response.status_code not in (200, 201):
+    if config_response.status_code != 201:
         api_client.clear_access_token()
         pytest.skip("Config creation not available")
 

--- a/tests/e2e/test_config_crud.py
+++ b/tests/e2e/test_config_crud.py
@@ -25,7 +25,7 @@ async def create_auth_session(api_client: PreprodAPIClient) -> str:
     """
     response = await api_client.post("/api/v2/auth/anonymous", json={})
     # API returns 201 Created for new sessions (correct HTTP semantics)
-    assert response.status_code in (200, 201)
+    assert response.status_code == 201
     return response.json()["token"]
 
 
@@ -96,7 +96,7 @@ async def test_config_create_with_ticker_metadata(
         response = await api_client.post("/api/v2/configurations", json=config_payload)
         if response.status_code == 500:
             pytest.skip("Config creation endpoint returning 500 - API issue")
-        assert response.status_code in (200, 201)
+        assert response.status_code == 201
 
         data = response.json()
         tickers = data.get("tickers", [])
@@ -139,7 +139,7 @@ async def test_config_read_by_id(
         )
         if create_response.status_code == 500:
             pytest.skip("Config creation endpoint returning 500 - API issue")
-        assert create_response.status_code in (200, 201)
+        assert create_response.status_code == 201
 
         config_id = create_response.json()["config_id"]
 
@@ -182,7 +182,7 @@ async def test_config_update_name_and_tickers(
         )
         if create_response.status_code == 500:
             pytest.skip("Config creation endpoint returning 500 - API issue")
-        assert create_response.status_code in (200, 201)
+        assert create_response.status_code == 201
 
         config_id = create_response.json()["config_id"]
 
@@ -237,7 +237,7 @@ async def test_config_delete(
         )
         if create_response.status_code == 500:
             pytest.skip("Config creation endpoint returning 500 - API issue")
-        assert create_response.status_code in (200, 201)
+        assert create_response.status_code == 201
 
         config_id = create_response.json()["config_id"]
 
@@ -291,7 +291,7 @@ async def test_config_max_limit_enforced(
 
             if response.status_code == 500:
                 pytest.skip("Config creation endpoint returning 500 - API issue")
-            if response.status_code in (200, 201):
+            if response.status_code == 201:
                 created_configs.append(response.json()["config_id"])
             elif response.status_code in (400, 403, 429):
                 # Limit reached

--- a/tests/e2e/test_failure_injection.py
+++ b/tests/e2e/test_failure_injection.py
@@ -25,7 +25,7 @@ async def create_auth_session(api_client: PreprodAPIClient) -> str:
     Returns the access token.
     """
     response = await api_client.post("/api/v2/auth/anonymous", json={})
-    assert response.status_code in (200, 201)
+    assert response.status_code == 201
     return response.json()["token"]
 
 
@@ -58,7 +58,7 @@ async def test_tiingo_failure_graceful_degradation(
         if create_response.status_code == 500:
             pytest.skip("Config creation endpoint returning 500 - API issue")
 
-        if create_response.status_code not in (200, 201):
+        if create_response.status_code != 201:
             pytest.skip("Config creation not available")
 
         config_id = create_response.json()["config_id"]
@@ -114,7 +114,7 @@ async def test_finnhub_failure_fallback(
             json=config_payload,
         )
 
-        if create_response.status_code not in (200, 201):
+        if create_response.status_code != 201:
             pytest.skip("Config creation not available")
 
         config_id = create_response.json()["config_id"]
@@ -230,7 +230,7 @@ async def test_malformed_response_handling(
             json=config_payload,
         )
 
-        if create_response.status_code not in (200, 201):
+        if create_response.status_code != 201:
             pytest.skip("Config creation not available")
 
         config_id = create_response.json()["config_id"]
@@ -285,7 +285,7 @@ async def test_timeout_retry_behavior(
             json=config_payload,
         )
 
-        if create_response.status_code not in (200, 201):
+        if create_response.status_code != 201:
             pytest.skip("Config creation not available")
 
         config_id = create_response.json()["config_id"]

--- a/tests/e2e/test_market_status.py
+++ b/tests/e2e/test_market_status.py
@@ -145,7 +145,7 @@ async def test_premarket_estimates_returned(
     # Create session and config
     session_response = await api_client.post("/api/v2/auth/anonymous", json={})
     # API returns 201 Created for new sessions (correct HTTP semantics)
-    assert session_response.status_code in (200, 201)
+    assert session_response.status_code == 201
     token = session_response.json()["token"]
 
     api_client.set_access_token(token)
@@ -155,7 +155,7 @@ async def test_premarket_estimates_returned(
             json=synthetic_config.to_api_payload(),
         )
 
-        if config_response.status_code not in (200, 201):
+        if config_response.status_code != 201:
             pytest.skip("Config creation not available")
 
         config_id = config_response.json()["config_id"]

--- a/tests/e2e/test_notifications.py
+++ b/tests/e2e/test_notifications.py
@@ -25,7 +25,7 @@ async def create_session_with_config(
     """
     session_response = await api_client.post("/api/v2/auth/anonymous", json={})
     # API returns 201 Created for new sessions (correct HTTP semantics)
-    assert session_response.status_code in (200, 201)
+    assert session_response.status_code == 201
     token = session_response.json()["token"]
 
     api_client.set_access_token(token)
@@ -37,7 +37,7 @@ async def create_session_with_config(
         json=synthetic_config.to_api_payload(),
     )
 
-    if config_response.status_code not in (200, 201):
+    if config_response.status_code != 201:
         api_client.clear_access_token()
         pytest.skip("Config creation not available")
 

--- a/tests/e2e/test_observability.py
+++ b/tests/e2e/test_observability.py
@@ -31,7 +31,7 @@ async def test_cloudwatch_logs_created(
     # Make a request that should generate logs
     session_response = await api_client.post("/api/v2/auth/anonymous", json={})
     # API returns 201 Created for new sessions (correct HTTP semantics)
-    assert session_response.status_code in (200, 201)
+    assert session_response.status_code == 201
 
     # Query CloudWatch Logs for evidence of the request
     # Note: Logs may take a few seconds to appear
@@ -100,7 +100,7 @@ async def test_xray_trace_exists(
     # Make a request
     session_response = await api_client.post("/api/v2/auth/anonymous", json={})
     # API returns 201 Created for new sessions (correct HTTP semantics)
-    assert session_response.status_code in (200, 201)
+    assert session_response.status_code == 201
 
     # Get trace ID from response header
     trace_header = session_response.headers.get("x-amzn-trace-id", "")
@@ -144,7 +144,7 @@ async def test_xray_cross_lambda_trace(
     # Create session and config to trigger multiple Lambda calls
     session_response = await api_client.post("/api/v2/auth/anonymous", json={})
     # API returns 201 Created for new sessions (correct HTTP semantics)
-    if session_response.status_code not in (200, 201):
+    if session_response.status_code != 201:
         pytest.skip("Cannot create session for cross-lambda test")
 
     token = session_response.json()["token"]
@@ -157,7 +157,7 @@ async def test_xray_cross_lambda_trace(
             json=synthetic_config.to_api_payload(),
         )
 
-        if config_response.status_code not in (200, 201):
+        if config_response.status_code != 201:
             pytest.skip("Config creation not available")
 
         # Get trace ID from response header

--- a/tests/e2e/test_rate_limiting.py
+++ b/tests/e2e/test_rate_limiting.py
@@ -42,7 +42,7 @@ async def test_requests_within_limit_succeed(
     # Create session
     session_response = await api_client.post("/api/v2/auth/anonymous", json={})
     # API returns 201 Created for new sessions (correct HTTP semantics)
-    assert session_response.status_code in (200, 201)
+    assert session_response.status_code == 201
     token = session_response.json()["token"]
 
     api_client.set_access_token(token)
@@ -76,7 +76,7 @@ async def test_rate_limit_headers_on_normal_response(
     """
     # Create session
     session_response = await api_client.post("/api/v2/auth/anonymous", json={})
-    assert session_response.status_code in (200, 201)
+    assert session_response.status_code == 201
     token = session_response.json()["token"]
 
     api_client.set_access_token(token)
@@ -128,7 +128,7 @@ async def test_rate_limit_triggers_429(
 
     # Create session
     session_response = await api_client.post("/api/v2/auth/anonymous", json={})
-    assert session_response.status_code in (200, 201)
+    assert session_response.status_code == 201
     token = session_response.json()["token"]
 
     api_client.set_access_token(token)
@@ -172,7 +172,7 @@ async def test_retry_after_header_present(
     # Create session
     session_response = await api_client.post("/api/v2/auth/anonymous", json={})
     # API returns 201 Created for new sessions (correct HTTP semantics)
-    assert session_response.status_code in (200, 201)
+    assert session_response.status_code == 201
     token = session_response.json()["token"]
 
     api_client.set_access_token(token)
@@ -229,7 +229,7 @@ async def test_rate_limit_recovery(
     # Create session
     session_response = await api_client.post("/api/v2/auth/anonymous", json={})
     # API returns 201 Created for new sessions (correct HTTP semantics)
-    assert session_response.status_code in (200, 201)
+    assert session_response.status_code == 201
     token = session_response.json()["token"]
 
     api_client.set_access_token(token)
@@ -323,7 +323,7 @@ async def test_rate_limit_per_endpoint(
     """
     session_response = await api_client.post("/api/v2/auth/anonymous", json={})
     # API returns 201 Created for new sessions (correct HTTP semantics)
-    assert session_response.status_code in (200, 201)
+    assert session_response.status_code == 201
     token = session_response.json()["token"]
 
     api_client.set_access_token(token)

--- a/tests/e2e/test_sentiment.py
+++ b/tests/e2e/test_sentiment.py
@@ -33,7 +33,7 @@ async def create_config_with_tickers(
     # Create anonymous session
     session_response = await api_client.post("/api/v2/auth/anonymous", json={})
     # API returns 201 Created for new sessions (correct HTTP semantics)
-    assert session_response.status_code in (200, 201)
+    assert session_response.status_code == 201
     token = session_response.json()["token"]
 
     # Create config
@@ -46,7 +46,7 @@ async def create_config_with_tickers(
         },
     )
 
-    if config_response.status_code not in (200, 201):
+    if config_response.status_code != 201:
         api_client.clear_access_token()
         pytest.skip("Config creation not available")
 
@@ -429,7 +429,7 @@ async def test_sentiment_invalid_config(
     # API returns 201 Created for new sessions (correct HTTP semantics)
     if session_response.status_code == 422:
         pytest.skip("Anonymous session requires JSON body")
-    assert session_response.status_code in (200, 201)
+    assert session_response.status_code == 201
     token = session_response.json()["token"]
 
     api_client.set_access_token(token)

--- a/tests/e2e/test_sse.py
+++ b/tests/e2e/test_sse.py
@@ -66,7 +66,7 @@ async def create_session_and_config(
     """Helper to create session and config."""
     session_response = await api_client.post("/api/v2/auth/anonymous", json={})
     # API returns 201 Created for new sessions (correct HTTP semantics)
-    assert session_response.status_code in (200, 201)
+    assert session_response.status_code == 201
     token = session_response.json()["token"]
 
     api_client.set_access_token(token)
@@ -75,7 +75,7 @@ async def create_session_and_config(
         json=synthetic_config.to_api_payload(),
     )
 
-    if config_response.status_code not in (200, 201):
+    if config_response.status_code != 201:
         api_client.clear_access_token()
         pytest.skip("Config creation not available")
 
@@ -252,7 +252,7 @@ async def test_sse_invalid_config_rejected(
     # Create session
     session_response = await api_client.post("/api/v2/auth/anonymous", json={})
     # API returns 201 Created for new sessions (correct HTTP semantics)
-    assert session_response.status_code in (200, 201)
+    assert session_response.status_code == 201
     token = session_response.json()["token"]
 
     api_client.set_access_token(token)


### PR DESCRIPTION
## Summary
Comprehensive audit and fix for HTTP status code assertions across all E2E tests.

All POST endpoints that create resources should return **201 Created** per RFC 7231:
- `POST /api/v2/auth/anonymous` - creates session
- `POST /api/v2/configurations` - creates config
- `POST /api/v2/alerts` - creates alert

Changed all `in (200, 201)` patterns to `== 201` across 14 test files.

## Files changed
- test_alerts.py
- test_anonymous_restrictions.py
- test_auth_anonymous.py
- test_auth_magic_link.py
- test_auth_oauth.py
- test_circuit_breaker.py
- test_config_crud.py
- test_failure_injection.py
- test_market_status.py
- test_notifications.py
- test_observability.py
- test_rate_limiting.py
- test_sentiment.py
- test_sse.py

## Test plan
- [x] All 1411 unit tests pass locally
- [ ] CI pipeline E2E tests pass after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)