### PR TITLE
fix(iam): Add CloudFront permissions and fix Lambda image format

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -540,6 +540,7 @@ jobs:
             ${{ steps.login-ecr.outputs.registry }}/preprod-sse-streaming-lambda:${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          provenance: false
 
   # ========================================================================
   # JOB 4: Deploy to Preprod
@@ -1015,6 +1016,7 @@ jobs:
             ${{ steps.login-ecr.outputs.registry }}/prod-sse-streaming-lambda:${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          provenance: false
 
   # ========================================================================
   # JOB 6: Deploy to Production

--- a/infrastructure/iam-policies/preprod-deployer-policy.json
+++ b/infrastructure/iam-policies/preprod-deployer-policy.json
@@ -273,6 +273,34 @@
       ]
     },
     {
+      "Sid": "CloudFrontDistributions",
+      "Effect": "Allow",
+      "Action": [
+        "cloudfront:GetDistribution",
+        "cloudfront:GetDistributionConfig",
+        "cloudfront:UpdateDistribution",
+        "cloudfront:CreateDistribution",
+        "cloudfront:DeleteDistribution",
+        "cloudfront:TagResource",
+        "cloudfront:UntagResource",
+        "cloudfront:ListTagsForResource"
+      ],
+      "Resource": [
+        "arn:aws:cloudfront::*:distribution/*"
+      ]
+    },
+    {
+      "Sid": "CloudFrontCachePolicies",
+      "Effect": "Allow",
+      "Action": [
+        "cloudfront:GetCachePolicy",
+        "cloudfront:GetOriginRequestPolicy",
+        "cloudfront:ListCachePolicies",
+        "cloudfront:ListOriginRequestPolicies"
+      ],
+      "Resource": "*"
+    },
+    {
       "Sid": "DenyInsecureTransport",
       "Effect": "Deny",
       "Action": "sqs:*",


### PR DESCRIPTION
## Summary
- Add CloudFront permissions to CIDeployCore managed policy
- Add `provenance: false` to docker build to produce Lambda-compatible images

## Problems Fixed
1. **cloudfront:UpdateDistribution AccessDenied** - preprod-deployer lacked CloudFront permissions
2. **Lambda CreateFunction InvalidParameterValueException** - Docker Buildx produces OCI format by default, Lambda requires Docker v2

## Changes
- Updated `CIDeployCore` managed policy (v19) with CloudFront statement
- Added `provenance: false` to both SSE image build jobs in deploy.yml
- Updated preprod-deployer-policy.json (for documentation)

## IAM Policy Change
```json
{
  "Sid": "CloudFront",
  "Effect": "Allow",
  "Action": [
    "cloudfront:GetDistribution",
    "cloudfront:GetDistributionConfig", 
    "cloudfront:UpdateDistribution",
    "cloudfront:CreateDistribution",
    "cloudfront:DeleteDistribution",
    ...
  ],
  "Resource": "*"
}
```

## Test plan
- [ ] PR checks pass
- [ ] Deploy pipeline passes (build-sse-image-preprod, deploy-preprod)

Canonical Sources:
- https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_actions-resources-contextkeys.html
- https://docs.docker.com/build/ci/github-actions/attestations/

🤖 Generated with [Claude Code](https://claude.com/claude-code)