### PR TITLE
feat(093): Remove E2E false-pass patterns that mask server failures

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -134,6 +134,17 @@ repos:
         always_run: true
         stages: [push]
 
+      # False-pass pattern detection (093-e2e-false-pass-remediation)
+      # Blocks tests that skip on 500 errors instead of failing
+      - id: check-false-pass-patterns
+        name: Check E2E false-pass patterns
+        entry: ./scripts/check-false-pass-patterns.sh --staged-only
+        language: script
+        types: [python]
+        pass_filenames: false
+        always_run: true
+        stages: [commit]
+
 # CI Integration:
 # In GitHub Actions, add:
 #   - name: Run pre-commit

--- a/scripts/audit-e2e-skips.py
+++ b/scripts/audit-e2e-skips.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""Audit E2E test skips and classify them by risk level.
+
+Usage:
+    python scripts/audit-e2e-skips.py [--json] [--critical-only]
+
+Output:
+    Categorized list of all pytest.skip() calls in E2E tests with risk levels.
+"""
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+
+
+class SkipCategory(Enum):
+    """Skip categories ordered by risk level."""
+
+    ERROR_500_MASKING = "500_masking"  # CRITICAL - masks server failures
+    NOT_IMPLEMENTED = "not_implemented"  # HIGH - missing functionality
+    CONFIG_UNAVAILABLE = "config_unavailable"  # HIGH - infrastructure issues
+    RATE_LIMIT = "rate_limit"  # MEDIUM - environment-specific
+    SYNTHETIC = "synthetic"  # MEDIUM - test infrastructure
+    ENVIRONMENT = "environment"  # LOW - legitimate constraints
+    OTHER = "other"  # VARIES
+
+
+RISK_LEVELS = {
+    SkipCategory.ERROR_500_MASKING: "CRITICAL",
+    SkipCategory.NOT_IMPLEMENTED: "HIGH",
+    SkipCategory.CONFIG_UNAVAILABLE: "HIGH",
+    SkipCategory.RATE_LIMIT: "MEDIUM",
+    SkipCategory.SYNTHETIC: "MEDIUM",
+    SkipCategory.ENVIRONMENT: "LOW",
+    SkipCategory.OTHER: "VARIES",
+}
+
+
+@dataclass
+class SkipEntry:
+    """A single pytest.skip() occurrence."""
+
+    file: str
+    line: int
+    category: SkipCategory
+    message: str
+    context: str = ""  # Code around the skip
+    has_500_check: bool = False  # True if preceded by status_code == 500
+
+    def to_dict(self) -> dict:
+        return {
+            "file": self.file,
+            "line": self.line,
+            "category": self.category.value,
+            "risk": RISK_LEVELS[self.category],
+            "message": self.message,
+            "has_500_check": self.has_500_check,
+        }
+
+
+@dataclass
+class AuditReport:
+    """Complete audit report."""
+
+    entries: list[SkipEntry] = field(default_factory=list)
+
+    def by_category(self) -> dict[SkipCategory, list[SkipEntry]]:
+        result: dict[SkipCategory, list[SkipEntry]] = {cat: [] for cat in SkipCategory}
+        for entry in self.entries:
+            result[entry.category].append(entry)
+        return result
+
+    def summary(self) -> dict[str, int]:
+        by_cat = self.by_category()
+        return {cat.value: len(entries) for cat, entries in by_cat.items()}
+
+    def critical_count(self) -> int:
+        return len([e for e in self.entries if RISK_LEVELS[e.category] == "CRITICAL"])
+
+    def high_count(self) -> int:
+        return len([e for e in self.entries if RISK_LEVELS[e.category] == "HIGH"])
+
+
+def classify_skip(message: str, context: str) -> tuple[SkipCategory, bool]:
+    """Classify a skip based on its message and surrounding context."""
+    message_lower = message.lower()
+
+    # Check for 500 error masking (CRITICAL)
+    has_500_check = "status_code == 500" in context or ".status_code == 500" in context
+    if has_500_check or "500" in message_lower:
+        return SkipCategory.ERROR_500_MASKING, has_500_check
+
+    # Check for "not implemented" patterns (HIGH)
+    not_impl_patterns = [
+        "not implemented",
+        "not available",
+        "endpoint not",
+        "not supported",
+    ]
+    if any(p in message_lower for p in not_impl_patterns):
+        if "config" in message_lower:
+            return SkipCategory.CONFIG_UNAVAILABLE, False
+        return SkipCategory.NOT_IMPLEMENTED, False
+
+    # Check for config unavailable (HIGH)
+    if "config" in message_lower and (
+        "unavailable" in message_lower
+        or "not available" in message_lower
+        or "creation" in message_lower
+    ):
+        return SkipCategory.CONFIG_UNAVAILABLE, False
+
+    # Check for rate limit (MEDIUM)
+    if "rate limit" in message_lower or "rate-limit" in message_lower:
+        return SkipCategory.RATE_LIMIT, False
+
+    # Check for synthetic/token (MEDIUM)
+    if "synthetic" in message_lower or "token" in message_lower:
+        return SkipCategory.SYNTHETIC, False
+
+    # Check for environment constraints (LOW)
+    env_patterns = [
+        "preprod",
+        "environment",
+        "env",
+        "not set",
+        "manual test",
+        "requires",
+    ]
+    if any(p in message_lower for p in env_patterns):
+        return SkipCategory.ENVIRONMENT, False
+
+    return SkipCategory.OTHER, False
+
+
+def extract_skip_message(line: str) -> str:
+    """Extract the message from a pytest.skip() call."""
+    # Match pytest.skip("message") or pytest.skip(f"message")
+    match = re.search(r'pytest\.skip\([f]?["\'](.+?)["\']', line)
+    if match:
+        return match.group(1)
+
+    # Multi-line skip - just get what we can
+    match = re.search(r'pytest\.skip\([f]?["\'](.+)', line)
+    if match:
+        return match.group(1).rstrip("\"')")
+
+    return "<message not extracted>"
+
+
+def audit_file(filepath: Path) -> list[SkipEntry]:
+    """Audit a single file for pytest.skip() calls."""
+    entries = []
+    content = filepath.read_text()
+    lines = content.split("\n")
+
+    for i, line in enumerate(lines):
+        if "pytest.skip(" in line:
+            # Get context (5 lines before)
+            start = max(0, i - 5)
+            context = "\n".join(lines[start:i])
+
+            message = extract_skip_message(line)
+            category, has_500 = classify_skip(message, context)
+
+            entries.append(
+                SkipEntry(
+                    file=str(filepath),
+                    line=i + 1,
+                    category=category,
+                    message=message,
+                    context=context,
+                    has_500_check=has_500,
+                )
+            )
+
+    return entries
+
+
+def audit_e2e_tests(e2e_path: Path) -> AuditReport:
+    """Audit all E2E test files."""
+    report = AuditReport()
+
+    for filepath in e2e_path.rglob("*.py"):
+        if filepath.name.startswith("__"):
+            continue
+        entries = audit_file(filepath)
+        report.entries.extend(entries)
+
+    return report
+
+
+def print_report(report: AuditReport, critical_only: bool = False) -> None:
+    """Print human-readable report."""
+    by_cat = report.by_category()
+
+    print("=" * 70)
+    print("E2E TEST SKIP AUDIT REPORT")
+    print("=" * 70)
+    print()
+
+    # Summary
+    print("SUMMARY")
+    print("-" * 40)
+    total = len(report.entries)
+    print(f"Total skips: {total}")
+    print(f"Critical (500 masking): {report.critical_count()}")
+    print(f"High risk: {report.high_count()}")
+    print()
+
+    # By category
+    categories_to_show = (
+        [SkipCategory.ERROR_500_MASKING] if critical_only else list(SkipCategory)
+    )
+
+    for category in categories_to_show:
+        entries = by_cat[category]
+        if not entries:
+            continue
+
+        risk = RISK_LEVELS[category]
+        print(f"\n{category.value.upper()} [{risk}] - {len(entries)} occurrences")
+        print("-" * 60)
+
+        for entry in entries:
+            rel_path = entry.file.replace(str(Path.cwd()) + "/", "")
+            flag = " [HAS 500 CHECK]" if entry.has_500_check else ""
+            print(f"  {rel_path}:{entry.line}{flag}")
+            print(f"    Message: {entry.message[:70]}...")
+            print()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Audit E2E test skips")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    parser.add_argument(
+        "--critical-only", action="store_true", help="Show only critical issues"
+    )
+    parser.add_argument(
+        "--path",
+        type=Path,
+        default=Path("tests/e2e"),
+        help="Path to E2E tests",
+    )
+    args = parser.parse_args()
+
+    if not args.path.exists():
+        print(f"Error: {args.path} does not exist", file=sys.stderr)
+        return 1
+
+    report = audit_e2e_tests(args.path)
+
+    if args.json:
+        output = {
+            "summary": report.summary(),
+            "critical_count": report.critical_count(),
+            "high_count": report.high_count(),
+            "total": len(report.entries),
+            "entries": [e.to_dict() for e in report.entries],
+        }
+        print(json.dumps(output, indent=2))
+    else:
+        print_report(report, args.critical_only)
+
+    # Exit with error if critical issues found
+    if report.critical_count() > 0:
+        print(
+            f"\nERROR: {report.critical_count()} CRITICAL issues found!",
+            file=sys.stderr,
+        )
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-false-pass-patterns.sh
+++ b/scripts/check-false-pass-patterns.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# check-false-pass-patterns.sh - Pre-commit hook to prevent false-pass test patterns
+#
+# Blocks patterns that mask test failures:
+# - status_code == 500 followed by pytest.skip
+# - Other patterns that hide server errors
+#
+# Usage: scripts/check-false-pass-patterns.sh [--staged-only]
+
+set -uo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m' # No Color
+
+STAGED_ONLY=false
+if [[ "${1:-}" == "--staged-only" ]]; then
+    STAGED_ONLY=true
+fi
+
+errors=0
+
+check_file() {
+    local file="$1"
+
+    # Check for 500 error masking: status_code == 500 followed by pytest.skip
+    while IFS=: read -r line_num _; do
+        # Check next 5 lines for pytest.skip
+        if sed -n "$((line_num+1)),$((line_num+5))p" "$file" | grep -q "pytest.skip"; then
+            echo -e "${RED}ERROR${NC}: False-pass pattern in $file:$line_num"
+            echo "       500 error followed by pytest.skip masks server failures"
+            ((errors++))
+        fi
+    done < <(grep -n "status_code == 500" "$file" 2>/dev/null || true)
+}
+
+echo "Checking for false-pass test patterns..."
+
+if $STAGED_ONLY; then
+    # Check only staged Python test files
+    files=$(git diff --cached --name-only --diff-filter=ACM | grep -E '^tests/.*\.py$' || true)
+else
+    # Check all E2E test files
+    files=$(find tests/e2e -name "*.py" -type f 2>/dev/null || true)
+fi
+
+if [[ -z "$files" ]]; then
+    echo -e "${GREEN}No test files to check${NC}"
+    exit 0
+fi
+
+while IFS= read -r file; do
+    [[ -z "$file" ]] && continue
+    check_file "$file"
+done <<< "$files"
+
+if [[ $errors -eq 0 ]]; then
+    echo -e "${GREEN}No false-pass patterns detected${NC}"
+    exit 0
+else
+    echo ""
+    echo "Found $errors false-pass pattern(s)."
+    echo ""
+    echo "Fix: Remove 'if status_code == 500: pytest.skip()' patterns."
+    echo "     Tests should FAIL on 500 errors, not skip."
+    echo ""
+    echo "See: specs/093-e2e-false-pass-remediation/spec.md"
+    exit 1
+fi

--- a/specs/093-e2e-false-pass-remediation/spec.md
+++ b/specs/093-e2e-false-pass-remediation/spec.md
@@ -1,0 +1,188 @@
+# 093: E2E False-Pass Remediation
+
+## Problem Statement
+
+The E2E test suite contains **139 `pytest.skip()` calls** that mask real failures, making the tests meaningless. When an endpoint returns 500, the test skips instead of failing. When functionality is missing, the test skips instead of documenting the gap. This creates a **false sense of confidence** - the test suite appears healthy (green) while hiding critical issues.
+
+### Severity: Critical
+
+A test suite that passes when the system is broken provides negative value - it's worse than having no tests at all because it actively deceives.
+
+## Current State Analysis
+
+### Skip Categories (139 total)
+
+| Category | Count | Example | Risk Level |
+|----------|-------|---------|------------|
+| **500 Error Masking** | 6 | `if status_code == 500: pytest.skip("API issue")` | **CRITICAL** |
+| **Endpoint Not Implemented** | 59 | `pytest.skip("endpoint not implemented")` | **HIGH** |
+| **Config Creation Unavailable** | 17 | `pytest.skip("Config creation not available")` | **HIGH** |
+| **Rate Limit Not Triggered** | 4 | `pytest.skip("Could not trigger rate limit")` | MEDIUM |
+| **Environment Constraints** | ~20 | `pytest.skip("PREPROD_API_URL not set")` | LOW |
+| **Synthetic Token Unavailable** | ~10 | `pytest.skip("Synthetic token not available")` | MEDIUM |
+| **Other** | ~23 | Various infrastructure conditions | VARIES |
+
+### Files with Most Skips
+
+```
+tests/e2e/test_notifications.py          - 9 skips
+tests/e2e/test_anonymous_restrictions.py - 7 skips
+tests/e2e/test_auth_magic_link.py        - 6 skips (500 masking)
+tests/e2e/test_market_status.py          - 6 skips
+tests/e2e/test_rate_limiting.py          - 5 skips (500 masking)
+tests/e2e/test_failure_injection.py      - 5 skips
+tests/e2e/test_dashboard_buffered.py     - 3 skips
+tests/e2e/test_circuit_breaker.py        - 3 skips
+```
+
+### The Core Problem
+
+```python
+# WRONG: This test passes (via skip) when the server is broken
+if response.status_code == 500:
+    pytest.skip("Magic link endpoint unavailable - email service may not be configured")
+```
+
+A 500 error is a **server failure**, not an acceptable alternative outcome. The test should:
+1. **FAIL** if the endpoint is supposed to work
+2. Be marked `@pytest.mark.xfail` if the endpoint is known broken with a ticket
+3. Be **deleted** if the functionality doesn't exist and isn't planned
+
+## Success Criteria
+
+| ID | Criterion | Measurement |
+|----|-----------|-------------|
+| SC-001 | Zero 500-error masking skips | `grep -c "status_code == 500.*skip" == 0` |
+| SC-002 | All "not implemented" skips converted to xfail with ticket | Each xfail has issue URL |
+| SC-003 | Skip rate < 15% in CI | TestMetrics.skip_rate < 0.15 |
+| SC-004 | No new false-pass patterns in future PRs | Pre-commit hook validates |
+| SC-005 | Documented remediation for each category | Audit report complete |
+
+## Remediation Strategy
+
+### Phase 1: Critical - Remove 500 Error Masking (6 files)
+
+**Action**: Delete `if status_code == 500: pytest.skip()` patterns. Let tests fail.
+
+Files:
+- `tests/e2e/test_auth_magic_link.py` (5 instances)
+- `tests/e2e/test_rate_limiting.py` (1 instance)
+
+**Result**: Tests will fail if endpoints return 500. This is correct behavior.
+
+### Phase 2: High - Convert "Not Implemented" to xfail (59 instances)
+
+**Action**: Replace `pytest.skip("endpoint not implemented")` with:
+
+```python
+@pytest.mark.xfail(
+    reason="Endpoint not implemented - tracking issue #XXX",
+    raises=AssertionError,
+    strict=False,
+)
+```
+
+**Or delete the test** if:
+- The endpoint is not planned
+- The test was speculative/wishful
+
+### Phase 3: High - Fix "Config Creation Unavailable" (17 instances)
+
+**Action**: Investigate root cause. Options:
+1. Fix infrastructure so config creation works
+2. Mark as xfail with issue
+3. Remove tests if functionality is deprecated
+
+### Phase 4: Medium - Rate Limit Skips (4 instances)
+
+**Action**: These may be legitimate (preprod has different limits). Convert to:
+
+```python
+@pytest.mark.skipif(
+    os.getenv("CI") == "true",
+    reason="Rate limits differ in CI vs preprod"
+)
+```
+
+### Phase 5: Low - Environment Constraint Skips (~20 instances)
+
+**Action**: These are mostly legitimate. Verify each uses `SkipInfo` pattern from conftest.py.
+
+### Phase 6: Prevention - Add Pre-commit Hook
+
+Create validation that:
+1. Blocks `status_code == 500.*pytest.skip` patterns
+2. Requires xfail to have issue URL
+3. Enforces skip rate threshold
+
+## Out of Scope
+
+- Unit test skip patterns (different concern)
+- Integration test skip patterns (different concern)
+- Refactoring test structure
+
+## Technical Approach
+
+### Skip Classification Script
+
+```python
+# scripts/audit-e2e-skips.py
+"""Audit E2E test skips and classify them."""
+
+import ast
+import re
+from pathlib import Path
+from dataclasses import dataclass
+from enum import Enum
+
+class SkipCategory(Enum):
+    ERROR_500_MASKING = "500_masking"  # CRITICAL
+    NOT_IMPLEMENTED = "not_implemented"  # HIGH
+    CONFIG_UNAVAILABLE = "config_unavailable"  # HIGH
+    RATE_LIMIT = "rate_limit"  # MEDIUM
+    ENVIRONMENT = "environment"  # LOW
+    SYNTHETIC = "synthetic"  # MEDIUM
+    OTHER = "other"  # VARIES
+
+@dataclass
+class SkipAuditEntry:
+    file: str
+    line: int
+    category: SkipCategory
+    message: str
+    context: str  # surrounding code
+```
+
+### TestMetrics Skip Rate Enforcement
+
+```python
+# In tests/e2e/conftest.py
+def pytest_sessionfinish(session, exitstatus):
+    """Enforce skip rate threshold."""
+    metrics = TestMetrics()
+    if metrics.skip_rate > 0.15:
+        print(f"ERROR: Skip rate {metrics.skip_rate:.1%} exceeds 15% threshold")
+        session.exitstatus = 1
+```
+
+## Dependencies
+
+- None (self-contained cleanup)
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Tests fail after removing 500 masking | Expected - exposes real issues |
+| Skip rate threshold too aggressive | Start at 15%, adjust based on data |
+| Some skips are legitimate | Classify before removing |
+
+## Timeline
+
+This spec does not include timeline estimates per project guidelines.
+
+## References
+
+- `tests/e2e/conftest.py` - TestMetrics class
+- `tests/conftest.py` - SkipInfo pattern
+- Forensic analysis from 091 dry-run showing this as Dec 10 stale work

--- a/specs/093-e2e-false-pass-remediation/tasks.md
+++ b/specs/093-e2e-false-pass-remediation/tasks.md
@@ -1,0 +1,59 @@
+# 093: E2E False-Pass Remediation - Tasks
+
+## Phase 1: Critical - Remove 500 Error Masking [COMPLETE]
+
+| Task | File | Status |
+|------|------|--------|
+| T001 | Remove 500 skip in test_magic_link_request | DONE |
+| T002 | Remove 500 skip in test_magic_link_request_rate_limited | DONE |
+| T003 | Remove 500 skip in test_magic_link_verification | DONE |
+| T004 | Remove 500 skip in test_anonymous_data_merge | DONE |
+| T005 | Remove 500 skip in test_full_anonymous_to_authenticated_journey | DONE |
+| T006 | Remove 500 skip in test_rate_limiting.py | DONE |
+
+## Phase 2: Prevention - Pre-commit Hook [COMPLETE]
+
+| Task | File | Status |
+|------|------|--------|
+| T007 | Create check-false-pass-patterns.sh | DONE |
+| T008 | Add to .pre-commit-config.yaml | DONE |
+| T009 | Create audit-e2e-skips.py | DONE |
+
+## Phase 3: HIGH Risk - "Not Implemented" Skips [FUTURE]
+
+These 70 skips are for endpoints that may not exist. Each needs:
+1. Investigation: Does the endpoint exist?
+2. Decision: xfail with issue, or delete test
+
+**Files affected**:
+- test_notifications.py (9 skips)
+- test_market_status.py (6 skips)
+- test_anonymous_restrictions.py (5 skips)
+- test_auth_oauth.py (2 skips)
+- test_dashboard_buffered.py (2 skips)
+- test_rate_limiting.py (1 skip)
+- test_session_consistency_preprod.py (4 skips)
+- Other files (41 skips)
+
+**Recommended approach**: Create GitHub issue to track each missing endpoint, then mark tests with `@pytest.mark.xfail(reason="Issue #XXX")`.
+
+## Phase 4: HIGH Risk - "Config Unavailable" Skips [FUTURE]
+
+These 19 skips indicate infrastructure issues. Options:
+1. Fix the infrastructure so config creation works
+2. Mark as xfail with tracking issue
+3. Delete if functionality is deprecated
+
+## Phase 5: Medium Risk - Rate Limit Skips [FUTURE]
+
+4 skips for rate limits that differ between environments. These may be legitimate - convert to environment-specific skipif.
+
+## Verification
+
+Run the audit script to confirm no critical issues:
+
+```bash
+python3 scripts/audit-e2e-skips.py --critical-only
+```
+
+Expected output: `Critical (500 masking): 0`

--- a/tests/e2e/test_auth_magic_link.py
+++ b/tests/e2e/test_auth_magic_link.py
@@ -37,12 +37,7 @@ async def test_magic_link_request(
 
     # Magic link request should succeed
     # Common responses: 200 (ok), 202 (accepted), 204 (no content)
-    # If 500: email service (SendGrid) may not be configured in preprod
-    if response.status_code == 500:
-        pytest.skip(
-            "Magic link endpoint unavailable - email service may not be configured"
-        )
-
+    # 500 is a server error and should FAIL the test, not be skipped
     assert response.status_code in (
         200,
         202,
@@ -82,12 +77,10 @@ async def test_magic_link_request_rate_limited(
         json={"email": test_email},
     )
 
-    if first_response.status_code == 500:
-        pytest.skip(
-            "Magic link endpoint unavailable - email service may not be configured"
-        )
-
-    assert first_response.status_code in (200, 202, 204)
+    # 500 is a server error - test should fail, not skip
+    assert (
+        first_response.status_code in (200, 202, 204)
+    ), f"Magic link request failed: {first_response.status_code} - {first_response.text}"
 
     # Make rapid follow-up requests - try more requests for preprod
     rate_limited = False
@@ -131,12 +124,10 @@ async def test_magic_link_verification(
         json={"email": test_email},
     )
 
-    if request_response.status_code == 500:
-        pytest.skip(
-            "Magic link endpoint unavailable - email service may not be configured"
-        )
-
-    assert request_response.status_code in (200, 202, 204)
+    # 500 is a server error - test should fail, not skip
+    assert (
+        request_response.status_code in (200, 202, 204)
+    ), f"Magic link request failed: {request_response.status_code} - {request_response.text}"
 
     # Get synthetic token from handler
     synthetic_token = sendgrid_handler.get_magic_link_token(test_email)
@@ -238,10 +229,10 @@ async def test_anonymous_data_merge(
         json={"email": test_email},
     )
 
-    if magic_response.status_code == 500:
-        pytest.skip(
-            "Magic link endpoint unavailable - email service may not be configured"
-        )
+    # 500 is a server error - test should fail, not skip
+    assert (
+        magic_response.status_code in (200, 202, 204)
+    ), f"Magic link request failed: {magic_response.status_code} - {magic_response.text}"
 
     # Step 4: Get synthetic token and verify with anonymous session
     synthetic_token = sendgrid_handler.get_magic_link_token(test_email)
@@ -340,12 +331,10 @@ async def test_full_anonymous_to_authenticated_journey(
         json={"email": test_email},
     )
 
-    if magic_response.status_code == 500:
-        pytest.skip(
-            "Magic link endpoint unavailable - email service may not be configured"
-        )
-
-    assert magic_response.status_code in (200, 202, 204), "Failed to request magic link"
+    # 500 is a server error - test should fail, not skip
+    assert (
+        magic_response.status_code in (200, 202, 204)
+    ), f"Magic link request failed: {magic_response.status_code} - {magic_response.text}"
 
     # === Phase 4: Verify Magic Link ===
     synthetic_token = sendgrid_handler.get_magic_link_token(test_email)

--- a/tests/e2e/test_rate_limiting.py
+++ b/tests/e2e/test_rate_limiting.py
@@ -287,11 +287,11 @@ async def test_magic_link_rate_limit(
     if first_response.status_code == 404:
         pytest.skip("Magic link endpoint not implemented")
 
-    if first_response.status_code == 500:
-        pytest.skip("Magic link endpoint returning 500 - API issue")
-
+    # 500 is a server error - test should fail, not skip
     # Should succeed
-    assert first_response.status_code in (200, 202, 204)
+    assert (
+        first_response.status_code in (200, 202, 204)
+    ), f"Magic link request failed: {first_response.status_code} - {first_response.text}"
 
     # Make rapid follow-up requests
     rate_limited = False


### PR DESCRIPTION
## Summary

E2E tests were skipping instead of failing when endpoints returned 500 errors. This creates false confidence - tests appear green while the system is broken.

### Critical Fixes (6 instances)
- `tests/e2e/test_auth_magic_link.py`: Remove 5 `status_code == 500` skips
- `tests/e2e/test_rate_limiting.py`: Remove 1 `status_code == 500` skip

### Prevention
- `scripts/check-false-pass-patterns.sh`: Pre-commit hook blocks new patterns
- `scripts/audit-e2e-skips.py`: Audit script classifies all skips by risk level
- `.pre-commit-config.yaml`: Hook runs on every commit

### Audit Results
| Category | Before | After |
|----------|--------|-------|
| **CRITICAL** (500 masking) | 6 | **0** |
| HIGH (not implemented) | 70 | 70 |
| HIGH (config unavailable) | 19 | 19 |

### Remaining Work (Future PRs)
- 70 "endpoint not implemented" skips need xfail with tracking issues
- 19 "config unavailable" skips need infrastructure investigation

## Test plan

- [x] Pre-commit hooks pass
- [x] `scripts/check-false-pass-patterns.sh` exits 0 (no false-pass patterns)
- [x] `scripts/audit-e2e-skips.py --critical-only` shows 0 critical issues
- [x] Unit tests pass (1947 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)