### PR TITLE
fix(lint): Format ohlc.py with black

### DIFF
--- a/src/lambdas/dashboard/ohlc.py
+++ b/src/lambdas/dashboard/ohlc.py
@@ -55,9 +55,8 @@ async def get_ohlc_data(
     ticker: str,
     request: Request,
     range: TimeRange = Query(TimeRange.ONE_MONTH, description="Time range for data"),
-    start_date: date | None = Query(
-        None, description="Custom start date (overrides range)"
-    ),
+    start_date: date
+    | None = Query(None, description="Custom start date (overrides range)"),
     end_date: date | None = Query(None, description="Custom end date"),
     tiingo: TiingoAdapter = Depends(get_tiingo_adapter),
     finnhub: FinnhubAdapter = Depends(get_finnhub_adapter),


### PR DESCRIPTION
## Summary
- Fix black formatting check failure in CI pipeline
- Reformats `src/lambdas/dashboard/ohlc.py` to pass lint checks

## Test plan
- [x] Pre-push hook ran all 1434 unit tests successfully
- [x] Black formatting check will pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)