### PR TITLE
fix(ci): Add environment declarations to SSE build jobs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -510,6 +510,7 @@ jobs:
     name: Build SSE Lambda Image (Preprod)
     runs-on: ubuntu-latest
     needs: [build, test]
+    environment: preprod
 
     steps:
       - name: Checkout code
@@ -981,6 +982,7 @@ jobs:
     name: Build SSE Lambda Image (Production)
     runs-on: ubuntu-latest
     needs: [build, deploy-preprod, test-preprod]
+    environment: production
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary

Fix deploy pipeline credential failure by adding missing `environment:` declarations to SSE build jobs.

## Root Cause

The `build-sse-image-preprod` and `build-sse-image-prod` jobs use environment-scoped secrets (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`) stored in the `preprod` and `production` GitHub environments, but lacked `environment:` declarations - preventing access to those secrets.

**Error**: "Credentials could not be loaded, please check your action inputs: Could not load credentials from any providers"

## Changes

- Add `environment: preprod` to `build-sse-image-preprod` job
- Add `environment: production` to `build-sse-image-prod` job

## Canonical Source

[GitHub Actions: Using environments for deployment](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment)

## Test Plan

- [ ] PR checks pass
- [ ] After merge, deploy pipeline `build-sse-image-preprod` job passes
- [ ] Full pipeline completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)