### PR TITLE
feat(analysis): Upload DistilBERT model + increase Lambda memory to 2048MB

### DIFF
--- a/infrastructure/scripts/build-and-upload-model-s3.sh
+++ b/infrastructure/scripts/build-and-upload-model-s3.sh
@@ -50,7 +50,8 @@ S3_KEY="distilbert/${MODEL_VERSION}/model.tar.gz"
 # Known good hash for model config (for supply chain security)
 # This is the SHA256 of the config.json file
 # Update this when upgrading model versions
-EXPECTED_CONFIG_HASH="a53dbee6f2c8f2f6e9a9c5f8f7d3c4e5b6a7d8e9f0a1b2c3d4e5f6a7b8c9d0e1"
+# Updated 2025-12-20 for distilbert-base-uncased-finetuned-sst-2-english
+EXPECTED_CONFIG_HASH="df80ff6a470008e42520222530ca1559e2533afc931a21277a08707391fbca74"
 
 # Colors for output
 RED='\033[0;31m'
@@ -166,10 +167,25 @@ echo "Verifying model files..."
 
 required_files=(
     "config.json"
-    "pytorch_model.bin"
     "tokenizer_config.json"
     "vocab.txt"
 )
+
+# Check for model weights (either pytorch_model.bin or model.safetensors)
+has_model_weights=false
+if [ -f "${MODEL_DIR}/pytorch_model.bin" ]; then
+    has_model_weights=true
+    echo "Found pytorch_model.bin"
+fi
+if [ -f "${MODEL_DIR}/model.safetensors" ]; then
+    has_model_weights=true
+    echo "Found model.safetensors (HuggingFace new default)"
+fi
+
+if [ "$has_model_weights" = false ]; then
+    echo -e "${RED}Error: No model weights found (need pytorch_model.bin or model.safetensors)${NC}"
+    exit 1
+fi
 
 missing_files=()
 for file in "${required_files[@]}"; do

--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -326,8 +326,9 @@ module "analysis_lambda" {
   source_code_hash = var.lambda_package_version
 
   # Resource configuration per task spec
-  # JUSTIFICATION (FR-024): 1024MB required for ML model inference (DistilBERT)
-  memory_size          = 1024
+  # JUSTIFICATION (FR-024): 2048MB required for ML model inference (DistilBERT)
+  # Increased from 1024MB - model requires ~700MB, Python runtime ~300MB, headroom for spikes
+  memory_size          = 2048
   timeout              = 30
   reserved_concurrency = 5
 

--- a/specs/1007-upload-distilbert-model/plan.md
+++ b/specs/1007-upload-distilbert-model/plan.md
@@ -1,0 +1,98 @@
+# Implementation Plan: Feature 1007
+
+## Overview
+
+Two-phase implementation:
+1. **Manual**: Run upload script to populate S3
+2. **Terraform**: Increase Lambda memory via PR
+
+## Phase 1: Upload Model to S3
+
+### Step 1.1: Run Upload Script
+**File**: `infrastructure/scripts/build-and-upload-model-s3.sh`
+
+```bash
+cd /home/traylorre/projects/sentiment-analyzer-gsk
+./infrastructure/scripts/build-and-upload-model-s3.sh
+```
+
+**Expected Output**:
+- Downloads ~250 MB from HuggingFace
+- Creates model.tar.gz
+- Uploads to S3
+- Verifies upload
+
+### Step 1.2: Verify S3 Upload
+```bash
+aws s3 ls s3://sentiment-analyzer-models-218795110243/distilbert/v1.0.0/
+```
+
+**Expected**: Object exists with size ~250 MB
+
+## Phase 2: Increase Lambda Memory
+
+### Step 2.1: Find Memory Configuration
+**File**: `infrastructure/terraform/modules/lambda/main.tf`
+
+Search for Analysis Lambda resource and memory_size attribute.
+
+### Step 2.2: Update Memory Value
+Change from 1024 to 2048.
+
+### Step 2.3: Create PR
+- Branch: `A-upload-distilbert-model`
+- Commit message: Descriptive
+- Auto-merge enabled
+
+## Phase 3: Verification
+
+### Step 3.1: Invoke Self-Healing
+```bash
+aws lambda invoke --function-name preprod-sentiment-ingestion --payload '{}' /tmp/out.json
+cat /tmp/out.json | jq '.body.self_healing'
+```
+
+**Expected**: `items_republished: 100`
+
+### Step 3.2: Wait for Analysis
+Wait 30-60 seconds for Analysis Lambda to process SNS messages.
+
+### Step 3.3: Check CloudWatch Logs
+```bash
+aws logs tail /aws/lambda/preprod-sentiment-analysis --since 2m | grep -E "(Model loaded|sentiment)"
+```
+
+**Expected**: "Model loaded successfully" with load_time_ms
+
+### Step 3.4: Check DynamoDB
+```bash
+aws dynamodb scan --table-name preprod-sentiment-items \
+  --filter-expression "attribute_exists(sentiment)" \
+  --select COUNT
+```
+
+**Expected**: Count > 0
+
+### Step 3.5: Check Dashboard
+Open https://d2z9uvoj5xlbd2.cloudfront.net
+
+**Expected**: Non-zero counts for Total/Positive/Neutral/Negative
+
+## Rollback Plan
+
+### If Model Upload Fails
+- Re-run script with `--no-verify` flag
+- Manually download from HuggingFace and upload via AWS Console
+
+### If Lambda OOMs at 2048 MB
+- Increase to 3072 MB (same Terraform process)
+- Consider INT8 quantized model (future optimization)
+
+## Timeline
+
+| Phase | Duration |
+|-------|----------|
+| Model upload | 5-10 min (includes HuggingFace download) |
+| Terraform PR | 10-15 min (includes CI/CD) |
+| Verification | 5-10 min |
+| **Total** | **~30 min** |

--- a/specs/1007-upload-distilbert-model/spec.md
+++ b/specs/1007-upload-distilbert-model/spec.md
@@ -1,0 +1,148 @@
+# Feature 1007: Upload DistilBERT Model to S3
+
+## Problem Statement
+
+The Analysis Lambda cannot perform sentiment analysis because the ML model was never uploaded to S3. The Lambda attempts to download from `s3://sentiment-analyzer-models-218795110243/distilbert/v1.0.0/model.tar.gz` but the bucket is empty, causing a 403 error (S3 returns 403 for non-existent objects when caller lacks ListBucket).
+
+**Root Cause**: The `build-and-upload-model-s3.sh` script was created but never executed.
+
+**Secondary Issue**: Lambda memory is set to 1024 MB but DistilBERT requires ~1050 MB, creating OOM risk.
+
+## Background
+
+### Current State
+- S3 bucket exists: `sentiment-analyzer-models-218795110243`
+- S3 bucket is **EMPTY** - no objects
+- Analysis Lambda configured correctly
+- IAM permissions correct (PR #446 added s3:HeadObject)
+- Lambda memory: 1024 MB (marginal)
+- Lambda ephemeral storage: 3072 MB (ample)
+- Lambda timeout: 30s (ample)
+
+### Model Details (from audit)
+| Property | Value |
+|----------|-------|
+| Model | distilbert-base-uncased-finetuned-sst-2-english |
+| Source | HuggingFace Hub |
+| pytorch_model.bin | 268 MB |
+| Compressed (tar.gz) | ~250 MB |
+| Memory at inference | ~700 MB |
+
+### Upload Script (ready to run)
+- Path: `infrastructure/scripts/build-and-upload-model-s3.sh`
+- Downloads from HuggingFace
+- Packages as tar.gz
+- Uploads to S3
+- Includes hash verification
+
+## Functional Requirements
+
+### FR-001: Model Available in S3
+The DistilBERT model MUST be available at:
+- Bucket: `sentiment-analyzer-models-218795110243`
+- Key: `distilbert/v1.0.0/model.tar.gz`
+- Size: ~250 MB
+
+### FR-002: Lambda Memory Increased
+The Analysis Lambda memory MUST be increased from 1024 MB to 2048 MB to:
+- Prevent OOM during inference
+- Provide proportionally faster CPU
+- Reduce cold start time
+
+### FR-003: Model Loads Successfully
+After fix, Analysis Lambda MUST:
+- Download model from S3 on cold start
+- Extract to /tmp/model
+- Load via transformers pipeline
+- Complete within 30s timeout
+
+### FR-004: Sentiment Analysis Works
+After fix, Analysis Lambda MUST:
+- Receive SNS messages from ingestion
+- Classify text as positive/negative/neutral
+- Update DynamoDB items with sentiment attribute
+
+## Non-Functional Requirements
+
+### NFR-001: Cold Start Performance
+Cold start (S3 download + model load) SHOULD complete in <15s.
+
+### NFR-002: Warm Start Performance
+Warm invocations SHOULD complete in <1s.
+
+### NFR-003: Memory Headroom
+Lambda memory SHOULD have 50%+ headroom for inference spikes.
+
+## Success Criteria
+
+### SC-001: S3 Object Exists
+```bash
+aws s3 ls s3://sentiment-analyzer-models-218795110243/distilbert/v1.0.0/model.tar.gz
+# Returns object with size ~250 MB
+```
+
+### SC-002: Lambda Memory Updated
+```bash
+aws lambda get-function-configuration --function-name preprod-sentiment-analysis --query 'MemorySize'
+# Returns: 2048
+```
+
+### SC-003: Model Downloads Successfully
+CloudWatch logs show:
+- "Downloading model from S3"
+- "Model downloaded from S3" with download_time_ms
+- "Model loaded successfully" with load_time_ms
+
+### SC-004: Sentiment Analysis Works
+```bash
+aws dynamodb scan --table-name preprod-sentiment-items \
+  --filter-expression "attribute_exists(sentiment)" \
+  --select COUNT
+# Returns Count > 0
+```
+
+### SC-005: Dashboard Shows Data
+Dashboard at https://d2z9uvoj5xlbd2.cloudfront.net shows:
+- Total Items > 0
+- Positive/Neutral/Negative counts > 0
+
+## Out of Scope
+
+- Container image migration (ADR-005 Phase 2)
+- INT8 quantized model optimization
+- Provisioned Concurrency (blocked by ephemeral storage >512 MB)
+- Lambda SnapStart (Python not supported)
+- CloudWatch warming events
+
+## Dependencies
+
+- PR #446 merged (s3:HeadObject permission) - DONE
+- PRs #441-445 merged (self-healing) - DONE
+- AWS credentials with S3 write access
+
+## Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| HuggingFace download fails | LOW | HIGH | Script has error handling, can retry |
+| S3 upload fails | LOW | HIGH | Script verifies upload, can retry |
+| Model hash mismatch | LOW | MEDIUM | Script warns but continues |
+| Lambda still OOMs at 2048 MB | VERY LOW | HIGH | Monitor CloudWatch, can increase further |
+
+## Implementation Approach
+
+### Phase 1: Upload Model (Manual, One-Time)
+1. Run `./infrastructure/scripts/build-and-upload-model-s3.sh`
+2. Verify S3 object exists
+3. This is a manual operation, not part of CI/CD
+
+### Phase 2: Increase Lambda Memory (Terraform)
+1. Update `infrastructure/terraform/modules/lambda/main.tf`
+2. Change Analysis Lambda memory from 1024 to 2048
+3. Create PR, merge, deploy
+
+### Phase 3: Verify End-to-End
+1. Invoke ingestion Lambda (triggers self-healing)
+2. Wait for Analysis Lambda to process items
+3. Check DynamoDB for sentiment attribute
+4. Check dashboard for non-zero counts

--- a/specs/1007-upload-distilbert-model/tasks.md
+++ b/specs/1007-upload-distilbert-model/tasks.md
@@ -1,0 +1,38 @@
+# Tasks: Feature 1007 - Upload DistilBERT Model
+
+## Phase 1: Upload Model to S3 (Manual)
+
+- [ ] T001 Run infrastructure/scripts/build-and-upload-model-s3.sh
+- [ ] T002 Verify S3 object exists at distilbert/v1.0.0/model.tar.gz
+- [ ] T003 Confirm object size is approximately 250 MB
+
+## Phase 2: Increase Lambda Memory (Terraform)
+
+### Goal: Update Analysis Lambda memory from 1024 MB to 2048 MB
+
+- [ ] T004 Find Analysis Lambda memory configuration in Terraform
+- [ ] T005 Update memory_size from 1024 to 2048
+- [ ] T006 Run terraform fmt and validate
+- [ ] T007 Create feature branch A-upload-distilbert-model
+- [ ] T008 Commit with descriptive message
+- [ ] T009 Push and create PR with auto-merge
+
+## Phase 3: Verification
+
+### Goal: Confirm end-to-end sentiment analysis works
+
+- [ ] T010 Wait for PR merge and deployment
+- [ ] T011 Verify Lambda memory is 2048 MB via AWS CLI
+- [ ] T012 Invoke ingestion Lambda to trigger self-healing
+- [ ] T013 Wait 60 seconds for Analysis Lambda to process
+- [ ] T014 Check CloudWatch logs for "Model loaded successfully"
+- [ ] T015 Query DynamoDB for items with sentiment attribute (Count > 0)
+- [ ] T016 Check dashboard shows non-zero counts
+
+## Definition of Done
+
+- [ ] S3 contains distilbert/v1.0.0/model.tar.gz (~250 MB)
+- [ ] Lambda memory is 2048 MB
+- [ ] CloudWatch shows successful model loads
+- [ ] DynamoDB items have sentiment attribute
+- [ ] Dashboard shows positive/neutral/negative counts > 0


### PR DESCRIPTION
## Summary
- Upload DistilBERT sentiment model to S3 bucket (247 MB)
- Increase Analysis Lambda memory from 1024MB to 2048MB for ML inference
- Fix script to accept model.safetensors format (HuggingFace new default)

## Root Cause
Dashboard showed zeros because:
1. S3 bucket `sentiment-analyzer-models-218795110243` was EMPTY - model never uploaded
2. Analysis Lambda memory (1024MB) marginal for DistilBERT (~700MB) + Python runtime

## Changes
- `infrastructure/terraform/main.tf`: Analysis Lambda memory 1024 → 2048 MB
- `infrastructure/scripts/build-and-upload-model-s3.sh`: Accept either pytorch_model.bin OR model.safetensors
- `specs/1007-upload-distilbert-model/`: Full specification

## Test plan
- [ ] Deploy completes without errors
- [ ] Model loads successfully (CloudWatch: "Model loaded successfully")
- [ ] Self-healing republishes pending items
- [ ] Analysis Lambda processes items (status: pending → analyzed)
- [ ] Dashboard shows non-zero sentiment counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)