### PR TITLE
feat(069): Add stale PR auto-update workflow and slash command

### DIFF
--- a/.claude/commands/poke-stale-prs.md
+++ b/.claude/commands/poke-stale-prs.md
@@ -1,0 +1,87 @@
+# Poke Stale PRs
+
+Update all open PR branches with the latest main branch.
+
+## When to Use
+
+- After merging a workflow fix to main (if auto-update hasn't run yet)
+- When PRs show failing checks due to stale workflow files
+- Before reviewing PRs to ensure they have latest main
+- To manually trigger what the auto-update workflow does
+
+## What This Does
+
+1. Lists all open PRs in the repository
+2. For each PR, calls the GitHub API to update the branch with main
+3. Skips PRs that have merge conflicts (they need manual rebase)
+4. Reports which PRs were updated vs skipped
+
+## Implementation
+
+Run the following bash commands to update all open PRs:
+
+```bash
+# Get repository name
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+echo "Repository: $REPO"
+echo ""
+
+# List all open PRs
+prs=$(gh pr list --state open --json number -q '.[].number')
+
+if [ -z "$prs" ]; then
+  echo "No open PRs to update"
+  exit 0
+fi
+
+echo "Found open PRs: $prs"
+echo ""
+
+# Update each PR
+updated=0
+skipped=0
+
+for pr in $prs; do
+  echo "Updating PR #$pr..."
+  if gh api repos/$REPO/pulls/$pr/update-branch -X PUT 2>/dev/null; then
+    echo "  ✓ Updated"
+    ((updated++))
+  else
+    echo "  ⚠ Skipped (conflicts or up to date)"
+    ((skipped++))
+  fi
+done
+
+echo ""
+echo "=== Summary ==="
+echo "Updated: $updated"
+echo "Skipped: $skipped"
+```
+
+## Related
+
+- **Automatic version**: `.github/workflows/update-pr-branches.yml` runs automatically when workflow files change in main
+- **GitHub API**: Uses `PUT /repos/{owner}/{repo}/pulls/{pull_number}/update-branch`
+
+## Troubleshooting
+
+### PR skipped due to conflicts
+
+The PR branch has merge conflicts with main. Fix manually:
+
+```bash
+git checkout feature-branch
+git fetch origin main
+git rebase origin/main  # or git merge origin/main
+# Resolve conflicts
+git push --force-with-lease
+```
+
+### Permission denied
+
+Ensure you're authenticated with `gh`:
+
+```bash
+gh auth status
+gh auth login  # if needed
+```

--- a/.github/workflows/update-pr-branches.yml
+++ b/.github/workflows/update-pr-branches.yml
@@ -1,0 +1,74 @@
+# Auto-update PR branches when workflow files change
+# ===================================================
+#
+# When workflow files are fixed in main, existing PRs still run the
+# old workflow from their branch. This workflow automatically updates
+# all open PR branches when workflow files change.
+#
+# For On-Call Engineers:
+#   - This workflow runs automatically on workflow file changes
+#   - Check job logs to see which PRs were updated/skipped
+#   - PRs with merge conflicts are skipped (not an error)
+#
+# For Developers:
+#   - Manual alternative: /poke-stale-prs slash command
+#   - PRs skipped due to conflicts need manual rebase
+
+name: Update PR Branches
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+
+jobs:
+  update-prs:
+    name: Update Open PRs
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Update all open PR branches
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          echo "=== Stale PR Auto-Update ==="
+          echo "Triggered by workflow file changes in main"
+          echo ""
+
+          echo "Fetching open PRs..."
+          prs=$(gh pr list --repo ${{ github.repository }} --state open --json number -q '.[].number')
+
+          if [ -z "$prs" ]; then
+            echo "No open PRs to update"
+            echo ""
+            echo "Summary: 0 updated, 0 skipped"
+            exit 0
+          fi
+
+          echo "Found PRs: $prs"
+          echo ""
+
+          updated=0
+          skipped=0
+
+          for pr in $prs; do
+            echo "Updating PR #$pr..."
+            if gh api repos/${{ github.repository }}/pulls/$pr/update-branch -X PUT 2>/dev/null; then
+              echo "  ✓ PR #$pr updated successfully"
+              ((updated++))
+            else
+              echo "  ⚠ PR #$pr skipped (likely has conflicts or is up to date)"
+              ((skipped++))
+            fi
+          done
+
+          echo ""
+          echo "=== Summary ==="
+          echo "Updated: $updated"
+          echo "Skipped: $skipped"
+          echo "Total PRs processed: $((updated + skipped))"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,10 @@ Auto-generated from all feature plans. Last updated: 2025-11-26
 - S3 (Terraform state bucket) (018-tfstate-bucket-fix)
 - Python 3.13 + None (stdlib `time` module only) (066-fix-latency-timing)
 - N/A (in-memory latency tracking) (066-fix-latency-timing)
+- YAML (GitHub Actions workflows, Dependabot config) + GitHub Dependabot service, dependabot/fetch-metadata@v2 action, GitHub CLI (gh) (067-dependabot-automerge-audit)
+- N/A (configuration files only) (067-dependabot-automerge-audit)
+- YAML (GitHub Actions workflow syntax), Bash (slash command) + GitHub Actions, GitHub CLI (`gh`), GitHub REST API (069-stale-pr-autoupdate)
+- N/A (workflow configuration only) (069-stale-pr-autoupdate)
 
 - **Python 3.13** with FastAPI, boto3, pydantic, aws-lambda-powertools, httpx
 - **AWS Services**: DynamoDB (single-table design), S3, Lambda, SNS, EventBridge, Cognito, CloudFront
@@ -400,9 +404,9 @@ const eventSource = new EventSource(streamUrl);
 ```
 
 ## Recent Changes
+- 069-stale-pr-autoupdate: Added YAML (GitHub Actions workflow syntax), Bash (slash command) + GitHub Actions, GitHub CLI (`gh`), GitHub REST API
+- 067-dependabot-automerge-audit: Added YAML (GitHub Actions workflows, Dependabot config) + GitHub Dependabot service, dependabot/fetch-metadata@v2 action, GitHub CLI (gh)
 - 066-fix-latency-timing: Added Python 3.13 + None (stdlib `time` module only)
-- 018-tfstate-bucket-fix: Added N/A (IAM Policy JSON, HCL configuration) + AWS IAM, S3, Terraform
-- 018-tfstate-bucket-fix: Added N/A (IAM Policy JSON, HCL configuration) + AWS IAM, S3, Terraform
 
 <!-- MANUAL ADDITIONS START -->
 

--- a/specs/069-stale-pr-autoupdate/checklists/requirements.md
+++ b/specs/069-stale-pr-autoupdate/checklists/requirements.md
@@ -1,0 +1,44 @@
+# Specification Quality Checklist: Stale PR Auto-Update
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2025-12-08
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Validation Summary
+
+| Category | Status | Notes |
+|----------|--------|-------|
+| Content Quality | PASS | All items verified |
+| Requirement Completeness | PASS | All items verified |
+| Feature Readiness | PASS | All items verified |
+
+## Notes
+
+- Specification is complete and ready for `/speckit.plan`
+- No clarifications needed - feature scope is well-defined from problem context
+- Problem statement derived from actual incident (PRs 312-316 blocked by infracost fix)

--- a/specs/069-stale-pr-autoupdate/plan.md
+++ b/specs/069-stale-pr-autoupdate/plan.md
@@ -1,0 +1,178 @@
+# Implementation Plan: Stale PR Auto-Update
+
+**Branch**: `069-stale-pr-autoupdate` | **Date**: 2025-12-08 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/069-stale-pr-autoupdate/spec.md`
+
+## Summary
+
+Implement automatic PR branch updates when workflow files change in main, plus a manual `/poke-stale-prs` slash command for on-demand updates. This eliminates manual intervention when CI workflow fixes are merged, unblocking stale PRs automatically.
+
+## Technical Context
+
+**Language/Version**: YAML (GitHub Actions workflow syntax), Bash (slash command)
+**Primary Dependencies**: GitHub Actions, GitHub CLI (`gh`), GitHub REST API
+**Storage**: N/A (workflow configuration only)
+**Testing**: Manual verification via PR creation and workflow trigger observation
+**Target Platform**: GitHub Actions runner (ubuntu-latest)
+**Project Type**: CI/CD automation (workflow + slash command)
+**Performance Goals**: < 60 seconds execution for up to 20 open PRs
+**Constraints**: Must use existing GITHUB_TOKEN permissions, no additional secrets
+**Scale/Scope**: Single workflow file, single slash command file
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Gate | Status | Notes |
+|------|--------|-------|
+| **Git Workflow & CI/CD Rules** | PASS | Feature branch workflow, GPG signing, no bypass |
+| **Pipeline Check Bypass** | PASS | Enhances pipeline, doesn't bypass any checks |
+| **Testing & Validation** | N/A | Workflow config, manual validation via PR checks |
+| **Security & Access Control** | PASS | Uses existing GITHUB_TOKEN, no new permissions |
+| **Deterministic Time Handling** | N/A | No time-dependent code |
+| **Tech Debt Tracking** | PASS | No shortcuts - proper implementation |
+
+**Gate Evaluation**: All applicable gates PASS. This is a CI automation that improves developer workflow.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/069-stale-pr-autoupdate/
+├── plan.md              # This file
+├── research.md          # Phase 0: GitHub API research
+├── quickstart.md        # Phase 1: Step-by-step implementation guide
+└── tasks.md             # Phase 2: Implementation tasks (created by /speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+.github/
+└── workflows/
+    └── update-pr-branches.yml    # New: Auto-update workflow
+
+.claude/
+└── commands/
+    └── poke-stale-prs.md         # New: Manual slash command
+```
+
+**Structure Decision**: Two new files - one GitHub Actions workflow triggered on push to main when workflow files change, one slash command for manual triggering.
+
+## Complexity Tracking
+
+> No violations requiring justification. This is a minimal automation feature with two simple files.
+
+---
+
+## Phase 0: Research ✅ COMPLETE
+
+### Research Summary
+
+No NEEDS CLARIFICATION items - GitHub API for updating PR branches is well-documented.
+
+| Topic | Finding | Source |
+|-------|---------|--------|
+| Update branch API | `PUT /repos/{owner}/{repo}/pulls/{pull_number}/update-branch` | [GitHub REST API Docs](https://docs.github.com/en/rest/pulls/pulls#update-a-pull-request-branch) |
+| Required permissions | `contents: write` on workflow, uses existing `GITHUB_TOKEN` | GitHub Actions default permissions |
+| Error handling | API returns 422 if branch cannot be updated (conflicts) | GitHub API response codes |
+| Path filtering | `on.push.paths` supports glob patterns like `.github/workflows/**` | GitHub Actions workflow syntax |
+
+### Research Output
+→ [research.md](./research.md) - Full findings documented
+
+---
+
+## Phase 1: Design ✅ COMPLETE
+
+This is a configuration-only feature - no data model or API contracts needed.
+
+### Workflow Design
+
+**File**: `.github/workflows/update-pr-branches.yml`
+
+```yaml
+name: Update PR Branches
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+
+jobs:
+  update-prs:
+    name: Update Open PRs
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Update all open PR branches
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          echo "Fetching open PRs..."
+          prs=$(gh pr list --repo ${{ github.repository }} --state open --json number,headRefName -q '.[].number')
+
+          if [ -z "$prs" ]; then
+            echo "No open PRs to update"
+            exit 0
+          fi
+
+          echo "Found PRs: $prs"
+
+          for pr in $prs; do
+            echo "Updating PR #$pr..."
+            if gh api repos/${{ github.repository }}/pulls/$pr/update-branch -X PUT 2>/dev/null; then
+              echo "✓ PR #$pr updated"
+            else
+              echo "⚠ PR #$pr skipped (likely has conflicts)"
+            fi
+          done
+
+          echo "Done!"
+```
+
+### Slash Command Design
+
+**File**: `.claude/commands/poke-stale-prs.md`
+
+```markdown
+# Poke Stale PRs
+
+Update all open PR branches with the latest main branch.
+
+## Usage
+
+Run this command when PRs need to be updated with workflow fixes from main.
+
+## Implementation
+
+Run the following command:
+
+```bash
+gh pr list --state open --json number -q '.[].number' | while read pr; do
+  echo "Updating PR #$pr..."
+  gh api repos/$(gh repo view --json nameWithOwner -q .nameWithOwner)/pulls/$pr/update-branch -X PUT 2>/dev/null && echo "✓ Updated" || echo "⚠ Skipped (conflicts)"
+done
+```
+```
+
+### Phase 1 Output
+→ [quickstart.md](./quickstart.md) - Step-by-step implementation guide
+
+---
+
+## Constitution Re-Check (Post-Design)
+
+| Gate | Status | Notes |
+|------|--------|-------|
+| **Git Workflow & CI/CD Rules** | PASS | No workflow bypass |
+| **Pipeline Check Bypass** | PASS | Enhances pipeline, doesn't bypass |
+| **Testing & Validation** | PASS | Manual validation via PR observation |
+| **Security & Access Control** | PASS | Uses existing GITHUB_TOKEN |
+| **Tech Debt Tracking** | PASS | No new debt introduced |
+
+**Gate Evaluation**: All gates PASS. Ready for `/speckit.tasks`.

--- a/specs/069-stale-pr-autoupdate/quickstart.md
+++ b/specs/069-stale-pr-autoupdate/quickstart.md
@@ -1,0 +1,173 @@
+# Quickstart: Stale PR Auto-Update
+
+**Feature**: 069-stale-pr-autoupdate
+**Date**: 2025-12-08
+
+## Prerequisites
+
+- Write access to repository
+- GitHub Actions enabled
+
+## Implementation
+
+### Step 1: Create Auto-Update Workflow
+
+Create `.github/workflows/update-pr-branches.yml`:
+
+```yaml
+# Auto-update PR branches when workflow files change
+# ===================================================
+#
+# When workflow files are fixed in main, existing PRs still run the
+# old workflow from their branch. This workflow automatically updates
+# all open PR branches when workflow files change.
+#
+# For On-Call Engineers:
+#   - This workflow runs automatically on workflow file changes
+#   - Check job logs to see which PRs were updated/skipped
+#   - PRs with merge conflicts are skipped (not an error)
+
+name: Update PR Branches
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+
+jobs:
+  update-prs:
+    name: Update Open PRs
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Update all open PR branches
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          echo "Fetching open PRs..."
+          prs=$(gh pr list --repo ${{ github.repository }} --state open --json number -q '.[].number')
+
+          if [ -z "$prs" ]; then
+            echo "No open PRs to update"
+            exit 0
+          fi
+
+          echo "Found PRs: $prs"
+          updated=0
+          skipped=0
+
+          for pr in $prs; do
+            echo "Updating PR #$pr..."
+            if gh api repos/${{ github.repository }}/pulls/$pr/update-branch -X PUT 2>/dev/null; then
+              echo "✓ PR #$pr updated"
+              ((updated++))
+            else
+              echo "⚠ PR #$pr skipped (likely has conflicts or is up to date)"
+              ((skipped++))
+            fi
+          done
+
+          echo ""
+          echo "Summary: $updated updated, $skipped skipped"
+```
+
+### Step 2: Create Slash Command
+
+Create `.claude/commands/poke-stale-prs.md`:
+
+```markdown
+# Poke Stale PRs
+
+Update all open PR branches with the latest main branch.
+
+## When to Use
+
+- After merging a workflow fix to main
+- When PRs show failing checks due to stale workflow files
+- Before reviewing PRs to ensure they have latest main
+
+## Implementation
+
+Run the following bash commands to update all open PRs:
+
+\`\`\`bash
+# Get repository name
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+
+# List all open PRs and update each
+for pr in $(gh pr list --state open --json number -q '.[].number'); do
+  echo "Updating PR #$pr..."
+  if gh api repos/$REPO/pulls/$pr/update-branch -X PUT 2>/dev/null; then
+    echo "✓ PR #$pr updated"
+  else
+    echo "⚠ PR #$pr skipped (conflicts or up to date)"
+  fi
+done
+\`\`\`
+```
+
+### Step 3: Commit and Push
+
+```bash
+git add .github/workflows/update-pr-branches.yml .claude/commands/poke-stale-prs.md
+git commit -S -m "feat(069): Add stale PR auto-update workflow and slash command"
+git push origin 069-stale-pr-autoupdate
+```
+
+### Step 4: Verify
+
+1. Create a test PR
+2. Merge a workflow change to main
+3. Verify the test PR branch gets updated automatically
+4. Test `/poke-stale-prs` command manually
+
+## Success Criteria Verification
+
+| Criterion | Verification |
+|-----------|--------------|
+| SC-001: Zero manual updates | Workflow auto-triggers on workflow changes |
+| SC-002: Updates within 5 min | Workflow runs immediately on push |
+| SC-003: Conflicts don't block | Error handling continues to next PR |
+| SC-004: < 60s execution | Check workflow run time |
+| SC-005: /poke-stale-prs works | Run command, verify PRs updated |
+
+## Troubleshooting
+
+### Workflow not triggering
+
+1. Verify path filter matches changed files:
+   ```bash
+   git diff --name-only HEAD~1 | grep '.github/workflows/'
+   ```
+
+2. Check workflow is on main branch
+
+### PRs not getting updated
+
+1. Check workflow permissions:
+   ```bash
+   gh api repos/OWNER/REPO/actions/permissions
+   ```
+
+2. Verify GITHUB_TOKEN has write access to PR branches
+
+### PR skipped due to conflicts
+
+This is expected behavior. Resolve conflicts manually:
+```bash
+git checkout feature-branch
+git fetch origin main
+git rebase origin/main  # or git merge origin/main
+# Resolve conflicts
+git push --force-with-lease
+```
+
+## Reference
+
+- [GitHub API: Update PR branch](https://docs.github.com/en/rest/pulls/pulls#update-a-pull-request-branch)
+- [GitHub Actions: Path filtering](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore)

--- a/specs/069-stale-pr-autoupdate/research.md
+++ b/specs/069-stale-pr-autoupdate/research.md
@@ -1,0 +1,137 @@
+# Research: Stale PR Auto-Update
+
+**Feature**: 069-stale-pr-autoupdate
+**Date**: 2025-12-08
+
+## Research Tasks & Findings
+
+### 1. GitHub API for Updating PR Branches
+
+**Question**: What API endpoint updates a PR branch with the base branch?
+
+**Finding**: The `PUT /repos/{owner}/{repo}/pulls/{pull_number}/update-branch` endpoint performs a merge from the base branch into the PR branch.
+
+**API Details**:
+```
+PUT /repos/{owner}/{repo}/pulls/{pull_number}/update-branch
+```
+
+**Request Body** (optional):
+```json
+{
+  "expected_head_sha": "string"  // Optional: fails if head doesn't match
+}
+```
+
+**Response Codes**:
+| Code | Meaning |
+|------|---------|
+| 202 | Accepted - Update in progress |
+| 403 | Forbidden - Insufficient permissions |
+| 422 | Unprocessable - Branch cannot be updated (conflicts or already up to date) |
+
+**Canonical Source**: [GitHub REST API - Update a pull request branch](https://docs.github.com/en/rest/pulls/pulls#update-a-pull-request-branch)
+
+---
+
+### 2. GitHub Actions Path Filtering
+
+**Question**: How to trigger workflow only when workflow files change?
+
+**Finding**: Use `on.push.paths` with glob patterns.
+
+**Syntax**:
+```yaml
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+```
+
+**Behavior**:
+- Workflow triggers ONLY if pushed files match at least one path pattern
+- `**` matches any number of directory levels
+- Multiple patterns are OR'd together
+
+**Canonical Source**: [GitHub Actions - Workflow syntax for paths](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore)
+
+---
+
+### 3. GITHUB_TOKEN Permissions
+
+**Question**: What permissions does GITHUB_TOKEN need?
+
+**Finding**: The default GITHUB_TOKEN needs `contents: write` and `pull-requests: write` permissions.
+
+**Required Permissions**:
+```yaml
+permissions:
+  contents: write        # To push updates to PR branches
+  pull-requests: write   # To access PR information
+```
+
+**Note**: These permissions are available by default in most repository configurations but should be explicitly declared for clarity.
+
+**Canonical Source**: [GitHub Actions - Permissions for GITHUB_TOKEN](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token)
+
+---
+
+### 4. GitHub CLI in Actions
+
+**Question**: How to use `gh` CLI in GitHub Actions?
+
+**Finding**: The `gh` CLI is pre-installed on all GitHub-hosted runners. Set `GH_TOKEN` environment variable for authentication.
+
+**Usage**:
+```yaml
+- name: Use GitHub CLI
+  env:
+    GH_TOKEN: ${{ github.token }}
+  run: |
+    gh pr list --state open --json number -q '.[].number'
+```
+
+**Pre-installed Tools**:
+- `gh` (GitHub CLI) - pre-installed on ubuntu-latest
+- `jq` - pre-installed for JSON processing
+
+**Canonical Source**: [GitHub Actions - Using the GitHub CLI](https://docs.github.com/en/actions/using-workflows/using-github-cli-in-workflows)
+
+---
+
+### 5. Error Handling Strategy
+
+**Question**: How to handle PRs that can't be updated (conflicts)?
+
+**Finding**: The API returns 422 when a PR has merge conflicts. Use `|| true` or conditional logic to continue processing other PRs.
+
+**Pattern**:
+```bash
+if gh api repos/REPO/pulls/$pr/update-branch -X PUT 2>/dev/null; then
+  echo "✓ Updated"
+else
+  echo "⚠ Skipped (likely conflicts)"
+fi
+```
+
+**Rationale**: Failing on one PR should not block updates to other PRs.
+
+---
+
+## Summary
+
+| Research Item | Status | Finding |
+|---------------|--------|---------|
+| Update branch API | Complete | `PUT /pulls/{n}/update-branch` returns 202/422 |
+| Path filtering | Complete | `on.push.paths: ['.github/workflows/**']` |
+| Permissions | Complete | `contents: write`, `pull-requests: write` |
+| GitHub CLI | Complete | Pre-installed, use `GH_TOKEN` env var |
+| Error handling | Complete | Continue on 422, log skipped PRs |
+
+## Sources
+
+- [GitHub REST API - Update a pull request branch](https://docs.github.com/en/rest/pulls/pulls#update-a-pull-request-branch)
+- [GitHub Actions - Workflow syntax](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions)
+- [GitHub Actions - GITHUB_TOKEN permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication)
+- [GitHub CLI in workflows](https://docs.github.com/en/actions/using-workflows/using-github-cli-in-workflows)

--- a/specs/069-stale-pr-autoupdate/spec.md
+++ b/specs/069-stale-pr-autoupdate/spec.md
@@ -1,0 +1,105 @@
+# Feature Specification: Stale PR Auto-Update
+
+**Feature Branch**: `069-stale-pr-autoupdate`
+**Created**: 2025-12-08
+**Status**: Draft
+**Input**: User description: "Add slash command /poke-stale-prs or a scheduled workflow that auto-updates PR branches when main changes"
+
+## Problem Statement
+
+When workflow files in `.github/workflows/` are fixed in main, existing open PRs continue to fail because they run the outdated workflow from their own branch. This requires manual intervention to update each PR branch with the latest main, causing:
+
+1. Developer friction (manual `gh api` calls for each PR)
+2. Delayed PR merges while waiting for manual updates
+3. Confusion about why PRs fail after a workflow fix is merged
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Automatic PR Updates on Workflow Changes (Priority: P1)
+
+When a workflow file is updated in main, all open PR branches are automatically updated to include the fix, ensuring they run the corrected CI pipeline without manual intervention.
+
+**Why this priority**: This is the core value proposition - eliminating manual PR updates when workflow files change. This addresses the root cause of the recurring CI failures observed with PRs 312-316 after the infracost fix.
+
+**Independent Test**: Create a PR, merge a workflow fix to main, verify the PR branch is automatically updated and re-runs CI with the new workflow.
+
+**Acceptance Scenarios**:
+
+1. **Given** an open PR with a stale branch, **When** a workflow file is pushed to main, **Then** the PR branch is updated with the latest main within 5 minutes
+2. **Given** multiple open PRs, **When** a workflow fix is merged to main, **Then** all open PR branches are updated in parallel
+3. **Given** a PR with merge conflicts, **When** auto-update is triggered, **Then** the update is skipped and no error disrupts other PR updates
+
+---
+
+### User Story 2 - Manual PR Refresh Command (Priority: P2)
+
+Developers can manually trigger a refresh of all stale PRs using the `/poke-stale-prs` slash command, providing on-demand control when immediate updates are needed.
+
+**Why this priority**: Provides manual override capability for situations where automatic updates haven't run yet or for debugging purposes.
+
+**Independent Test**: Run `/poke-stale-prs` command and verify all open PRs are updated with latest main.
+
+**Acceptance Scenarios**:
+
+1. **Given** multiple open PRs behind main, **When** developer runs `/poke-stale-prs`, **Then** all PR branches are updated with latest main
+2. **Given** a PR that cannot be auto-merged due to conflicts, **When** `/poke-stale-prs` runs, **Then** that PR is skipped with a warning message and other PRs proceed
+3. **Given** no open PRs exist, **When** `/poke-stale-prs` runs, **Then** command completes with "No open PRs to update" message
+
+---
+
+### User Story 3 - Visibility into Auto-Update Activity (Priority: P3)
+
+Repository maintainers can see when and which PRs were auto-updated, providing transparency into the automated process.
+
+**Why this priority**: Useful for debugging and audit trails, but not essential for core functionality.
+
+**Independent Test**: Check GitHub Actions workflow run history to see auto-update executions and which PRs were processed.
+
+**Acceptance Scenarios**:
+
+1. **Given** auto-update workflow runs, **When** maintainer views Actions tab, **Then** they see which PRs were updated and any that were skipped
+2. **Given** a PR was skipped due to conflicts, **When** viewing workflow logs, **Then** the reason for skipping is clearly logged
+
+---
+
+### Edge Cases
+
+- What happens when a PR has merge conflicts with main? → Skip that PR, continue with others, log warning
+- What happens when GitHub API rate limits are hit? → Workflow fails gracefully with clear error message
+- What happens when no open PRs exist? → Workflow completes successfully with informational message
+- What happens when auto-update is triggered during an ongoing CI run? → GitHub handles this naturally (new push cancels in-progress runs for that branch)
+- What happens when GITHUB_TOKEN lacks permissions? → Clear error message identifying missing permission
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST automatically update all open PR branches when any file in `.github/workflows/` is modified in main
+- **FR-002**: System MUST provide a `/poke-stale-prs` slash command for manual triggering of PR branch updates
+- **FR-003**: System MUST skip PRs that have merge conflicts and continue processing remaining PRs
+- **FR-004**: System MUST log which PRs were updated and which were skipped (with reasons)
+- **FR-005**: System MUST complete PR updates within 5 minutes of workflow file changes to main
+- **FR-006**: System MUST use existing `GITHUB_TOKEN` permissions (no additional secrets required)
+- **FR-007**: System MUST NOT fail the entire workflow if individual PR updates fail
+
+### Non-Functional Requirements
+
+- **NFR-001**: Auto-update workflow must not consume excessive GitHub Actions minutes (target: < 1 minute per execution)
+- **NFR-002**: Solution must work with standard GitHub repository permissions (no admin access required)
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Zero manual `gh api update-branch` commands needed after workflow fixes are merged to main
+- **SC-002**: All open PRs are updated within 5 minutes of workflow file changes to main
+- **SC-003**: PRs with merge conflicts do not block updates to other PRs
+- **SC-004**: Workflow execution completes in under 60 seconds for repositories with up to 20 open PRs
+- **SC-005**: `/poke-stale-prs` command successfully updates all eligible PRs in a single invocation
+
+## Assumptions
+
+- Repository uses GitHub Actions for CI/CD
+- `GITHUB_TOKEN` has sufficient permissions to update PR branches (standard for PR-triggered workflows)
+- PR branches are configured to allow updates from base branch (GitHub default)
+- Open PRs target the `main` branch (or configurable base branch)

--- a/specs/069-stale-pr-autoupdate/tasks.md
+++ b/specs/069-stale-pr-autoupdate/tasks.md
@@ -1,0 +1,183 @@
+# Tasks: Stale PR Auto-Update
+
+**Input**: Design documents from `/specs/069-stale-pr-autoupdate/`
+**Prerequisites**: plan.md ✅, spec.md ✅, research.md ✅, quickstart.md ✅
+
+**Tests**: Not required for this feature (workflow configuration only - no source code)
+
+**Organization**: Tasks grouped by user story for independent verification
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Branch creation and verification
+
+- [x] T001 Create feature branch `069-stale-pr-autoupdate` from main
+- [x] T002 Verify `.github/workflows/` directory exists
+
+**Checkpoint**: Branch ready for implementation
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: No foundational tasks required - this is a simple two-file feature
+
+**⚠️ Note**: This feature has no foundational dependencies. Proceed directly to user stories.
+
+**Checkpoint**: N/A - no foundational work required
+
+---
+
+## Phase 3: User Story 1 - Automatic PR Updates on Workflow Changes (Priority: P1) 🎯 MVP
+
+**Goal**: When workflow files change in main, automatically update all open PR branches
+
+**Independent Test**: Merge a workflow change to main, verify all open PRs get updated automatically
+
+### Implementation for User Story 1
+
+- [x] T003 [US1] Create auto-update workflow file at .github/workflows/update-pr-branches.yml
+- [x] T004 [US1] Configure workflow trigger for push to main with paths filter `.github/workflows/**`
+- [x] T005 [US1] Add job with permissions `contents: write` and `pull-requests: write`
+- [x] T006 [US1] Implement PR listing using `gh pr list --state open --json number`
+- [x] T007 [US1] Implement update loop using `gh api repos/REPO/pulls/PR/update-branch -X PUT`
+- [x] T008 [US1] Add error handling to skip PRs with conflicts and continue to next PR
+- [x] T009 [US1] Add summary output showing updated vs skipped PRs
+- [x] T010 [US1] Validate YAML syntax using `python -c "import yaml; yaml.safe_load(open('.github/workflows/update-pr-branches.yml'))"`
+
+**Checkpoint**: Auto-update workflow complete and validated
+
+---
+
+## Phase 4: User Story 2 - Manual PR Refresh Command (Priority: P2)
+
+**Goal**: Developers can manually trigger PR updates using `/poke-stale-prs` slash command
+
+**Independent Test**: Run `/poke-stale-prs` command and verify all open PRs are updated
+
+### Implementation for User Story 2
+
+- [x] T011 [US2] Create slash command file at .claude/commands/poke-stale-prs.md
+- [x] T012 [US2] Add usage documentation explaining when to use the command
+- [x] T013 [US2] Implement bash commands to list and update all open PRs
+- [x] T014 [US2] Add error handling for PRs that can't be updated (conflicts)
+- [x] T015 [US2] Add output messages showing success/skip status for each PR
+
+**Checkpoint**: Manual command complete and documented
+
+---
+
+## Phase 5: User Story 3 - Visibility into Auto-Update Activity (Priority: P3)
+
+**Goal**: Maintainers can see which PRs were auto-updated via workflow logs
+
+**Independent Test**: Check workflow run logs to see PR update status
+
+### Implementation for User Story 3
+
+- [x] T016 [US3] Add echo statements in .github/workflows/update-pr-branches.yml showing PR numbers found
+- [x] T017 [US3] Add counters for updated and skipped PRs in workflow output
+- [x] T018 [US3] Add final summary line showing totals
+
+**Checkpoint**: Workflow provides clear visibility into operations
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Commit, push, and verify
+
+- [ ] T019 Commit changes with GPG signature: `feat(069): Add stale PR auto-update workflow and slash command`
+- [ ] T020 Push branch and create PR
+- [ ] T021 Verify workflow triggers on a test scenario (create test PR, merge workflow change to main)
+- [ ] T022 Verify `/poke-stale-prs` command works locally
+- [ ] T023 Merge PR after all checks pass
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - start immediately
+- **Foundational (Phase 2)**: N/A for this feature
+- **User Story 1 (Phase 3)**: Depends on Setup - CRITICAL PATH
+- **User Story 2 (Phase 4)**: Can run in parallel with US1 (different files)
+- **User Story 3 (Phase 5)**: Depends on US1 (modifies same file)
+- **Polish (Phase 6)**: Depends on all user stories completing
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: No dependencies - can start immediately after setup
+- **User Story 2 (P2)**: Independent file - can run in parallel with US1
+- **User Story 3 (P3)**: Modifies US1 file - must wait for US1 completion
+
+### Within Each User Story
+
+- Write before validate
+- Validate YAML syntax before commit
+- Commit before push
+
+### Parallel Opportunities
+
+- T003-T010 (US1) and T011-T015 (US2) can run in parallel (different files)
+- T021 and T022 can run in parallel (independent verification)
+
+---
+
+## Parallel Example: User Stories 1 and 2
+
+```bash
+# Launch both user stories together (different files):
+Task: "Create auto-update workflow at .github/workflows/update-pr-branches.yml"
+Task: "Create slash command at .claude/commands/poke-stale-prs.md"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup (T001-T002)
+2. Skip Phase 2: No foundational work needed
+3. Complete Phase 3: User Story 1 (T003-T010)
+4. **STOP and VALIDATE**: Verify workflow triggers on workflow file changes
+5. Merge if ready - automatic updates now working
+
+### Incremental Delivery
+
+1. Complete US1 → Auto-updates working → Core value delivered (MVP!)
+2. Complete US2 → Manual command available → Developer convenience added
+3. Complete US3 → Better visibility → Operations improved
+
+### Single Developer Strategy
+
+This feature has only 2 files - implement sequentially:
+1. T001-T010: Workflow file (~10 minutes)
+2. T011-T015: Slash command (~5 minutes)
+3. T016-T018: Add visibility to workflow (~5 minutes)
+4. T019-T023: Commit, push, verify (~10 minutes)
+
+---
+
+## Notes
+
+- This is a minimal feature with only 2 new files
+- No source code tests required - manual verification via PR observation
+- US1 and US2 can be implemented in parallel (different files)
+- US3 modifies US1's file, so must follow US1
+- Success criteria from spec.md:
+  - SC-001: Zero manual update-branch commands needed
+  - SC-002: Updates within 5 minutes of workflow changes
+  - SC-003: Conflicts don't block other PRs
+  - SC-004: < 60s execution time
+  - SC-005: /poke-stale-prs works in single invocation


### PR DESCRIPTION
## Summary

- Add automatic PR branch updates when workflow files change in main
- Add `/poke-stale-prs` slash command for manual triggering

## Problem

When workflow files are fixed in main, existing open PRs continue to fail because they run the outdated workflow from their branch. This required manual `gh api update-branch` calls for each PR (as we experienced with PRs 312-316 after the infracost fix).

## Solution

### Auto-Update Workflow (`.github/workflows/update-pr-branches.yml`)
- Triggers on push to main when `.github/workflows/**` files change
- Lists all open PRs and updates each with latest main
- Skips PRs with merge conflicts (continues to next)
- Provides summary showing updated vs skipped counts

### Manual Slash Command (`.claude/commands/poke-stale-prs.md`)
- `/poke-stale-prs` command for on-demand PR updates
- Documents when to use and troubleshooting steps

## Test plan

- [ ] Merge a workflow change to main
- [ ] Verify all open PRs are automatically updated
- [ ] Test `/poke-stale-prs` command manually

## Success Criteria

- SC-001: Zero manual update-branch commands needed after workflow fixes
- SC-002: Updates within 5 minutes of workflow changes
- SC-003: Conflicts don't block other PRs
- SC-004: < 60s execution time
- SC-005: /poke-stale-prs works in single invocation

🤖 Generated with [Claude Code](https://claude.com/claude-code)