### PR TITLE
fix(timeseries): Move fanout module to shared lib for Docker build

### DIFF
--- a/src/lambdas/analysis/handler.py
+++ b/src/lambdas/analysis/handler.py
@@ -67,7 +67,6 @@ from src.lambdas.analysis.sentiment import (
     get_model_load_time_ms,
     load_model,
 )
-from src.lambdas.ingestion.timeseries_fanout import write_fanout
 from src.lambdas.shared.chaos_injection import get_chaos_delay_ms
 from src.lambdas.shared.dynamodb import get_table
 from src.lib.metrics import (
@@ -75,7 +74,7 @@ from src.lib.metrics import (
     emit_metrics_batch,
     log_structured,
 )
-from src.lib.timeseries import SentimentScore
+from src.lib.timeseries import SentimentScore, write_fanout
 
 # Structured logging
 logger = logging.getLogger(__name__)

--- a/src/lib/timeseries/__init__.py
+++ b/src/lib/timeseries/__init__.py
@@ -11,6 +11,11 @@ This module provides utilities for:
 
 from src.lib.timeseries.aggregation import aggregate_ohlc
 from src.lib.timeseries.bucket import calculate_bucket_progress, floor_to_bucket
+from src.lib.timeseries.fanout import (
+    generate_fanout_items,
+    write_fanout,
+    write_fanout_with_update,
+)
 from src.lib.timeseries.models import (
     OHLCBucket,
     PartialBucket,
@@ -30,4 +35,7 @@ __all__ = [
     "floor_to_bucket",
     "calculate_bucket_progress",
     "aggregate_ohlc",
+    "generate_fanout_items",
+    "write_fanout",
+    "write_fanout_with_update",
 ]

--- a/src/lib/timeseries/fanout.py
+++ b/src/lib/timeseries/fanout.py
@@ -17,7 +17,8 @@ from typing import Any
 
 from botocore.exceptions import ClientError
 
-from src.lib.timeseries import Resolution, SentimentScore, floor_to_bucket
+from src.lib.timeseries.bucket import floor_to_bucket
+from src.lib.timeseries.models import Resolution, SentimentScore
 
 logger = logging.getLogger(__name__)
 

--- a/tests/unit/test_timeseries_fanout.py
+++ b/tests/unit/test_timeseries_fanout.py
@@ -20,12 +20,13 @@ import boto3
 import pytest
 from moto import mock_aws
 
-from src.lambdas.ingestion.timeseries_fanout import (
+from src.lib.timeseries import (
+    Resolution,
+    SentimentScore,
     generate_fanout_items,
     write_fanout,
     write_fanout_with_update,
 )
-from src.lib.timeseries import Resolution, SentimentScore
 
 
 def parse_iso(s: str) -> datetime:


### PR DESCRIPTION
## Summary

The Analysis Lambda Docker container build was failing because `handler.py` imported from `src.lambdas.ingestion.timeseries_fanout`, but the ingestion directory is not copied into the Analysis Lambda container.

**Root cause**: `timeseries_fanout.py` was architecturally misplaced in the ingestion module when it's actually a shared utility that operates on `src/lib/timeseries` types and is used by the Analysis Lambda.

**Fix**:
- Move `timeseries_fanout.py` → `src/lib/timeseries/fanout.py`
- Update `__init__.py` exports: `generate_fanout_items`, `write_fanout`, `write_fanout_with_update`
- Fix circular imports by using direct submodule imports in `fanout.py`
- Update `handler.py` import: `from src.lib.timeseries import write_fanout`
- Update test imports to use new location

This follows the existing pattern where `src/lib/` is copied to all Lambda containers (line 47 of Dockerfile: `COPY lib /var/task/src/lib`).

## Test plan

- [x] All 2068 unit tests passing locally
- [ ] CI passes (lint, tests, security)
- [ ] "Build Analysis Lambda Image (Preprod)" Docker smoke test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)