### PR TITLE
fix(infra): Increase SSE Lambda reserved_concurrency to 25

### DIFF
--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -630,7 +630,7 @@ module "sse_streaming_lambda" {
   # Resource configuration per spec
   memory_size          = 512
   timeout              = 900 # 15 minutes - max Lambda timeout for SSE connections
-  reserved_concurrency = 10  # Start with 10 concurrent instances
+  reserved_concurrency = 25  # Increased from 10 to handle E2E test suite SSE connections
 
   # X-Ray tracing (FR-016)
   tracing_mode = "Active"


### PR DESCRIPTION
## Summary

- Increase SSE Lambda `reserved_concurrency` from 10 to 25

## Problem

The E2E test suite opens many SSE connections rapidly, exhausting the Lambda Function URL concurrency limit and causing 429 Too Many Requests errors in preprod integration tests.

**Evidence from run 20330692014:**
- 34 SSE tests passed before throttling occurred
- `test_sse_receives_heartbeat_event` failed with 429
- `test_dashboard_sse_connection_flow` failed with 429
- CloudWatch logs showed no Lambda runtime errors

## Solution

Increase `reserved_concurrency` from 10 to 25 to accommodate the test suite's concurrent SSE connection requirements.

## Test plan

- [ ] Preprod integration tests pass (should no longer see 429 errors)
- [ ] SSE connection tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)