### PR TITLE
fix(153): Add SSE_HEARTBEAT_INTERVAL default to test conftest

### DIFF
--- a/src/lambdas/sse_streaming/handler.py
+++ b/src/lambdas/sse_streaming/handler.py
@@ -104,9 +104,9 @@ async def debug_info() -> dict:
         "AWS_LWA_INVOKE_MODE": os.environ.get("AWS_LWA_INVOKE_MODE"),
         "AWS_LWA_READINESS_CHECK_PATH": os.environ.get("AWS_LWA_READINESS_CHECK_PATH"),
         "PYTHONPATH": os.environ.get("PYTHONPATH"),
-        "SSE_HEARTBEAT_INTERVAL": os.environ.get("SSE_HEARTBEAT_INTERVAL"),
-        "SSE_MAX_CONNECTIONS": os.environ.get("SSE_MAX_CONNECTIONS"),
-        "SSE_POLL_INTERVAL": os.environ.get("SSE_POLL_INTERVAL"),
+        "SSE_HEARTBEAT_INTERVAL": os.environ.get("SSE_HEARTBEAT_INTERVAL", "30"),
+        "SSE_MAX_CONNECTIONS": os.environ.get("SSE_MAX_CONNECTIONS", "100"),
+        "SSE_POLL_INTERVAL": os.environ.get("SSE_POLL_INTERVAL", "5"),
     }
 
     return {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,6 +80,7 @@ os.environ.setdefault("AWS_ACCESS_KEY_ID", "testing")
 os.environ.setdefault("AWS_SECRET_ACCESS_KEY", "testing")
 os.environ.setdefault("AWS_REGION", "us-east-1")
 os.environ.setdefault("SSE_POLL_INTERVAL", "1")
+os.environ.setdefault("SSE_HEARTBEAT_INTERVAL", "1")  # Fast heartbeats for tests
 
 # Disable X-Ray SDK in tests to suppress "cannot find the current segment" errors.
 # X-Ray requires a Lambda runtime context with an active segment. In tests, there's no


### PR DESCRIPTION
## Summary
- Add `SSE_HEARTBEAT_INTERVAL` default to tests/conftest.py for test consistency alongside existing `SSE_POLL_INTERVAL`
- Update handler.py debug endpoint to show default values (30, 100, 5) instead of None when env vars not set

## Test plan
- [x] All 1947 unit tests pass
- [x] All 153 SSE streaming tests pass
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)