### PR TITLE
fix(sentiment): Deterministic seed and consistent threshold operators

### DIFF
--- a/src/lambdas/dashboard/market.py
+++ b/src/lambdas/dashboard/market.py
@@ -346,9 +346,9 @@ def get_premarket_estimates(
                             "score": round(sentiment_score, 2),
                             "label": (
                                 "positive"
-                                if sentiment_score > 0.33
+                                if sentiment_score >= 0.33
                                 else "negative"
-                                if sentiment_score < -0.33
+                                if sentiment_score <= -0.33
                                 else "neutral"
                             ),
                             "confidence": 0.65,

--- a/src/lambdas/dashboard/ohlc.py
+++ b/src/lambdas/dashboard/ohlc.py
@@ -261,9 +261,12 @@ async def get_sentiment_history(
     history: list[SentimentPoint] = []
     current_date = start_date
 
+    import hashlib
     import random
 
-    random.seed(hash(ticker))  # Deterministic based on ticker
+    # Use hashlib for deterministic seed (hash() is randomized by PYTHONHASHSEED)
+    ticker_hash = int(hashlib.sha256(ticker.encode()).hexdigest(), 16)
+    random.seed(ticker_hash)
 
     base_score = 0.3  # Slightly positive base
     while current_date <= end_date:

--- a/src/lambdas/notification/digest_service.py
+++ b/src/lambdas/notification/digest_service.py
@@ -318,10 +318,10 @@ class DigestService:
                 ]
                 prev_score = sum(prev_scores) / len(prev_scores) if prev_scores else 0.0
 
-                # Determine label
-                if current_score > 0.33:
+                # Determine label (inclusive thresholds per project standard)
+                if current_score >= 0.33:
                     label = "positive"
-                elif current_score < -0.33:
+                elif current_score <= -0.33:
                     label = "negative"
                 else:
                     label = "neutral"

--- a/src/lambdas/shared/models/sentiment_result.py
+++ b/src/lambdas/shared/models/sentiment_result.py
@@ -94,8 +94,8 @@ def sentiment_label_from_score(
     Returns:
         Sentiment label: positive, neutral, or negative
     """
-    if score < -0.33:
+    if score <= -0.33:
         return "negative"
-    elif score > 0.33:
+    elif score >= 0.33:
         return "positive"
     return "neutral"


### PR DESCRIPTION
## Summary
- Fix flaky `sentiment_history` tests caused by non-deterministic random seed and inconsistent threshold operators
- Replace `hash(ticker)` with `hashlib.sha256` for deterministic behavior across Python versions
- Standardize all sentiment threshold operators to inclusive (`>=` and `<=`)

## Root Cause Analysis

**Bucket 1: Non-deterministic random seed**
- `ohlc.py` used `random.seed(hash(ticker))` for generating synthetic sentiment data
- `hash()` is randomized by `PYTHONHASHSEED` in Python 3.x (security feature)
- Different Python processes get different hash seeds → different random sequences

**Bucket 2: Inconsistent threshold operators**
- Some files used exclusive operators (`> 0.33`, `< -0.33`)
- Some files used inclusive operators (`>= 0.33`, `<= -0.33`)
- Score exactly 0.33 could be "neutral" or "positive" depending on which code path ran
- Standardized to inclusive operators per project convention

## Files Changed
- `src/lambdas/dashboard/ohlc.py`: Use `hashlib.sha256` for deterministic random seed
- `src/lambdas/dashboard/market.py`: `>=` and `<=` thresholds
- `src/lambdas/notification/digest_service.py`: `>=` and `<=` thresholds
- `src/lambdas/shared/models/sentiment_result.py`: `>=` and `<=` thresholds

## Test Plan
- [x] All 45 `sentiment_history` integration tests pass
- [x] All 1411 unit tests pass
- [x] Tests produce deterministic results across runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)