### PR TITLE
fix(sse): Add detailed error context to DynamoDB get_item logging

### DIFF
--- a/src/lambdas/sse_streaming/config.py
+++ b/src/lambdas/sse_streaming/config.py
@@ -101,11 +101,18 @@ class ConfigLookupService:
             return config
 
         except ClientError as e:
+            error_code = e.response.get("Error", {}).get("Code", "Unknown")
+            error_message = e.response.get("Error", {}).get("Message", str(e))
             logger.error(
                 "DynamoDB get_item failed",
                 extra={
                     "error": str(e),
+                    "error_code": error_code,
+                    "error_message": error_message,
+                    "table_name": self._table_name,
+                    "operation": "get_item",
                     "config_id": sanitize_for_log(config_id[:8] if config_id else ""),
+                    "user_id_prefix": sanitize_for_log(user_id[:8] if user_id else ""),
                 },
             )
             return None


### PR DESCRIPTION
## Summary
- Enhance ClientError logging in `config.py` to include AWS error code, message, table name, and operation context
- Makes it easier to diagnose IAM permission issues and table misconfigurations

## Changes
The DynamoDB `get_item` error handler now logs:
- `error_code`: AWS error code (e.g., `AccessDeniedException`)
- `error_message`: Detailed AWS error message  
- `table_name`: DynamoDB table being accessed
- `operation`: The DynamoDB operation (`get_item`)
- `user_id_prefix`: Truncated user ID for debugging

## Why
Previously, CloudWatch logs only showed "DynamoDB get_item failed" with a generic error string, making it difficult to diagnose the root cause (IAM permissions vs table name vs network issues).

## Test plan
- [ ] CI pipeline passes
- [ ] Unit tests pass
- [ ] Verify enhanced logging appears in CloudWatch when errors occur

🤖 Generated with [Claude Code](https://claude.com/claude-code)