### PR TITLE
fix: Force SSE Lambda to use new Docker image after build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -838,6 +838,30 @@ jobs:
           terraform apply -auto-approve -lock-timeout=5m preprod.tfplan
           echo "✅ Preprod infrastructure deployed"
 
+      # Force SSE Lambda to use the new Docker image
+      # Terraform doesn't detect :latest tag changes because the image_uri is unchanged.
+      # We use the immutable SHA tag pushed by build-sse-image-preprod job.
+      - name: Force SSE Lambda Image Update
+        run: |
+          echo "🔄 Forcing SSE Lambda to use new Docker image..."
+
+          ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+          REGION="${{ vars.AWS_REGION }}"
+          IMAGE_URI="${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/preprod-sse-streaming-lambda:${{ github.sha }}"
+
+          echo "Image URI: ${IMAGE_URI}"
+
+          aws lambda update-function-code \
+            --function-name preprod-sentiment-sse-streaming \
+            --image-uri "${IMAGE_URI}"
+
+          # Wait for update to complete
+          echo "⏳ Waiting for Lambda update to complete..."
+          aws lambda wait function-updated \
+            --function-name preprod-sentiment-sse-streaming
+
+          echo "✅ SSE Lambda updated to use new image"
+
       - name: Get Preprod Outputs
         id: outputs
         run: |


### PR DESCRIPTION
## Summary
- Add explicit `aws lambda update-function-code` step after Terraform apply
- Uses immutable git SHA tag instead of relying on :latest
- Waits for Lambda update to complete before proceeding

## Root Cause
Terraform does not detect `:latest` tag changes because the `image_uri` value is unchanged. The Lambda caches the image digest at deploy time and does not check for updates when pushing a new image to the same tag.

## Fix
After Terraform apply, force the Lambda to pull the specific image built in this workflow using the immutable git SHA tag.

## Test plan
- [x] Unit tests pass (1947 passed)
- [ ] Deploy workflow runs Lambda update step
- [ ] SSE Lambda starts successfully with new image
- [ ] Integration tests pass (SSE connection health checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)