### PR TITLE
fix(dashboard): Add /api/v2/metrics endpoint and missing config values

### DIFF
--- a/src/dashboard/config.js
+++ b/src/dashboard/config.js
@@ -23,11 +23,20 @@ const CONFIG = {
     ENDPOINTS: {
         SENTIMENT: '/api/v2/sentiment',
         TRENDS: '/api/v2/trends',
-        ARTICLES: '/api/v2/articles'
+        ARTICLES: '/api/v2/articles',
+        METRICS: '/api/v2/metrics',
+        STREAM: '/api/v2/stream'  // SSE endpoint (may not be implemented)
     },
 
     // Polling interval for sentiment data (milliseconds)
     SENTIMENT_POLL_INTERVAL: 30000, // 30 seconds
+
+    // Metrics polling interval (milliseconds) - used as fallback when SSE fails
+    METRICS_POLL_INTERVAL: 30000, // 30 seconds
+
+    // SSE connection settings
+    SSE_MAX_RETRIES: 3,
+    SSE_RECONNECT_DELAY: 1000, // 1 second (doubles with each retry)
 
     // Chart colors (must match CSS custom properties)
     COLORS: {


### PR DESCRIPTION
## Summary

Fixes the operator dashboard "Disconnected" status issue by:
- Adding the missing `/api/v2/metrics` endpoint to handler.py
- Adding missing config values to config.js (ENDPOINTS.METRICS, ENDPOINTS.STREAM, SSE_MAX_RETRIES, SSE_RECONNECT_DELAY, METRICS_POLL_INTERVAL)

## Root Cause

The dashboard's `app.js` referenced several config values that were not defined in `config.js`:
- `CONFIG.ENDPOINTS.METRICS` - endpoint for fetching aggregated metrics
- `CONFIG.ENDPOINTS.STREAM` - SSE streaming endpoint
- `CONFIG.SSE_MAX_RETRIES` - max retries for SSE connection
- `CONFIG.SSE_RECONNECT_DELAY` - delay between SSE reconnection attempts
- `CONFIG.METRICS_POLL_INTERVAL` - polling interval when SSE fails

Additionally, the `/api/v2/metrics` endpoint was not implemented in the backend, causing 404 errors when the dashboard tried to fetch metrics.

## Changes

### `src/lambdas/dashboard/handler.py`
- Added `/api/v2/metrics` endpoint that returns aggregated dashboard metrics using the existing `aggregate_dashboard_metrics` function from `metrics.py`
- Returns: total items, sentiment counts, tag distribution, ingestion rates, and recent items

### `src/dashboard/config.js`
- Added `ENDPOINTS.METRICS` pointing to `/api/v2/metrics`
- Added `ENDPOINTS.STREAM` pointing to `/api/v2/stream` (SSE endpoint - may not be implemented yet)
- Added `SSE_MAX_RETRIES: 3`
- Added `SSE_RECONNECT_DELAY: 1000` (1 second, doubles with each retry)
- Added `METRICS_POLL_INTERVAL: 30000` (30 seconds fallback polling)

## Test Plan

- [x] Unit tests pass (dashboard handler tests)
- [x] JavaScript syntax validation passes
- [ ] Deploy to preprod and verify dashboard shows "Connected" status
- [ ] Run traffic generator and verify metrics update

## Notes

The `/api/v2/stream` SSE endpoint is still not implemented. The dashboard will gracefully fall back to polling after SSE connection fails (3 retries with exponential backoff, then switches to 30-second polling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)