### PR TITLE
fix(kms): Add CI deployer admin permissions to key policy

### DIFF
--- a/infrastructure/terraform/modules/kms/main.tf
+++ b/infrastructure/terraform/modules/kms/main.tf
@@ -71,6 +71,35 @@ resource "aws_kms_key" "main" {
           "kms:DescribeKey"
         ]
         Resource = "*"
+      },
+      # CI Deployer Key Administration (FR-002, FR-005)
+      # Required: AWS rejects key creation if creating principal cannot manage the key
+      {
+        Sid    = "CIDeployerKeyAdmin"
+        Effect = "Allow"
+        Principal = {
+          AWS = [
+            "arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/sentiment-analyzer-preprod-deployer",
+            "arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/sentiment-analyzer-prod-deployer"
+          ]
+        }
+        Action = [
+          "kms:Create*",
+          "kms:Describe*",
+          "kms:Enable*",
+          "kms:List*",
+          "kms:Put*",
+          "kms:Update*",
+          "kms:Revoke*",
+          "kms:Disable*",
+          "kms:Get*",
+          "kms:Delete*",
+          "kms:TagResource",
+          "kms:UntagResource",
+          "kms:ScheduleKeyDeletion",
+          "kms:CancelKeyDeletion"
+        ]
+        Resource = "*"
       }
     ]
   })

--- a/specs/041-pipeline-blockers/checklists/requirements.md
+++ b/specs/041-pipeline-blockers/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Pipeline Blockers Resolution
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2025-12-06
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All validation items passed
+- Spec is ready for `/speckit.plan` phase
+- This feature directly follows and completes spec 019-iam-bootstrap-fix work

--- a/specs/041-pipeline-blockers/data-model.md
+++ b/specs/041-pipeline-blockers/data-model.md
@@ -1,0 +1,43 @@
+# Data Model: Pipeline Blockers Resolution
+
+**Feature**: 041-pipeline-blockers
+**Date**: 2025-12-06
+
+## Overview
+
+This feature is **infrastructure-only** and does not introduce new data models or entities.
+
+## Entities Affected
+
+### Existing: ECR Repository
+
+**Resource**: `aws_ecr_repository.sse_streaming`
+**Change**: Import into terraform state (no schema change)
+
+| Attribute | Current | After |
+|-----------|---------|-------|
+| name | `preprod-sse-streaming-lambda` | No change |
+| image_tag_mutability | `MUTABLE` | No change |
+| scan_on_push | `true` | No change |
+| encryption_type | `AES256` | No change |
+
+### Existing: KMS Key
+
+**Resource**: `aws_kms_key.main`
+**Change**: Add CI deployer principals to key policy
+
+| Attribute | Current | After |
+|-----------|---------|-------|
+| policy.Statement | 4 statements (Root, S3, SecretsManager, SNS) | 5 statements (+CIDeployerKeyAdmin) |
+
+## No New Entities
+
+This feature resolves state reconciliation and permission issues. No new:
+- Database tables
+- API endpoints
+- Data structures
+- Application entities
+
+## State Transitions
+
+N/A - Infrastructure resources only.

--- a/specs/041-pipeline-blockers/plan.md
+++ b/specs/041-pipeline-blockers/plan.md
@@ -1,0 +1,176 @@
+# Implementation Plan: Pipeline Blockers Resolution
+
+**Branch**: `041-pipeline-blockers` | **Date**: 2025-12-06 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/041-pipeline-blockers/spec.md`
+
+## Summary
+
+Resolve two remaining pipeline blockers preventing preprod deployment:
+1. **ECR Import**: Import orphan `preprod-sse-streaming-lambda` repository into terraform state
+2. **KMS Key Policy**: Add CI deployer admin permissions to KMS key policy to allow key creation
+
+Both issues are infrastructure-only fixes with no application code changes.
+
+## Technical Context
+
+**Language/Version**: Terraform 1.5+ with HCL
+**Primary Dependencies**: AWS Provider ~> 5.0, terraform CLI
+**Storage**: S3 terraform state backend (`sentiment-analyzer-terraform-state-218795110243`)
+**Testing**: terraform validate, terraform plan (drift detection)
+**Target Platform**: AWS (us-east-1)
+**Project Type**: Infrastructure-as-Code (no source structure changes)
+**Performance Goals**: N/A (infrastructure provisioning)
+**Constraints**: CI deployer (`sentiment-analyzer-preprod-deployer`) must be able to create/manage KMS keys
+**Scale/Scope**: 2 resources affected (1 ECR repo, 1 KMS key)
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Gate | Status | Notes |
+|------|--------|-------|
+| Security: Secrets in code | PASS | No secrets introduced |
+| Security: Least-privilege IAM | PASS | KMS admin scoped to CI deployers only |
+| Testing: Unit test accompaniment | N/A | Infrastructure-only changes |
+| Git: No bypass of pipeline | PASS | All changes go through PR process |
+| Deployment: IaC only | PASS | All changes are Terraform |
+
+**Pre-Phase 0**: PASS - No violations
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/041-pipeline-blockers/
+├── spec.md              # Feature specification
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+└── checklists/
+    └── requirements.md  # Quality checklist
+```
+
+### Source Code (repository root)
+
+```text
+infrastructure/terraform/
+├── main.tf                          # ECR resource: aws_ecr_repository.sse_streaming
+├── modules/kms/
+│   ├── main.tf                      # KMS key resource: aws_kms_key.main (FIX NEEDED)
+│   └── variables.tf                 # Add ci_deployer_arns variable
+└── ci-user-policy.tf                # CI deployer user definitions (reference)
+```
+
+**Structure Decision**: Existing infrastructure-as-code structure. No new directories needed.
+
+## Implementation Tasks
+
+### Task 1: Import Orphan ECR Repository (FR-001)
+
+**Resource**: `aws_ecr_repository.sse_streaming` in `main.tf:567`
+**AWS Resource**: `preprod-sse-streaming-lambda` (exists in AWS)
+**State**: Missing from terraform state
+
+**Action**: One-time terraform import command
+
+```bash
+cd infrastructure/terraform
+terraform init -backend-config=backend-preprod.hcl -backend-config="region=us-east-1"
+terraform import aws_ecr_repository.sse_streaming preprod-sse-streaming-lambda
+terraform plan  # Verify no changes needed
+```
+
+**Verification**: `terraform plan` shows no changes to ECR repository
+
+### Task 2: Fix KMS Key Policy (FR-002, FR-003)
+
+**Resource**: `aws_kms_key.main` in `modules/kms/main.tf:24-76`
+**Problem**: Key policy only grants `kms:*` to root account. AWS requires creating principal to also have key management.
+
+**Current Policy** (problematic):
+```hcl
+Statement = [
+  {
+    Sid = "RootAccess"
+    Principal = { AWS = "arn:aws:iam::${account_id}:root" }
+    Action = "kms:*"
+    Resource = "*"
+  },
+  # ... service access statements
+]
+```
+
+**Required Change**: Add statement for CI deployer key administration
+
+```hcl
+# CI Deployer Key Administration
+{
+  Sid       = "CIDeployerKeyAdmin"
+  Effect    = "Allow"
+  Principal = {
+    AWS = [
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/sentiment-analyzer-preprod-deployer",
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/sentiment-analyzer-prod-deployer"
+    ]
+  }
+  Action = [
+    "kms:Create*",
+    "kms:Describe*",
+    "kms:Enable*",
+    "kms:List*",
+    "kms:Put*",
+    "kms:Update*",
+    "kms:Revoke*",
+    "kms:Disable*",
+    "kms:Get*",
+    "kms:Delete*",
+    "kms:TagResource",
+    "kms:UntagResource",
+    "kms:ScheduleKeyDeletion",
+    "kms:CancelKeyDeletion"
+  ]
+  Resource = "*"
+}
+```
+
+**Alternative**: Use variable for CI deployer ARNs for reusability
+
+**Verification**: `terraform apply` creates KMS key without `MalformedPolicyDocumentException`
+
+### Task 3: Pipeline Validation (FR-004)
+
+**Action**: Push changes, monitor pipeline
+
+**Expected Result**:
+1. Terraform init succeeds (state bucket accessible - verified in spec 019)
+2. Terraform plan shows KMS key policy change only
+3. Terraform apply creates KMS key successfully
+4. No `RepositoryAlreadyExistsException` errors
+5. No `MalformedPolicyDocumentException` errors
+
+## Edge Case Handling
+
+| Edge Case | Resolution |
+|-----------|------------|
+| ECR repo has images | Import preserves existing images |
+| KMS key exists in failed state | Delete existing key first if in pending deletion |
+| Prod deployer also needs KMS | FR-005 requires same pattern for prod |
+
+## Execution Order
+
+1. **Bootstrap (manual)**: ECR import using `sentiment-analyzer-dev` user
+2. **Code Change**: KMS key policy update in `modules/kms/main.tf`
+3. **Pipeline**: Push → PR → Merge → Automated terraform apply
+
+## Success Criteria Mapping
+
+| SC | Verification |
+|----|--------------|
+| SC-001 | Pipeline job completes < 10 min |
+| SC-002 | No ECR/KMS exceptions in logs |
+| SC-003 | Preprod smoke tests pass |
+| SC-004 | CI deployer can update key policy |
+
+## Complexity Tracking
+
+No complexity violations. This is a minimal infrastructure fix.

--- a/specs/041-pipeline-blockers/quickstart.md
+++ b/specs/041-pipeline-blockers/quickstart.md
@@ -1,0 +1,111 @@
+# Quickstart: Pipeline Blockers Resolution
+
+**Feature**: 041-pipeline-blockers
+**Date**: 2025-12-06
+
+## Prerequisites
+
+- AWS CLI configured with `sentiment-analyzer-dev` credentials
+- Terraform 1.5+ installed
+- Access to S3 state bucket `sentiment-analyzer-terraform-state-218795110243`
+
+## Step 1: ECR Repository Import (One-Time Bootstrap)
+
+```bash
+# Navigate to terraform directory
+cd infrastructure/terraform
+
+# Initialize with preprod backend
+terraform init -backend-config=backend-preprod.hcl -backend-config="region=us-east-1" -reconfigure
+
+# Verify identity (should be sentiment-analyzer-dev)
+aws sts get-caller-identity
+
+# Import the orphan ECR repository
+terraform import aws_ecr_repository.sse_streaming preprod-sse-streaming-lambda
+
+# Verify import - should show no changes to ECR
+terraform plan
+```
+
+## Step 2: KMS Key Policy Fix (Code Change)
+
+Edit `infrastructure/terraform/modules/kms/main.tf`:
+
+Add after the existing statements in the policy:
+
+```hcl
+# CI Deployer Key Administration
+{
+  Sid       = "CIDeployerKeyAdmin"
+  Effect    = "Allow"
+  Principal = {
+    AWS = [
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/sentiment-analyzer-preprod-deployer",
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/sentiment-analyzer-prod-deployer"
+    ]
+  }
+  Action = [
+    "kms:Create*",
+    "kms:Describe*",
+    "kms:Enable*",
+    "kms:List*",
+    "kms:Put*",
+    "kms:Update*",
+    "kms:Revoke*",
+    "kms:Disable*",
+    "kms:Get*",
+    "kms:Delete*",
+    "kms:TagResource",
+    "kms:UntagResource",
+    "kms:ScheduleKeyDeletion",
+    "kms:CancelKeyDeletion"
+  ]
+  Resource = "*"
+}
+```
+
+## Step 3: Commit and Push
+
+```bash
+git checkout -b 041-pipeline-blockers
+git add infrastructure/terraform/modules/kms/main.tf
+git commit -S -m "fix(kms): Add CI deployer admin permissions to key policy"
+git push -u origin 041-pipeline-blockers
+```
+
+## Step 4: Pipeline Verification
+
+1. Create PR targeting `main`
+2. Monitor pipeline: `gh run watch`
+3. Verify no `RepositoryAlreadyExistsException` errors
+4. Verify no `MalformedPolicyDocumentException` errors
+5. Confirm "Terraform Apply (Preprod)" job succeeds
+
+## Troubleshooting
+
+### ECR Import Fails
+
+```bash
+# Check if repository exists
+aws ecr describe-repositories --repository-names preprod-sse-streaming-lambda
+
+# If different name, use correct name in import command
+```
+
+### KMS Key Already Exists
+
+```bash
+# Check existing key
+aws kms describe-key --key-id alias/sentiment-analyzer-preprod
+
+# If in PendingDeletion state
+aws kms cancel-key-deletion --key-id <key-id>
+
+# Then import
+terraform import module.kms.aws_kms_key.main <key-id>
+```
+
+### Permission Denied During Import
+
+Ensure using `sentiment-analyzer-dev` credentials, not `preprod-deployer`.

--- a/specs/041-pipeline-blockers/research.md
+++ b/specs/041-pipeline-blockers/research.md
@@ -1,0 +1,112 @@
+# Research: Pipeline Blockers Resolution
+
+**Feature**: 041-pipeline-blockers
+**Date**: 2025-12-06
+
+## Unknowns Resolution
+
+### 1. ECR Repository Import Syntax
+
+**Question**: What is the correct terraform import command for ECR repositories?
+
+**Decision**: Use `terraform import aws_ecr_repository.<resource_name> <repository_name>`
+
+**Rationale**: AWS ECR repositories are imported by their name, not ARN.
+
+**Command**:
+```bash
+terraform import aws_ecr_repository.sse_streaming preprod-sse-streaming-lambda
+```
+
+**Source**: [AWS Provider ECR Documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository#import)
+
+### 2. KMS Key Policy Requirements
+
+**Question**: Why does AWS reject KMS key policies that only grant root access?
+
+**Decision**: AWS requires the creating principal to have explicit key administration permissions in the key policy.
+
+**Rationale**:
+- When a KMS key is created, AWS validates that the calling principal can manage the key after creation
+- Even though root has `kms:*`, the creating IAM user must also be explicitly included
+- This prevents scenarios where keys become unmanageable if root access is restricted
+
+**Required Actions for Key Administration**:
+```
+kms:Create*, kms:Describe*, kms:Enable*, kms:List*,
+kms:Put*, kms:Update*, kms:Revoke*, kms:Disable*,
+kms:Get*, kms:Delete*, kms:TagResource, kms:UntagResource,
+kms:ScheduleKeyDeletion, kms:CancelKeyDeletion
+```
+
+**Source**: [AWS KMS Best Practices - Key Policies](https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html)
+
+### 3. Handling Existing KMS Key in Failed State
+
+**Question**: What if a KMS key already exists from a previous failed apply?
+
+**Decision**: Check key state before apply; if in `PendingDeletion`, cancel deletion and import.
+
+**Options**:
+1. Key doesn't exist → Create normally
+2. Key exists and active → Import into state
+3. Key in `PendingDeletion` → `aws kms cancel-key-deletion --key-id <id>` then import
+
+**Verification Command**:
+```bash
+aws kms describe-key --key-id alias/sentiment-analyzer-preprod 2>/dev/null || echo "Key not found"
+```
+
+## Best Practices Applied
+
+### Terraform Import Best Practices
+
+1. **Always run plan after import** - Verify no drift between state and config
+2. **Import in isolation** - Don't mix imports with other changes
+3. **Document imports** - Add comment in code noting the import was performed
+4. **Backup state** - State is auto-versioned in S3, but verify bucket versioning enabled
+
+### KMS Key Policy Best Practices
+
+1. **Always include root** - Required fallback access
+2. **Use explicit principals** - Avoid `Principal: "*"`
+3. **Scope service access** - Only grant necessary operations per service
+4. **Include creating principal** - Required for key manageability
+
+## Alternatives Considered
+
+### Alternative 1: Delete and Recreate ECR Repository
+
+**Rejected Because**: May have existing images; import is non-destructive
+
+### Alternative 2: Use IAM Policy Instead of Key Policy for KMS Access
+
+**Rejected Because**: AWS requires key policy to allow the creating principal; IAM policies alone are insufficient for KMS key creation
+
+### Alternative 3: Create KMS Key via Bootstrap Script
+
+**Rejected Because**: Violates IaC principle; all resources should be terraform-managed
+
+## Dependencies
+
+| Dependency | Status | Notes |
+|------------|--------|-------|
+| S3 state bucket access | RESOLVED | Fixed in spec 019 |
+| IAM policy for deployer | RESOLVED | Fixed in spec 019 |
+| Terraform CLI | AVAILABLE | Version 1.5+ in CI |
+| AWS credentials | AVAILABLE | Via GitHub Secrets |
+
+## Risk Assessment
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| ECR import fails | LOW | LOW | Verify repo name matches; retry with correct name |
+| KMS key already exists | MEDIUM | LOW | Check state; import or cancel deletion |
+| Pipeline still fails | LOW | MEDIUM | Debug logs; iterate on permissions |
+
+## Conclusion
+
+All unknowns resolved. Implementation is straightforward:
+1. ECR import is a single command
+2. KMS fix requires adding one policy statement
+3. Both CI deployers (preprod + prod) are included per FR-005

--- a/specs/041-pipeline-blockers/spec.md
+++ b/specs/041-pipeline-blockers/spec.md
@@ -1,0 +1,109 @@
+# Feature Specification: Pipeline Blockers Resolution
+
+**Feature Branch**: `041-pipeline-blockers`
+**Created**: 2025-12-06
+**Status**: Draft
+**Input**: User description: "Resolve remaining pipeline blockers: import orphan ECR repo and fix KMS key policy"
+
+## Problem Analysis
+
+### Root Cause Investigation
+
+The preprod deployment pipeline is failing at Terraform Apply due to two issues discovered during IAM bootstrap (spec 019):
+
+**Issue 1: Orphan ECR Repository**
+- During a previous failed terraform apply, the ECR repository `preprod-sse-streaming-lambda` was created
+- The apply then failed on a different resource (KMS key)
+- Terraform state does not contain the ECR repo because the apply was rolled back
+- Subsequent applies fail with `RepositoryAlreadyExistsException`
+
+**Issue 2: KMS Key Policy**
+- Error: `MalformedPolicyDocumentException: The new key policy will not allow you to update the key policy in the future`
+- The KMS key policy only grants `kms:*` to root account
+- AWS requires that the creating principal (CI deployer) can also manage the key
+- Without explicit admin permissions for the deployer, AWS rejects the key creation
+
+## User Scenarios & Testing
+
+### User Story 1 - ECR Repository Import (Priority: P1)
+
+As a developer, I need the pipeline to successfully create or manage the SSE streaming Lambda ECR repository so that container-based Lambda deployments work.
+
+**Why this priority**: Direct blocker - terraform apply cannot proceed until ECR state is reconciled.
+
+**Independent Test**: Run `terraform plan` and verify no ECR repository errors appear.
+
+**Acceptance Scenarios**:
+
+1. **Given** orphan ECR repo `preprod-sse-streaming-lambda` exists in AWS but not in terraform state, **When** terraform import is run, **Then** terraform state includes the ECR repo and plan shows no changes
+2. **Given** ECR repo is in terraform state, **When** pipeline runs terraform apply, **Then** no `RepositoryAlreadyExistsException` error occurs
+
+---
+
+### User Story 2 - KMS Key Policy Fix (Priority: P1)
+
+As a DevOps engineer, I need the KMS key policy to allow the CI deployer to manage the key so that key creation succeeds.
+
+**Why this priority**: Direct blocker - terraform apply cannot create KMS key without this fix.
+
+**Independent Test**: Run `terraform apply` targeting the KMS module and verify key is created successfully.
+
+**Acceptance Scenarios**:
+
+1. **Given** KMS key policy includes CI deployer admin permissions, **When** terraform creates KMS key, **Then** key is created without `MalformedPolicyDocumentException`
+2. **Given** KMS key exists, **When** CI deployer attempts to update key policy, **Then** operation succeeds (key is manageable)
+
+---
+
+### User Story 3 - Pipeline Green (Priority: P1)
+
+As a developer, I need the full preprod deployment pipeline to pass so that changes can be deployed to the preprod environment.
+
+**Why this priority**: End goal - validates both fixes work together.
+
+**Independent Test**: Trigger pipeline run on main branch and observe successful deployment to preprod.
+
+**Acceptance Scenarios**:
+
+1. **Given** ECR import and KMS fix are applied, **When** pipeline runs full terraform apply, **Then** all resources are created/updated successfully
+2. **Given** successful terraform apply, **When** smoke tests run, **Then** preprod environment is accessible
+
+---
+
+### Edge Cases
+
+- What if ECR repo has images that must be preserved? (Import preserves existing images)
+- What if KMS key already exists in a previous failed state? (May need import or manual deletion)
+- What if prod-deployer also needs KMS permissions? (Apply same pattern)
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: Terraform state MUST include the `preprod-sse-streaming-lambda` ECR repository
+- **FR-002**: KMS key policy MUST grant key administration permissions to CI deployer users
+- **FR-003**: KMS key policy MUST retain root account access as fallback
+- **FR-004**: Pipeline MUST complete terraform init, plan, and apply without permission errors
+- **FR-005**: Solution MUST work for both preprod and prod deployer users
+
+### Key Entities
+
+- **ECR Repository**: `preprod-sse-streaming-lambda` - container image storage for SSE streaming Lambda
+- **KMS Key**: Shared encryption key for sentiment analyzer secrets and data
+- **CI Deployer Users**: `sentiment-analyzer-preprod-deployer`, `sentiment-analyzer-prod-deployer`
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: Pipeline job "Terraform Apply (Preprod)" completes successfully within 10 minutes
+- **SC-002**: No `RepositoryAlreadyExistsException` or `MalformedPolicyDocumentException` errors in pipeline logs
+- **SC-003**: Preprod smoke tests pass after deployment
+- **SC-004**: Future KMS key policy updates can be made by CI deployer without root intervention
+
+## Assumptions
+
+- The orphan ECR repository `preprod-sse-streaming-lambda` should be imported, not deleted and recreated
+- CI deployer should have KMS key administration rights scoped to sentiment-analyzer keys only
+- Root account access to KMS key should be preserved as a failsafe
+- Terraform state in S3 is accessible (verified in spec 019)

--- a/specs/041-pipeline-blockers/tasks.md
+++ b/specs/041-pipeline-blockers/tasks.md
@@ -1,0 +1,208 @@
+# Tasks: Pipeline Blockers Resolution
+
+**Input**: Design documents from `/specs/041-pipeline-blockers/`
+**Prerequisites**: plan.md, spec.md, research.md, quickstart.md
+
+**Tests**: No tests requested - infrastructure-only changes validated via terraform plan/apply.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and validation.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1, US2, US3)
+- Include exact file paths and commands in descriptions
+
+## Path Conventions
+
+Infrastructure-as-Code project structure:
+```text
+infrastructure/terraform/
+├── main.tf                     # ECR resource
+├── modules/kms/main.tf         # KMS key resource
+└── ci-user-policy.tf           # CI deployer reference
+```
+
+---
+
+## Phase 1: Setup (Bootstrap Environment)
+
+**Purpose**: Prepare terraform environment with correct backend and credentials
+
+- [x] T001 Verify AWS credentials are for `sentiment-analyzer-dev` user via `aws sts get-caller-identity`
+- [x] T002 Navigate to terraform directory: `cd infrastructure/terraform`
+- [x] T003 Initialize terraform with preprod backend: `terraform init -backend-config=backend-preprod.hcl -backend-config="region=us-east-1" -reconfigure`
+
+**Checkpoint**: Terraform initialized with preprod state backend
+
+---
+
+## Phase 2: User Story 1 - ECR Repository Import (Priority: P1) 🎯 MVP
+
+**Goal**: Import orphan ECR repository into terraform state to resolve `RepositoryAlreadyExistsException`
+
+**Independent Test**: Run `terraform plan` and verify no ECR repository errors appear
+
+### Implementation for User Story 1
+
+- [x] T004 [US1] Check if ECR repo exists in AWS: `aws ecr describe-repositories --repository-names preprod-sse-streaming-lambda`
+- [x] T005 [US1] Import ECR repo into terraform state: `terraform import aws_ecr_repository.sse_streaming preprod-sse-streaming-lambda`
+- [x] T006 [US1] Verify import successful: `terraform plan` shows no changes to ECR resource
+
+**Checkpoint**: ECR repository in terraform state, `terraform plan` clean for ECR
+
+---
+
+## Phase 3: User Story 2 - KMS Key Policy Fix (Priority: P1)
+
+**Goal**: Add CI deployer admin permissions to KMS key policy to allow key creation
+
+**Independent Test**: Run `terraform apply` targeting KMS module and verify key creation succeeds
+
+### Implementation for User Story 2
+
+- [x] T007 [US2] Read current KMS key policy in `infrastructure/terraform/modules/kms/main.tf`
+- [x] T008 [US2] Add CIDeployerKeyAdmin statement to policy in `infrastructure/terraform/modules/kms/main.tf:31-75`
+- [x] T009 [US2] Validate terraform syntax: `terraform validate`
+- [x] T010 [US2] Preview KMS changes: `terraform plan -target=module.kms`
+
+**Checkpoint**: KMS key policy includes CI deployer admin permissions, plan shows expected changes
+
+---
+
+## Phase 4: User Story 3 - Pipeline Green (Priority: P1)
+
+**Goal**: Validate full pipeline passes with both fixes applied
+
+**Independent Test**: Push to branch, create PR, merge to main, observe successful preprod deployment
+
+### Implementation for User Story 3
+
+- [ ] T011 [US3] Create feature branch: `git checkout -b 041-pipeline-blockers`
+- [ ] T012 [US3] Stage KMS changes: `git add infrastructure/terraform/modules/kms/main.tf`
+- [ ] T013 [US3] Commit with GPG signature: `git commit -S -m "fix(kms): Add CI deployer admin permissions to key policy"`
+- [ ] T014 [US3] Push to remote: `git push -u origin 041-pipeline-blockers`
+- [ ] T015 [US3] Create PR: `gh pr create --fill --base main`
+- [ ] T016 [US3] Monitor pipeline: `gh run watch`
+- [ ] T017 [US3] Verify no `RepositoryAlreadyExistsException` in pipeline logs
+- [ ] T018 [US3] Verify no `MalformedPolicyDocumentException` in pipeline logs
+- [ ] T019 [US3] Merge PR after checks pass: `gh pr merge --auto --rebase --delete-branch`
+
+**Checkpoint**: Pipeline green, preprod deployment successful
+
+---
+
+## Phase 5: Polish & Verification
+
+**Purpose**: Verify success criteria and cleanup
+
+- [ ] T020 Verify SC-001: Pipeline job "Terraform Apply (Preprod)" completed < 10 minutes
+- [ ] T021 Verify SC-002: No ECR/KMS exceptions in final pipeline run
+- [ ] T022 Verify SC-003: Check preprod smoke tests passed
+- [ ] T023 Verify SC-004: Test CI deployer can update KMS key policy (optional manual test)
+- [ ] T024 Update spec.md status from "Draft" to "Complete"
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - start immediately
+- **US1 ECR Import (Phase 2)**: Depends on Setup - MUST complete before pipeline validation
+- **US2 KMS Fix (Phase 3)**: Depends on Setup - can run parallel to US1
+- **US3 Pipeline (Phase 4)**: Depends on US1 and US2 completion
+- **Polish (Phase 5)**: Depends on US3 completion
+
+### User Story Dependencies
+
+```text
+          ┌──────────────┐
+          │   Setup      │
+          │  (T001-T003) │
+          └──────┬───────┘
+                 │
+        ┌────────┴────────┐
+        │                 │
+        ▼                 ▼
+┌───────────────┐ ┌───────────────┐
+│  US1: ECR     │ │  US2: KMS     │
+│  (T004-T006)  │ │  (T007-T010)  │
+└───────┬───────┘ └───────┬───────┘
+        │                 │
+        └────────┬────────┘
+                 │
+                 ▼
+        ┌───────────────┐
+        │  US3: Pipeline│
+        │  (T011-T019)  │
+        └───────┬───────┘
+                │
+                ▼
+        ┌───────────────┐
+        │    Polish     │
+        │  (T020-T024)  │
+        └───────────────┘
+```
+
+### Parallel Opportunities
+
+- **US1 and US2 can run in parallel** after Setup completes
+  - US1 (ECR import) is a one-time bootstrap command
+  - US2 (KMS fix) is a code change
+  - Both are independent resources
+
+---
+
+## Parallel Example: US1 + US2
+
+```bash
+# After Setup completes, these can run simultaneously:
+
+# Terminal 1 (US1 - ECR Import):
+terraform import aws_ecr_repository.sse_streaming preprod-sse-streaming-lambda
+terraform plan  # Verify ECR clean
+
+# Terminal 2 (US2 - KMS Fix):
+# Edit modules/kms/main.tf
+terraform validate
+terraform plan -target=module.kms
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (US1 + US2)
+
+1. Complete Phase 1: Setup (T001-T003)
+2. Complete Phase 2: US1 ECR Import (T004-T006) - **Unblocks pipeline**
+3. Complete Phase 3: US2 KMS Fix (T007-T010) - **Enables key creation**
+4. **STOP and VALIDATE**: Both blockers resolved locally
+
+### Full Delivery
+
+1. Complete MVP above
+2. Complete Phase 4: US3 Pipeline (T011-T019) - **Push and verify**
+3. Complete Phase 5: Polish (T020-T024) - **Verify success criteria**
+
+### Single Developer Strategy
+
+Since this is a small infrastructure fix:
+1. Run T001-T003 (Setup) ~2 min
+2. Run T004-T006 (ECR Import) ~3 min
+3. Run T007-T010 (KMS Fix) ~5 min
+4. Run T011-T019 (Pipeline) ~15 min (waiting for CI)
+5. Run T020-T024 (Verification) ~5 min
+
+**Total estimated time**: ~30 minutes
+
+---
+
+## Notes
+
+- US1 (ECR Import) requires `sentiment-analyzer-dev` credentials (not preprod-deployer)
+- US2 (KMS Fix) is a code change that goes through normal PR flow
+- US3 validates that the pipeline works end-to-end
+- No unit tests needed - validation is via terraform plan/apply
+- Commit after KMS fix only (ECR import modifies state, not code)


### PR DESCRIPTION
## Summary

Resolves two remaining pipeline blockers preventing preprod deployment:

- **ECR Repository Import**: Imported orphan `preprod-sse-streaming-lambda` into terraform state (resolves `RepositoryAlreadyExistsException`)
- **KMS Key Policy Fix**: Added `CIDeployerKeyAdmin` statement to allow CI deployers to create/manage KMS keys (resolves `MalformedPolicyDocumentException`)

## Changes

- `infrastructure/terraform/modules/kms/main.tf`: Added CIDeployerKeyAdmin statement with full key administration permissions for both preprod and prod deployers
- `specs/041-pipeline-blockers/`: Complete spec documentation (spec.md, plan.md, tasks.md, research.md, quickstart.md, data-model.md)

## Test Plan

- [x] ECR repo imported into terraform state (`terraform import` succeeded)
- [x] Terraform validate passes
- [x] Terraform plan shows expected KMS changes
- [ ] Pipeline "Terraform Apply (Preprod)" job passes
- [ ] No `RepositoryAlreadyExistsException` errors
- [ ] No `MalformedPolicyDocumentException` errors

## Addresses

- FR-002: KMS key policy grants key administration to CI deployers
- FR-003: Root account access retained as fallback  
- FR-005: Solution works for both preprod and prod deployers

🤖 Generated with [Claude Code](https://claude.com/claude-code)