### PR TITLE
fix: Add /app to Dockerfile PYTHONPATH for src.lambdas.shared imports

### DIFF
--- a/src/lambdas/sse_streaming/Dockerfile
+++ b/src/lambdas/sse_streaming/Dockerfile
@@ -36,15 +36,14 @@ COPY sse_streaming /app
 
 # Copy shared modules for logging utilities and models
 # Structure: /app/src/lambdas/shared/
-# Note: PYTHONPATH is set via Lambda environment variables in Terraform,
-# not via Docker ENV, because Lambda Web Adapter subprocess doesn't
-# reliably inherit container environment variables.
 RUN mkdir -p /app/src/lambdas && \
     touch /app/src/__init__.py /app/src/lambdas/__init__.py
 COPY shared /app/src/lambdas/shared
 
-# Set Python path to include packages directory
-ENV PYTHONPATH=/app/packages
+# Set Python path to include packages and app directories
+# Both paths needed: /app/packages for pip dependencies, /app for src.lambdas.shared imports
+# Note: Also set via Lambda env vars in Terraform as belt-and-suspenders
+ENV PYTHONPATH=/app/packages:/app
 ENV AWS_LWA_INVOKE_MODE=RESPONSE_STREAM
 
 # Expose port for Lambda Web Adapter


### PR DESCRIPTION
## Summary
- Add `/app` to Dockerfile `PYTHONPATH` alongside `/app/packages`
- Enables `src.lambdas.shared.*` imports in Lambda runtime
- Provides belt-and-suspenders with Terraform env var from PR #383

## Root Cause
Lambda Web Adapter runs uvicorn in a subprocess that may not reliably inherit Lambda environment variables. The previous fix (PR #383) set PYTHONPATH in Terraform, but the Dockerfile ENV only had `/app/packages`.

## Fix
```dockerfile
ENV PYTHONPATH=/app/packages:/app
```

- `/app/packages`: pip dependencies
- `/app`: enables `from src.lambdas.shared.logging_utils import ...`

## Test plan
- [x] Unit tests pass (1947 passed)
- [ ] Smoke tests verify imports
- [ ] SSE stream endpoint responds with heartbeat events

🤖 Generated with [Claude Code](https://claude.com/claude-code)