### PR TITLE
fix(iam): Add KMS encryption permissions for CI deployers

### DIFF
--- a/infrastructure/terraform/ci-user-policy.tf
+++ b/infrastructure/terraform/ci-user-policy.tf
@@ -1075,6 +1075,10 @@ data "aws_iam_policy_document" "ci_deploy_storage" {
     ]
     resources = ["*"]
   }
+
+  # NOTE: KMS encryption operations (Encrypt, Decrypt, GenerateDataKey) are granted
+  # via KMS key policy in modules/kms/main.tf (CIDeployerEncryption statement).
+  # Key policies are authoritative and don't require IAM policy grants.
 }
 
 # ==================================================================

--- a/infrastructure/terraform/modules/kms/main.tf
+++ b/infrastructure/terraform/modules/kms/main.tf
@@ -100,6 +100,26 @@ resource "aws_kms_key" "main" {
           "kms:CancelKeyDeletion"
         ]
         Resource = "*"
+      },
+      # CI Deployer Encryption Operations
+      # Required for Secrets Manager UpdateSecret when secrets use KMS encryption
+      # Canonical Source: https://docs.aws.amazon.com/kms/latest/developerguide/services-secrets-manager.html
+      {
+        Sid    = "CIDeployerEncryption"
+        Effect = "Allow"
+        Principal = {
+          AWS = [
+            "arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/sentiment-analyzer-preprod-deployer",
+            "arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/sentiment-analyzer-prod-deployer"
+          ]
+        }
+        Action = [
+          "kms:Encrypt",
+          "kms:Decrypt",
+          "kms:GenerateDataKey",
+          "kms:GenerateDataKeyWithoutPlaintext"
+        ]
+        Resource = "*"
       }
     ]
   })


### PR DESCRIPTION
## Summary

- Pipeline failing with "Access to KMS is not allowed" when updating Secrets Manager secrets
- KMS key policy had admin actions but not encryption operations (Encrypt, Decrypt, GenerateDataKey)
- Add CIDeployerEncryption statement to KMS key policy

## Root Cause

The KMS key policy granted CI deployers administrative actions:
- `kms:Create*`, `kms:Describe*`, `kms:Put*`, etc.

But **not** encryption operations needed for Secrets Manager UpdateSecret:
- `kms:Encrypt`, `kms:Decrypt`, `kms:GenerateDataKey`

## Fix

Add `CIDeployerEncryption` statement to `modules/kms/main.tf` granting encryption operations to both preprod and prod deployer users.

## Canonical Source

https://docs.aws.amazon.com/kms/latest/developerguide/services-secrets-manager.html

## Test plan

- [ ] KMS key policy update applies successfully
- [ ] Secrets Manager UpdateSecret no longer fails with KMS AccessDeniedException
- [ ] Pipeline Deploy to Preprod completes

## Note

The ECR image issue (`preprod-sse-streaming-lambda:latest does not exist`) is a separate problem and will be addressed in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)