### PR TITLE
fix(128): Add missing __init__.py files to SSE Lambda Docker image

### DIFF
--- a/src/lambdas/sse_streaming/Dockerfile
+++ b/src/lambdas/sse_streaming/Dockerfile
@@ -33,6 +33,9 @@ COPY --from=builder /app/packages /app/packages
 
 # Copy shared module for logging utilities
 # Structure: /app/src/lambdas/shared/
+# Create parent package __init__.py files (required for from src.lambdas.shared imports)
+RUN mkdir -p /app/src/lambdas && \
+    touch /app/src/__init__.py /app/src/lambdas/__init__.py
 COPY shared /app/src/lambdas/shared
 
 # Copy application code from sse_streaming subdirectory


### PR DESCRIPTION
## Summary
- Fixes SSE Lambda Runtime.ExitError causing dashboard "Disconnected" status
- Adds missing `__init__.py` files for parent packages in Docker image
- Root cause: `from src.lambdas.shared.logging_utils import...` failed because `/app/src/__init__.py` and `/app/src/lambdas/__init__.py` were never created

## Root Cause Analysis
The Dockerfile copied `shared/` to `/app/src/lambdas/shared/` but didn't create the parent package marker files:
- ❌ `/app/src/__init__.py` (missing)
- ❌ `/app/src/lambdas/__init__.py` (missing)
- ✓ `/app/src/lambdas/shared/__init__.py` (present from COPY)

Python requires `__init__.py` at every level of a package path.

## Fix
```dockerfile
RUN mkdir -p /app/src/lambdas && \
    touch /app/src/__init__.py /app/src/lambdas/__init__.py
```

## Test plan
- [x] Unit tests pass (1947 passed)
- [ ] Deploy to preprod
- [ ] Verify SSE stream returns `text/event-stream` content-type
- [ ] Verify dashboard shows "Connected" status

🤖 Generated with [Claude Code](https://claude.com/claude-code)