### PR TITLE
fix(iam): Add SSE Lambda permission for Feature 006 users table

### DIFF
--- a/infrastructure/terraform/modules/iam/main.tf
+++ b/infrastructure/terraform/modules/iam/main.tf
@@ -678,6 +678,31 @@ resource "aws_iam_role_policy" "sse_streaming_dynamodb" {
   })
 }
 
+# SSE Streaming Lambda: Feature 006 Users Table Access (read-only for user config validation)
+resource "aws_iam_role_policy" "sse_streaming_feature_006_users" {
+  count = var.enable_feature_006 ? 1 : 0
+  name  = "${var.environment}-sse-streaming-feature-006-users-policy"
+  role  = aws_iam_role.sse_streaming_lambda.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "dynamodb:GetItem",
+          "dynamodb:Query"
+        ]
+        Resource = [
+          var.feature_006_users_table_arn,
+          "${var.feature_006_users_table_arn}/index/by_email",
+          "${var.feature_006_users_table_arn}/index/by_cognito_sub"
+        ]
+      }
+    ]
+  })
+}
+
 # SSE Streaming Lambda: CloudWatch Logs
 resource "aws_iam_role_policy_attachment" "sse_streaming_logs" {
   role       = aws_iam_role.sse_streaming_lambda.name


### PR DESCRIPTION
## Summary
- Add `sse_streaming_feature_006_users` IAM policy granting GetItem/Query access to Feature 006 users table
- Fixes E2E test failures where SSE Lambda couldn't validate user configurations
- Policy is conditional on `enable_feature_006` (consistent with other Feature 006 resources)

## Root Cause
The SSE Streaming Lambda's `config.py` validates user access via DynamoDB GetItem on the Feature 006 users table. However, the IAM role at `modules/iam/main.tf:656-679` only granted access to the sentiment-items table (`dynamodb_table_arn`), not the users table (`feature_006_users_table_arn`).

## Evidence
- CloudWatch logs: "DynamoDB get_item failed" followed by "Config stream rejected - configuration not found"
- SSE tests correctly routed to Lambda (verified via debug endpoint)
- Lambda's `DATABASE_TABLE` env var pointed to `feature_006_users_table_name`

## Test plan
- [ ] CI pipeline passes
- [ ] Preprod E2E tests pass (SSE streaming tests)
- [ ] Verify CloudWatch logs no longer show DynamoDB access errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)