### PR TITLE
feat(101): Add navigation buttons to all Interview Dashboard pages

### DIFF
--- a/interview/index.html
+++ b/interview/index.html
@@ -631,6 +631,24 @@
             animation: spin 1s linear infinite;
         }
 
+        /* Section Navigation */
+        .section-nav {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-top: 48px;
+            padding-top: 24px;
+            border-top: 1px solid var(--border);
+        }
+
+        .section-nav .btn {
+            min-width: 120px;
+        }
+
+        .section-nav-spacer {
+            width: 120px;
+        }
+
         /* Status Indicators */
         .status-dot {
             width: 8px;
@@ -924,6 +942,11 @@ by_tag: tag → timestamp</div>
                     </div>
                 </div>
             </div>
+
+            <div class="section-nav">
+                <button class="btn btn-secondary" onclick="navigateTo('welcome')">← Back</button>
+                <button class="btn btn-primary" onclick="navigateTo('auth')">Next →</button>
+            </div>
         </section>
 
         <!-- Auth Section -->
@@ -975,6 +998,11 @@ by_tag: tag → timestamp</div>
                 <div class="api-demo-body">
                     <div id="auth-anon-response" class="response-box">Click "Execute" to create an anonymous session</div>
                 </div>
+            </div>
+
+            <div class="section-nav">
+                <button class="btn btn-secondary" onclick="navigateTo('architecture')">← Back</button>
+                <button class="btn btn-primary" onclick="navigateTo('config')">Next →</button>
             </div>
         </section>
 
@@ -1039,6 +1067,11 @@ by_tag: tag → timestamp</div>
                     <div id="config-list-response" class="response-box">Create a session first, then execute</div>
                 </div>
             </div>
+
+            <div class="section-nav">
+                <button class="btn btn-secondary" onclick="navigateTo('auth')">← Back</button>
+                <button class="btn btn-primary" onclick="navigateTo('sentiment')">Next →</button>
+            </div>
         </section>
 
         <!-- Sentiment Section -->
@@ -1091,6 +1124,11 @@ by_tag: tag → timestamp</div>
                     <div id="sentiment-response" class="response-box">Create a configuration first, then get sentiment for its tickers</div>
                 </div>
             </div>
+
+            <div class="section-nav">
+                <button class="btn btn-secondary" onclick="navigateTo('config')">← Back</button>
+                <button class="btn btn-primary" onclick="navigateTo('external')">Next →</button>
+            </div>
         </section>
 
         <!-- External APIs Section -->
@@ -1135,6 +1173,11 @@ by_tag: tag → timestamp</div>
                     <div class="stat-value purple" id="sendgrid-quota">--</div>
                     <div class="stat-label">SendGrid (100/day)</div>
                 </div>
+            </div>
+
+            <div class="section-nav">
+                <button class="btn btn-secondary" onclick="navigateTo('sentiment')">← Back</button>
+                <button class="btn btn-primary" onclick="navigateTo('circuit')">Next →</button>
             </div>
         </section>
 
@@ -1200,6 +1243,11 @@ by_tag: tag → timestamp</div>
                         <div>Failures: 0/5</div>
                     </div>
                 </div>
+            </div>
+
+            <div class="section-nav">
+                <button class="btn btn-secondary" onclick="navigateTo('external')">← Back</button>
+                <button class="btn btn-primary" onclick="navigateTo('traffic')">Next →</button>
             </div>
         </section>
 
@@ -1297,6 +1345,11 @@ python3 traffic_generator.py --env preprod --scenario all
                     </div>
                 </div>
             </div>
+
+            <div class="section-nav">
+                <button class="btn btn-secondary" onclick="navigateTo('circuit')">← Back</button>
+                <button class="btn btn-primary" onclick="navigateTo('chaos')">Next →</button>
+            </div>
         </section>
 
         <!-- Chaos Engineering Section -->
@@ -1366,6 +1419,11 @@ python3 traffic_generator.py --env preprod --scenario all
                         <div class="timeline-desc">After 60 seconds, circuit enters HALF-OPEN state and tests with a single request. If successful, circuit closes.</div>
                     </div>
                 </div>
+            </div>
+
+            <div class="section-nav">
+                <button class="btn btn-secondary" onclick="navigateTo('traffic')">← Back</button>
+                <button class="btn btn-primary" onclick="navigateTo('caching')">Next →</button>
             </div>
         </section>
 
@@ -1440,6 +1498,11 @@ python3 traffic_generator.py --env preprod --scenario all
                     <div class="stat-label">Cached Entries</div>
                 </div>
             </div>
+
+            <div class="section-nav">
+                <button class="btn btn-secondary" onclick="navigateTo('chaos')">← Back</button>
+                <button class="btn btn-primary" onclick="navigateTo('observability')">Next →</button>
+            </div>
         </section>
 
         <!-- Observability Section -->
@@ -1491,6 +1554,11 @@ python3 traffic_generator.py --env preprod --scenario all
                 <div class="api-demo-body">
                     <div id="health-response" class="response-box">Service health and dependencies status</div>
                 </div>
+            </div>
+
+            <div class="section-nav">
+                <button class="btn btn-secondary" onclick="navigateTo('caching')">← Back</button>
+                <button class="btn btn-primary" onclick="navigateTo('testing')">Next →</button>
             </div>
         </section>
 
@@ -1553,6 +1621,11 @@ python3 traffic_generator.py --env preprod --scenario all
                         </ul>
                     </div>
                 </div>
+            </div>
+
+            <div class="section-nav">
+                <button class="btn btn-secondary" onclick="navigateTo('observability')">← Back</button>
+                <button class="btn btn-primary" onclick="navigateTo('infra')">Next →</button>
             </div>
         </section>
 
@@ -1636,6 +1709,11 @@ infrastructure/terraform/modules/<br>
                         </tr>
                     </tbody>
                 </table>
+            </div>
+
+            <div class="section-nav">
+                <button class="btn btn-secondary" onclick="navigateTo('testing')">← Back</button>
+                <div class="section-nav-spacer"></div>
             </div>
         </section>
     </main>

--- a/specs/101-navigation-buttons/spec.md
+++ b/specs/101-navigation-buttons/spec.md
@@ -1,0 +1,73 @@
+# Feature 101: Add Navigation Buttons to All Pages
+
+## Summary
+
+Add visible back/forward navigation buttons to all pages in the Interview Dashboard to complement existing swipe gesture navigation.
+
+## Problem Statement
+
+The Interview Dashboard relies solely on swipe gestures for navigation between sections. While this works on touch devices, it's not discoverable and requires users to know the gesture exists. Adding visible navigation buttons improves UX and provides an obvious navigation mechanism.
+
+## Solution
+
+Add a `.section-nav` container at the bottom of each section (except welcome) with:
+- "← Back" button linking to the previous section
+- "Next →" button linking to the next section
+- Last section (infra) only has back button with spacer for layout balance
+
+## Changes
+
+### CSS (interview/index.html)
+
+Added `.section-nav` styles:
+```css
+.section-nav {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-top: 48px;
+    padding-top: 24px;
+    border-top: 1px solid var(--border);
+}
+
+.section-nav .btn {
+    min-width: 120px;
+}
+
+.section-nav-spacer {
+    width: 120px;
+}
+```
+
+### HTML (interview/index.html)
+
+Added navigation to 12 sections (2-13):
+
+| Section | Back → | Next → |
+|---------|--------|--------|
+| architecture | welcome | auth |
+| auth | architecture | config |
+| config | auth | sentiment |
+| sentiment | config | external |
+| external | sentiment | circuit |
+| circuit | external | traffic |
+| traffic | circuit | chaos |
+| chaos | traffic | caching |
+| caching | chaos | observability |
+| observability | caching | testing |
+| testing | observability | infra |
+| infra | testing | (none) |
+
+## Testing
+
+- Visual verification: Navigate through all 13 sections using buttons
+- Verify swipe gestures still work alongside buttons
+- Verify consistent styling across all sections
+
+## Success Criteria
+
+- [x] All 12 sections (2-13) have navigation buttons
+- [x] Welcome section retains "Start the Tour" button only
+- [x] Last section has only back button
+- [x] Buttons are consistent with existing `.btn` styling
+- [x] Border separator provides visual distinction


### PR DESCRIPTION
## Summary

- Add visible back/forward navigation buttons to all 12 sections (2-13)
- Welcome section retains existing "Start the Tour" button
- Last section (infra) has only back button

## Changes

- **CSS**: Add `.section-nav` styles with flexbox layout and border separator
- **HTML**: Add navigation divs with onclick handlers to each section

## Navigation Flow

```
welcome → architecture → auth → config → sentiment → external → circuit → traffic → chaos → caching → observability → testing → infra
```

## UX Improvements

- Border separator provides visual distinction from section content
- Consistent button styling with existing `.btn` classes  
- Min-width ensures buttons don't shrink on narrow screens
- Complements existing swipe gesture navigation

## Test plan

- [ ] Navigate through all 13 sections using buttons
- [ ] Verify swipe gestures still work alongside buttons
- [ ] Verify consistent styling across all sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)