### PR TITLE
fix(071): Remove all user-derived values from ohlc.py log contexts

### DIFF
--- a/src/lambdas/dashboard/ohlc.py
+++ b/src/lambdas/dashboard/ohlc.py
@@ -112,15 +112,9 @@ async def get_ohlc_data(
         time_range_str = range.value
 
     # Log without user-derived values to prevent log injection (CWE-117)
-    # CodeQL's Python taint tracking doesn't recognize sanitization patterns reliably
+    # CodeQL traces taint from range param -> days -> start_date/end_date
     # See: https://github.com/github/codeql/discussions/10702
-    logger.info(
-        "Fetching OHLC data",
-        extra={
-            "start_date": str(start_date),
-            "end_date": str(end_date),
-        },
-    )
+    logger.info("Fetching OHLC data")
 
     # Try Tiingo first (primary source per FR-014)
     source = "tiingo"
@@ -238,15 +232,9 @@ async def get_sentiment_history(
         start_date = end_date - timedelta(days=days)
 
     # Log without user-derived values to prevent log injection (CWE-117)
-    # CodeQL's Python taint tracking doesn't recognize sanitization patterns reliably
+    # CodeQL traces taint from range param -> days -> start_date/end_date
     # See: https://github.com/github/codeql/discussions/10702
-    logger.info(
-        "Fetching sentiment history",
-        extra={
-            "start_date": str(start_date),
-            "end_date": str(end_date),
-        },
-    )
+    logger.info("Fetching sentiment history")
 
     # Generate sentiment history
     # In production, this would query DynamoDB for historical sentiment records


### PR DESCRIPTION
## Summary

- Remove `start_date` and `end_date` from log extra contexts in `ohlc.py`
- CodeQL traces taint from `range` param -> `days` -> `start_date`/`end_date`
- Logs remain useful with internal values (source, candle_count, point_count)

## Why This Is Needed

PR #324 removed `ticker` from log contexts, but CodeQL opened new alerts (112, 113) because:
1. `range` is a user-provided TimeRange enum parameter
2. `days = TIME_RANGE_DAYS.get(range, 30)` - taint flows to `days`
3. `start_date = end_date - timedelta(days=days)` - taint flows to dates
4. Logging `start_date`/`end_date` logs user-derived values

## Fix

Remove all user-derived values from log contexts. The logs still provide useful information:
- "Fetching OHLC data" / "Fetching sentiment history" - action being taken
- Success logs still include `source`, `candle_count`, `point_count` (internal values)

Fixes: security/code-scanning/112, security/code-scanning/113

## Test Plan

- [x] All 1613 unit tests pass
- [x] Pre-commit hooks pass (ruff, bandit, detect-secrets)
- [ ] CodeQL analysis passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)