### PR TITLE
fix(infra): Enable RESPONSE_STREAM for Lambda Function URL to support SSE

### DIFF
--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -394,6 +394,9 @@ module "dashboard_lambda" {
   # This prevents duplicate Access-Control-Allow-Origin headers
   create_function_url    = true
   function_url_auth_type = "NONE"
+  # RESPONSE_STREAM required for SSE endpoints (FR-001, FR-002, FR-003)
+  # Without this, Lambda buffers the response which breaks SSE streaming
+  function_url_invoke_mode = "RESPONSE_STREAM"
   function_url_cors = {
     allow_credentials = false
     allow_headers     = ["content-type", "authorization", "x-api-key", "x-user-id", "x-auth-type"]

--- a/infrastructure/terraform/modules/lambda/main.tf
+++ b/infrastructure/terraform/modules/lambda/main.tf
@@ -101,11 +101,13 @@ resource "aws_lambda_function" "this" {
 
 # Lambda Function URL (optional)
 # Creates a public HTTPS endpoint for the Lambda
+# Note: For SSE/streaming responses, set invoke_mode = "RESPONSE_STREAM"
 resource "aws_lambda_function_url" "this" {
   count = var.create_function_url ? 1 : 0
 
   function_name      = aws_lambda_function.this.function_name
   authorization_type = var.function_url_auth_type
+  invoke_mode        = var.function_url_invoke_mode
 
   cors {
     allow_credentials = var.function_url_cors.allow_credentials

--- a/infrastructure/terraform/modules/lambda/variables.tf
+++ b/infrastructure/terraform/modules/lambda/variables.tf
@@ -159,6 +159,17 @@ variable "function_url_auth_type" {
   }
 }
 
+variable "function_url_invoke_mode" {
+  description = "Invoke mode for Function URL (BUFFERED or RESPONSE_STREAM). Use RESPONSE_STREAM for SSE/streaming responses."
+  type        = string
+  default     = "BUFFERED"
+
+  validation {
+    condition     = contains(["BUFFERED", "RESPONSE_STREAM"], var.function_url_invoke_mode)
+    error_message = "Function URL invoke mode must be BUFFERED or RESPONSE_STREAM."
+  }
+}
+
 variable "function_url_cors" {
   description = "CORS configuration for Function URL"
   type = object({


### PR DESCRIPTION
## Summary

- Enable streaming response mode for Lambda Function URL to fix SSE endpoints
- Add `function_url_invoke_mode` variable to Lambda module for configurable streaming support
- Dashboard shows "Disconnected" because SSE endpoint returns no data without RESPONSE_STREAM

## Root Cause

Lambda Function URLs default to `BUFFERED` invoke mode, which waits for the entire Lambda response before sending to the client. SSE (Server-Sent Events) endpoints require `RESPONSE_STREAM` mode to stream data incrementally.

Evidence:
- `/api/v2/stream/status` (non-streaming) returns instantly: `{"connections":0,"max_connections":100,"available":100}`
- `/api/v2/stream` (SSE) times out after 35s with NO data returned

## Changes

### Lambda Module
- **modules/lambda/variables.tf**: Add `function_url_invoke_mode` variable (BUFFERED/RESPONSE_STREAM)
- **modules/lambda/main.tf**: Apply invoke_mode to aws_lambda_function_url resource

### Dashboard Lambda
- **main.tf**: Set `function_url_invoke_mode = "RESPONSE_STREAM"` for dashboard Lambda

## Test plan

- [x] Terraform fmt/validate passes
- [x] All 1434 unit tests pass
- [ ] After deploy, `/api/v2/stream` returns SSE events instead of timing out
- [ ] Dashboard shows "Connected" status for SSE connection

## References

- FR-001, FR-002, FR-003: SSE streaming requirements
- Related: PR #282 (E2E test improvements for SSE)

🤖 Generated with [Claude Code](https://claude.com/claude-code)