### PR TITLE
fix: Use dynamic account ID for model S3 bucket

### DIFF
--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -198,7 +198,7 @@ locals {
   metrics_lambda_name   = "${var.environment}-sentiment-metrics"
 
   # S3 bucket for ML model storage
-  model_s3_bucket = "sentiment-analyzer-models-218795110243"
+  model_s3_bucket = "sentiment-analyzer-models-${data.aws_caller_identity.current.account_id}"
 
   # S3 bucket for ticker cache data (Feature 006)
   ticker_cache_bucket = "${var.environment}-sentiment-ticker-cache-${data.aws_caller_identity.current.account_id}"


### PR DESCRIPTION
## Summary
- Replaced hardcoded AWS account ID (218795110243) with `data.aws_caller_identity.current.account_id`
- Makes model_s3_bucket local variable portable across AWS accounts

## Test plan
- [ ] Verify terraform plan shows no changes (bucket name should resolve to same value)

🤖 Generated with [Claude Code](https://claude.com/claude-code)