### PR TITLE
ci(154): Use CLAUDE_CODE_PAT for PR merge operations

### DIFF
--- a/.github/workflows/pr-merge.yml
+++ b/.github/workflows/pr-merge.yml
@@ -120,7 +120,7 @@ jobs:
       - name: Enable auto-merge
         uses: peter-evans/enable-pull-request-automerge@v3
         with:
-          token: ${{ secrets.REPO_PAT }}
+          token: ${{ secrets.CLAUDE_CODE_PAT }}
           pull-request-number: ${{ github.event.pull_request.number }}
           merge-method: squash
 
@@ -129,7 +129,7 @@ jobs:
           gh pr comment "$PR_URL" --body "Auto-merge enabled. This PR will automatically merge once all required checks pass."
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.CLAUDE_CODE_PAT }}
 
   # ========================================================================
   # JOB 4: Dependabot Auto-Merge
@@ -151,7 +151,7 @@ jobs:
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.CLAUDE_CODE_PAT }}
 
       - name: Auto-merge GitHub Actions major version updates
         if: |
@@ -160,14 +160,14 @@ jobs:
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.CLAUDE_CODE_PAT }}
 
       - name: Auto-merge security updates
         if: steps.metadata.outputs.dependency-type == 'direct:production' && contains(github.event.pull_request.title, 'security')
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.CLAUDE_CODE_PAT }}
 
       - name: Approve PR (patch/minor or GitHub Actions)
         if: |
@@ -177,7 +177,7 @@ jobs:
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.CLAUDE_CODE_PAT }}
 
       - name: Comment on Python major version updates
         if: |
@@ -191,4 +191,4 @@ jobs:
           This PR will NOT be auto-merged."
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.CLAUDE_CODE_PAT }}


### PR DESCRIPTION
## Summary
- Replace `GITHUB_TOKEN` with `CLAUDE_CODE_PAT` for operations requiring elevated permissions in `pull_request_target` events
- Updates 6 token references in pr-merge.yml for write operations (auto-merge, approval, comments)
- Keeps `GITHUB_TOKEN` for read-only operations (fetch-metadata)

## Why
`pull_request_target` events have restricted `GITHUB_TOKEN` permissions that cannot reliably enable auto-merge or approve PRs. The PAT with workflow scope provides the necessary permissions.

## Test plan
- [ ] Verify next Dependabot PR auto-merges correctly
- [ ] Verify manual PRs get "Auto-merge enabled" comment
- [ ] Check workflow run logs for permission errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)