### PR TITLE
fix(151): Add DATABASE_TABLE to error logs for debugging 500 errors

### DIFF
--- a/src/lambdas/analysis/handler.py
+++ b/src/lambdas/analysis/handler.py
@@ -47,6 +47,7 @@ Security Notes:
 
 import json
 import logging
+import os
 import time
 from decimal import Decimal
 from typing import Any


### PR DESCRIPTION
## Summary
- Added DATABASE_TABLE environment variable to error log context for debugging 500 errors
- Enhanced logging in `_update_item_with_sentiment` exception handler
- Includes request_id for CloudWatch log correlation

## Root Cause Analysis
When 500 errors occur in the Analysis Lambda, it wasn't always clear if the DATABASE_TABLE environment variable was correctly set. This PR adds the table name to error logs for faster debugging.

## Test Plan
- [x] All existing unit tests pass
- [ ] Deploy to preprod and verify error logs include database_table field

🤖 Generated with [Claude Code](https://claude.com/claude-code)