### PR TITLE
fix(ci): Replace CLAUDE_CODE_PAT with REPO_PAT in pr-merge workflow

### DIFF
--- a/.github/workflows/pr-merge.yml
+++ b/.github/workflows/pr-merge.yml
@@ -120,7 +120,7 @@ jobs:
       - name: Enable auto-merge
         uses: peter-evans/enable-pull-request-automerge@v3
         with:
-          token: ${{ secrets.CLAUDE_CODE_PAT }}
+          token: ${{ secrets.REPO_PAT }}
           pull-request-number: ${{ github.event.pull_request.number }}
           merge-method: squash
 
@@ -129,7 +129,7 @@ jobs:
           gh pr comment "$PR_URL" --body "Auto-merge enabled. This PR will automatically merge once all required checks pass."
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.CLAUDE_CODE_PAT }}
+          GH_TOKEN: ${{ secrets.REPO_PAT }}
 
   # ========================================================================
   # JOB 4: Dependabot Auto-Merge
@@ -151,7 +151,7 @@ jobs:
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.CLAUDE_CODE_PAT }}
+          GH_TOKEN: ${{ secrets.REPO_PAT }}
 
       - name: Auto-merge GitHub Actions major version updates
         if: |
@@ -160,14 +160,14 @@ jobs:
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.CLAUDE_CODE_PAT }}
+          GH_TOKEN: ${{ secrets.REPO_PAT }}
 
       - name: Auto-merge security updates
         if: steps.metadata.outputs.dependency-type == 'direct:production' && contains(github.event.pull_request.title, 'security')
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.CLAUDE_CODE_PAT }}
+          GH_TOKEN: ${{ secrets.REPO_PAT }}
 
       - name: Approve PR (patch/minor or GitHub Actions)
         if: |
@@ -177,7 +177,7 @@ jobs:
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.CLAUDE_CODE_PAT }}
+          GH_TOKEN: ${{ secrets.REPO_PAT }}
 
       - name: Comment on Python major version updates
         if: |
@@ -191,4 +191,4 @@ jobs:
           This PR will NOT be auto-merged."
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.CLAUDE_CODE_PAT }}
+          GH_TOKEN: ${{ secrets.REPO_PAT }}


### PR DESCRIPTION
## Summary
- Replace all 7 references to `CLAUDE_CODE_PAT` with `REPO_PAT` in pr-merge.yml
- Fixes Enable Auto-Merge check failing with exit code 4
- `CLAUDE_CODE_PAT` was undefined; `REPO_PAT` is the established secret name

## Root Cause
The workflow was using `CLAUDE_CODE_PAT` secret which doesn't exist in this repository, causing the peter-evans/enable-pull-request-automerge action to fail with exit code 4 (authentication failure).

## Test plan
- [x] All 1948 unit tests pass
- [x] Pre-commit hooks pass
- [ ] PR merge workflow should now succeed with valid REPO_PAT secret

## Files changed
- `.github/workflows/pr-merge.yml` (lines 123, 132, 154, 163, 170, 180, 194)

🤖 Generated with [Claude Code](https://claude.com/claude-code)