### PR TITLE
fix(ci): Add Docker Buildx setup for GHA cache support

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -527,6 +527,9 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build and Push SSE Lambda Image
         uses: docker/build-push-action@v6
         with:
@@ -998,6 +1001,9 @@ jobs:
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Build and Push SSE Lambda Image
         uses: docker/build-push-action@v6


### PR DESCRIPTION
## Summary
- Add `docker/setup-buildx-action@v3` to both SSE image build jobs

## Problem
The `docker/build-push-action@v6` with `cache-to: type=gha` requires Docker Buildx with a docker-container driver. The default docker driver does not support cache export.

Error: `Cache export is not supported for the docker driver.`

## Changes
- Add `docker/setup-buildx-action@v3` step before `docker/build-push-action@v6` in:
  - `build-sse-image-preprod` job (line 530-531)
  - `build-sse-image-prod` job (line 1005-1006)

## Test plan
- [ ] Pipeline passes `build-sse-image-preprod` job
- [ ] Pipeline passes end-to-end

Canonical Source: https://docs.docker.com/build/cache/backends/gha/

🤖 Generated with [Claude Code](https://claude.com/claude-code)