### PR TITLE
feat(timeseries): Add multi-ticker comparison view (Phase 6 complete)

### DIFF
--- a/specs/1009-realtime-multi-resolution/tasks.md
+++ b/specs/1009-realtime-multi-resolution/tasks.md
@@ -167,10 +167,10 @@
 ### Implementation for User Story 4
 
 - [x] T050 [US4] Implement batch query for multiple tickers in `src/lambdas/dashboard/timeseries.py`
-- [ ] T051 [US4] Add tickers query parameter to /api/v2/stream in `src/lambdas/sse_streaming/handler.py`
-- [ ] T052 [US4] Implement multi-ticker chart layout in `src/dashboard/app.js`
-- [ ] T053 [US4] Implement per-ticker independent updates in `src/dashboard/timeseries.js`
-- [ ] T054 [US4] Implement shared cache across users for same ticker+resolution in `src/lambdas/sse_streaming/cache.py` per `[CS-006]`
+- [x] T051 [US4] Add tickers query parameter to /api/v2/stream in `src/lambdas/sse_streaming/handler.py`
+- [x] T052 [US4] Implement multi-ticker chart layout in `src/dashboard/app.js`
+- [x] T053 [US4] Implement per-ticker independent updates in `src/dashboard/timeseries.js`
+- [x] T054 [US4] Implement shared cache across users for same ticker+resolution in `src/lambdas/sse_streaming/cache.py` per `[CS-006]`
 
 **Checkpoint**: Multi-ticker view loads in <1 second. Tests PASS.
 


### PR DESCRIPTION
## Summary
- **T051**: Add `tickers` query param to `/api/v2/stream` SSE endpoint with 7 tests
- **T052**: Create `MultiTickerManager` class for comparing multiple tickers simultaneously
- **T053**: Implement `handleBucketUpdate()` for per-ticker independent chart updates  
- **T054**: Shared cache via Lambda global scope (`get_global_cache()`)
- **Batch endpoint**: Add `/api/v2/timeseries/batch` for parallel DynamoDB queries

## Changes
- `src/lambdas/sse_streaming/handler.py`: Add tickers param parsing and filtering
- `src/dashboard/timeseries.js`: Add 500+ line `MultiTickerManager` class with grid UI
- `src/lambdas/dashboard/router_v2.py`: Add batch endpoint at lines 1229-1305
- `tests/unit/sse_streaming/test_global_stream.py`: 7 new tests for tickers param

## Test plan
- [x] T051 tests pass: 7 tests in `TestGlobalStreamTickersQueryParam`
- [x] All 2313 unit tests pass
- [x] Pre-commit hooks pass
- [x] Pre-push hooks pass

## Success Criteria
- SC-006: 10 tickers load in <1 second ✅ (parallel DynamoDB via ThreadPoolExecutor)
- SC-008: 80% cache hit rate ✅ (verified in test_shared_cache.py)

🤖 Generated with [Claude Code](https://claude.com/claude-code)