### PR TITLE
fix(126): Reset CloudFront Terraform state to fix InvalidOriginReadTimeout

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -745,6 +745,39 @@ jobs:
           echo "⏳ Waiting 30s for CloudFront to propagate changes..."
           sleep 30
 
+      - name: Reset CloudFront Terraform State
+        run: |
+          echo "🔄 Resetting CloudFront resource in Terraform state..."
+          echo "This fixes state drift that causes InvalidOriginReadTimeout errors"
+          echo ""
+
+          DIST_ID=$(terraform output -raw cloudfront_distribution_id 2>/dev/null || echo "")
+
+          if [ -z "$DIST_ID" ]; then
+            echo "⚠️ No CloudFront distribution found - skipping state reset"
+            exit 0
+          fi
+
+          echo "Distribution ID: $DIST_ID"
+          echo ""
+
+          # Remove CloudFront distribution from state
+          echo "📤 Removing CloudFront distribution from Terraform state..."
+          terraform state rm module.cloudfront.aws_cloudfront_distribution.dashboard || {
+            echo "⚠️ Resource not in state (may have already been removed)"
+          }
+
+          # Re-import the CloudFront distribution
+          echo "📥 Re-importing CloudFront distribution into Terraform state..."
+          terraform import \
+            -var-file=preprod.tfvars \
+            -var="model_version=${{ needs.build.outputs.artifact-sha }}" \
+            -var="lambda_package_version=${{ needs.build.outputs.artifact-sha }}" \
+            module.cloudfront.aws_cloudfront_distribution.dashboard "$DIST_ID"
+
+          echo ""
+          echo "✅ CloudFront state reset complete - state now matches AWS"
+
       - name: Terraform Plan (Preprod)
         id: plan
         timeout-minutes: 10
@@ -1346,6 +1379,31 @@ jobs:
           echo ""
           echo "⏳ Waiting 30s for CloudFront to propagate changes..."
           sleep 30
+
+      - name: Reset CloudFront Terraform State
+        run: |
+          echo "🔄 Resetting CloudFront resource in Terraform state..."
+
+          DIST_ID=$(terraform output -raw cloudfront_distribution_id 2>/dev/null || echo "")
+
+          if [ -z "$DIST_ID" ]; then
+            echo "⚠️ No CloudFront distribution found - skipping state reset"
+            exit 0
+          fi
+
+          echo "Distribution ID: $DIST_ID"
+
+          terraform state rm module.cloudfront.aws_cloudfront_distribution.dashboard || {
+            echo "⚠️ Resource not in state"
+          }
+
+          terraform import \
+            -var-file=prod.tfvars \
+            -var="model_version=${{ needs.build.outputs.artifact-sha }}" \
+            -var="lambda_package_version=${{ needs.build.outputs.artifact-sha }}" \
+            module.cloudfront.aws_cloudfront_distribution.dashboard "$DIST_ID"
+
+          echo "✅ CloudFront state reset complete"
 
       - name: Terraform Plan (Production)
         id: plan


### PR DESCRIPTION
## Summary

- Add step to reset CloudFront Terraform state before plan/apply
- This fixes the persistent `InvalidOriginReadTimeout` error

## Root Cause Analysis

The Terraform state had stale origin configurations that didn't match AWS:

1. **terraform refresh** only syncs attribute values, not structural representation
2. The plan showed origins being **removed and re-added** rather than updated in-place
3. When Terraform constructed the UpdateDistribution API request, it included stale data from the old state representation
4. CloudFront validates the ENTIRE request configuration, not just changes
5. The stale data included invalid timeout values, causing the API to reject the update

## Why Previous Fixes Didn't Work

- **PR #366** (origin_read_timeout=180): Fixed the Terraform code ✅
- **PR #367** (terraform refresh): Synced state values ✅ 
- **PR #368** (AWS CLI fix): Fixed AWS values ✅
- But: State STRUCTURE was still misaligned, causing origin recreation

## The Fix

Add a "Reset CloudFront Terraform State" step that:

```bash
# Remove from state
terraform state rm module.cloudfront.aws_cloudfront_distribution.dashboard

# Re-import fresh from AWS
terraform import module.cloudfront.aws_cloudfront_distribution.dashboard $DIST_ID
```

This ensures Terraform state exactly matches AWS configuration structure.

## Test plan

- [ ] Verify preprod deployment succeeds
- [ ] Verify CloudFront distribution configuration is correct after deploy
- [ ] Monitor for any state drift in subsequent deployments

## Related

- Issue #124: Original CloudFront timeout failure
- PR #366: Fixed Terraform code
- PR #367: Added terraform refresh
- PR #368: Added AWS CLI fix
- PR #59 (template): CloudFront validator for prevention

🤖 Generated with [Claude Code](https://claude.com/claude-code)