### PR TITLE
fix(iam): Add resource patterns for {env}-prefixed AWS resources

### DIFF
--- a/infrastructure/terraform/ci-user-policy.tf
+++ b/infrastructure/terraform/ci-user-policy.tf
@@ -111,9 +111,18 @@ data "aws_iam_policy_document" "ci_deploy_core" {
       "dynamodb:DeleteItem"
     ]
     resources = [
+      # Pattern: sentiment-analyzer-* (legacy)
       "arn:aws:dynamodb:*:*:table/sentiment-analyzer-*",
       "arn:aws:dynamodb:*:*:table/sentiment-analyzer-*/stream/*",
-      "arn:aws:dynamodb:*:*:table/sentiment-analyzer-*/index/*"
+      "arn:aws:dynamodb:*:*:table/sentiment-analyzer-*/index/*",
+      # Pattern: {env}-sentiment-* (preprod-sentiment-items, prod-sentiment-users, etc.)
+      "arn:aws:dynamodb:*:*:table/*-sentiment-*",
+      "arn:aws:dynamodb:*:*:table/*-sentiment-*/stream/*",
+      "arn:aws:dynamodb:*:*:table/*-sentiment-*/index/*",
+      # Pattern: {env}-chaos-* (preprod-chaos-experiments, prod-chaos-experiments)
+      "arn:aws:dynamodb:*:*:table/*-chaos-*",
+      "arn:aws:dynamodb:*:*:table/*-chaos-*/stream/*",
+      "arn:aws:dynamodb:*:*:table/*-chaos-*/index/*"
     ]
   }
 
@@ -136,7 +145,10 @@ data "aws_iam_policy_document" "ci_deploy_core" {
       "sns:ListTagsForResource"
     ]
     resources = [
-      "arn:aws:sns:*:*:sentiment-analyzer-*"
+      # Pattern: sentiment-analyzer-* (legacy)
+      "arn:aws:sns:*:*:sentiment-analyzer-*",
+      # Pattern: {env}-sentiment-* (preprod-sentiment-alarms, prod-sentiment-analysis-requests, etc.)
+      "arn:aws:sns:*:*:*-sentiment-*"
     ]
   }
 
@@ -157,7 +169,10 @@ data "aws_iam_policy_document" "ci_deploy_core" {
       "sqs:ListQueueTags"
     ]
     resources = [
-      "arn:aws:sqs:*:*:sentiment-analyzer-*"
+      # Pattern: sentiment-analyzer-* (legacy)
+      "arn:aws:sqs:*:*:sentiment-analyzer-*",
+      # Pattern: {env}-sentiment-* (preprod-sentiment-analysis-dlq, etc.)
+      "arn:aws:sqs:*:*:*-sentiment-*"
     ]
   }
 
@@ -222,7 +237,10 @@ data "aws_iam_policy_document" "ci_deploy_core" {
       "secretsmanager:UntagResource"
     ]
     resources = [
-      "arn:aws:secretsmanager:*:*:secret:sentiment-analyzer-*"
+      # Pattern: sentiment-analyzer-* (legacy)
+      "arn:aws:secretsmanager:*:*:secret:sentiment-analyzer-*",
+      # Pattern: {env}/sentiment-analyzer/* (preprod/sentiment-analyzer/newsapi, etc.)
+      "arn:aws:secretsmanager:*:*:secret:*/sentiment-analyzer/*"
     ]
   }
 


### PR DESCRIPTION
## Summary
Update CI policy resource ARN patterns to match actual AWS resource naming conventions. Resources use `{env}-sentiment-*` pattern (e.g., `preprod-sentiment-items`) not `sentiment-analyzer-*` pattern.

## Fixes Applied
| Service | Added Pattern | Example Resource |
|---------|---------------|------------------|
| DynamoDB | `*-sentiment-*`, `*-chaos-*` | `preprod-sentiment-items`, `preprod-chaos-experiments` |
| SNS | `*-sentiment-*` | `preprod-sentiment-alarms` |
| SQS | `*-sentiment-*` | `preprod-sentiment-analysis-dlq` |
| Secrets Manager | `*/sentiment-analyzer/*` | `preprod/sentiment-analyzer/newsapi` |

## Errors Resolved
- `dynamodb:DescribeTable` on preprod-sentiment-items/users/chaos-experiments
- `SNS:GetTopicAttributes` on preprod-sentiment-alarms/analysis-requests
- `secretsmanager:DescribeSecret` on preprod/sentiment-analyzer/*
- `sqs:GetQueueAttributes` on preprod-sentiment-analysis-dlq

## Test plan
- [x] Terraform validates locally
- [x] Pre-commit hooks pass
- [ ] Preprod deploy succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)