### PR TITLE
fix(security): Sanitize user input in log statements to prevent log injection

### DIFF
--- a/src/lambdas/dashboard/handler.py
+++ b/src/lambdas/dashboard/handler.py
@@ -569,7 +569,7 @@ async def get_metrics_v2(
         logger.error(
             "Failed to get dashboard metrics",
             extra={
-                "hours": hours,
+                "hours": sanitize_for_log(hours),
                 **get_safe_error_info(e),
             },
         )

--- a/src/lambdas/dashboard/metrics.py
+++ b/src/lambdas/dashboard/metrics.py
@@ -108,7 +108,7 @@ def calculate_sentiment_distribution(items: list[dict[str, Any]]) -> dict[str, i
         If all counts are 0, verify items have 'sentiment' field populated.
         Items with status='pending' won't have sentiment yet.
     """
-    distribution = {sentiment: 0 for sentiment in SENTIMENT_VALUES}
+    distribution = dict.fromkeys(SENTIMENT_VALUES, 0)
 
     for item in items:
         sentiment = item.get("sentiment", "").lower()
@@ -421,7 +421,7 @@ def aggregate_dashboard_metrics(
         if cached is not None:
             logger.debug(
                 "Dashboard metrics cache hit",
-                extra={"hours": hours},
+                extra={"hours": sanitize_for_log(hours)},
             )
             return cached
 

--- a/src/lambdas/dashboard/ohlc.py
+++ b/src/lambdas/dashboard/ohlc.py
@@ -55,8 +55,9 @@ async def get_ohlc_data(
     ticker: str,
     request: Request,
     range: TimeRange = Query(TimeRange.ONE_MONTH, description="Time range for data"),
-    start_date: date
-    | None = Query(None, description="Custom start date (overrides range)"),
+    start_date: date | None = Query(
+        None, description="Custom start date (overrides range)"
+    ),
     end_date: date | None = Query(None, description="Custom end date"),
     tiingo: TiingoAdapter = Depends(get_tiingo_adapter),
     finnhub: FinnhubAdapter = Depends(get_finnhub_adapter),
@@ -114,7 +115,7 @@ async def get_ohlc_data(
         "Fetching OHLC data",
         extra={
             "ticker": sanitize_for_log(ticker),
-            "range": time_range_str,
+            "range": sanitize_for_log(time_range_str),
             "start_date": str(start_date),
             "end_date": str(end_date),
         },
@@ -249,7 +250,7 @@ async def get_sentiment_history(
         "Fetching sentiment history",
         extra={
             "ticker": sanitize_for_log(ticker),
-            "source": source,
+            "source": sanitize_for_log(source),
             "start_date": str(start_date),
             "end_date": str(end_date),
         },
@@ -307,7 +308,7 @@ async def get_sentiment_history(
         "Sentiment history retrieved",
         extra={
             "ticker": sanitize_for_log(ticker),
-            "source": source,
+            "source": sanitize_for_log(source),
             "point_count": len(history),
         },
     )

--- a/src/lambdas/shared/adapters/finnhub.py
+++ b/src/lambdas/shared/adapters/finnhub.py
@@ -18,6 +18,7 @@ from src.lambdas.shared.adapters.base import (
     RateLimitError,
     SentimentData,
 )
+from src.lambdas.shared.logging_utils import sanitize_for_log
 
 logger = logging.getLogger(__name__)
 
@@ -327,7 +328,7 @@ class FinnhubAdapter(BaseAdapter):
         cached_data = _get_from_cache(cache_key, API_CACHE_TTL_OHLC_SECONDS)
 
         if cached_data is not None:
-            logger.debug(f"Finnhub OHLC cache hit for {ticker}")
+            logger.debug("Finnhub OHLC cache hit for %s", sanitize_for_log(ticker))
             data = cached_data
         else:
             try:
@@ -338,7 +339,9 @@ class FinnhubAdapter(BaseAdapter):
                 data = self._handle_response(response)
                 # Cache the raw response
                 _put_in_cache(cache_key, data)
-                logger.debug(f"Finnhub OHLC cache miss for {ticker}, cached")
+                logger.debug(
+                    "Finnhub OHLC cache miss for %s, cached", sanitize_for_log(ticker)
+                )
             except httpx.RequestError as e:
                 logger.error(f"Finnhub OHLC request failed: {e}")
                 raise AdapterError(f"Finnhub OHLC request failed: {e}") from e

--- a/src/lambdas/shared/adapters/tiingo.py
+++ b/src/lambdas/shared/adapters/tiingo.py
@@ -18,6 +18,7 @@ from src.lambdas.shared.adapters.base import (
     RateLimitError,
     SentimentData,
 )
+from src.lambdas.shared.logging_utils import sanitize_for_log
 
 logger = logging.getLogger(__name__)
 
@@ -277,7 +278,7 @@ class TiingoAdapter(BaseAdapter):
         cache_key = _get_cache_key(endpoint, cache_params)
         cached_data = _get_from_cache(cache_key, API_CACHE_TTL_OHLC_SECONDS)
         if cached_data is not None:
-            logger.debug(f"Tiingo OHLC cache hit for {ticker}")
+            logger.debug("Tiingo OHLC cache hit for %s", sanitize_for_log(ticker))
             data = cached_data
         else:
             try:
@@ -291,7 +292,9 @@ class TiingoAdapter(BaseAdapter):
                 data = self._handle_response(response)
                 # Cache the raw response
                 _put_in_cache(cache_key, data)
-                logger.debug(f"Tiingo OHLC cache miss for {ticker}, cached")
+                logger.debug(
+                    "Tiingo OHLC cache miss for %s, cached", sanitize_for_log(ticker)
+                )
             except httpx.RequestError as e:
                 logger.error(f"Tiingo OHLC request failed: {e}")
                 raise AdapterError(f"Tiingo OHLC request failed: {e}") from e


### PR DESCRIPTION
## Summary

- Fixes all 9 CodeQL `py/log-injection` findings
- Wraps user-controlled values with `sanitize_for_log()` before logging
- Prevents CWE-117 log injection attacks

## Files Changed

| File | Fix |
|------|-----|
| `src/lambdas/shared/adapters/finnhub.py` | Sanitize ticker in cache logs |
| `src/lambdas/shared/adapters/tiingo.py` | Sanitize ticker in cache logs |
| `src/lambdas/dashboard/handler.py` | Sanitize hours parameter |
| `src/lambdas/dashboard/metrics.py` | Sanitize hours parameter |
| `src/lambdas/dashboard/ohlc.py` | Sanitize time_range_str and source |

## Test plan

- [x] All 1434 unit tests pass
- [ ] Run CodeQL locally to verify findings are resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)