### PR TITLE
fix(127): Reduce CloudFront origin_read_timeout to 60s (default limit)

### DIFF
--- a/infrastructure/terraform/modules/cloudfront/main.tf
+++ b/infrastructure/terraform/modules/cloudfront/main.tf
@@ -223,9 +223,10 @@ resource "aws_cloudfront_distribution" "dashboard" {
         origin_ssl_protocols   = ["TLSv1.2"]
         # SSE streaming timeout configuration (Feature 119)
         # origin_read_timeout: Max time CloudFront waits for origin response
-        # AWS CloudFront limit: 180 seconds max without quota increase (300+ requires AWS support approval)
-        # origin_keepalive_timeout: Keep connection alive during streaming (1 min between messages)
-        origin_read_timeout      = 180
+        # AWS CloudFront DEFAULT limit: 60 seconds max (quota increase required for 61-180s)
+        # See: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/cloudfront-limits.html
+        # origin_keepalive_timeout: Keep connection alive during streaming (max 60s)
+        origin_read_timeout      = 60
         origin_keepalive_timeout = 60
       }
     }


### PR DESCRIPTION
## Summary
- Reduces `origin_read_timeout` from 180 to 60 seconds (CloudFront's default maximum)
- CloudFront DEFAULT limit is 60s; values 61-180s require AWS Support quota increase
- Updates comments to clarify quota requirements and link to AWS docs

## Context
Previous attempts (#366-#369) reduced from 300→180, but 180s still exceeds the default quota. This fix uses the default maximum of 60s which requires no quota increase.

## Test plan
- [x] Terraform validate passes locally
- [ ] Preprod deployment succeeds (currently blocked by this issue)
- [ ] SSE streaming remains functional with 60s timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)