### PR TITLE
fix(ci): Replace REPO_PAT with CLAUDE_CODE_PAT in pr-merge workflow

### DIFF
--- a/.github/workflows/pr-merge.yml
+++ b/.github/workflows/pr-merge.yml
@@ -120,7 +120,7 @@ jobs:
       - name: Enable auto-merge
         uses: peter-evans/enable-pull-request-automerge@v3
         with:
-          token: ${{ secrets.REPO_PAT }}
+          token: ${{ secrets.CLAUDE_CODE_PAT }}
           pull-request-number: ${{ github.event.pull_request.number }}
           merge-method: squash
 
@@ -129,7 +129,7 @@ jobs:
           gh pr comment "$PR_URL" --body "Auto-merge enabled. This PR will automatically merge once all required checks pass."
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.REPO_PAT }}
+          GH_TOKEN: ${{ secrets.CLAUDE_CODE_PAT }}
 
   # ========================================================================
   # JOB 4: Dependabot Auto-Merge
@@ -151,7 +151,7 @@ jobs:
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.REPO_PAT }}
+          GH_TOKEN: ${{ secrets.CLAUDE_CODE_PAT }}
 
       - name: Auto-merge GitHub Actions major version updates
         if: |
@@ -160,14 +160,14 @@ jobs:
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.REPO_PAT }}
+          GH_TOKEN: ${{ secrets.CLAUDE_CODE_PAT }}
 
       - name: Auto-merge security updates
         if: steps.metadata.outputs.dependency-type == 'direct:production' && contains(github.event.pull_request.title, 'security')
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.REPO_PAT }}
+          GH_TOKEN: ${{ secrets.CLAUDE_CODE_PAT }}
 
       - name: Approve PR (patch/minor or GitHub Actions)
         if: |
@@ -177,7 +177,7 @@ jobs:
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.REPO_PAT }}
+          GH_TOKEN: ${{ secrets.CLAUDE_CODE_PAT }}
 
       - name: Comment on Python major version updates
         if: |
@@ -191,4 +191,4 @@ jobs:
           This PR will NOT be auto-merged."
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.REPO_PAT }}
+          GH_TOKEN: ${{ secrets.CLAUDE_CODE_PAT }}


### PR DESCRIPTION
## Summary

Replace stale `REPO_PAT` secret references with the new `CLAUDE_CODE_PAT` secret in the PR merge workflow.

**Root Cause:** The `REPO_PAT` secret was deleted and replaced with `CLAUDE_CODE_PAT`, but the `pr-merge.yml` workflow was missed during the migration audit. This caused 401 Unauthorized "Bad credentials" errors when enabling auto-merge on PRs.

## Changes

- Replace 7 occurrences of `secrets.REPO_PAT` with `secrets.CLAUDE_CODE_PAT`
- Affected jobs:
  - `enable-auto-merge`: 2 occurrences (line 123, 132)
  - `dependabot-auto-merge`: 5 occurrences (lines 154, 163, 170, 180, 194)

## Test Plan

- [ ] Verify CLAUDE_CODE_PAT secret exists in repo settings
- [ ] Merge this PR and verify auto-merge works on subsequent PRs
- [ ] Check that Dependabot PRs can auto-merge patch/minor updates

## Bootstrap Note

This PR itself will fail the "Enable Auto-Merge" check because it's still using the old secret until merged. After merging, future PRs will work correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)