### PR TITLE
fix(iam): Add Lambda concurrency permissions for CI deployer

### DIFF
--- a/infrastructure/terraform/ci-user-policy.tf
+++ b/infrastructure/terraform/ci-user-policy.tf
@@ -79,7 +79,11 @@ data "aws_iam_policy_document" "ci_deploy_core" {
       "lambda:ListLayerVersions",
       "lambda:ListLayers",
       "lambda:GetFunctionCodeSigningConfig",
-      "lambda:ListFunctionUrlConfigs"
+      "lambda:ListFunctionUrlConfigs",
+      # Lambda concurrency management (required for reserved_concurrency changes)
+      "lambda:PutFunctionConcurrency",
+      "lambda:DeleteFunctionConcurrency",
+      "lambda:GetFunctionConcurrency"
     ]
     resources = [
       # Pattern: {env}-sentiment-* (preprod-sentiment-ingestion, prod-sentiment-dashboard, etc.)


### PR DESCRIPTION
## Summary

- Add `lambda:PutFunctionConcurrency` to CI deployer IAM policy
- Add `lambda:DeleteFunctionConcurrency` to CI deployer IAM policy
- Add `lambda:GetFunctionConcurrency` to CI deployer IAM policy

## Problem

Pipeline run 20332929564 failed at Terraform Apply (Preprod) with:
```
AccessDeniedException: User is not authorized to perform: lambda:PutFunctionConcurrency
```

PR #424 changed SSE Lambda `reserved_concurrency` from 10 to 25, but the CI deployer user lacks the IAM permission to modify Lambda concurrency settings.

## Root Cause

The CI deployer IAM policy at `ci-user-policy.tf` had comprehensive Lambda function management permissions but was missing the specific concurrency-related actions:
- `lambda:PutFunctionConcurrency` (required to set/update concurrency)
- `lambda:DeleteFunctionConcurrency` (required to remove concurrency limit)
- `lambda:GetFunctionConcurrency` (required to read concurrency settings)

## Bootstrap Requirement

This is an IAM chicken-and-egg issue. The CI deployer cannot modify its own IAM policy, so this change must be applied via:
1. AWS Console manual update, OR
2. Local Terraform apply with admin credentials

After IAM is updated, re-run the deploy pipeline.

## Test Plan

- [x] Validator `ci-iam-permissions` created in terraform-gsk-template detects this issue
- [x] Validator passes after fix is applied
- [ ] Manual IAM bootstrap required
- [ ] Pipeline re-run after IAM update

🤖 Generated with [Claude Code](https://claude.com/claude-code)