### PR TITLE
fix(125): Add AWS CLI step to fix CloudFront invalid timeouts before Terraform

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -686,6 +686,65 @@ jobs:
             -lock-timeout=5m
           echo "✅ State refresh complete"
 
+      - name: Fix CloudFront Invalid Timeout (AWS CLI)
+        run: |
+          echo "🔍 Checking CloudFront distribution for invalid timeout values..."
+
+          # Get the CloudFront distribution ID from Terraform outputs
+          DIST_ID=$(terraform output -raw cloudfront_distribution_id 2>/dev/null || echo "")
+
+          if [ -z "$DIST_ID" ]; then
+            echo "⚠️ No CloudFront distribution found - skipping timeout check"
+            exit 0
+          fi
+
+          echo "Distribution ID: $DIST_ID"
+
+          # Get current distribution config
+          aws cloudfront get-distribution-config --id "$DIST_ID" > /tmp/cf-config.json
+          ETAG=$(jq -r '.ETag' /tmp/cf-config.json)
+
+          # Check if any origin has invalid timeout (>180)
+          INVALID_TIMEOUT=$(jq -r '.DistributionConfig.Origins.Items[]? |
+            select(.CustomOriginConfig.OriginReadTimeout > 180) |
+            "\(.Id): \(.CustomOriginConfig.OriginReadTimeout)s"' /tmp/cf-config.json)
+
+          if [ -z "$INVALID_TIMEOUT" ]; then
+            echo "✅ All origin timeouts are valid (<=180s)"
+            exit 0
+          fi
+
+          echo "⚠️ Found invalid timeout values:"
+          echo "$INVALID_TIMEOUT"
+          echo ""
+          echo "🔧 Fixing timeout values via AWS CLI..."
+
+          # Update config: set all origin_read_timeout > 180 to 180
+          jq '.DistributionConfig.Origins.Items = [.DistributionConfig.Origins.Items[] |
+            if .CustomOriginConfig.OriginReadTimeout > 180
+            then .CustomOriginConfig.OriginReadTimeout = 180
+            else . end]' /tmp/cf-config.json > /tmp/cf-config-fixed.json
+
+          # Also fix keepalive timeout if > 60
+          jq '.DistributionConfig.Origins.Items = [.DistributionConfig.Origins.Items[] |
+            if .CustomOriginConfig.OriginKeepaliveTimeout > 60
+            then .CustomOriginConfig.OriginKeepaliveTimeout = 60
+            else . end]' /tmp/cf-config-fixed.json > /tmp/cf-config-final.json
+
+          # Extract just the DistributionConfig for the update
+          jq '.DistributionConfig' /tmp/cf-config-final.json > /tmp/cf-update.json
+
+          # Update the distribution
+          aws cloudfront update-distribution \
+            --id "$DIST_ID" \
+            --if-match "$ETAG" \
+            --distribution-config file:///tmp/cf-update.json
+
+          echo "✅ CloudFront distribution updated with valid timeout values"
+          echo ""
+          echo "⏳ Waiting 30s for CloudFront to propagate changes..."
+          sleep 30
+
       - name: Terraform Plan (Preprod)
         id: plan
         timeout-minutes: 10
@@ -1235,6 +1294,58 @@ jobs:
             -var="lambda_package_version=${{ needs.build.outputs.artifact-sha }}" \
             -lock-timeout=5m
           echo "✅ State refresh complete"
+
+      - name: Fix CloudFront Invalid Timeout (AWS CLI)
+        run: |
+          echo "🔍 Checking CloudFront distribution for invalid timeout values..."
+
+          DIST_ID=$(terraform output -raw cloudfront_distribution_id 2>/dev/null || echo "")
+
+          if [ -z "$DIST_ID" ]; then
+            echo "⚠️ No CloudFront distribution found - skipping timeout check"
+            exit 0
+          fi
+
+          echo "Distribution ID: $DIST_ID"
+
+          aws cloudfront get-distribution-config --id "$DIST_ID" > /tmp/cf-config.json
+          ETAG=$(jq -r '.ETag' /tmp/cf-config.json)
+
+          INVALID_TIMEOUT=$(jq -r '.DistributionConfig.Origins.Items[]? |
+            select(.CustomOriginConfig.OriginReadTimeout > 180) |
+            "\(.Id): \(.CustomOriginConfig.OriginReadTimeout)s"' /tmp/cf-config.json)
+
+          if [ -z "$INVALID_TIMEOUT" ]; then
+            echo "✅ All origin timeouts are valid (<=180s)"
+            exit 0
+          fi
+
+          echo "⚠️ Found invalid timeout values:"
+          echo "$INVALID_TIMEOUT"
+          echo ""
+          echo "🔧 Fixing timeout values via AWS CLI..."
+
+          jq '.DistributionConfig.Origins.Items = [.DistributionConfig.Origins.Items[] |
+            if .CustomOriginConfig.OriginReadTimeout > 180
+            then .CustomOriginConfig.OriginReadTimeout = 180
+            else . end]' /tmp/cf-config.json > /tmp/cf-config-fixed.json
+
+          jq '.DistributionConfig.Origins.Items = [.DistributionConfig.Origins.Items[] |
+            if .CustomOriginConfig.OriginKeepaliveTimeout > 60
+            then .CustomOriginConfig.OriginKeepaliveTimeout = 60
+            else . end]' /tmp/cf-config-fixed.json > /tmp/cf-config-final.json
+
+          jq '.DistributionConfig' /tmp/cf-config-final.json > /tmp/cf-update.json
+
+          aws cloudfront update-distribution \
+            --id "$DIST_ID" \
+            --if-match "$ETAG" \
+            --distribution-config file:///tmp/cf-update.json
+
+          echo "✅ CloudFront distribution updated with valid timeout values"
+          echo ""
+          echo "⏳ Waiting 30s for CloudFront to propagate changes..."
+          sleep 30
 
       - name: Terraform Plan (Production)
         id: plan


### PR DESCRIPTION
## Summary

- Add AWS CLI step before Terraform plan/apply to fix invalid CloudFront timeout values
- This resolves the `InvalidOriginReadTimeout` error that's been blocking preprod deployments

## Problem

The Terraform apply was failing because:
1. AWS CloudFront has `origin_read_timeout=300` (set before AWS enforced the 180s limit)
2. Terraform refresh syncs state with AWS (now correctly shows 300)
3. Terraform plan wants to change 300 → 180 (correct)
4. **BUT**: CloudFront `UpdateDistribution` API validates the ENTIRE distribution config
5. Since the current AWS config has an invalid value (300), the update fails with:
   ```
   InvalidOriginReadTimeout: Your request of setting originReadTimeout is not within the valid range
   ```

## Solution

Add a new workflow step that:
1. Gets current CloudFront distribution config via AWS CLI
2. Checks if any origin has timeout > 180s (or keepalive > 60s)
3. If invalid, uses AWS CLI to directly update the distribution with valid values
4. Then Terraform can proceed with its normal apply

This is a one-time remediation - once fixed, future deploys will work normally.

## Test plan

- [ ] Verify preprod deployment succeeds after merge
- [ ] Check CloudFront distribution has origin_read_timeout=180 after fix

## Related

- Issue #124: CloudFront deployment failures
- PR #367: Added terraform refresh (partial fix - state sync only)
- PR #59: CloudFront validator in template repo (prevent future issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)