### PR TITLE
fix(frontend): Update SSE endpoint path from /api/stream to /api/v2/stream

### DIFF
--- a/frontend/src/hooks/use-sse.ts
+++ b/frontend/src/hooks/use-sse.ts
@@ -69,8 +69,8 @@ export function useSSE(options: UseSSEOptions = {}): UseSSEResult {
 
     const baseUrl = process.env.NEXT_PUBLIC_API_URL || '';
     const url = configId
-      ? `${baseUrl}/api/stream?configId=${configId}`
-      : `${baseUrl}/api/stream`;
+      ? `${baseUrl}/api/v2/stream?configId=${configId}`
+      : `${baseUrl}/api/v2/stream`;
 
     clientRef.current = new SSEClient(url, {
       onMessage: handleMessage,


### PR DESCRIPTION
## Summary
- Updated SSE streaming endpoint path from `/api/stream` to `/api/v2/stream` in `use-sse.ts` hook
- Both configId-specific and default URL paths now use the v2 endpoint
- Aligns frontend with backend Lambda expectations for SSE connections

## Context
The backend Lambda expects SSE requests at `/api/v2/stream`, but the frontend hook was using the legacy `/api/stream` path. This path mismatch caused connection failures when establishing Server-Sent Events for real-time sentiment updates.

## Test plan
- [ ] Verify SSE connections establish successfully in browser DevTools Network tab
- [ ] Confirm real-time sentiment updates flow to dashboard
- [ ] Check useSSE hook status transitions correctly (disconnected → connecting → connected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)