### PR TITLE
fix(self-healing): Use composite key (PK+SK) for DynamoDB GetItem

### DIFF
--- a/specs/1005-fix-self-healing-composite-key/checklists/requirements.md
+++ b/specs/1005-fix-self-healing-composite-key/checklists/requirements.md
@@ -1,0 +1,22 @@
+# Requirements Checklist
+
+## Content Quality
+
+- [x] No implementation details in spec (technology-agnostic where possible)
+- [x] Focused on user/system value, not technical tasks
+- [x] Clear problem statement with evidence
+- [x] Root cause identified and documented
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remaining
+- [x] All requirements are testable
+- [x] Success criteria are measurable
+- [x] Edge cases identified (missing timestamp)
+
+## Feature Readiness
+
+- [x] All functional requirements have acceptance criteria
+- [x] Out of scope section defined
+- [x] Technical context documented
+- [x] Test requirements specified

--- a/specs/1005-fix-self-healing-composite-key/plan.md
+++ b/specs/1005-fix-self-healing-composite-key/plan.md
@@ -1,0 +1,79 @@
+# Implementation Plan
+
+## Overview
+
+Fix the `get_full_items()` function in `self_healing.py` to use the composite primary key (source_id + timestamp) when calling DynamoDB GetItem.
+
+## Phase 1: Code Fix
+
+### Task 1.1: Update GetItem Key
+**File:** `src/lambdas/ingestion/self_healing.py`
+
+Change line ~198-199 from:
+```python
+response = table.get_item(
+    Key={"source_id": source_id},
+```
+
+To:
+```python
+response = table.get_item(
+    Key={"source_id": source_id, "timestamp": timestamp},
+```
+
+### Task 1.2: Extract Timestamp from Item
+Before the GetItem call, extract timestamp from the GSI response item:
+```python
+source_id = item.get("source_id")
+timestamp = item.get("timestamp")
+if not source_id or not timestamp:
+    logger.warning("Skipping item missing required keys", ...)
+    continue
+```
+
+### Task 1.3: Update ProjectionExpression
+Remove `#ts` from ProjectionExpression since we already have timestamp from GSI:
+```python
+ProjectionExpression=(
+    "source_id, source_type, text_for_analysis, "
+    "matched_tickers, sentiment, metadata"
+),
+```
+Remove the ExpressionAttributeNames for timestamp as well.
+
+## Phase 2: Unit Tests
+
+### Task 2.1: Update Existing Tests
+Update `tests/unit/lambdas/ingestion/test_self_healing.py` to verify:
+- GetItem is called with both source_id and timestamp
+- Mock responses include timestamp in Key
+
+### Task 2.2: Add Missing Timestamp Test
+Add test case for when GSI returns item without timestamp:
+- Verify warning is logged
+- Verify item is skipped
+- Verify processing continues
+
+## Phase 3: Validation
+
+### Task 3.1: Run Unit Tests
+```bash
+python -m pytest tests/unit/lambdas/ingestion/test_self_healing.py -v
+```
+
+### Task 3.2: Verify Linting
+```bash
+ruff check src/lambdas/ingestion/self_healing.py
+```
+
+## Dependencies
+
+- No infrastructure changes required
+- No new dependencies
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Existing tests may mock single-key GetItem | Update mocks to expect composite key |
+| GSI may not return timestamp for some items | Add null check with warning log |

--- a/specs/1005-fix-self-healing-composite-key/spec.md
+++ b/specs/1005-fix-self-healing-composite-key/spec.md
@@ -1,0 +1,112 @@
+# Fix Self-Healing Composite Key Bug
+
+## Problem Statement
+
+The self-healing module in the ingestion Lambda fails to retrieve full item data from DynamoDB because it only provides the partition key (`source_id`) to GetItem, but the table uses a composite primary key (`source_id` + `timestamp`).
+
+### Evidence
+
+CloudWatch logs show repeated "Failed to get full item" warnings:
+```
+2025-12-20T16:37:49.236Z [WARNING] Failed to get full item
+2025-12-20T16:37:49.245Z [WARNING] Failed to get full item
+... (100+ occurrences per invocation)
+```
+
+Despite 466 pending items in DynamoDB older than 1 hour, self-healing reports:
+```json
+{
+  "items_found": 0,
+  "items_republished": 0
+}
+```
+
+### Root Cause
+
+The `get_full_items()` function in `self_healing.py` line 198-199:
+```python
+response = table.get_item(
+    Key={"source_id": source_id},  # Missing timestamp
+)
+```
+
+The DynamoDB table `preprod-sentiment-items` has:
+- Partition Key (PK): `source_id`
+- Sort Key (SK): `timestamp`
+
+GetItem requires BOTH keys for a composite primary key.
+
+### Why GSI Query Works But GetItem Fails
+
+1. The `by_status` GSI query succeeds and returns items with `source_id`, `timestamp`, `status`
+2. GSI uses `KEYS_ONLY` projection, so full item data is not available
+3. GetItem is called to fetch full item data (text_for_analysis, matched_tickers, etc.)
+4. GetItem fails because only `source_id` is provided, not `source_id` + `timestamp`
+
+## User Stories
+
+### P0: Self-Healing Retrieves Full Item Data
+As a system operator, I need self-healing to successfully retrieve full item data from DynamoDB so that stale pending items can be republished to SNS for analysis.
+
+## Functional Requirements
+
+### FR-001: Use Composite Key for GetItem
+The `get_full_items()` function MUST provide both `source_id` and `timestamp` when calling DynamoDB GetItem.
+
+**Acceptance Criteria:**
+- GetItem Key includes both `source_id` and `timestamp` from GSI response
+- No "Failed to get full item" warnings in CloudWatch logs
+- Items are successfully retrieved when they exist
+
+### FR-002: Handle Missing Timestamp Gracefully
+If an item from the GSI response is missing the `timestamp` attribute, the function MUST skip that item and log a warning.
+
+**Acceptance Criteria:**
+- Items without timestamp are skipped, not causing exceptions
+- Warning logged with source_id for debugging
+- Processing continues for remaining items
+
+### FR-003: Maintain Existing Filter Logic
+The existing logic to filter out items that already have a `sentiment` attribute MUST be preserved.
+
+**Acceptance Criteria:**
+- Items with sentiment attribute are still excluded
+- Debug log still generated for skipped items
+
+## Success Criteria
+
+| Metric | Target |
+|--------|--------|
+| SC-001 | Self-healing finds >0 items when pending items exist older than threshold |
+| SC-002 | Self-healing successfully republishes stale items to SNS |
+| SC-003 | Dashboard shows sentiment data within 10 minutes of fix deployment |
+| SC-004 | Zero "Failed to get full item" warnings for valid items |
+
+## Out of Scope
+
+- Changing GSI projection type (would require infrastructure change)
+- Changing table primary key design (would require migration)
+- Modifying deduplication logic
+
+## Technical Context
+
+### Affected File
+- `src/lambdas/ingestion/self_healing.py` - `get_full_items()` function
+
+### DynamoDB Table Schema
+- Table: `preprod-sentiment-items`
+- PK: `source_id` (String)
+- SK: `timestamp` (String, ISO8601 format)
+
+### GSI Schema
+- GSI: `by_status`
+- Hash Key: `status`
+- Range Key: `timestamp`
+- Projection: `KEYS_ONLY` (returns source_id, timestamp, status)
+
+## Test Requirements
+
+### Unit Tests
+- Test GetItem called with both source_id and timestamp
+- Test handling of missing timestamp in GSI response
+- Test existing sentiment filter logic preserved

--- a/specs/1005-fix-self-healing-composite-key/tasks.md
+++ b/specs/1005-fix-self-healing-composite-key/tasks.md
@@ -1,0 +1,20 @@
+# Tasks
+
+## Phase 1: Code Fix
+
+- [ ] T001: Update get_full_items() to extract timestamp from item
+- [ ] T002: Update GetItem Key to include both source_id and timestamp
+- [ ] T003: Add null check for missing timestamp with warning log
+- [ ] T004: Update ProjectionExpression to remove redundant timestamp
+
+## Phase 2: Unit Tests
+
+- [ ] T005: Update test mocks to expect composite key in GetItem
+- [ ] T006: Add test for missing timestamp handling
+- [ ] T007: Verify all existing tests still pass
+
+## Phase 3: Validation
+
+- [ ] T008: Run ruff check on modified files
+- [ ] T009: Run full unit test suite
+- [ ] T010: Verify no regressions

--- a/src/lambdas/ingestion/self_healing.py
+++ b/src/lambdas/ingestion/self_healing.py
@@ -191,17 +191,26 @@ def get_full_items(
 
     for item in item_keys:
         source_id = item.get("source_id")
-        if not source_id:
+        timestamp = item.get("timestamp")
+
+        # Both keys required for composite primary key
+        if not source_id or not timestamp:
+            logger.warning(
+                "Skipping item missing required keys",
+                extra={
+                    "has_source_id": bool(source_id),
+                    "has_timestamp": bool(timestamp),
+                },
+            )
             continue
 
         try:
             response = table.get_item(
-                Key={"source_id": source_id},
+                Key={"source_id": source_id, "timestamp": timestamp},
                 ProjectionExpression=(
                     "source_id, source_type, text_for_analysis, "
-                    "matched_tickers, #ts, sentiment, metadata"
+                    "matched_tickers, sentiment, metadata"
                 ),
-                ExpressionAttributeNames={"#ts": "timestamp"},
             )
 
             full_item = response.get("Item")


### PR DESCRIPTION
## Summary

Fix the self-healing module to use the full composite primary key when calling DynamoDB GetItem.

## Problem

The `get_full_items()` function was only providing `source_id` to GetItem, but the table uses a composite primary key (`source_id` + `timestamp`). This caused all GetItem calls to fail with "Failed to get full item" warnings, preventing self-healing from republishing stale items.

**Evidence:**
- 466 pending items in DynamoDB older than 1 hour
- Self-healing reported: `items_found: 0, items_republished: 0`
- CloudWatch logs: 100+ "Failed to get full item" warnings per invocation

## Root Cause

DynamoDB requires ALL primary key attributes for GetItem. The `by_status` GSI already returns both `source_id` and `timestamp` (KEYS_ONLY projection includes table PK), but the code wasn't using the timestamp value.

## Changes

- Extract `timestamp` from GSI response alongside `source_id`
- Include both keys in GetItem: `Key={source_id, timestamp}`
- Add validation: skip items missing either key with warning log
- Remove redundant timestamp from ProjectionExpression
- Add 2 new unit tests for missing key handling

## Test Plan

- [x] 21 self-healing unit tests pass (including 2 new tests)
- [x] 1995 total unit tests pass
- [x] ruff check passes
- [ ] Deploy to preprod
- [ ] Invoke ingestion Lambda
- [ ] Verify self-healing finds and republishes stale items
- [ ] Verify dashboard shows sentiment data

🤖 Generated with [Claude Code](https://claude.com/claude-code)