### PR TITLE
fix(124): Add terraform refresh step to sync state before plan

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -674,6 +674,18 @@ jobs:
           echo "   Terraform will wait for lock release (timeout: 5 minutes)"
           echo ""
 
+      - name: Terraform Refresh (Preprod)
+        run: |
+          echo "🔄 Syncing Terraform state with AWS..."
+          # Refresh ensures state matches actual AWS resources
+          # This fixes drift where state has origin_read_timeout=30 but AWS has 300
+          terraform refresh \
+            -var-file=preprod.tfvars \
+            -var="model_version=${{ needs.build.outputs.artifact-sha }}" \
+            -var="lambda_package_version=${{ needs.build.outputs.artifact-sha }}" \
+            -lock-timeout=5m
+          echo "✅ State refresh complete"
+
       - name: Terraform Plan (Preprod)
         id: plan
         timeout-minutes: 10
@@ -1213,6 +1225,16 @@ jobs:
           echo "⏳ Proceeding with deployment..."
           echo "   Terraform will wait for lock release (timeout: 5 minutes)"
           echo ""
+
+      - name: Terraform Refresh (Production)
+        run: |
+          echo "🔄 Syncing Terraform state with AWS..."
+          terraform refresh \
+            -var-file=prod.tfvars \
+            -var="model_version=${{ needs.build.outputs.artifact-sha }}" \
+            -var="lambda_package_version=${{ needs.build.outputs.artifact-sha }}" \
+            -lock-timeout=5m
+          echo "✅ State refresh complete"
 
       - name: Terraform Plan (Production)
         id: plan


### PR DESCRIPTION
## Summary
- Add terraform refresh step before plan in preprod and prod deployments
- Syncs Terraform state with actual AWS resource configuration

## Root Cause
The preprod deployment fails with `InvalidOriginReadTimeout` because:
1. Terraform state shows `origin_read_timeout=30` (default)
2. Actual AWS CloudFront distribution has `origin_read_timeout=300` (pre-limit value)
3. CloudFront validates the entire distribution during any update
4. The stale 300 value triggers validation failure even though we're setting 180

## Fix
Add `terraform refresh` step before `terraform plan` to sync state with AWS. After refresh:
- State correctly shows 300 (actual AWS value)
- Plan shows drift: 300 → 180 (what we're changing)
- Apply succeeds because the starting point is accurate

## Test plan
- [ ] PR checks pass
- [ ] Preprod deployment succeeds
- [ ] CloudFront origin_read_timeout is set to 180

🤖 Generated with [Claude Code](https://claude.com/claude-code)