### PR TITLE
fix(069): Fix bash arithmetic exit code issue in PR update workflow

### DIFF
--- a/.github/workflows/update-pr-branches.yml
+++ b/.github/workflows/update-pr-branches.yml
@@ -60,10 +60,10 @@ jobs:
             echo "Updating PR #$pr..."
             if gh api repos/${{ github.repository }}/pulls/$pr/update-branch -X PUT 2>/dev/null; then
               echo "  ✓ PR #$pr updated successfully"
-              ((updated++))
+              updated=$((updated + 1))
             else
               echo "  ⚠ PR #$pr skipped (likely has conflicts or is up to date)"
-              ((skipped++))
+              skipped=$((skipped + 1))
             fi
           done
 


### PR DESCRIPTION
## Summary
- Fixed bash arithmetic `((var++))` returning exit code 1 when incrementing from 0
- Changed to assignment form `var=$((var + 1))` which always succeeds
- Affects both `updated` and `skipped` counters

## Root Cause
The `((var++))` syntax returns the **pre-increment** value as the exit code. When `var=0`, the expression evaluates to 0, which bash treats as "false" → exit code 1. Combined with `set -e` (GitHub Actions default), this aborts the script.

## Test Plan
- [x] Verify workflow syntax is valid
- [ ] Trigger workflow by merging this PR (meta: the fix will be tested by its own merge)

Fixes: https://github.com/traylorre/sentiment-analyzer-gsk/actions/runs/20281918819

🤖 Generated with [Claude Code](https://claude.com/claude-code)