### PR TITLE
feat(142): Add warmup support for Ingestion and Analysis Lambdas

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1133,6 +1133,56 @@ jobs:
             fi
           done
 
+          # Warm up Ingestion Lambda (Feature 142: Reduce cold start delays)
+          # Uses aws lambda invoke since no HTTP endpoint
+          echo ""
+          echo "6. Invoking Ingestion Lambda for warmup..."
+          INGESTION_FUNCTION="preprod-sentiment-ingestion"
+          # Send a warmup event that will be recognized and short-circuited
+          WARMUP_PAYLOAD='{"warmup": true}'
+          for i in 1 2 3; do
+            RESULT=$(aws lambda invoke \
+              --function-name "$INGESTION_FUNCTION" \
+              --invocation-type RequestResponse \
+              --payload "$WARMUP_PAYLOAD" \
+              --cli-binary-format raw-in-base64-out \
+              /tmp/ingestion-response.json 2>&1) || true
+            if echo "$RESULT" | grep -q "200"; then
+              echo "  ✅ Ingestion Lambda warmed up successfully"
+              break
+            fi
+            if [ $i -lt 3 ]; then
+              echo "  Attempt $i: Retrying in 5s..."
+              sleep 5
+            else
+              echo "  ⚠️ Ingestion Lambda warmup did not complete (continuing anyway)"
+            fi
+          done
+
+          # Warm up Analysis Lambda (Feature 142: ML model loading)
+          # Analysis Lambda has heavy ML dependencies, warmup helps with model loading
+          echo ""
+          echo "7. Invoking Analysis Lambda for warmup..."
+          ANALYSIS_FUNCTION="preprod-sentiment-analysis"
+          for i in 1 2 3; do
+            RESULT=$(aws lambda invoke \
+              --function-name "$ANALYSIS_FUNCTION" \
+              --invocation-type RequestResponse \
+              --payload "$WARMUP_PAYLOAD" \
+              --cli-binary-format raw-in-base64-out \
+              /tmp/analysis-response.json 2>&1) || true
+            if echo "$RESULT" | grep -q "200"; then
+              echo "  ✅ Analysis Lambda warmed up successfully"
+              break
+            fi
+            if [ $i -lt 3 ]; then
+              echo "  Attempt $i: Retrying in 5s..."
+              sleep 5
+            else
+              echo "  ⚠️ Analysis Lambda warmup did not complete (continuing anyway)"
+            fi
+          done
+
           # Wait for CloudWatch metrics to propagate
           echo ""
           echo "⏳ Waiting 60s for CloudWatch metrics to propagate..."


### PR DESCRIPTION
## Summary

- Added warmup invocations for Ingestion and Analysis Lambdas in deploy.yml before integration tests
- Added warmup event handling in both Lambda handlers to short-circuit on `{"warmup": true}` events
- Reduces cold start delays, especially important for Analysis Lambda with ML model loading

## Changes

- **deploy.yml**: Added steps 6 and 7 to invoke `preprod-sentiment-ingestion` and `preprod-sentiment-analysis` with warmup payloads (with retry logic)
- **ingestion/handler.py**: Returns early with 200 for warmup events
- **analysis/handler.py**: Returns early with 200 for warmup events (critical for ML cold starts)

## Test plan

- [ ] Verify warmup invocations succeed in preprod deploy pipeline
- [ ] Verify preprod integration tests experience reduced cold start delays
- [ ] Verify warmup events are logged in CloudWatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)