### PR TITLE
fix(ci): Add DATABASE_TABLE env var for preprod integration tests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1144,7 +1144,10 @@ jobs:
         env:
           AWS_REGION: ${{ vars.AWS_REGION }}
           ENVIRONMENT: preprod
+          # Legacy table for news/sentiment data (v1 API)
           DYNAMODB_TABLE: preprod-sentiment-items
+          # Feature 006 users table for user configs (v2 API, used by dashboard handler)
+          DATABASE_TABLE: preprod-sentiment-users
           SNS_TOPIC_ARN: ${{ steps.infra.outputs.sns_topic_arn }}
           NEWSAPI_SECRET_ARN: ${{ secrets.NEWSAPI_SECRET_ARN }}
           DASHBOARD_API_KEY: ${{ secrets.DASHBOARD_API_KEY }}


### PR DESCRIPTION
## Summary
- Add DATABASE_TABLE env var to preprod integration test step
- Fixes 503 errors in TestClient-based preprod tests that import dashboard handler in-process
- Dashboard handler reads DATABASE_TABLE at import time; without it, conftest.py defaults to test-sentiment-items which doesn't exist in AWS

## Root Cause
TestClient-based preprod tests (test_dashboard_preprod.py) import the dashboard handler module directly, which reads `os.environ["DATABASE_TABLE"]` at module load. Without the env var set in CI, conftest.py's default of `test-sentiment-items` is used, causing 503 when the Lambda tries to connect to a non-existent table.

## Test plan
- [ ] CI preprod integration tests pass without 503 errors
- [ ] Health check returns correct table name (`preprod-sentiment-users`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)