### PR TITLE
feat(386): Create separate IAM role for SSE Lambda

### DIFF
--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -618,8 +618,8 @@ module "sse_streaming_lambda" {
 
   function_name = local.sse_lambda_name
   description   = "Real-time SSE streaming for sentiment updates (Feature 016)"
-  iam_role_arn  = module.iam.dashboard_lambda_role_arn # Reuse dashboard role for DynamoDB access
-  handler       = null                                 # Not used for Docker-based Lambda
+  iam_role_arn  = module.iam.sse_streaming_lambda_role_arn # Dedicated role with Scan/Query/GetItem (Spec 386)
+  handler       = null                                     # Not used for Docker-based Lambda
 
   # Docker-based deployment via ECR
   # Image URI will be updated by CI/CD pipeline after first terraform apply

--- a/infrastructure/terraform/modules/iam/outputs.tf
+++ b/infrastructure/terraform/modules/iam/outputs.tf
@@ -49,3 +49,13 @@ output "notification_lambda_role_name" {
   description = "Name of the Notification Lambda IAM role (Feature 006)"
   value       = aws_iam_role.notification_lambda.name
 }
+
+output "sse_streaming_lambda_role_arn" {
+  description = "ARN of the SSE Streaming Lambda IAM role (Feature 016)"
+  value       = aws_iam_role.sse_streaming_lambda.arn
+}
+
+output "sse_streaming_lambda_role_name" {
+  description = "Name of the SSE Streaming Lambda IAM role (Feature 016)"
+  value       = aws_iam_role.sse_streaming_lambda.name
+}

--- a/specs/386-sse-lambda-separate-iam-role/plan.md
+++ b/specs/386-sse-lambda-separate-iam-role/plan.md
@@ -1,0 +1,92 @@
+# Plan: Spec 386 - Separate IAM Role for SSE Lambda
+
+## Overview
+
+Create a dedicated IAM role for the SSE Streaming Lambda, following the established pattern from other Lambda roles (ingestion, analysis, dashboard, metrics, notification).
+
+## Implementation Steps
+
+### Step 1: Add SSE Streaming Lambda Role to IAM Module
+
+**File**: `infrastructure/terraform/modules/iam/main.tf`
+
+Add new role definition following the established pattern:
+1. Create `aws_iam_role.sse_streaming_lambda` with Lambda trust policy
+2. Create `aws_iam_role_policy.sse_streaming_dynamodb` with:
+   - `dynamodb:Scan` (metrics polling every 5s)
+   - `dynamodb:Query` (config lookup)
+   - `dynamodb:GetItem` (config validation)
+   - Resource: sentiment-items table + indexes
+3. Attach `AWSLambdaBasicExecutionRole` managed policy for CloudWatch Logs
+4. Create `aws_iam_role_policy.sse_streaming_metrics` for CloudWatch:PutMetricData
+5. Attach `AWSXRayDaemonWriteAccess` managed policy for X-Ray tracing
+
+### Step 2: Export Role ARN from IAM Module
+
+**File**: `infrastructure/terraform/modules/iam/outputs.tf`
+
+Add outputs:
+- `sse_streaming_lambda_role_arn`
+- `sse_streaming_lambda_role_name`
+
+### Step 3: Update SSE Lambda to Use New Role
+
+**File**: `infrastructure/terraform/main.tf`
+
+Change line 621 from:
+```hcl
+iam_role_arn = module.iam.dashboard_lambda_role_arn # Reuse dashboard role
+```
+To:
+```hcl
+iam_role_arn = module.iam.sse_streaming_lambda_role_arn
+```
+
+### Step 4: Validate with Terraform Plan
+
+Run `terraform plan` to verify:
+- New IAM role resource will be created
+- New IAM policies will be attached
+- SSE Lambda configuration will be updated
+- No unexpected changes to other resources
+
+## Architectural Decision
+
+**Why separate roles instead of adding permissions to existing role?**
+
+1. **Least Privilege**: SSE Lambda only needs Scan access; Dashboard needs complex Feature 006 permissions, Secrets Manager, chaos testing, etc.
+
+2. **Blast Radius**: If SSE Lambda is compromised, attacker cannot access:
+   - Secrets Manager (API keys)
+   - Feature 006 users table (PII)
+   - S3 ticker cache
+   - FIS chaos testing
+
+3. **Auditability**: CloudTrail logs clearly identify which Lambda performed which action.
+
+4. **Existing Pattern**: Every other Lambda (ingestion, analysis, dashboard, metrics, notification) has its own role.
+
+## Risk Assessment
+
+| Risk | Mitigation |
+|------|------------|
+| New role creation fails | Terraform will rollback on apply failure |
+| SSE Lambda fails with new role | Rollback by changing IAM ARN back to dashboard role |
+| Missing permission discovered later | Role is isolated, can add permission without affecting other Lambdas |
+
+## Rollback Plan
+
+If deployment fails:
+```hcl
+# Revert main.tf line 621 to:
+iam_role_arn = module.iam.dashboard_lambda_role_arn
+```
+
+Run `terraform apply` - SSE Lambda returns to using Dashboard role.
+
+## Acceptance Validation
+
+After deployment:
+1. Check CloudWatch logs for SSE Lambda - no AccessDeniedException
+2. Test `/api/v2/stream` endpoint - receives sentiment data
+3. Verify Dashboard Lambda still works - no regression

--- a/specs/386-sse-lambda-separate-iam-role/spec.md
+++ b/specs/386-sse-lambda-separate-iam-role/spec.md
@@ -1,0 +1,126 @@
+# Spec 386: Separate IAM Role for SSE Lambda
+
+## Problem Statement
+
+The SSE Lambda currently reuses the Dashboard Lambda's IAM role (`preprod-dashboard-lambda-role`). This causes two issues:
+
+1. **Missing permissions**: The Dashboard role lacks `dynamodb:Scan` which the SSE Lambda needs for metrics polling, causing `AccessDeniedException` errors.
+
+2. **Architectural smell**: Sharing roles between Lambdas with different purposes violates least-privilege principle and increases blast radius.
+
+## Root Cause Analysis
+
+From CloudWatch logs:
+```
+botocore.exceptions.ClientError: An error occurred (AccessDeniedException) when calling the Scan operation:
+User: arn:aws:sts::218795110243:assumed-role/preprod-dashboard-lambda-role/preprod-sentiment-sse-streaming
+is not authorized to perform: dynamodb:Scan
+```
+
+The SSE Lambda needs to scan the `sentiment-items` table for metrics aggregation, but the Dashboard role only grants `Query`, `GetItem`, and `DescribeTable`.
+
+## Solution
+
+Create a dedicated IAM role for the SSE Lambda with exactly the permissions it needs:
+
+### Required Permissions
+
+| Service | Actions | Resource | Reason |
+|---------|---------|----------|--------|
+| DynamoDB | `Scan` | sentiment-items table | Metrics polling every 5s |
+| DynamoDB | `Query`, `GetItem` | sentiment-items table | Config validation |
+| CloudWatch Logs | Basic execution | Log group | Standard Lambda logging |
+| CloudWatch | `PutMetricData` | SentimentAnalyzer/SSE namespace | Custom metrics |
+| X-Ray | Write access | Traces | Distributed tracing |
+
+### Permissions NOT Needed (vs Dashboard Role)
+
+- DynamoDB access to Feature 006 users table
+- Secrets Manager access
+- S3 ticker cache access
+- FIS chaos testing permissions
+- DynamoDB access to chaos_experiments table
+
+## Implementation
+
+### Files to Modify
+
+1. `infrastructure/terraform/modules/iam/main.tf` - Add SSE role definition
+2. `infrastructure/terraform/modules/iam/outputs.tf` - Export SSE role ARN
+3. `infrastructure/terraform/main.tf` - Use SSE role for SSE Lambda
+
+### Terraform Pattern
+
+Follow the established pattern from ingestion Lambda:
+1. Create role with trust policy for Lambda service
+2. Create inline policies per AWS service
+3. Attach managed policies for common permissions
+4. Output role ARN
+
+### Role Definition
+
+```hcl
+resource "aws_iam_role" "sse_streaming_lambda" {
+  name = "${var.environment}-sse-streaming-lambda-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = { Service = "lambda.amazonaws.com" }
+      Action = "sts:AssumeRole"
+    }]
+  })
+
+  tags = {
+    Environment = var.environment
+    Feature     = "016-sse-streaming-lambda"
+    Lambda      = "sse-streaming"
+  }
+}
+```
+
+### DynamoDB Policy
+
+```hcl
+resource "aws_iam_role_policy" "sse_streaming_dynamodb" {
+  name = "${var.environment}-sse-streaming-dynamodb-policy"
+  role = aws_iam_role.sse_streaming_lambda.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = [
+        "dynamodb:Scan",
+        "dynamodb:Query",
+        "dynamodb:GetItem"
+      ]
+      Resource = var.dynamodb_table_arn
+    }]
+  })
+}
+```
+
+## Acceptance Criteria
+
+- [ ] SSE Lambda has its own IAM role separate from Dashboard
+- [ ] SSE Lambda can successfully scan DynamoDB for metrics
+- [ ] SSE Lambda CloudWatch logs show no AccessDeniedException
+- [ ] Role follows least-privilege principle
+- [ ] Existing Dashboard Lambda functionality is unchanged
+
+## Test Plan
+
+1. Deploy to preprod
+2. Invoke SSE Lambda `/api/v2/stream` endpoint
+3. Check CloudWatch logs for successful DynamoDB scans
+4. Verify metrics appear in CloudWatch under SentimentAnalyzer/SSE namespace
+5. Run preprod integration tests
+
+## Rollback
+
+If issues occur, revert to using Dashboard role by changing:
+```hcl
+iam_role_arn = module.iam.dashboard_lambda_role_arn
+```

--- a/specs/386-sse-lambda-separate-iam-role/tasks.md
+++ b/specs/386-sse-lambda-separate-iam-role/tasks.md
@@ -1,0 +1,45 @@
+# Tasks: Spec 386 - Separate IAM Role for SSE Lambda
+
+## Pre-Implementation
+
+- [x] Create spec.md with problem statement and solution
+- [x] Create plan.md with implementation steps
+- [x] Create tasks.md (this file)
+
+## Implementation Tasks
+
+### Task 1: Add SSE Streaming Lambda IAM Role
+
+**File**: `infrastructure/terraform/modules/iam/main.tf`
+
+- [x] Add `aws_iam_role.sse_streaming_lambda` resource
+- [x] Add `aws_iam_role_policy.sse_streaming_dynamodb` with Scan/Query/GetItem
+- [x] Attach `AWSLambdaBasicExecutionRole` managed policy
+- [x] Add `aws_iam_role_policy.sse_streaming_metrics` for CloudWatch
+- [x] Attach `AWSXRayDaemonWriteAccess` managed policy
+
+### Task 2: Export Role from IAM Module
+
+**File**: `infrastructure/terraform/modules/iam/outputs.tf`
+
+- [x] Add `sse_streaming_lambda_role_arn` output
+- [x] Add `sse_streaming_lambda_role_name` output
+
+### Task 3: Update SSE Lambda Configuration
+
+**File**: `infrastructure/terraform/main.tf`
+
+- [x] Change `iam_role_arn` from `module.iam.dashboard_lambda_role_arn` to `module.iam.sse_streaming_lambda_role_arn`
+- [x] Update comment to reflect dedicated role
+
+### Task 4: Validation
+
+- [x] Run `terraform fmt` to format changes
+- [x] Run `terraform validate` to check syntax
+- [ ] Run `terraform plan` to verify expected changes (CI will do this)
+
+## Post-Implementation
+
+- [ ] Commit changes with descriptive message
+- [ ] Create PR for review
+- [ ] Monitor preprod deployment for IAM errors


### PR DESCRIPTION
## Summary

- Creates dedicated IAM role for SSE Lambda instead of reusing Dashboard Lambda's role
- Grants least-privilege permissions: DynamoDB Scan/Query/GetItem, CloudWatch Logs, CloudWatch PutMetricData, X-Ray
- Fixes `AccessDeniedException` errors caused by missing `dynamodb:Scan` permission

## Problem

SSE Lambda was reusing Dashboard Lambda's IAM role which lacked `dynamodb:Scan` permission needed for metrics polling, causing runtime errors.

## Solution

New `sse_streaming_lambda` role with exactly the permissions needed:
- DynamoDB: Scan, Query, GetItem on sentiment-items table + 3 indexes
- CloudWatch Logs: Basic execution role
- CloudWatch: PutMetricData for custom metrics
- X-Ray: Write access for tracing

## Test Plan

- [ ] CI terraform plan passes
- [ ] Preprod deployment succeeds
- [ ] SSE Lambda CloudWatch logs show no AccessDeniedException
- [ ] Metrics endpoint returns data successfully

## Spec Reference

See `specs/386-sse-lambda-separate-iam-role/` for full specification and implementation plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)