### PR TITLE
fix(iam): Add sentiment-analyzer-* alias pattern to KMS permissions

### DIFF
--- a/infrastructure/terraform/ci-user-policy.tf
+++ b/infrastructure/terraform/ci-user-policy.tf
@@ -1048,6 +1048,9 @@ data "aws_iam_policy_document" "ci_deploy_storage" {
   }
 
   # KMS Alias Management
+  # Note: Supports both patterns:
+  # - *-sentiment-* (preprod-sentiment-shared-key)
+  # - sentiment-analyzer-* (sentiment-analyzer-preprod)
   statement {
     sid    = "KMSAlias"
     effect = "Allow"
@@ -1057,7 +1060,8 @@ data "aws_iam_policy_document" "ci_deploy_storage" {
       "kms:UpdateAlias"
     ]
     resources = [
-      "arn:aws:kms:*:*:alias/*-sentiment-*"
+      "arn:aws:kms:*:*:alias/*-sentiment-*",
+      "arn:aws:kms:*:*:alias/sentiment-analyzer-*"
     ]
   }
 


### PR DESCRIPTION
## Summary
- Added `alias/sentiment-analyzer-*` pattern to KMS alias permissions in CIDeployStorage policy
- Imported orphan CloudWatch log group `/aws/lambda/preprod-sentiment-sse-streaming` into Terraform state
- IAM policy already bootstrapped via targeted apply

## Root Cause
The KMS alias pattern `alias/*-sentiment-*` didn't match `alias/sentiment-analyzer-preprod` created by the KMS module.

## Test Plan
- [x] Terraform validate passes
- [x] IAM policy update applied via targeted Terraform apply
- [ ] Pipeline runs and deploys successfully to preprod
- [ ] No `kms:CreateAlias` AccessDeniedException
- [ ] No CloudWatch log group `ResourceAlreadyExistsException`

🤖 Generated with [Claude Code](https://claude.com/claude-code)