### PR TITLE
fix(iam): Add s3:HeadObject permission for Analysis Lambda model access

### DIFF
--- a/.specify/scripts/bash/common.sh
+++ b/.specify/scripts/bash/common.sh
@@ -37,7 +37,7 @@ get_current_branch() {
         for dir in "$specs_dir"/*; do
             if [[ -d "$dir" ]]; then
                 local dirname=$(basename "$dir")
-                if [[ "$dirname" =~ ^([0-9]{3})- ]]; then
+                if [[ "$dirname" =~ ^([0-9]+)- ]]; then
                     local number=${BASH_REMATCH[1]}
                     number=$((10#$number))
                     if [[ "$number" -gt "$highest" ]]; then
@@ -72,9 +72,9 @@ check_feature_branch() {
         return 0
     fi
 
-    if [[ ! "$branch" =~ ^[0-9]{3}- ]]; then
+    if [[ ! "$branch" =~ ^[0-9]+- ]]; then
         echo "ERROR: Not on a feature branch. Current branch: $branch" >&2
-        echo "Feature branches should be named like: 001-feature-name" >&2
+        echo "Feature branches should be named like: 001-feature-name or 1006-feature-name" >&2
         return 1
     fi
 
@@ -91,7 +91,7 @@ find_feature_dir_by_prefix() {
     local specs_dir="$repo_root/specs"
 
     # Extract numeric prefix from branch (e.g., "004" from "004-whatever")
-    if [[ ! "$branch_name" =~ ^([0-9]{3})- ]]; then
+    if [[ ! "$branch_name" =~ ^([0-9]+)- ]]; then
         # If branch doesn't have numeric prefix, fall back to exact match
         echo "$specs_dir/$branch_name"
         return

--- a/infrastructure/terraform/modules/iam/main.tf
+++ b/infrastructure/terraform/modules/iam/main.tf
@@ -269,7 +269,8 @@ resource "aws_iam_role_policy" "analysis_s3_model" {
       {
         Effect = "Allow"
         Action = [
-          "s3:GetObject"
+          "s3:GetObject",
+          "s3:HeadObject"
         ]
         Resource = "${var.model_s3_bucket_arn}/*"
       }

--- a/specs/1006-analysis-s3-iam/checklists/requirements.md
+++ b/specs/1006-analysis-s3-iam/checklists/requirements.md
@@ -1,0 +1,40 @@
+# Specification Quality Checklist: Fix Analysis Lambda S3 IAM Permissions
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2025-12-20
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+All items pass. This is a well-bounded IAM permission fix with:
+- Clear root cause (missing s3:HeadObject)
+- Specific file location (main.tf lines 274-276)
+- Measurable success criteria (403 errors resolved, dashboard shows data)
+- Defined assumptions and out-of-scope items
+
+Spec is ready for `/speckit.plan`.

--- a/specs/1006-analysis-s3-iam/plan.md
+++ b/specs/1006-analysis-s3-iam/plan.md
@@ -1,0 +1,108 @@
+# Implementation Plan: Fix Analysis Lambda S3 IAM Permissions
+
+**Branch**: `1006-analysis-s3-iam` | **Date**: 2025-12-20 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/1006-analysis-s3-iam/spec.md`
+
+## Summary
+
+Add `s3:HeadObject` permission to the Analysis Lambda's IAM policy to enable boto3's `download_file()` method to successfully download ML models from S3. Currently the policy only has `s3:GetObject`, but `download_file()` internally calls `HeadObject` first to get object metadata, resulting in a 403 Forbidden error.
+
+## Technical Context
+
+**Language/Version**: Terraform 1.5+ (HCL), existing infrastructure-as-code
+**Primary Dependencies**: AWS IAM, S3, Lambda (no code changes - infrastructure only)
+**Storage**: S3 bucket `sentiment-analyzer-models-{account_id}`
+**Testing**: terraform validate, terraform plan, manual Lambda invocation
+**Target Platform**: AWS us-east-1
+**Project Type**: Infrastructure fix (single file change)
+**Performance Goals**: N/A (IAM permission, no performance impact)
+**Constraints**: Must not remove existing `s3:GetObject` permission
+**Scale/Scope**: Single IAM policy statement, 1 line addition
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Gate | Status | Notes |
+|------|--------|-------|
+| Security & IAM least-privilege | PASS | Adding minimal required permission (HeadObject) scoped to specific bucket ARN |
+| Infrastructure as Code | PASS | Change via Terraform, not console |
+| Model artifacts access | PASS | Constitution requires Lambda access to S3 model artifacts (§84-86) |
+
+No violations. Proceed with implementation.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/1006-analysis-s3-iam/
+├── spec.md              # Feature specification
+├── plan.md              # This file
+├── checklists/
+│   └── requirements.md  # Validation checklist
+└── tasks.md             # Implementation tasks (next step)
+```
+
+### Source Code (repository root)
+
+```text
+infrastructure/terraform/modules/iam/main.tf   # Line 274-276 - analysis_s3_model policy
+```
+
+**Structure Decision**: Infrastructure-only change. Single file modification in existing IAM module.
+
+## Complexity Tracking
+
+No violations to justify - this is the simplest possible fix (adding one S3 action to an existing policy).
+
+## Phase 0: Research
+
+**No research required** - this is a well-documented AWS pattern:
+- boto3 `download_file()` uses S3 Transfer Manager which calls `HeadObject` before `GetObject`
+- AWS documentation confirms this behavior
+- Root cause already confirmed via CloudWatch logs (`403 on HeadObject operation`)
+
+## Phase 1: Design
+
+### Data Model
+
+N/A - no data model changes. This is an IAM permission fix.
+
+### API Contracts
+
+N/A - no API changes. This is an IAM permission fix.
+
+### Implementation Approach
+
+**File**: `infrastructure/terraform/modules/iam/main.tf`
+**Location**: Lines 274-276 (analysis_s3_model policy)
+
+**Current State**:
+```hcl
+Action = [
+  "s3:GetObject"
+]
+```
+
+**Target State**:
+```hcl
+Action = [
+  "s3:GetObject",
+  "s3:HeadObject"
+]
+```
+
+### Verification Steps
+
+1. `terraform fmt` - format check
+2. `terraform validate` - syntax validation
+3. `terraform plan` - verify only IAM policy changes
+4. Deploy to preprod
+5. Invoke Analysis Lambda - verify no 403 errors
+6. Check DynamoDB - verify items get sentiment attribute
+7. Check dashboard - verify non-zero counts
+
+## Next Steps
+
+Run `/speckit.tasks` to generate the implementation task list.

--- a/specs/1006-analysis-s3-iam/spec.md
+++ b/specs/1006-analysis-s3-iam/spec.md
@@ -1,0 +1,83 @@
+# Feature Specification: Fix Analysis Lambda S3 IAM Permissions
+
+**Feature Branch**: `1006-analysis-s3-iam`
+**Created**: 2025-12-20
+**Status**: Draft
+**Input**: User description: "Analysis Lambda has s3:GetObject but lacks s3:HeadObject permission for model bucket. boto3 download_file() requires both. Fix: infrastructure/terraform/modules/iam/main.tf lines 274-276. Add s3:HeadObject to analysis_s3_model policy."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Sentiment Analysis Pipeline Completion (Priority: P1)
+
+When a news article is received for sentiment analysis, the Analysis Lambda successfully downloads the ML model from S3 and processes the article, updating the sentiment classification in DynamoDB.
+
+**Why this priority**: This is the core functionality that's currently broken. Without S3 model access, no sentiment analysis can occur, resulting in zero data on the dashboard.
+
+**Independent Test**: Deploy the IAM fix and invoke the Analysis Lambda with a test SNS message. Verify the model downloads successfully and the article receives a sentiment classification.
+
+**Acceptance Scenarios**:
+
+1. **Given** an article message arrives via SNS, **When** the Analysis Lambda starts processing, **Then** the ML model downloads from S3 without 403 errors
+2. **Given** the model downloads successfully, **When** sentiment analysis completes, **Then** the DynamoDB item is updated with a sentiment attribute (positive/neutral/negative)
+3. **Given** the self-healing process republishes 100 pending items, **When** the Analysis Lambda processes them, **Then** all items receive sentiment classification within the processing window
+
+---
+
+### User Story 2 - Dashboard Data Visibility (Priority: P2)
+
+After sentiment analysis completes, the dashboard displays updated metrics showing the count of positive, neutral, and negative articles.
+
+**Why this priority**: This is the user-facing outcome that proves the pipeline works end-to-end. Dependent on P1 being resolved.
+
+**Independent Test**: After P1 fix is deployed and items are analyzed, load the dashboard and verify non-zero counts appear for sentiment categories.
+
+**Acceptance Scenarios**:
+
+1. **Given** items have been analyzed with sentiment, **When** the dashboard loads, **Then** Total Items shows a non-zero count
+2. **Given** items have mixed sentiments, **When** viewing the sentiment breakdown, **Then** Positive/Neutral/Negative counts reflect actual analyzed items
+
+---
+
+### Edge Cases
+
+- What happens when the S3 bucket is temporarily unavailable? The Lambda fails with a retriable error, and SNS will redeliver the message.
+- What happens when the model file is corrupted or missing? The Lambda logs a specific error and fails for that item.
+- What happens when KMS encryption is added to the model bucket? Additional kms:Decrypt permission would be required - out of scope for this fix.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Analysis Lambda IAM role MUST have `s3:HeadObject` permission on the model bucket
+- **FR-002**: Analysis Lambda IAM role MUST have `s3:GetObject` permission on the model bucket (already exists)
+- **FR-003**: Permissions MUST be scoped to the model bucket ARN with `/*` suffix for objects
+- **FR-004**: The fix MUST be applied in Terraform to maintain infrastructure-as-code practices
+
+### Key Entities
+
+- **IAM Policy**: `analysis_s3_model` - grants S3 permissions for model access
+- **S3 Bucket**: `sentiment-analyzer-models-{account_id}` - stores ML model files
+- **Lambda Role**: `{environment}-analysis-lambda-role` - execution role for Analysis Lambda
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Analysis Lambda can download model files from S3 without 403 errors
+- **SC-002**: Items republished by self-healing receive sentiment classification within 5 minutes
+- **SC-003**: Dashboard displays non-zero values for Total Items and sentiment categories after fix deployment
+- **SC-004**: No regression in existing S3 GetObject functionality
+
+## Assumptions
+
+- The S3 model bucket exists and contains the required model files
+- The model bucket does not have a bucket policy that explicitly denies the Lambda role
+- boto3's `download_file()` method is the only S3 operation requiring HeadObject (confirmed by error logs)
+- No KMS encryption is currently applied to the model bucket (KMS permissions out of scope)
+
+## Out of Scope
+
+- Adding ListBucket permission (not required for download_file)
+- Changing model storage location or format
+- KMS encryption support for model bucket
+- Model versioning or multi-model support

--- a/specs/1006-analysis-s3-iam/tasks.md
+++ b/specs/1006-analysis-s3-iam/tasks.md
@@ -1,0 +1,46 @@
+# Implementation Tasks: Fix Analysis Lambda S3 IAM Permissions
+
+**Feature**: 1006-analysis-s3-iam
+**Date**: 2025-12-20
+**Spec**: [spec.md](./spec.md) | **Plan**: [plan.md](./plan.md)
+
+## Phase 1: Implementation
+
+### Goal: Add s3:HeadObject permission to Analysis Lambda IAM policy
+
+**Independent Test**: After deploying, invoke Analysis Lambda and verify no 403 errors on S3 HeadObject
+
+- [x] T001 Add s3:HeadObject to analysis_s3_model policy in infrastructure/terraform/modules/iam/main.tf:274-276
+- [x] T002 Run terraform fmt in infrastructure/terraform/
+- [x] T003 Run terraform validate in infrastructure/terraform/
+
+## Phase 2: Verification
+
+### Goal: Confirm fix resolves the 403 error
+
+- [ ] T004 Commit changes with descriptive message
+- [ ] T005 Push and create PR with auto-merge
+- [ ] T006 After deploy, invoke Analysis Lambda via aws lambda invoke
+- [ ] T007 Check CloudWatch logs for absence of 403 errors
+- [ ] T008 Query DynamoDB for items with sentiment attribute
+- [ ] T009 Verify dashboard shows non-zero counts
+
+## Dependencies
+
+```
+T001 (IAM fix) → T002 (format) → T003 (validate) → T004 (commit) → T005 (PR)
+    → T006 (invoke) → T007 (logs) → T008 (DynamoDB) → T009 (dashboard)
+```
+
+## Parallel Execution
+
+No parallel tasks - this is a sequential infrastructure fix.
+
+## Summary
+
+| Metric | Value |
+|--------|-------|
+| Total Tasks | 9 |
+| Phase 1 (Implementation) | 3 |
+| Phase 2 (Verification) | 6 |
+| MVP Scope | T001-T005 (PR merged) |


### PR DESCRIPTION
## Summary
- Add `s3:HeadObject` permission to Analysis Lambda IAM policy
- boto3 `download_file()` requires both `s3:GetObject` AND `s3:HeadObject`
- Fixes 403 Forbidden on model download from S3

## Problem
The Analysis Lambda was failing with:
```
Failed to download model from S3: An error occurred (403) when calling the HeadObject operation: Forbidden
```

## Root Cause
boto3's `download_file()` uses the S3 Transfer Manager which calls `HeadObject` first to get object metadata before downloading. The IAM policy only granted `s3:GetObject`.

## Changes
- `infrastructure/terraform/modules/iam/main.tf`: Add `s3:HeadObject` to `analysis_s3_model` policy
- `.specify/scripts/bash/common.sh`: Support 4-digit feature numbers in regex

## Test Plan
- [x] terraform fmt passes
- [x] terraform validate passes
- [x] Checkov passes
- [ ] Deploy to preprod
- [ ] Invoke Analysis Lambda - verify no 403 errors
- [ ] Check DynamoDB - verify items get sentiment attribute
- [ ] Check dashboard - verify non-zero counts

## Related
- Previous PR #445 fixed self-healing SNS republish
- Self-healing now works: 100 items republished
- This PR unblocks the Analysis Lambda to process those items

🤖 Generated with [Claude Code](https://claude.com/claude-code)