### PR TITLE
feat(iam): Add CloudWatch observability permissions for E2E tests

### DIFF
--- a/docs/iam-policies/dev-deployer-policy.json
+++ b/docs/iam-policies/dev-deployer-policy.json
@@ -200,7 +200,10 @@
                 "logs:DeleteRetentionPolicy",
                 "logs:TagLogGroup",
                 "logs:UntagLogGroup",
-                "logs:ListTagsLogGroup"
+                "logs:ListTagsLogGroup",
+                "logs:StartQuery",
+                "logs:GetQueryResults",
+                "logs:StopQuery"
             ],
             "Resource": [
                 "arn:aws:logs:*:*:log-group:/aws/lambda/dev-*",
@@ -216,11 +219,22 @@
                 "cloudwatch:DescribeAlarms",
                 "cloudwatch:TagResource",
                 "cloudwatch:UntagResource",
-                "cloudwatch:ListTagsForResource"
+                "cloudwatch:ListTagsForResource",
+                "cloudwatch:GetMetricData",
+                "cloudwatch:PutMetricData"
             ],
             "Resource": [
                 "arn:aws:cloudwatch:*:*:alarm:dev-*"
             ]
+        },
+        {
+            "Sid": "XRayDevResources",
+            "Effect": "Allow",
+            "Action": [
+                "xray:BatchGetTraces",
+                "xray:GetTraceSummaries"
+            ],
+            "Resource": "*"
         },
         {
             "Sid": "TerraformStateAccess",

--- a/infrastructure/iam-policies/preprod-deployer-policy.json
+++ b/infrastructure/iam-policies/preprod-deployer-policy.json
@@ -200,7 +200,10 @@
         "logs:DeleteRetentionPolicy",
         "logs:TagLogGroup",
         "logs:UntagLogGroup",
-        "logs:ListTagsLogGroup"
+        "logs:ListTagsLogGroup",
+        "logs:StartQuery",
+        "logs:GetQueryResults",
+        "logs:StopQuery"
       ],
       "Resource": [
         "arn:aws:logs:*:*:log-group:/aws/lambda/preprod-*",
@@ -216,11 +219,22 @@
         "cloudwatch:DescribeAlarms",
         "cloudwatch:TagResource",
         "cloudwatch:UntagResource",
-        "cloudwatch:ListTagsForResource"
+        "cloudwatch:ListTagsForResource",
+        "cloudwatch:GetMetricData",
+        "cloudwatch:PutMetricData"
       ],
       "Resource": [
         "arn:aws:cloudwatch:*:*:alarm:preprod-*"
       ]
+    },
+    {
+      "Sid": "XRayPreprodResources",
+      "Effect": "Allow",
+      "Action": [
+        "xray:BatchGetTraces",
+        "xray:GetTraceSummaries"
+      ],
+      "Resource": "*"
     },
     {
       "Sid": "TerraformStateAccess",

--- a/infrastructure/iam-policies/prod-deployer-policy.json
+++ b/infrastructure/iam-policies/prod-deployer-policy.json
@@ -185,7 +185,10 @@
         "logs:PutRetentionPolicy",
         "logs:TagLogGroup",
         "logs:UntagLogGroup",
-        "logs:ListTagsLogGroup"
+        "logs:ListTagsLogGroup",
+        "logs:StartQuery",
+        "logs:GetQueryResults",
+        "logs:StopQuery"
       ],
       "Resource": [
         "arn:aws:logs:*:*:log-group:/aws/lambda/prod-*",
@@ -200,11 +203,22 @@
         "cloudwatch:DescribeAlarms",
         "cloudwatch:TagResource",
         "cloudwatch:UntagResource",
-        "cloudwatch:ListTagsForResource"
+        "cloudwatch:ListTagsForResource",
+        "cloudwatch:GetMetricData",
+        "cloudwatch:PutMetricData"
       ],
       "Resource": [
         "arn:aws:cloudwatch:*:*:alarm:prod-*"
       ]
+    },
+    {
+      "Sid": "XRayProdResources",
+      "Effect": "Allow",
+      "Action": [
+        "xray:BatchGetTraces",
+        "xray:GetTraceSummaries"
+      ],
+      "Resource": "*"
     },
     {
       "Sid": "TerraformStateAccess",

--- a/specs/604-cloudwatch-iam-permissions/spec.md
+++ b/specs/604-cloudwatch-iam-permissions/spec.md
@@ -1,0 +1,57 @@
+# Feature 604: CloudWatch IAM Permissions for E2E Observability Tests
+
+## Problem Statement
+
+E2E observability tests fail intermittently because the CI/CD deployer roles lack permissions to:
+1. Query CloudWatch Logs Insights (verify Lambda log output)
+2. Read/write CloudWatch Metrics (verify Lambda custom metrics)
+3. Query X-Ray traces (verify Lambda tracing)
+
+## Root Cause
+
+The `cloudwatch-iam-validate` validator detected 9 MEDIUM severity findings across 3 deployer policy files:
+- `docs/iam-policies/dev-deployer-policy.json`
+- `infrastructure/iam-policies/preprod-deployer-policy.json`
+- `infrastructure/iam-policies/prod-deployer-policy.json`
+
+## Requirements
+
+### FR-001: Add CloudWatch Logs Insights Permissions
+Add to each deployer policy:
+- `logs:StartQuery`
+- `logs:GetQueryResults`
+- `logs:StopQuery`
+
+Resource scope: Same as existing CloudWatchLogsDevResources statement
+
+### FR-002: Add CloudWatch Metrics Permissions
+Add to each deployer policy:
+- `cloudwatch:GetMetricData`
+- `cloudwatch:PutMetricData`
+
+Resource scope: Lambda function metrics only
+
+### FR-003: Add X-Ray Permissions
+Add to each deployer policy:
+- `xray:BatchGetTraces`
+- `xray:GetTraceSummaries`
+
+Resource scope: Traces for environment-specific Lambda functions
+
+## Implementation
+
+### Files to Modify
+1. `docs/iam-policies/dev-deployer-policy.json`
+2. `infrastructure/iam-policies/preprod-deployer-policy.json`
+3. `infrastructure/iam-policies/prod-deployer-policy.json`
+
+### Implementation Approach
+Add new statement blocks for each permission set, scoped to environment-specific resources.
+
+## Verification
+
+Re-run `cloudwatch-iam-validate` and confirm 0 findings.
+
+## Non-Goals
+- Changing existing permissions
+- Adding permissions beyond what validators flagged


### PR DESCRIPTION
## Summary
- Add CloudWatch Logs Insights permissions (logs:StartQuery, GetQueryResults, StopQuery)
- Add CloudWatch Metrics permissions (cloudwatch:GetMetricData, PutMetricData)
- Add X-Ray tracing permissions (xray:BatchGetTraces, GetTraceSummaries)

Addresses 9 CloudWatch IAM findings (CW-011, CW-012, CW-013) detected by cloudwatch-iam validator across dev, preprod, and prod deployer policies.

## Files Changed
- `docs/iam-policies/dev-deployer-policy.json`
- `infrastructure/iam-policies/preprod-deployer-policy.json`
- `infrastructure/iam-policies/prod-deployer-policy.json`

## Test plan
- [x] cloudwatch-iam validator passes after changes
- [ ] CI pipeline passes
- [ ] E2E tests with observability enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)