### PR TITLE
fix: Remove xray_recorder.capture from async streaming endpoints

### DIFF
--- a/src/lambdas/sse_streaming/handler.py
+++ b/src/lambdas/sse_streaming/handler.py
@@ -77,7 +77,10 @@ async def stream_status() -> StreamStatus:
 
 
 @app.get("/api/v2/stream")
-@xray_recorder.capture("global_stream")
+# Note: X-Ray @xray_recorder.capture() is intentionally NOT used here.
+# The capture decorator only works with synchronous functions (per AWS docs)
+# and interferes with async streaming responses. Streaming requests are traced
+# via the X-Ray middleware applied at startup via patch_all().
 async def global_stream(
     request: Request,
     last_event_id: str | None = Header(None, alias="Last-Event-ID"),
@@ -183,7 +186,10 @@ async def global_stream(
 
 
 @app.get("/api/v2/configurations/{config_id}/stream")
-@xray_recorder.capture("config_stream")
+# Note: X-Ray @xray_recorder.capture() is intentionally NOT used here.
+# The capture decorator only works with synchronous functions (per AWS docs)
+# and interferes with async streaming responses. Streaming requests are traced
+# via the X-Ray middleware applied at startup via patch_all().
 async def config_stream(
     request: Request,
     config_id: str,


### PR DESCRIPTION
## Summary
- Remove `@xray_recorder.capture()` decorators from async streaming endpoints
- Add explanatory comments about X-Ray async compatibility

## Details
The `@xray_recorder.capture()` decorator only works with synchronous functions per AWS X-Ray SDK documentation. Using it on async functions causes interference with streaming responses.

Async streaming requests are still traced via the X-Ray middleware applied at startup via `patch_all()`.

## Test plan
- [x] Local unit tests pass (1947 tests)
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)