### PR TITLE
fix: Copy logging_utils to SSE Lambda image for Lambda Web Adapter

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -561,7 +561,7 @@ jobs:
           from handler import app
           from config import config_lookup_service
           from stream import stream_generator
-          from src.lambdas.shared.logging_utils import sanitize_for_log
+          from logging_utils import sanitize_for_log
 
           print('✅ All imports successful')
           sys.exit(0)
@@ -1227,7 +1227,7 @@ jobs:
           from handler import app
           from config import config_lookup_service
           from stream import stream_generator
-          from src.lambdas.shared.logging_utils import sanitize_for_log
+          from logging_utils import sanitize_for_log
           print('✅ All imports successful')
           sys.exit(0)
           "

--- a/src/lambdas/sse_streaming/Dockerfile
+++ b/src/lambdas/sse_streaming/Dockerfile
@@ -31,15 +31,12 @@ COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:0.9.1 /lambda-adapter /opt
 # Copy installed packages
 COPY --from=builder /app/packages /app/packages
 
-# Copy shared module for logging utilities
-# Structure: /app/src/lambdas/shared/
-# Create parent package __init__.py files (required for from src.lambdas.shared imports)
-RUN mkdir -p /app/src/lambdas && \
-    touch /app/src/__init__.py /app/src/lambdas/__init__.py
-COPY shared /app/src/lambdas/shared
-
 # Copy application code from sse_streaming subdirectory
 COPY sse_streaming /app
+
+# Copy shared logging utilities directly into app directory
+# This avoids complex PYTHONPATH issues with Lambda Web Adapter
+COPY shared/logging_utils.py /app/logging_utils.py
 
 # Set Python path to include packages and app root for imports
 ENV PYTHONPATH=/app/packages:/app

--- a/src/lambdas/sse_streaming/handler.py
+++ b/src/lambdas/sse_streaming/handler.py
@@ -27,7 +27,12 @@ from sse_starlette.sse import EventSourceResponse
 from starlette.responses import StreamingResponse
 from stream import stream_generator
 
-from src.lambdas.shared.logging_utils import sanitize_for_log
+# Import logging utilities - try Docker path first (logging_utils.py copied to /app/),
+# fall back to full path for tests
+try:
+    from logging_utils import sanitize_for_log
+except ImportError:
+    from src.lambdas.shared.logging_utils import sanitize_for_log
 
 # Configure logging
 logging.basicConfig(


### PR DESCRIPTION
## Summary
- Copy logging_utils.py directly to /app/ in SSE Lambda Docker image
- Use try/except import pattern to support both Docker and test environments
- Update smoke test in workflow to match new import path

## Problem
The SSE Lambda was failing with `ModuleNotFoundError: No module named 'src'` despite the Docker image being built correctly. The issue was that Lambda Web Adapter runs uvicorn in a subprocess that doesn't inherit Docker ENV variables (like PYTHONPATH) reliably.

## Solution
1. Copy `logging_utils.py` directly to `/app/` instead of relying on complex PYTHONPATH
2. Use try/except in handler.py to try Docker path first, fall back to full path for tests

## Test plan
- [x] Local unit tests pass (1947 tests)
- [ ] CI pipeline passes
- [ ] SSE Lambda starts without RuntimeError
- [ ] E2E SSE connection tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)