### PR TITLE
fix(tests): Correct ticker payload format in E2E tests

### DIFF
--- a/specs/1002-fix-config-payload-tests/spec.md
+++ b/specs/1002-fix-config-payload-tests/spec.md
@@ -1,0 +1,45 @@
+# Spec 1002: Fix CONFIG_UNAVAILABLE Test Skips
+
+## Problem Statement
+
+19 E2E tests are skipped with "Config creation not available" because they use incorrect payload format for POST /api/v2/configurations.
+
+**Root Cause**: Tests pass `"tickers": [{"symbol": "AAPL"}]` but API expects `"tickers": ["AAPL"]`.
+
+## Evidence
+
+API Schema (`src/lambdas/shared/models/configuration.py:ConfigurationCreate`):
+```python
+tickers: list[str] = Field(..., max_length=5)  # list of strings
+```
+
+Working tests use:
+```python
+synthetic_config.to_api_payload()  # Returns {"name": "...", "tickers": ["AAPL", "MSFT", "GOOGL"]}
+```
+
+Failing tests use:
+```python
+"tickers": [{"symbol": "AAPL"}]  # Wrong: list of dicts
+```
+
+## Fix
+
+Update all 19 occurrences to use string list format:
+- Change `[{"symbol": "AAPL"}]` to `["AAPL"]`
+
+## Files to Update
+
+| File | Line Numbers | Fix |
+|------|--------------|-----|
+| tests/e2e/test_anonymous_restrictions.py | 127, 174, 224, 332 | Change ticker format |
+
+## Testing
+
+After fix:
+- Run `pytest tests/e2e/test_anonymous_restrictions.py -v --tb=short`
+- Verify skipped tests now run (may pass or fail based on actual API behavior)
+
+## Impact
+
+Reduces E2E skip count from 61 to ~57 (4 of 19 CONFIG_UNAVAILABLE skips are in this file).

--- a/tests/e2e/test_anonymous_restrictions.py
+++ b/tests/e2e/test_anonymous_restrictions.py
@@ -71,7 +71,7 @@ async def test_unauthenticated_create_config_returns_401(
 
     response = await api_client.post(
         "/api/v2/configurations",
-        json={"name": "Test", "tickers": [{"symbol": "AAPL"}]},
+        json={"name": "Test", "tickers": ["AAPL"]},
     )
 
     assert response.status_code in (
@@ -124,7 +124,7 @@ async def test_anonymous_cannot_access_other_users_config(
         "/api/v2/configurations",
         json={
             "name": f"Private Config {test_run_id}",
-            "tickers": [{"symbol": "AAPL"}],
+            "tickers": ["AAPL"],
         },
     )
 
@@ -171,7 +171,7 @@ async def test_anonymous_cannot_modify_other_users_config(
         "/api/v2/configurations",
         json={
             "name": f"Protected Config {test_run_id}",
-            "tickers": [{"symbol": "MSFT"}],
+            "tickers": ["MSFT"],
         },
     )
 
@@ -221,7 +221,7 @@ async def test_anonymous_cannot_delete_other_users_config(
         "/api/v2/configurations",
         json={
             "name": f"Deletion Target {test_run_id}",
-            "tickers": [{"symbol": "GOOGL"}],
+            "tickers": ["GOOGL"],
         },
     )
 
@@ -282,7 +282,7 @@ async def test_anonymous_config_limit_enforced(
                 "/api/v2/configurations",
                 json={
                     "name": f"Limit Test {test_run_id} #{i}",
-                    "tickers": [{"symbol": "AAPL"}],
+                    "tickers": ["AAPL"],
                 },
             )
 
@@ -329,7 +329,7 @@ async def test_anonymous_alert_limit_enforced(
             "/api/v2/configurations",
             json={
                 "name": f"Alert Limit Test {test_run_id}",
-                "tickers": [{"symbol": "AAPL"}],
+                "tickers": ["AAPL"],
             },
         )
 


### PR DESCRIPTION
## Summary
- Fix 6 occurrences of incorrect ticker payload format in `test_anonymous_restrictions.py`
- API expects `tickers: list[str]` (e.g., `["AAPL"]`) but tests were sending `list[dict]` (e.g., `[{"symbol": "AAPL"}]`)
- Pydantic validation was returning 422, causing tests to skip with "Config creation not available"

## Root Cause
The `ConfigurationCreate` model at `src/lambdas/shared/models/configuration.py` defines:
```python
tickers: list[str] = Field(..., max_length=5)
```

Tests using `SyntheticConfiguration.to_api_payload()` work correctly because it returns strings.
Tests with inline JSON were using the wrong format.

## Changes
Fixed payload format at 6 locations in `test_anonymous_restrictions.py`:
- Line 74: `[{"symbol": "AAPL"}]` → `["AAPL"]`
- Line 127: `[{"symbol": "AAPL"}]` → `["AAPL"]` (Private Config)
- Line 174: `[{"symbol": "MSFT"}]` → `["MSFT"]` (Protected Config)
- Line 224: `[{"symbol": "GOOGL"}]` → `["GOOGL"]` (Deletion Target)
- Line 285: `[{"symbol": "AAPL"}]` → `["AAPL"]` (Limit Test loop)
- Line 332: `[{"symbol": "AAPL"}]` → `["AAPL"]` (Alert Limit Test)

## Test plan
- [x] All 2000 unit tests pass
- [ ] Preprod E2E tests should now run instead of skipping

🤖 Generated with [Claude Code](https://claude.com/claude-code)