### PR TITLE
fix(123): Reduce CloudFront origin_read_timeout to 180s (AWS limit)

### DIFF
--- a/infrastructure/terraform/modules/cloudfront/main.tf
+++ b/infrastructure/terraform/modules/cloudfront/main.tf
@@ -222,9 +222,10 @@ resource "aws_cloudfront_distribution" "dashboard" {
         origin_protocol_policy = "https-only"
         origin_ssl_protocols   = ["TLSv1.2"]
         # SSE streaming timeout configuration (Feature 119)
-        # origin_read_timeout: Max time CloudFront waits for origin response (5 min for long sentiment analysis)
+        # origin_read_timeout: Max time CloudFront waits for origin response
+        # AWS CloudFront limit: 180 seconds max without quota increase (300+ requires AWS support approval)
         # origin_keepalive_timeout: Keep connection alive during streaming (1 min between messages)
-        origin_read_timeout      = 300
+        origin_read_timeout      = 180
         origin_keepalive_timeout = 60
       }
     }


### PR DESCRIPTION
## Summary
- Reduce `origin_read_timeout` from 300s to 180s (CloudFront's maximum without quota increase)
- Fixes pipeline deployment failure: `InvalidOriginReadTimeout`

## Root Cause
CloudFront enforces a hard limit of 180 seconds for custom origin response timeout. Values >180 require AWS support quota increase request.

## Fix
`infrastructure/terraform/modules/cloudfront/main.tf`:
```diff
-origin_read_timeout = 300
+origin_read_timeout = 180
```

## Test plan
- [x] Terraform validate passes
- [ ] Pipeline deployment succeeds
- [ ] SSE streaming works within 180s timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)