### PR TITLE
fix(terraform): Remove cross-variable validation in memory_size

### DIFF
--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -319,7 +319,6 @@ module "analysis_lambda" {
   # Resource configuration per task spec
   # JUSTIFICATION (FR-024): 1024MB required for ML model inference (DistilBERT)
   memory_size          = 1024
-  allow_high_memory    = true # ML model requires more memory
   timeout              = 30
   reserved_concurrency = 5
 
@@ -380,7 +379,6 @@ module "dashboard_lambda" {
   # Resource configuration per task spec
   # JUSTIFICATION (FR-024): 1024MB required for FastAPI+Mangum with async handlers
   memory_size          = 1024
-  allow_high_memory    = true # Dashboard API requires more memory for concurrent requests
   timeout              = 60
   reserved_concurrency = 10
 

--- a/infrastructure/terraform/modules/lambda/variables.tf
+++ b/infrastructure/terraform/modules/lambda/variables.tf
@@ -58,22 +58,14 @@ variable "timeout" {
 }
 
 variable "memory_size" {
-  description = "Lambda memory in MB"
+  description = "Lambda memory in MB. COST CONTROL (FR-024): Keep at 512MB unless justified."
   type        = number
   default     = 512
 
-  # COST CONTROL (FR-024): Warn when memory exceeds 512MB
-  # Higher memory = higher cost. Use allow_high_memory to acknowledge.
   validation {
-    condition     = var.memory_size <= 512 || var.allow_high_memory
-    error_message = "Memory > 512MB requires allow_high_memory = true with justification in code comments."
+    condition     = var.memory_size >= 128 && var.memory_size <= 10240
+    error_message = "Memory must be between 128 MB and 10240 MB."
   }
-}
-
-variable "allow_high_memory" {
-  description = "Explicitly allow memory > 512MB (FR-024). Set to true with justification comment."
-  type        = bool
-  default     = false
 }
 
 variable "ephemeral_storage_size" {


### PR DESCRIPTION
## Summary
- Remove invalid cross-variable reference in Terraform variable validation
- Terraform variable validation blocks can only reference the variable being validated
- The `allow_high_memory` variable was incorrectly referenced from `memory_size` validation
- Cost control guidance moved to variable description

## Root Cause
The preprod deploy failed with:
```
Error: Invalid reference in variable validation
The condition for variable "memory_size" can only refer to the variable itself
```

## Changes
- Removed `allow_high_memory` variable from lambda module
- Updated `memory_size` validation to only check valid range (128-10240 MB)
- Removed `allow_high_memory = true` references from main.tf

## Test plan
- [x] Local unit tests pass (1596 tests)
- [ ] Terraform init/validate in CI
- [ ] Preprod deployment succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)