### PR TITLE
fix(074): Add Name tags to CloudFront and FIS resources for IAM conditions

### DIFF
--- a/docs/FUTURE_WORK.md
+++ b/docs/FUTURE_WORK.md
@@ -1,0 +1,13 @@
+
+## Project Name Parameterization (Deferred)
+
+**Context**: The naming pattern `*-sentiment-*` is used throughout IAM policies and resource names. Currently hardcoded.
+
+**Future improvement**:
+1. Create a `local.project_slug = "sentiment"` in `infrastructure/terraform/main.tf`
+2. Update all resource names to use `${local.project_slug}` instead of hardcoded "sentiment"
+3. Update `iam_resource_alignment.py` validator to resolve Terraform locals (separate feature)
+
+**Why deferred**: The `iam_resource_alignment.py` validator does static text analysis and cannot resolve Terraform variables/locals. Would need plan-based parsing or local resolution logic.
+
+**Current state**: Pattern `*-sentiment-*` correctly matches all resources. No mismatch exists.

--- a/infrastructure/terraform/modules/chaos/main.tf
+++ b/infrastructure/terraform/modules/chaos/main.tf
@@ -43,6 +43,7 @@ resource "aws_iam_role" "fis_execution" {
   })
 
   tags = {
+    Name        = "${var.environment}-sentiment-fis-execution"
     Environment = var.environment
     Purpose     = "chaos-testing"
     ManagedBy   = "Terraform"
@@ -109,6 +110,7 @@ resource "aws_cloudwatch_log_group" "fis_experiments" {
   retention_in_days = 14 # 2 weeks for chaos testing analysis
 
   tags = {
+    Name        = "${var.environment}-sentiment-fis-logs"
     Environment = var.environment
     Purpose     = "chaos-testing"
     ManagedBy   = "Terraform"

--- a/infrastructure/terraform/modules/cloudfront/main.tf
+++ b/infrastructure/terraform/modules/cloudfront/main.tf
@@ -276,6 +276,7 @@ resource "aws_cloudfront_distribution" "dashboard" {
   }
 
   tags = {
+    Name        = "${var.environment}-sentiment-dashboard"
     Environment = var.environment
     Feature     = "006-user-config-dashboard"
     Component   = "cdn"


### PR DESCRIPTION
## Summary

- Add `Name` tag to CloudFront distribution (`preprod-sentiment-dashboard`) to match IAM policy condition `aws:ResourceTag/Name` pattern `*-sentiment-*`
- Add `Name` tags to FIS/Chaos module resources (execution role and log group) for IAM consistency
- Document project name parameterization as future work in `docs/FUTURE_WORK.md`

## Root Cause

Deploy pipeline failed with `cloudfront:UpdateDistribution` permission denied because:
1. IAM policy at `ci-user-policy.tf:871-875` requires `aws:ResourceTag/Name` matching `*-sentiment-*`
2. CloudFront distribution had no `Name` tag, so condition never matched

## Bootstrap Requirement

**Before merging**, admin must manually tag the existing CloudFront distribution:

```bash
# Run with admin credentials
aws cloudfront tag-resource \
  --resource arn:aws:cloudfront::218795110243:distribution/E14HOKHFRMG5XG \
  --tags Items="[{Key=Name,Value=preprod-sentiment-dashboard}]"

# Verify tag was added
aws cloudfront list-tags-for-resource \
  --resource arn:aws:cloudfront::218795110243:distribution/E14HOKHFRMG5XG
```

## Test plan

- [x] Unit tests passing (1890 tests)
- [ ] Admin bootstraps Name tag on CloudFront
- [ ] Deploy pipeline succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)