### PR TITLE
feat: Add Terraform variables for SSE poll and heartbeat intervals

### DIFF
--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -411,7 +411,7 @@ module "dashboard_lambda" {
     COGNITO_USER_POOL_ID         = module.cognito.user_pool_id
     COGNITO_CLIENT_ID            = module.cognito.client_id
     TICKER_CACHE_BUCKET          = aws_s3_bucket.ticker_cache.id
-    SSE_POLL_INTERVAL            = "5"
+    SSE_POLL_INTERVAL            = tostring(var.sse_poll_interval)
     ENVIRONMENT                  = var.environment
     CHAOS_EXPERIMENTS_TABLE      = module.dynamodb.chaos_experiments_table_name
     # CORS: Pass explicit origins from tfvars (no wildcard fallback)
@@ -643,9 +643,9 @@ module "sse_streaming_lambda" {
     PYTHONPATH             = "/app/packages:/app"
     DYNAMODB_TABLE         = module.dynamodb.table_name
     DATABASE_TABLE         = module.dynamodb.feature_006_users_table_name
-    SSE_HEARTBEAT_INTERVAL = "30"
+    SSE_HEARTBEAT_INTERVAL = tostring(var.sse_heartbeat_interval)
     SSE_MAX_CONNECTIONS    = "100"
-    SSE_POLL_INTERVAL      = "5"
+    SSE_POLL_INTERVAL      = tostring(var.sse_poll_interval)
     ENVIRONMENT            = var.environment
     AWS_LWA_INVOKE_MODE    = "RESPONSE_STREAM"
     # Fix(141): Tell Lambda Web Adapter to check /health instead of default /

--- a/infrastructure/terraform/variables.tf
+++ b/infrastructure/terraform/variables.tf
@@ -156,3 +156,27 @@ variable "notification_from_email" {
   type        = string
   default     = "noreply@sentiment-analyzer.com"
 }
+
+# ===================================================================
+# SSE Streaming Configuration
+# ===================================================================
+
+variable "sse_poll_interval" {
+  description = "SSE poll interval in seconds for checking new data"
+  type        = number
+  default     = 5
+  validation {
+    condition     = var.sse_poll_interval >= 1 && var.sse_poll_interval <= 60
+    error_message = "SSE poll interval must be between 1 and 60 seconds."
+  }
+}
+
+variable "sse_heartbeat_interval" {
+  description = "SSE heartbeat interval in seconds for keeping connection alive"
+  type        = number
+  default     = 30
+  validation {
+    condition     = var.sse_heartbeat_interval >= 10 && var.sse_heartbeat_interval <= 300
+    error_message = "SSE heartbeat interval must be between 10 and 300 seconds."
+  }
+}


### PR DESCRIPTION
## Summary
- Replace hardcoded SSE_POLL_INTERVAL (5s) and SSE_HEARTBEAT_INTERVAL (30s) with configurable Terraform variables
- Add validation constraints for poll interval (1-60s) and heartbeat interval (10-300s)
- Maintain backward compatibility with existing defaults

## Test plan
- [ ] Verify `terraform validate` passes
- [ ] Verify no changes when using default values
- [ ] Verify custom values can be set via tfvars

🤖 Generated with [Claude Code](https://claude.com/claude-code)