### PR TITLE
fix(iam): Add kms:Decrypt permission for secrets using customer-managed KMS

### DIFF
--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -776,6 +776,7 @@ module "iam" {
   finnhub_secret_arn           = module.secrets.finnhub_secret_arn
   feature_006_users_table_arn  = module.dynamodb.feature_006_users_table_arn
   enable_feature_006           = true
+  secrets_kms_key_arn          = module.kms.key_arn
 }
 
 # ===================================================================

--- a/infrastructure/terraform/modules/iam/main.tf
+++ b/infrastructure/terraform/modules/iam/main.tf
@@ -54,7 +54,7 @@ resource "aws_iam_role_policy" "ingestion_secrets" {
 
   policy = jsonencode({
     Version = "2012-10-17"
-    Statement = [
+    Statement = concat([
       {
         Effect = "Allow"
         Action = [
@@ -65,7 +65,17 @@ resource "aws_iam_role_policy" "ingestion_secrets" {
           var.finnhub_secret_arn
         ]
       }
-    ]
+      ],
+      # KMS decrypt required when secrets use customer-managed KMS keys
+      var.secrets_kms_key_arn != "" ? [
+        {
+          Effect = "Allow"
+          Action = [
+            "kms:Decrypt"
+          ]
+          Resource = var.secrets_kms_key_arn
+        }
+    ] : [])
   })
 }
 

--- a/infrastructure/terraform/modules/iam/variables.tf
+++ b/infrastructure/terraform/modules/iam/variables.tf
@@ -71,3 +71,9 @@ variable "enable_feature_006" {
   type        = bool
   default     = true
 }
+
+variable "secrets_kms_key_arn" {
+  description = "ARN of the KMS key used to encrypt secrets (required for secretsmanager:GetSecretValue)"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
## Summary
- Add `secrets_kms_key_arn` variable to IAM module
- Conditionally add `kms:Decrypt` statement when KMS key ARN is provided
- Pass `module.kms.key_arn` to IAM module from main.tf

## Root Cause
Ingestion Lambda returned "Access denied to secret" even with correct `secretsmanager:GetSecretValue` permission because secrets module encrypts secrets with a customer-managed KMS key (`var.kms_key_arn`), requiring both permissions to decrypt.

## Test plan
- [x] Terraform fmt passes
- [x] Terraform validate passes
- [ ] Deploy to preprod and verify ingestion Lambda can read Tiingo/Finnhub secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)