### PR TITLE
fix(117): Align keyboard shortcuts with hamburger menu order

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,0 +1,26 @@
+# Feature Backlog
+
+## Queued Features
+
+### 117 - Fix Keyboard Shortcuts Order
+**Priority**: Low
+**Spec**: specs/117-keyboard-shortcuts-fix/spec.md
+
+CTRL+7,8,9 keyboard shortcuts navigate to wrong sections compared to hamburger menu order.
+- Current: circuit, chaos, caching
+- Expected: chaos, caching, circuit
+
+### 118 - Fix Dashboard Connection Status
+**Priority**: Medium
+**Spec**: specs/118-dashboard-connection-status/spec.md
+
+ONE URL dashboard shows "Disconnected" because SSE stream endpoint routes to wrong Lambda.
+- Dashboard Lambda has BUFFERED mode
+- SSE requires RESPONSE_STREAM mode
+- Need CloudFront routing fix or graceful fallback
+
+---
+
+## Completed Features
+
+(Features moved here after completion)

--- a/interview/index.html
+++ b/interview/index.html
@@ -2176,7 +2176,8 @@ infrastructure/terraform/modules/<br>
             // Ctrl/Cmd + number to navigate
             if ((e.ctrlKey || e.metaKey) && e.key >= '1' && e.key <= '9') {
                 e.preventDefault();
-                const sections = ['welcome', 'architecture', 'auth', 'config', 'sentiment', 'external', 'circuit', 'chaos', 'caching'];
+                // Order matches hamburger menu sidebar (nav-items)
+                const sections = ['welcome', 'architecture', 'auth', 'config', 'sentiment', 'external', 'chaos', 'caching', 'circuit'];
                 const idx = parseInt(e.key) - 1;
                 if (idx < sections.length) {
                     navigateTo(sections[idx]);

--- a/specs/117-keyboard-shortcuts-fix/spec.md
+++ b/specs/117-keyboard-shortcuts-fix/spec.md
@@ -1,0 +1,53 @@
+# Feature 117: Fix Keyboard Shortcuts Order
+
+## Problem Statement
+
+The Interview Dashboard's keyboard shortcuts (CTRL+7, CTRL+8, CTRL+9) navigate to different sections than expected based on the hamburger menu ordering.
+
+**Current keyboard shortcuts array (line 2179):**
+```javascript
+['welcome', 'architecture', 'auth', 'config', 'sentiment', 'external', 'circuit', 'chaos', 'caching']
+```
+
+**Hamburger menu order (lines 742-807):**
+1. welcome
+2. architecture
+3. auth
+4. config
+5. sentiment
+6. external
+7. chaos (keyboard goes to circuit)
+8. caching (keyboard goes to chaos)
+9. circuit (keyboard goes to caching)
+10. traffic
+11. observability
+12. testing
+13. infra
+
+## Expected Behavior
+
+CTRL+N should navigate to the Nth item in the hamburger menu sidebar.
+
+## Solution
+
+Update the keyboard shortcuts array to match hamburger menu order:
+
+```javascript
+['welcome', 'architecture', 'auth', 'config', 'sentiment', 'external', 'chaos', 'caching', 'circuit', 'traffic', 'observability', 'testing', 'infra']
+```
+
+Note: This extends to all 13 sections, but only 1-9 will be usable via keyboard (CTRL+0 might go to 10th item or be ignored).
+
+## Changes
+
+### interview/index.html
+
+Line 2179: Update sections array to match hamburger menu order.
+
+## Success Criteria
+
+| ID | Criterion | Verification |
+|----|-----------|--------------|
+| SC-001 | CTRL+7 navigates to Chaos Engineering | Manual test |
+| SC-002 | CTRL+8 navigates to Caching Strategy | Manual test |
+| SC-003 | CTRL+9 navigates to Circuit Breaker | Manual test |

--- a/specs/118-dashboard-connection-status/spec.md
+++ b/specs/118-dashboard-connection-status/spec.md
@@ -1,0 +1,52 @@
+# Feature 118: Fix Dashboard Connection Status
+
+## Problem Statement
+
+The ONE URL dashboard (https://d2z9uvoj5xlbd2.cloudfront.net) shows "Connecting..." with a disconnected (red) status indicator. The dashboard never connects to the SSE stream.
+
+## Root Cause Analysis
+
+The dashboard's `config.js` has:
+- `API_BASE_URL: ''` (empty, meaning same origin)
+- `SSE_BASE_URL: ''` (empty, meaning same origin)
+- `ENDPOINTS.STREAM: '/api/v2/stream'`
+
+The dashboard tries to connect to `/api/v2/stream` for SSE streaming, but:
+
+1. CloudFront routes `/api/*` to API Gateway
+2. API Gateway routes to Dashboard Lambda (BUFFERED mode)
+3. SSE requires RESPONSE_STREAM mode (SSE Lambda)
+4. The SSE Lambda has a different Function URL
+
+## Solution Options
+
+### Option A: Route /api/v2/stream to SSE Lambda via CloudFront
+Add another CloudFront cache behavior for `/api/v2/stream*` that routes to the SSE Lambda Function URL.
+
+### Option B: Configure SSE_BASE_URL in config.js
+Set `SSE_BASE_URL` to the SSE Lambda Function URL directly.
+
+### Option C: Show graceful degradation
+If SSE fails, fall back to polling mode and update status to "Polling" instead of "Disconnected".
+
+## Recommended: Option A + Option C
+
+1. Add CloudFront behavior for SSE endpoint to proper Lambda
+2. Improve UX with fallback status indication
+
+## Changes
+
+### Option A: infrastructure/terraform/modules/cloudfront/main.tf
+- Add cache behavior for `/api/v2/stream*` to SSE Lambda origin
+
+### Option C: src/dashboard/app.js
+- Update `updateConnectionStatus()` to show "Polling" when using fallback
+- Change indicator color for polling mode (yellow/amber)
+
+## Success Criteria
+
+| ID | Criterion | Verification |
+|----|-----------|--------------|
+| SC-001 | Dashboard connects to SSE or falls back gracefully | Visual check |
+| SC-002 | Status shows "Connected" or "Polling", not "Disconnected" | Visual check |
+| SC-003 | Metrics update in real-time (SSE) or via polling | Observe changes |


### PR DESCRIPTION
## Summary
Fix CTRL+7,8,9 keyboard shortcuts to match hamburger menu sidebar order.

## Changes
- Reorder sections array: `circuit, chaos, caching` → `chaos, caching, circuit`

## Test Plan
- [ ] CTRL+7 → Chaos Engineering
- [ ] CTRL+8 → Caching Strategy  
- [ ] CTRL+9 → Circuit Breaker

🤖 Generated with [Claude Code](https://claude.com/claude-code)