### PR TITLE
fix(150): Forward Last-Event-ID and X-User-ID headers in CloudFront SSE behaviors

### DIFF
--- a/infrastructure/terraform/modules/cloudfront/main.tf
+++ b/infrastructure/terraform/modules/cloudfront/main.tf
@@ -265,7 +265,10 @@ resource "aws_cloudfront_distribution" "dashboard" {
 
       forwarded_values {
         query_string = true
-        headers      = ["Authorization", "Origin", "Accept"]
+        # Fix(150): Forward Last-Event-ID and X-User-ID headers for SSE reconnection and auth
+        # Last-Event-ID: Required for FR-007 SSE reconnection replay
+        # X-User-ID: Required for FR-014 authentication on config streams
+        headers = ["Authorization", "Origin", "Accept", "Last-Event-ID", "X-User-ID"]
         cookies {
           forward = "none"
         }
@@ -294,7 +297,8 @@ resource "aws_cloudfront_distribution" "dashboard" {
 
       forwarded_values {
         query_string = true
-        headers      = ["Authorization", "Origin", "Accept"]
+        # Fix(150): Forward Last-Event-ID and X-User-ID headers for SSE reconnection and auth
+        headers = ["Authorization", "Origin", "Accept", "Last-Event-ID", "X-User-ID"]
         cookies {
           forward = "none"
         }


### PR DESCRIPTION
## Summary
- Added `Last-Event-ID` header forwarding for SSE reconnection replay (FR-007)
- Added `X-User-ID` header forwarding for config stream authentication (FR-014)
- Updated both `/api/v2/stream*` and `/api/v2/configurations/*/stream` cache behaviors

## Root Cause
CloudFront SSE cache behaviors were only forwarding `Authorization`, `Origin`, and `Accept` headers, but not the headers required by the SSE Lambda handler for:
1. Event replay after client disconnection (`Last-Event-ID`)
2. User authentication on configuration streams (`X-User-ID`)

## Test Plan
- [ ] Deploy to preprod and verify SSE reconnection works
- [ ] Test config stream authentication via X-User-ID header

🤖 Generated with [Claude Code](https://claude.com/claude-code)