### PR TITLE
fix(092): Align IAM policy patterns with actual resource names

### DIFF
--- a/infrastructure/terraform/ci-user-policy.tf
+++ b/infrastructure/terraform/ci-user-policy.tf
@@ -818,7 +818,7 @@ data "aws_iam_policy_document" "ci_deploy_storage" {
   }
 
   # Terraform State S3 Access
-  # Updated from sentiment-analyzer-terraform-state-* to *-sentiment-tfstate per 090-security-first-burndown
+  # Fix: Match actual bucket name pattern (sentiment-analyzer-terraform-state-{account_id})
   statement {
     sid    = "TerraformState"
     effect = "Allow"
@@ -829,8 +829,8 @@ data "aws_iam_policy_document" "ci_deploy_storage" {
       "s3:DeleteObject"
     ]
     resources = [
-      "arn:aws:s3:::*-sentiment-tfstate",
-      "arn:aws:s3:::*-sentiment-tfstate/*"
+      "arn:aws:s3:::sentiment-analyzer-terraform-state-*",
+      "arn:aws:s3:::sentiment-analyzer-terraform-state-*/*"
     ]
   }
 

--- a/infrastructure/terraform/modules/cloudfront/main.tf
+++ b/infrastructure/terraform/modules/cloudfront/main.tf
@@ -14,6 +14,7 @@ resource "aws_s3_bucket" "dashboard_assets" {
   bucket = "${var.environment}-sentiment-dashboard-${var.account_suffix}"
 
   tags = {
+    Name        = "${var.environment}-sentiment-dashboard-assets"
     Environment = var.environment
     Feature     = "006-user-config-dashboard"
     Component   = "cdn-origin"


### PR DESCRIPTION
## Summary

Fix IAM AccessDenied errors by aligning policy patterns with actual resource names.

### Changes
- Fix TerraformState S3 pattern: `*-sentiment-tfstate` → `sentiment-analyzer-terraform-state-*`
- Add `Name` tag to CloudFront S3 bucket for IAM tag condition

### Root Cause
The S3 bucket pattern was changed in 090-security-first-burndown but didn't match the actual bucket name in backend-preprod.hcl, causing terraform init to fail with AccessDenied.

## Test plan
- [x] Pattern matches actual bucket name in backend-preprod.hcl
- [x] Name tag added for IAM tag condition compliance

🤖 Generated with [Claude Code](https://claude.com/claude-code)