### PR TITLE
fix(119): Increase integration test timeout from 180s to 300s

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -963,8 +963,10 @@ jobs:
         run: |
           # Run tests marked as "preprod" (auto-marked by conftest.py for *_preprod.py files)
           # These tests use REAL AWS resources, not moto mocks
+          # Timeout: 300s (5 min) - allows ~112 tests to complete
+          # Previous 180s was hitting 87% completion before timeout
           set +e  # Don't exit on error
-          timeout 180 pytest tests/ \
+          timeout 300 pytest tests/ \
             -m "preprod" \
             -v \
             --tb=short \
@@ -976,7 +978,7 @@ jobs:
             echo "✅ Integration tests passed"
             echo "passed=true" >> $GITHUB_OUTPUT
           elif [ $TEST_EXIT_CODE -eq 124 ]; then
-            echo "⚠️ Integration tests timed out (180s limit)"
+            echo "⚠️ Integration tests timed out (300s limit)"
             echo "passed=false" >> $GITHUB_OUTPUT
             echo "reason=timeout" >> $GITHUB_OUTPUT
           else

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -121,15 +121,6 @@
         "line_number": 842
       }
     ],
-    ".github/workflows/deploy.yml": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".github/workflows/deploy.yml",
-        "hashed_secret": "dc724af18fbdd4e59189f5fe768a5f8311527050",
-        "is_verified": false,
-        "line_number": 458
-      }
-    ],
     "CONTRIBUTING.md": [
       {
         "type": "Secret Keyword",


### PR DESCRIPTION
The pipeline was failing because the 180-second timeout was insufficient
for the ~112 preprod integration tests. Analysis of run 20191568607 showed:

- Test start: 12:10:13
- Timeout kill: 12:13:13 (exactly 180s later)
- Progress: 87% complete (test_auth_rejected_without_header was starting)
- Tests were running normally (~1s each, SSE tests ~7s)

The timeout was hitting the wall clock limit, not a hung test.
Increasing to 300s (5 minutes) provides adequate headroom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
