### PR TITLE
fix(061): SSE Lambda ModuleNotFoundError for shared imports

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -533,7 +533,8 @@ jobs:
       - name: Build and Push SSE Lambda Image
         uses: docker/build-push-action@v6
         with:
-          context: src/lambdas/sse_streaming
+          context: src/lambdas
+          file: src/lambdas/sse_streaming/Dockerfile
           push: true
           tags: |
             ${{ steps.login-ecr.outputs.registry }}/preprod-sse-streaming-lambda:latest
@@ -1009,7 +1010,8 @@ jobs:
       - name: Build and Push SSE Lambda Image
         uses: docker/build-push-action@v6
         with:
-          context: src/lambdas/sse_streaming
+          context: src/lambdas
+          file: src/lambdas/sse_streaming/Dockerfile
           push: true
           tags: |
             ${{ steps.login-ecr.outputs.registry }}/prod-sse-streaming-lambda:latest

--- a/src/lambdas/sse_streaming/Dockerfile
+++ b/src/lambdas/sse_streaming/Dockerfile
@@ -1,5 +1,8 @@
 # SSE Streaming Lambda - Docker Image
 # Uses AWS Lambda Web Adapter for RESPONSE_STREAM mode
+#
+# Build context: src/lambdas (parent directory)
+# This allows importing from shared modules
 FROM python:3.13-slim AS builder
 
 WORKDIR /app
@@ -9,8 +12,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     gcc \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy and install Python dependencies
-COPY requirements.txt .
+# Copy and install Python dependencies from sse_streaming subdirectory
+COPY sse_streaming/requirements.txt .
 RUN pip install --no-cache-dir --target /app/packages -r requirements.txt
 
 # Production image
@@ -24,10 +27,14 @@ COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:0.9.1 /lambda-adapter /opt
 # Copy installed packages
 COPY --from=builder /app/packages /app/packages
 
-# Copy application code
-COPY . .
+# Copy shared module for logging utilities
+# Structure: /app/src/lambdas/shared/
+COPY shared /app/src/lambdas/shared
 
-# Set Python path to include packages
+# Copy application code from sse_streaming subdirectory
+COPY sse_streaming /app
+
+# Set Python path to include packages and app root for imports
 ENV PYTHONPATH=/app/packages:/app
 ENV AWS_LWA_INVOKE_MODE=RESPONSE_STREAM
 


### PR DESCRIPTION
## Summary
- Fixes SSE Lambda crash with `ModuleNotFoundError: No module named 'src'`
- Expands Docker build context to include shared modules
- Updates both preprod and prod builds

## Root Cause
The SSE Lambda Docker build context was limited to `src/lambdas/sse_streaming`,
which excluded the `shared/` module needed by `handler.py` for logging utilities.

CloudWatch error from preprod Lambda invocation:
```
File "/app/handler.py", line 20, in <module>
    from src.lambdas.shared.logging_utils import sanitize_for_log
ModuleNotFoundError: No module named 'src'
```

## Solution
1. Change Docker build context from `src/lambdas/sse_streaming` to `src/lambdas`
2. Add `file:` parameter to specify Dockerfile path in workflow
3. Update Dockerfile to copy from subdirectories:
   - `sse_streaming/` for application code
   - `shared/` for logging utilities (preserving import path structure)

## Changes
- `.github/workflows/deploy.yml`: Updated both preprod and prod SSE Lambda builds
- `src/lambdas/sse_streaming/Dockerfile`: Updated COPY commands for new context

## Test Plan
- [ ] Pipeline builds SSE Lambda image successfully
- [ ] Lambda starts without ModuleNotFoundError
- [ ] 5 SSE tests pass (test_global_stream_available, etc.)
- [ ] 2 Dashboard tests pass (test_configs_list_returns_json, etc.)

## Canonical Sources
- [Docker build-push-action context](https://github.com/docker/build-push-action#inputs)
- [AWS Lambda Web Adapter](https://github.com/awslabs/aws-lambda-web-adapter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)