### PR TITLE
feat(test): Add PreprodEnvValidator for test environment validation

### DIFF
--- a/tests/fixtures/validators/__init__.py
+++ b/tests/fixtures/validators/__init__.py
@@ -1,6 +1,16 @@
 """Validators for test data and API responses."""
 
 from tests.fixtures.validators.ohlc_validator import OHLCValidator, ValidationError
+from tests.fixtures.validators.preprod_env_validator import (
+    EnvValidationError,
+    PreprodEnvValidator,
+)
 from tests.fixtures.validators.sentiment_validator import SentimentValidator
 
-__all__ = ["OHLCValidator", "SentimentValidator", "ValidationError"]
+__all__ = [
+    "EnvValidationError",
+    "OHLCValidator",
+    "PreprodEnvValidator",
+    "SentimentValidator",
+    "ValidationError",
+]

--- a/tests/fixtures/validators/preprod_env_validator.py
+++ b/tests/fixtures/validators/preprod_env_validator.py
@@ -1,0 +1,298 @@
+"""Preprod test environment validator.
+
+Validates environment variable configuration before running preprod tests.
+Detects misconfigurations that cause ResourceNotFoundException, 404s, and other
+environment-related test failures.
+
+Common issues caught:
+- DATABASE_TABLE vs DYNAMODB_TABLE mismatch (Issue #13)
+- Missing required env vars for preprod tests
+- Invalid URL formats for Lambda function URLs
+- Environment value mismatch (ENVIRONMENT != preprod for preprod tests)
+
+Usage in conftest.py:
+    from tests.fixtures.validators.preprod_env_validator import PreprodEnvValidator
+
+    @pytest.fixture(scope="session", autouse=True)
+    def validate_preprod_env():
+        validator = PreprodEnvValidator()
+        errors = validator.validate()
+        if errors:
+            pytest.fail(validator.format_errors(errors))
+"""
+
+import os
+import re
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class EnvValidationError:
+    """Single environment validation error with context."""
+
+    var: str
+    message: str
+    value: Any = None
+    suggestion: str | None = None
+
+
+class PreprodEnvValidator:
+    """Validates preprod test environment configuration.
+
+    Checks for common misconfigurations that cause test failures:
+    1. Missing required environment variables
+    2. DATABASE_TABLE vs DYNAMODB_TABLE conflicts
+    3. Invalid URL formats
+    4. Environment value consistency
+    """
+
+    # Required for all preprod tests
+    REQUIRED_VARS = [
+        "AWS_REGION",
+        "ENVIRONMENT",
+    ]
+
+    # Required for integration/analysis tests
+    INTEGRATION_VARS = [
+        "DYNAMODB_TABLE",
+        "DATABASE_TABLE",
+    ]
+
+    # Required for E2E tests
+    E2E_VARS = [
+        "PREPROD_DASHBOARD_URL",
+        "SSE_LAMBDA_URL",
+        "API_KEY",
+    ]
+
+    # URL pattern for Lambda function URLs
+    URL_PATTERN = re.compile(r"^https://[a-z0-9]+\.lambda-url\.[a-z0-9-]+\.on\.aws/?$")
+
+    # Alternative URL patterns (CloudFront, API Gateway)
+    ALT_URL_PATTERNS = [
+        re.compile(r"^https://[a-z0-9]+\.cloudfront\.net/?.*$"),
+        re.compile(r"^https://[a-z0-9]+\.execute-api\.[a-z0-9-]+\.amazonaws\.com/?.*$"),
+        re.compile(r"^https?://localhost(:\d+)?/?.*$"),  # Local dev
+    ]
+
+    def validate(self, test_type: str = "all") -> list[EnvValidationError]:
+        """Validate environment configuration.
+
+        Args:
+            test_type: Type of tests to validate for:
+                       "all" - validate all vars
+                       "integration" - validate for integration tests
+                       "e2e" - validate for E2E tests
+
+        Returns:
+            List of EnvValidationError objects (empty if valid)
+        """
+        errors: list[EnvValidationError] = []
+
+        # Always validate required vars
+        errors.extend(self._validate_required_vars())
+
+        # Validate based on test type
+        if test_type in ("all", "integration"):
+            errors.extend(self._validate_integration_vars())
+            errors.extend(self._validate_table_consistency())
+
+        if test_type in ("all", "e2e"):
+            errors.extend(self._validate_e2e_vars())
+            errors.extend(self._validate_urls())
+
+        # Always validate environment consistency
+        errors.extend(self._validate_environment_value())
+
+        return errors
+
+    def _validate_required_vars(self) -> list[EnvValidationError]:
+        """Check that required vars are present."""
+        errors = []
+        for var in self.REQUIRED_VARS:
+            if var not in os.environ:
+                errors.append(
+                    EnvValidationError(
+                        var=var,
+                        message=f"Missing required environment variable: {var}",
+                        suggestion=f"Set {var} in CI workflow or test setup",
+                    )
+                )
+        return errors
+
+    def _validate_integration_vars(self) -> list[EnvValidationError]:
+        """Check that integration test vars are present."""
+        errors = []
+        for var in self.INTEGRATION_VARS:
+            if var not in os.environ:
+                errors.append(
+                    EnvValidationError(
+                        var=var,
+                        message=f"Missing environment variable for integration tests: {var}",
+                        suggestion=f"Set {var} in CI workflow env section",
+                    )
+                )
+        return errors
+
+    def _validate_e2e_vars(self) -> list[EnvValidationError]:
+        """Check that E2E test vars are present."""
+        errors = []
+        for var in self.E2E_VARS:
+            if var not in os.environ:
+                errors.append(
+                    EnvValidationError(
+                        var=var,
+                        message=f"Missing environment variable for E2E tests: {var}",
+                        suggestion=f"Set {var} in CI workflow env section",
+                    )
+                )
+        return errors
+
+    def _validate_table_consistency(self) -> list[EnvValidationError]:
+        """Check DATABASE_TABLE vs DYNAMODB_TABLE consistency.
+
+        Issue #13: Analysis handler uses DATABASE_TABLE via get_table(),
+        but tests often insert data using DYNAMODB_TABLE. If these point
+        to different tables, tests fail with ResourceNotFoundException.
+
+        This validator WARNS when they differ, allowing intentional
+        configurations but flagging potential issues.
+        """
+        errors = []
+
+        dynamodb_table = os.environ.get("DYNAMODB_TABLE")
+        database_table = os.environ.get("DATABASE_TABLE")
+
+        # Only check if both are set
+        if dynamodb_table and database_table:
+            if dynamodb_table != database_table:
+                errors.append(
+                    EnvValidationError(
+                        var="DATABASE_TABLE",
+                        message=(
+                            f"DATABASE_TABLE ({database_table}) differs from "
+                            f"DYNAMODB_TABLE ({dynamodb_table}). This may cause "
+                            f"ResourceNotFoundException in analysis tests if tests "
+                            f"insert data into DYNAMODB_TABLE but handler reads from "
+                            f"DATABASE_TABLE."
+                        ),
+                        value={
+                            "DATABASE_TABLE": database_table,
+                            "DYNAMODB_TABLE": dynamodb_table,
+                        },
+                        suggestion=(
+                            "If running analysis tests, ensure DATABASE_TABLE points "
+                            "to the same table as DYNAMODB_TABLE, or override in test "
+                            "fixture (see test_analysis_preprod.py env_vars fixture)."
+                        ),
+                    )
+                )
+
+        return errors
+
+    def _validate_environment_value(self) -> list[EnvValidationError]:
+        """Check ENVIRONMENT value consistency."""
+        errors = []
+
+        env_value = os.environ.get("ENVIRONMENT", "")
+
+        # For preprod tests, ENVIRONMENT should be "preprod"
+        if env_value and env_value not in ("preprod", "dev", "test"):
+            errors.append(
+                EnvValidationError(
+                    var="ENVIRONMENT",
+                    message=(
+                        f"ENVIRONMENT={env_value} is not a recognized value. "
+                        f"Expected: preprod, dev, or test"
+                    ),
+                    value=env_value,
+                    suggestion="Set ENVIRONMENT=preprod for preprod tests",
+                )
+            )
+
+        return errors
+
+    def _validate_urls(self) -> list[EnvValidationError]:
+        """Validate URL format for Lambda function URLs."""
+        errors = []
+
+        url_vars = ["PREPROD_DASHBOARD_URL", "SSE_LAMBDA_URL", "DASHBOARD_FUNCTION_URL"]
+
+        for var in url_vars:
+            url = os.environ.get(var)
+            if not url:
+                continue
+
+            # Check if URL matches expected patterns
+            is_valid = self.URL_PATTERN.match(url) or any(
+                p.match(url) for p in self.ALT_URL_PATTERNS
+            )
+
+            if not is_valid:
+                errors.append(
+                    EnvValidationError(
+                        var=var,
+                        message=(
+                            f"URL format may be invalid: {url}. "
+                            f"Expected Lambda Function URL, CloudFront, or API Gateway URL."
+                        ),
+                        value=url,
+                        suggestion=(
+                            "Verify the URL is correct. Lambda Function URLs look like: "
+                            "https://xxxxx.lambda-url.us-east-1.on.aws/"
+                        ),
+                    )
+                )
+
+        return errors
+
+    def format_errors(self, errors: list[EnvValidationError]) -> str:
+        """Format errors into a readable string for pytest.fail().
+
+        Args:
+            errors: List of validation errors
+
+        Returns:
+            Formatted error message
+        """
+        if not errors:
+            return ""
+
+        lines = ["Preprod environment validation failed:"]
+        for err in errors:
+            lines.append(f"\n  {err.var}:")
+            lines.append(f"    Error: {err.message}")
+            if err.value is not None:
+                lines.append(f"    Value: {err.value}")
+            if err.suggestion:
+                lines.append(f"    Fix: {err.suggestion}")
+
+        return "\n".join(lines)
+
+    def assert_valid(self, test_type: str = "all") -> None:
+        """Assert environment is valid, raise AssertionError if not.
+
+        Args:
+            test_type: Type of tests to validate for
+
+        Raises:
+            AssertionError: If validation fails
+        """
+        errors = self.validate(test_type)
+        if errors:
+            raise AssertionError(self.format_errors(errors))
+
+    def warn_on_issues(self, test_type: str = "all") -> list[EnvValidationError]:
+        """Return issues as warnings instead of hard failures.
+
+        Useful for non-critical validations that should be logged but
+        not fail the test run.
+
+        Args:
+            test_type: Type of tests to validate for
+
+        Returns:
+            List of validation errors (for logging)
+        """
+        return self.validate(test_type)

--- a/tests/unit/fixtures/test_preprod_env_validator.py
+++ b/tests/unit/fixtures/test_preprod_env_validator.py
@@ -1,0 +1,338 @@
+"""Unit tests for PreprodEnvValidator.
+
+Tests environment validation logic including:
+- Missing required environment variables
+- DATABASE_TABLE vs DYNAMODB_TABLE consistency
+- URL format validation
+- Environment value validation
+"""
+
+import os
+
+import pytest
+
+from tests.fixtures.validators.preprod_env_validator import (
+    EnvValidationError,
+    PreprodEnvValidator,
+)
+
+
+@pytest.fixture
+def validator():
+    """Create a fresh validator instance."""
+    return PreprodEnvValidator()
+
+
+@pytest.fixture
+def clean_env():
+    """Fixture that cleans relevant env vars before and after test."""
+    # Store original values
+    original = {}
+    env_vars = [
+        "AWS_REGION",
+        "ENVIRONMENT",
+        "DYNAMODB_TABLE",
+        "DATABASE_TABLE",
+        "PREPROD_DASHBOARD_URL",
+        "SSE_LAMBDA_URL",
+        "DASHBOARD_FUNCTION_URL",
+        "API_KEY",
+    ]
+    for var in env_vars:
+        original[var] = os.environ.get(var)
+
+    # Clear all
+    for var in env_vars:
+        os.environ.pop(var, None)
+
+    yield
+
+    # Restore original values
+    for var, value in original.items():
+        if value is not None:
+            os.environ[var] = value
+        else:
+            os.environ.pop(var, None)
+
+
+class TestRequiredVars:
+    """Tests for required environment variable validation."""
+
+    def test_missing_aws_region(self, validator, clean_env):
+        """Missing AWS_REGION should produce error."""
+        os.environ["ENVIRONMENT"] = "preprod"
+
+        errors = validator._validate_required_vars()
+
+        assert len(errors) == 1
+        assert errors[0].var == "AWS_REGION"
+        assert "Missing required" in errors[0].message
+
+    def test_missing_environment(self, validator, clean_env):
+        """Missing ENVIRONMENT should produce error."""
+        os.environ["AWS_REGION"] = "us-east-1"
+
+        errors = validator._validate_required_vars()
+
+        assert len(errors) == 1
+        assert errors[0].var == "ENVIRONMENT"
+
+    def test_all_required_present(self, validator, clean_env):
+        """No errors when all required vars are present."""
+        os.environ["AWS_REGION"] = "us-east-1"
+        os.environ["ENVIRONMENT"] = "preprod"
+
+        errors = validator._validate_required_vars()
+
+        assert len(errors) == 0
+
+
+class TestTableConsistency:
+    """Tests for DATABASE_TABLE vs DYNAMODB_TABLE consistency."""
+
+    def test_matching_tables_no_error(self, validator, clean_env):
+        """No error when tables match."""
+        os.environ["DYNAMODB_TABLE"] = "preprod-sentiment-items"
+        os.environ["DATABASE_TABLE"] = "preprod-sentiment-items"
+
+        errors = validator._validate_table_consistency()
+
+        assert len(errors) == 0
+
+    def test_different_tables_produces_warning(self, validator, clean_env):
+        """Different tables should produce warning error."""
+        os.environ["DYNAMODB_TABLE"] = "preprod-sentiment-items"
+        os.environ["DATABASE_TABLE"] = "preprod-sentiment-users"
+
+        errors = validator._validate_table_consistency()
+
+        assert len(errors) == 1
+        assert errors[0].var == "DATABASE_TABLE"
+        assert "differs from DYNAMODB_TABLE" in errors[0].message
+        assert "ResourceNotFoundException" in errors[0].message
+        assert errors[0].value["DATABASE_TABLE"] == "preprod-sentiment-users"
+        assert errors[0].value["DYNAMODB_TABLE"] == "preprod-sentiment-items"
+
+    def test_only_dynamodb_table_no_error(self, validator, clean_env):
+        """No error when only DYNAMODB_TABLE is set."""
+        os.environ["DYNAMODB_TABLE"] = "preprod-sentiment-items"
+
+        errors = validator._validate_table_consistency()
+
+        assert len(errors) == 0
+
+    def test_only_database_table_no_error(self, validator, clean_env):
+        """No error when only DATABASE_TABLE is set."""
+        os.environ["DATABASE_TABLE"] = "preprod-sentiment-users"
+
+        errors = validator._validate_table_consistency()
+
+        assert len(errors) == 0
+
+
+class TestEnvironmentValue:
+    """Tests for ENVIRONMENT value validation."""
+
+    def test_valid_preprod(self, validator, clean_env):
+        """ENVIRONMENT=preprod is valid."""
+        os.environ["ENVIRONMENT"] = "preprod"
+
+        errors = validator._validate_environment_value()
+
+        assert len(errors) == 0
+
+    def test_valid_dev(self, validator, clean_env):
+        """ENVIRONMENT=dev is valid."""
+        os.environ["ENVIRONMENT"] = "dev"
+
+        errors = validator._validate_environment_value()
+
+        assert len(errors) == 0
+
+    def test_valid_test(self, validator, clean_env):
+        """ENVIRONMENT=test is valid."""
+        os.environ["ENVIRONMENT"] = "test"
+
+        errors = validator._validate_environment_value()
+
+        assert len(errors) == 0
+
+    def test_invalid_environment(self, validator, clean_env):
+        """Invalid ENVIRONMENT value should produce error."""
+        os.environ["ENVIRONMENT"] = "production"
+
+        errors = validator._validate_environment_value()
+
+        assert len(errors) == 1
+        assert errors[0].var == "ENVIRONMENT"
+        assert "not a recognized value" in errors[0].message
+
+
+class TestURLValidation:
+    """Tests for URL format validation."""
+
+    def test_valid_lambda_function_url(self, validator, clean_env):
+        """Valid Lambda function URL should pass."""
+        os.environ["PREPROD_DASHBOARD_URL"] = (
+            "https://abc123def456.lambda-url.us-east-1.on.aws/"
+        )
+
+        errors = validator._validate_urls()
+
+        assert len(errors) == 0
+
+    def test_valid_lambda_url_no_trailing_slash(self, validator, clean_env):
+        """Lambda URL without trailing slash should pass."""
+        os.environ["SSE_LAMBDA_URL"] = (
+            "https://xyz789ghi012.lambda-url.us-east-1.on.aws"
+        )
+
+        errors = validator._validate_urls()
+
+        assert len(errors) == 0
+
+    def test_valid_cloudfront_url(self, validator, clean_env):
+        """CloudFront URL should pass."""
+        os.environ["PREPROD_DASHBOARD_URL"] = "https://d1234567890.cloudfront.net/"
+
+        errors = validator._validate_urls()
+
+        assert len(errors) == 0
+
+    def test_valid_api_gateway_url(self, validator, clean_env):
+        """API Gateway URL should pass."""
+        os.environ["PREPROD_DASHBOARD_URL"] = (
+            "https://abc123.execute-api.us-east-1.amazonaws.com/prod/"
+        )
+
+        errors = validator._validate_urls()
+
+        assert len(errors) == 0
+
+    def test_valid_localhost_url(self, validator, clean_env):
+        """Localhost URL should pass (for local dev)."""
+        os.environ["PREPROD_DASHBOARD_URL"] = "http://localhost:8080/"
+
+        errors = validator._validate_urls()
+
+        assert len(errors) == 0
+
+    def test_invalid_url_format(self, validator, clean_env):
+        """Invalid URL format should produce error."""
+        os.environ["PREPROD_DASHBOARD_URL"] = "not-a-valid-url"
+
+        errors = validator._validate_urls()
+
+        assert len(errors) == 1
+        assert errors[0].var == "PREPROD_DASHBOARD_URL"
+        assert "URL format may be invalid" in errors[0].message
+
+    def test_missing_url_no_error(self, validator, clean_env):
+        """Missing URL vars should not produce URL format errors."""
+        # URLs are validated in _validate_e2e_vars for presence
+        # _validate_urls only checks format if present
+        errors = validator._validate_urls()
+
+        assert len(errors) == 0
+
+
+class TestFullValidation:
+    """Tests for full validation workflow."""
+
+    def test_validate_all_with_valid_config(self, validator, clean_env):
+        """Full validation should pass with valid config."""
+        os.environ["AWS_REGION"] = "us-east-1"
+        os.environ["ENVIRONMENT"] = "preprod"
+        os.environ["DYNAMODB_TABLE"] = "preprod-sentiment-items"
+        os.environ["DATABASE_TABLE"] = "preprod-sentiment-items"
+        os.environ["PREPROD_DASHBOARD_URL"] = (
+            "https://abc123.lambda-url.us-east-1.on.aws/"
+        )
+        os.environ["SSE_LAMBDA_URL"] = "https://xyz789.lambda-url.us-east-1.on.aws/"
+        os.environ["API_KEY"] = "test-api-key"
+
+        errors = validator.validate(test_type="all")
+
+        assert len(errors) == 0
+
+    def test_validate_integration_only(self, validator, clean_env):
+        """Integration validation should check table vars."""
+        os.environ["AWS_REGION"] = "us-east-1"
+        os.environ["ENVIRONMENT"] = "preprod"
+        os.environ["DYNAMODB_TABLE"] = "preprod-sentiment-items"
+        os.environ["DATABASE_TABLE"] = "preprod-sentiment-users"
+
+        errors = validator.validate(test_type="integration")
+
+        # Should have warning about different tables
+        assert len(errors) == 1
+        assert errors[0].var == "DATABASE_TABLE"
+
+    def test_validate_e2e_only(self, validator, clean_env):
+        """E2E validation should check URL vars."""
+        os.environ["AWS_REGION"] = "us-east-1"
+        os.environ["ENVIRONMENT"] = "preprod"
+
+        errors = validator.validate(test_type="e2e")
+
+        # Should have errors for missing E2E vars
+        assert len(errors) >= 3  # PREPROD_DASHBOARD_URL, SSE_LAMBDA_URL, API_KEY
+
+    def test_format_errors(self, validator, clean_env):
+        """Error formatting should produce readable output."""
+        errors = [
+            EnvValidationError(
+                var="DATABASE_TABLE",
+                message="differs from DYNAMODB_TABLE",
+                value="preprod-sentiment-users",
+                suggestion="Set DATABASE_TABLE to match",
+            ),
+        ]
+
+        formatted = validator.format_errors(errors)
+
+        assert "Preprod environment validation failed" in formatted
+        assert "DATABASE_TABLE" in formatted
+        assert "differs from DYNAMODB_TABLE" in formatted
+        assert "preprod-sentiment-users" in formatted
+        assert "Set DATABASE_TABLE to match" in formatted
+
+    def test_format_errors_empty(self, validator):
+        """Empty error list should return empty string."""
+        assert validator.format_errors([]) == ""
+
+    def test_assert_valid_raises(self, validator, clean_env):
+        """assert_valid should raise AssertionError on invalid config."""
+        # Missing required vars
+        with pytest.raises(AssertionError) as exc_info:
+            validator.assert_valid()
+
+        assert "Preprod environment validation failed" in str(exc_info.value)
+
+    def test_assert_valid_passes(self, validator, clean_env):
+        """assert_valid should not raise on valid config."""
+        os.environ["AWS_REGION"] = "us-east-1"
+        os.environ["ENVIRONMENT"] = "preprod"
+        os.environ["DYNAMODB_TABLE"] = "preprod-sentiment-items"
+        os.environ["DATABASE_TABLE"] = "preprod-sentiment-items"
+        os.environ["PREPROD_DASHBOARD_URL"] = (
+            "https://abc123.lambda-url.us-east-1.on.aws/"
+        )
+        os.environ["SSE_LAMBDA_URL"] = "https://xyz789.lambda-url.us-east-1.on.aws/"
+        os.environ["API_KEY"] = "test-api-key"
+
+        # Should not raise
+        validator.assert_valid()
+
+    def test_warn_on_issues(self, validator, clean_env):
+        """warn_on_issues should return errors without raising."""
+        os.environ["AWS_REGION"] = "us-east-1"
+        os.environ["ENVIRONMENT"] = "preprod"
+        os.environ["DYNAMODB_TABLE"] = "preprod-sentiment-items"
+        os.environ["DATABASE_TABLE"] = "preprod-sentiment-users"
+
+        errors = validator.warn_on_issues(test_type="integration")
+
+        # Should return errors, not raise
+        assert len(errors) == 1
+        assert errors[0].var == "DATABASE_TABLE"


### PR DESCRIPTION
## Summary
- Add `PreprodEnvValidator` to detect preprod test misconfigurations before tests run
- Catches DATABASE_TABLE vs DYNAMODB_TABLE mismatch (Issue #13 root cause)
- Validates missing required env vars for preprod/integration/E2E tests
- Validates Lambda Function URL formats
- Validates ENVIRONMENT value consistency

## Root Cause Analysis
Issue #13 (fix-analysis-dynamodb-updateitem) showed that CI sets different tables:
- `DYNAMODB_TABLE=preprod-sentiment-items` (legacy news/sentiment data)
- `DATABASE_TABLE=preprod-sentiment-users` (user configs)

Tests insert data into DYNAMODB_TABLE but the analysis handler reads from DATABASE_TABLE
via `get_table()`, causing ResourceNotFoundException.

## New Validator Features
The `PreprodEnvValidator` class provides:
- `validate(test_type)` - validates for "all", "integration", or "e2e" tests
- `assert_valid()` - raises AssertionError on invalid config
- `warn_on_issues()` - returns errors without raising (for warnings)
- `format_errors()` - produces readable pytest.fail() messages

## Test plan
- [x] 26 unit tests covering all validation scenarios
- [x] All 1948 existing unit tests pass
- [x] Ruff lint passes

## Usage
```python
from tests.fixtures.validators import PreprodEnvValidator

# In conftest.py session fixture (optional)
@pytest.fixture(scope="session", autouse=True)
def validate_preprod_env():
    if os.environ.get("ENVIRONMENT") == "preprod":
        validator = PreprodEnvValidator()
        errors = validator.warn_on_issues()
        for err in errors:
            print(f"WARNING: {err.var}: {err.message}")
```

Fixes queue item #14: add-preprod-test-env-validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)