### PR TITLE
feat(113): Add dashboard deployment to S3 in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -706,11 +706,58 @@ jobs:
           API_URL=$(terraform output -raw dashboard_api_url 2>/dev/null || echo "")
           SNS_TOPIC_ARN=$(terraform output -raw sns_topic_arn 2>/dev/null || echo "")
           SSE_LAMBDA_URL=$(terraform output -raw sse_lambda_function_url 2>/dev/null || echo "")
+          DASHBOARD_S3_BUCKET=$(terraform output -raw dashboard_s3_bucket 2>/dev/null || echo "")
+          CLOUDFRONT_DISTRIBUTION_ID=$(terraform output -raw cloudfront_distribution_id 2>/dev/null || echo "")
 
           echo "dashboard_url=${DASHBOARD_URL}" >> $GITHUB_OUTPUT
           echo "api_url=${API_URL}" >> $GITHUB_OUTPUT
           echo "sns_topic_arn=${SNS_TOPIC_ARN}" >> $GITHUB_OUTPUT
           echo "sse_lambda_url=${SSE_LAMBDA_URL}" >> $GITHUB_OUTPUT
+          echo "dashboard_s3_bucket=${DASHBOARD_S3_BUCKET}" >> $GITHUB_OUTPUT
+          echo "cloudfront_distribution_id=${CLOUDFRONT_DISTRIBUTION_ID}" >> $GITHUB_OUTPUT
+
+      - name: Deploy Dashboard to S3 (Preprod)
+        run: |
+          BUCKET="${{ steps.outputs.outputs.dashboard_s3_bucket }}"
+          DISTRIBUTION_ID="${{ steps.outputs.outputs.cloudfront_distribution_id }}"
+
+          if [ -z "$BUCKET" ]; then
+            echo "⚠️ Dashboard S3 bucket not found - skipping dashboard deploy"
+            exit 0
+          fi
+
+          echo "📤 Deploying dashboard to S3: ${BUCKET}"
+
+          # Sync dashboard files to S3 with appropriate cache headers
+          # HTML files: no-cache (always fetch fresh)
+          # JS/CSS files: cache for 1 year (versioned by content hash)
+          aws s3 sync ../../src/dashboard/ s3://${BUCKET}/ \
+            --exclude ".gitkeep" \
+            --exclude "README.md" \
+            --cache-control "public, max-age=31536000" \
+            --delete
+
+          # Override cache for HTML files (no cache)
+          aws s3 cp ../../src/dashboard/index.html s3://${BUCKET}/index.html \
+            --cache-control "no-cache, no-store, must-revalidate" \
+            --content-type "text/html"
+
+          aws s3 cp ../../src/dashboard/chaos.html s3://${BUCKET}/chaos.html \
+            --cache-control "no-cache, no-store, must-revalidate" \
+            --content-type "text/html"
+
+          echo "✅ Dashboard deployed to S3"
+
+          # Invalidate CloudFront cache for immediate update
+          if [ -n "$DISTRIBUTION_ID" ]; then
+            echo "🔄 Invalidating CloudFront cache..."
+            aws cloudfront create-invalidation \
+              --distribution-id "$DISTRIBUTION_ID" \
+              --paths "/*" \
+              --query 'Invalidation.Id' \
+              --output text
+            echo "✅ CloudFront invalidation created"
+          fi
 
       - name: Smoke Test (Post-Deployment)
         id: smoke_test

--- a/specs/113-dashboard-s3-deploy/spec.md
+++ b/specs/113-dashboard-s3-deploy/spec.md
@@ -1,0 +1,41 @@
+# Feature 113: Deploy Dashboard to S3
+
+## Problem Statement
+
+The "View Live Dashboard" button in the Interview Dashboard returns 403 AccessDenied because the CloudFront S3 bucket is empty. The dashboard files in `src/dashboard/` are never deployed.
+
+## Solution
+
+Add a step to the deploy workflow that:
+1. Uploads `src/dashboard/*` files to the CloudFront S3 bucket
+2. Sets appropriate cache headers (no-cache for HTML, long-cache for JS/CSS)
+3. Invalidates CloudFront cache for immediate updates
+
+## Changes
+
+### .github/workflows/deploy.yml
+
+Add "Deploy Dashboard to S3 (Preprod)" step after "Get Preprod Outputs":
+- Get `dashboard_s3_bucket` and `cloudfront_distribution_id` from Terraform outputs
+- `aws s3 sync` dashboard files with cache headers
+- Override HTML files with no-cache headers
+- Create CloudFront invalidation
+
+## Files Deployed
+
+| File | Purpose | Cache |
+|------|---------|-------|
+| index.html | Main dashboard | no-cache |
+| chaos.html | Chaos engineering dashboard | no-cache |
+| app.js | Application logic | 1 year |
+| config.js | Configuration | 1 year |
+| styles.css | Styles | 1 year |
+
+## Success Criteria
+
+| ID | Criterion | Verification |
+|----|-----------| -------------|
+| SC-001 | CloudFront root returns 200 | `curl -I https://d2z9uvoj5xlbd2.cloudfront.net/` |
+| SC-002 | Dashboard loads in browser | Visual test |
+| SC-003 | Cache headers set correctly | Check S3 object metadata |
+| SC-004 | CloudFront invalidation created | Check deploy logs |


### PR DESCRIPTION
## Summary
- Add step to deploy `src/dashboard/*` files to CloudFront S3 bucket
- Set appropriate cache headers (no-cache for HTML, 1 year for JS/CSS)
- Create CloudFront invalidation for immediate updates

## Problem
The "View Live Dashboard" button in the Interview Dashboard returns 403 AccessDenied because the S3 bucket behind CloudFront is empty.

## Solution
Deploy workflow now automatically syncs dashboard files to S3 after Terraform apply.

## Test plan
- [ ] SC-001: CloudFront root returns 200 after deploy
- [ ] SC-002: Dashboard loads in browser
- [ ] SC-003: Cache headers set correctly on S3 objects
- [ ] SC-004: CloudFront invalidation created in deploy logs

See: specs/113-dashboard-s3-deploy/spec.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)