### PR TITLE
feat(dashboard): Add multi-resolution config to config.js (T068)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,8 +39,8 @@ Auto-generated from all feature plans. Last updated: 2025-11-26
 - DynamoDB with `by_status` GSI (hash: status, range: timestamp, projection: KEYS_ONLY) (1003-self-healing-ingestion)
 - Python 3.13 (existing project standard) + FastAPI, boto3, sse-starlette (existing SSE stack), pydantic (1009-realtime-multi-resolution)
 - DynamoDB with new time-series table (`{env}-sentiment-timeseries`) (1009-realtime-multi-resolution)
-- Python 3.13 (existing project standard) + structlog (existing), boto3 (existing), pytest-playwright (E2E) (1020-validate-cache-hit-rate)
-- CloudWatch Logs (structured JSON via structlog) (1020-validate-cache-hit-rate)
+- Python 3.13 (for any helper scripts), Terraform HCL (infrastructure) + infracost CLI, make, jq (for parsing) (1020-validate-budget-60-month)
+- N/A (documentation output only) (1020-validate-budget-60-month)
 
 - **Python 3.13** with FastAPI, boto3, pydantic, aws-lambda-powertools, httpx
 - **AWS Services**: DynamoDB (single-table design), S3, Lambda, SNS, EventBridge, Cognito, CloudFront
@@ -818,7 +818,7 @@ aws cloudwatch get-metric-data --metric-data-queries '[...]' --start-time ... --
 ```
 
 ## Recent Changes
-- 1020-validate-cache-hit-rate: Added Python 3.13 (existing project standard) + structlog (existing), boto3 (existing), pytest-playwright (E2E)
+- 1020-validate-budget-60-month: Added Python 3.13 (for any helper scripts), Terraform HCL (infrastructure) + infracost CLI, make, jq (for parsing)
 - 1009-realtime-multi-resolution: Added Python 3.13 (existing project standard) + FastAPI, boto3, sse-starlette (existing SSE stack), pydantic
 - 1003-self-healing-ingestion: Added Python 3.13 (existing project standard) + boto3, aws-xray-sdk (existing)
 

--- a/specs/1021-dashboard-resolution-config/checklists/requirements.md
+++ b/specs/1021-dashboard-resolution-config/checklists/requirements.md
@@ -1,0 +1,41 @@
+# Requirements Validation Checklist
+
+Feature-1021 | Dashboard Resolution Config
+
+## Spec Quality Gates
+
+### Completeness (4/4)
+- [x] CG-1: All user stories have acceptance criteria
+- [x] CG-2: Functional requirements trace to user stories
+- [x] CG-3: Non-functional requirements have measurable targets
+- [x] CG-4: Success criteria have validation methods
+
+### Clarity (4/4)
+- [x] CL-1: No ambiguous terms (e.g., "fast", "user-friendly")
+- [x] CL-2: Technical terms are defined or referenced
+- [x] CL-3: Dependencies explicitly listed
+- [x] CL-4: Out of scope clearly stated
+
+### Testability (4/4)
+- [x] TE-1: Each AC can be verified with a test
+- [x] TE-2: Success criteria have specific validation methods
+- [x] TE-3: NFRs have numeric thresholds
+- [x] TE-4: No subjective requirements
+
+### Consistency (4/4)
+- [x] CO-1: No contradicting requirements
+- [x] CO-2: Terminology used consistently
+- [x] CO-3: Aligned with parent spec (1009)
+- [x] CO-4: Aligned with existing config.js patterns
+
+## Summary
+
+| Category | Pass | Total |
+|----------|------|-------|
+| Completeness | 4 | 4 |
+| Clarity | 4 | 4 |
+| Testability | 4 | 4 |
+| Consistency | 4 | 4 |
+| **Total** | **16** | **16** |
+
+**Status: PASS**

--- a/specs/1021-dashboard-resolution-config/plan.md
+++ b/specs/1021-dashboard-resolution-config/plan.md
@@ -1,0 +1,69 @@
+# Implementation Plan
+
+Feature-1021 | Dashboard Resolution Config
+
+## Technical Context
+
+| Dimension | Value |
+|-----------|-------|
+| Language | JavaScript (ES6+) |
+| Target File | src/dashboard/config.js |
+| Dependencies | None (static config) |
+| Testing | Unit test for config validation |
+| Platform | Browser (Chrome, Firefox, Safari) |
+
+## Constitution Check
+
+| Section | Gate | Status |
+|---------|------|--------|
+| Section 5 | IaC for infrastructure changes | N/A (frontend only) |
+| Section 6 | Observability for new components | N/A (config only) |
+| Section 7 | Integration tests for AWS resources | N/A (no AWS) |
+| Section 10 | Local SAST before push | PASS (pre-commit) |
+
+**Result: 4/4 PASS** (N/A gates don't apply to frontend config changes)
+
+## Implementation Approach
+
+### Phase 0: Research
+
+No research needed - resolution values are defined in `src/lib/timeseries/models.py`.
+
+### Phase 1: Add Resolution Configuration
+
+1. Add RESOLUTIONS object after existing config
+2. Add RESOLUTION_ORDER array for UI display
+3. Add DEFAULT_RESOLUTION constant
+4. Add TIMESERIES endpoint
+5. Freeze new config objects
+
+### Phase 2: Unit Test
+
+1. Create test to verify resolution values match Python models
+2. Test immutability of config objects
+3. Test endpoint format
+
+## File Changes
+
+| File | Change Type | Description |
+|------|-------------|-------------|
+| src/dashboard/config.js | Modify | Add RESOLUTIONS, TIMESERIES endpoint |
+| tests/unit/dashboard/test_config.py | Create | Validate config values |
+
+## Risk Assessment
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| TTL mismatch with server | Low | Medium | Unit test comparing to Python values |
+| Breaking existing code | Low | High | Add new config, don't modify existing |
+| Config mutation | Low | Medium | Object.freeze() |
+
+## Alternatives Considered
+
+1. **Dynamic config from API**: Rejected - adds latency, fails offline
+2. **Shared JSON config file**: Rejected - requires build pipeline changes
+3. **Generate from Python**: Rejected - over-engineering for 8 values
+
+## Quickstart
+
+See [quickstart.md](quickstart.md) for running and testing.

--- a/specs/1021-dashboard-resolution-config/quickstart.md
+++ b/specs/1021-dashboard-resolution-config/quickstart.md
@@ -1,0 +1,63 @@
+# Quickstart Guide
+
+Feature-1021 | Dashboard Resolution Config
+
+## Prerequisites
+
+- Node.js (for serving static files)
+- Python 3.13 (for running tests)
+
+## Verify Configuration
+
+After implementation, verify the config in browser console:
+
+```javascript
+// Open dashboard and run in browser console:
+console.log(CONFIG.RESOLUTIONS);
+// Should show 8 resolution objects
+
+console.log(CONFIG.DEFAULT_RESOLUTION);
+// Should show "5m"
+
+console.log(CONFIG.ENDPOINTS.TIMESERIES);
+// Should show "/api/v2/timeseries"
+
+console.log(CONFIG.RESOLUTION_ORDER);
+// Should show ["1m", "5m", "10m", "1h", "3h", "6h", "12h", "24h"]
+```
+
+## Run Unit Tests
+
+```bash
+cd /home/traylorre/projects/sentiment-analyzer-gsk
+python -m pytest tests/unit/dashboard/test_config.py -v
+```
+
+## Validate TTL Alignment
+
+The unit test compares JavaScript config TTLs against Python model values:
+
+```bash
+python -m pytest tests/unit/dashboard/test_config.py::TestResolutionConfig::test_ttl_matches_python_model -v
+```
+
+## Common Issues
+
+### Issue: CONFIG.RESOLUTIONS undefined
+
+**Cause**: Script loaded before config.js
+**Fix**: Ensure config.js is loaded first in HTML
+
+### Issue: Cannot modify frozen config
+
+**Expected behavior**: Config is intentionally frozen. Use spread operator to create copies:
+
+```javascript
+const myConfig = { ...CONFIG.RESOLUTIONS["5m"] };
+myConfig.customField = "value";  // OK
+```
+
+### Issue: Endpoint 404
+
+**Cause**: Backend doesn't have /api/v2/timeseries endpoint yet
+**Note**: This feature only adds frontend config; backend endpoint is separate feature

--- a/specs/1021-dashboard-resolution-config/spec.md
+++ b/specs/1021-dashboard-resolution-config/spec.md
@@ -1,0 +1,125 @@
+# Dashboard Resolution Config
+
+Feature-1021 | Parent: [1009-realtime-multi-resolution](../1009-realtime-multi-resolution/spec.md) | Task: T068
+
+## Purpose
+
+Add resolution configuration to the dashboard's config.js to enable multi-resolution timeseries functionality on the client side. The dashboard currently lacks configuration for the 8 resolution levels needed by the realtime multi-resolution feature.
+
+## Context
+
+The backend timeseries library (`src/lib/timeseries/models.py`) defines 8 resolution levels (1m, 5m, 10m, 1h, 3h, 6h, 12h, 24h) with corresponding duration_seconds and ttl_seconds values. The dashboard needs matching configuration to:
+
+1. Display resolution options in the UI
+2. Request appropriate endpoints with resolution parameters
+3. Configure client-side cache TTLs aligned with server TTLs
+
+## User Stories
+
+### US1: Resolution Selector Display
+
+**As a** dashboard user
+**I want to** see all 8 resolution options in the time selector
+**So that** I can choose the granularity of sentiment data to view
+
+**Acceptance Criteria:**
+- [ ] AC-1.1: All 8 resolutions visible: 1m, 5m, 10m, 1h, 3h, 6h, 12h, 24h
+- [ ] AC-1.2: Display names are human-readable: "1 min", "5 min", etc.
+- [ ] AC-1.3: Default resolution is 5m (per FR-002)
+
+### US2: Timeseries API Configuration
+
+**As a** dashboard developer
+**I want to** have configured timeseries endpoints
+**So that** API calls include the correct resolution parameter
+
+**Acceptance Criteria:**
+- [ ] AC-2.1: TIMESERIES endpoint configured: /api/v2/timeseries/{ticker}
+- [ ] AC-2.2: STREAM endpoint already exists, ensure resolution support
+- [ ] AC-2.3: Resolution passed as query parameter: ?resolution=5m
+
+### US3: Client Cache Alignment
+
+**As a** dashboard
+**I want to** cache timeseries data with appropriate TTLs
+**So that** cache invalidation matches server-side TTLs
+
+**Acceptance Criteria:**
+- [ ] AC-3.1: Each resolution has a matching cache TTL
+- [ ] AC-3.2: TTLs match server values from Resolution.ttl_seconds
+- [ ] AC-3.3: Cache configuration is immutable (Object.freeze)
+
+## Functional Requirements
+
+| ID | Requirement | Source |
+|----|-------------|--------|
+| FR-001 | RESOLUTIONS object with all 8 resolution levels | T068 |
+| FR-002 | Each resolution has: key, displayName, durationSeconds, ttlSeconds | T068 |
+| FR-003 | TIMESERIES endpoint template: /api/v2/timeseries/{ticker} | T068 |
+| FR-004 | Default resolution constant: DEFAULT_RESOLUTION = '5m' | FR-002 |
+| FR-005 | RESOLUTION_ORDER array for UI display order | T068 |
+| FR-006 | Object.freeze on RESOLUTIONS to prevent mutation | T068 |
+
+## Non-Functional Requirements
+
+| ID | Requirement | Target |
+|----|-------------|--------|
+| NFR-001 | Config file size increase < 2KB | < 2KB |
+| NFR-002 | No runtime API calls for config | Zero API calls |
+| NFR-003 | Backwards compatible with existing code | No breaking changes |
+
+## Success Criteria
+
+| ID | Criterion | Validation Method |
+|----|-----------|-------------------|
+| SC-001 | All 8 resolutions defined in config | Code review |
+| SC-002 | TTL values match server Resolution.ttl_seconds | Unit test |
+| SC-003 | TIMESERIES endpoint returns 200 with resolution param | E2E test |
+| SC-004 | Existing CONFIG.ENDPOINTS unchanged | Regression test |
+| SC-005 | Config is frozen/immutable | Unit test |
+
+## Out of Scope
+
+- Resolution selector UI component (T069)
+- Timeseries chart rendering
+- IndexedDB cache implementation
+- SSE stream resolution switching
+
+## Dependencies
+
+- `src/lib/timeseries/models.py` - Source of truth for resolution values
+- `src/dashboard/config.js` - File to modify
+- Existing ENDPOINTS configuration must remain unchanged
+
+## Technical Notes
+
+### Resolution Value Mapping
+
+From `Resolution.ttl_seconds` in models.py:
+
+| Resolution | Duration (s) | TTL (s) | Display Name |
+|------------|-------------|---------|--------------|
+| 1m | 60 | 21600 | 1 min |
+| 5m | 300 | 43200 | 5 min |
+| 10m | 600 | 86400 | 10 min |
+| 1h | 3600 | 604800 | 1 hour |
+| 3h | 10800 | 1209600 | 3 hours |
+| 6h | 21600 | 2592000 | 6 hours |
+| 12h | 43200 | 5184000 | 12 hours |
+| 24h | 86400 | 7776000 | 24 hours |
+
+### Endpoint Format
+
+```javascript
+ENDPOINTS: {
+    // Existing endpoints (unchanged)
+    SENTIMENT: '/api/v2/sentiment',
+    TRENDS: '/api/v2/trends',
+    ARTICLES: '/api/v2/articles',
+    METRICS: '/api/v2/metrics',
+    STREAM: '/api/v2/stream',
+
+    // New endpoint
+    TIMESERIES: '/api/v2/timeseries'  // Append /{ticker}?resolution=5m
+}
+```

--- a/specs/1021-dashboard-resolution-config/tasks.md
+++ b/specs/1021-dashboard-resolution-config/tasks.md
@@ -1,0 +1,41 @@
+# Implementation Tasks
+
+Feature-1021 | Dashboard Resolution Config
+
+## Phase 1: Configuration (US1, US2, US3)
+
+- [x] [T001] Add RESOLUTIONS object to `src/dashboard/config.js` with all 8 resolution levels
+- [x] [T002] Add each resolution with: key, displayName, durationSeconds, ttlSeconds
+- [x] [T003] Add RESOLUTION_ORDER array: ["1m", "5m", "10m", "1h", "3h", "6h", "12h", "24h"]
+- [x] [T004] Add DEFAULT_RESOLUTION constant: "5m"
+- [x] [T005] Add TIMESERIES endpoint to ENDPOINTS: "/api/v2/timeseries"
+- [x] [T006] Add Object.freeze(CONFIG.RESOLUTIONS) after declaration
+- [x] [T007] Add Object.freeze(CONFIG.RESOLUTION_ORDER) after declaration
+
+## Phase 2: Testing (SC-002, SC-005)
+
+- [x] [T008] Create `tests/unit/dashboard/test_config_resolution.py` with TestResolutionConfig class
+- [x] [T009] Add test_all_resolutions_defined: verify 8 resolutions exist
+- [x] [T010] [P] Add test_ttl_matches_python_model: compare TTLs with Resolution.ttl_seconds
+- [x] [T011] [P] Add test_duration_matches_python_model: compare durations with Resolution.duration_seconds
+- [x] [T012] Add test_default_resolution_is_5m: verify DEFAULT_RESOLUTION = "5m"
+- [x] [T013] Add test_timeseries_endpoint_exists: verify ENDPOINTS.TIMESERIES defined
+
+## Phase 3: Validation (SC-001, SC-004)
+
+- [x] [T014] Run existing dashboard tests to verify no regressions
+- [x] [T015] Verify CONFIG.ENDPOINTS unchanged (existing endpoints still present)
+
+## Summary
+
+| Metric | Count |
+|--------|-------|
+| Total Tasks | 15 |
+| Phase 1 (Config) | 7 |
+| Phase 2 (Testing) | 6 |
+| Phase 3 (Validation) | 2 |
+| Parallel Opportunities | 2 tasks marked [P] |
+
+## MVP Scope
+
+All 15 tasks COMPLETE.

--- a/src/dashboard/config.js
+++ b/src/dashboard/config.js
@@ -36,8 +36,68 @@ const CONFIG = {
         TRENDS: '/api/v2/trends',
         ARTICLES: '/api/v2/articles',
         METRICS: '/api/v2/metrics',
-        STREAM: '/api/v2/stream'  // SSE endpoint (served by SSE Lambda)
+        STREAM: '/api/v2/stream',  // SSE endpoint (served by SSE Lambda)
+        TIMESERIES: '/api/v2/timeseries'  // Timeseries endpoint: append /{ticker}?resolution=5m
     },
+
+    // Resolution configuration for multi-resolution timeseries (Feature 1009)
+    // Values sourced from src/lib/timeseries/models.py Resolution enum
+    RESOLUTIONS: {
+        '1m': {
+            key: '1m',
+            displayName: '1 min',
+            durationSeconds: 60,
+            ttlSeconds: 21600  // 6 hours
+        },
+        '5m': {
+            key: '5m',
+            displayName: '5 min',
+            durationSeconds: 300,
+            ttlSeconds: 43200  // 12 hours
+        },
+        '10m': {
+            key: '10m',
+            displayName: '10 min',
+            durationSeconds: 600,
+            ttlSeconds: 86400  // 24 hours
+        },
+        '1h': {
+            key: '1h',
+            displayName: '1 hour',
+            durationSeconds: 3600,
+            ttlSeconds: 604800  // 7 days
+        },
+        '3h': {
+            key: '3h',
+            displayName: '3 hours',
+            durationSeconds: 10800,
+            ttlSeconds: 1209600  // 14 days
+        },
+        '6h': {
+            key: '6h',
+            displayName: '6 hours',
+            durationSeconds: 21600,
+            ttlSeconds: 2592000  // 30 days
+        },
+        '12h': {
+            key: '12h',
+            displayName: '12 hours',
+            durationSeconds: 43200,
+            ttlSeconds: 5184000  // 60 days
+        },
+        '24h': {
+            key: '24h',
+            displayName: '24 hours',
+            durationSeconds: 86400,
+            ttlSeconds: 7776000  // 90 days
+        }
+    },
+
+    // Resolution display order for UI selectors
+    RESOLUTION_ORDER: ['1m', '5m', '10m', '1h', '3h', '6h', '12h', '24h'],
+
+    // Default resolution (Feature 1009 FR-002)
+    DEFAULT_RESOLUTION: '5m',
 
     // Polling interval for sentiment data (milliseconds)
     SENTIMENT_POLL_INTERVAL: 30000, // 30 seconds
@@ -89,3 +149,7 @@ Object.freeze(CONFIG.COLORS);
 Object.freeze(CONFIG.COLORS_BG);
 Object.freeze(CONFIG.DATE_FORMAT);
 Object.freeze(CONFIG.SENTIMENT_LABELS);
+Object.freeze(CONFIG.RESOLUTIONS);
+Object.freeze(CONFIG.RESOLUTION_ORDER);
+// Deep freeze each resolution object
+Object.values(CONFIG.RESOLUTIONS).forEach(r => Object.freeze(r));

--- a/tests/unit/dashboard/test_config_resolution.py
+++ b/tests/unit/dashboard/test_config_resolution.py
@@ -1,0 +1,142 @@
+"""
+Test dashboard config.js resolution values match Python models.
+
+Feature-1021: Dashboard Resolution Config
+Validates that JavaScript config values are synchronized with
+src/lib/timeseries/models.py Resolution enum.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+from src.lib.timeseries.models import Resolution
+
+
+class TestResolutionConfig:
+    """Test resolution configuration in config.js."""
+
+    @pytest.fixture
+    def config_js_content(self) -> str:
+        """Load config.js content."""
+        config_path = (
+            Path(__file__).parent.parent.parent.parent
+            / "src"
+            / "dashboard"
+            / "config.js"
+        )
+        return config_path.read_text()
+
+    @pytest.fixture
+    def parsed_resolutions(self, config_js_content: str) -> dict[str, dict]:
+        """Parse RESOLUTIONS object from config.js."""
+        resolutions = {}
+
+        # Extract each resolution block using regex
+        # Pattern matches: '1m': { key: '1m', displayName: '...', durationSeconds: N, ttlSeconds: N }
+        pattern = r"'(\d+[mh])': \{\s*key: '(\d+[mh])',\s*displayName: '([^']+)',\s*durationSeconds: (\d+),\s*ttlSeconds: (\d+)"
+
+        for match in re.finditer(pattern, config_js_content):
+            key, _, display_name, duration, ttl = match.groups()
+            resolutions[key] = {
+                "displayName": display_name,
+                "durationSeconds": int(duration),
+                "ttlSeconds": int(ttl),
+            }
+
+        return resolutions
+
+    def test_all_resolutions_defined(self, parsed_resolutions: dict) -> None:
+        """Verify all 8 resolutions are defined in config.js."""
+        expected_keys = {"1m", "5m", "10m", "1h", "3h", "6h", "12h", "24h"}
+        assert set(parsed_resolutions.keys()) == expected_keys
+
+    def test_ttl_matches_python_model(self, parsed_resolutions: dict) -> None:
+        """Verify TTL values match Resolution.ttl_seconds."""
+        for resolution in Resolution:
+            js_ttl = parsed_resolutions[resolution.value]["ttlSeconds"]
+            python_ttl = resolution.ttl_seconds
+            assert js_ttl == python_ttl, (
+                f"TTL mismatch for {resolution.value}: "
+                f"JS={js_ttl}, Python={python_ttl}"
+            )
+
+    def test_duration_matches_python_model(self, parsed_resolutions: dict) -> None:
+        """Verify duration values match Resolution.duration_seconds."""
+        for resolution in Resolution:
+            js_duration = parsed_resolutions[resolution.value]["durationSeconds"]
+            python_duration = resolution.duration_seconds
+            assert js_duration == python_duration, (
+                f"Duration mismatch for {resolution.value}: "
+                f"JS={js_duration}, Python={python_duration}"
+            )
+
+    def test_default_resolution_is_5m(self, config_js_content: str) -> None:
+        """Verify DEFAULT_RESOLUTION is set to '5m'."""
+        assert "DEFAULT_RESOLUTION: '5m'" in config_js_content
+
+    def test_timeseries_endpoint_exists(self, config_js_content: str) -> None:
+        """Verify TIMESERIES endpoint is defined."""
+        assert "TIMESERIES: '/api/v2/timeseries'" in config_js_content
+
+    def test_resolution_order_defined(self, config_js_content: str) -> None:
+        """Verify RESOLUTION_ORDER array is defined with correct order."""
+        expected = (
+            "RESOLUTION_ORDER: ['1m', '5m', '10m', '1h', '3h', '6h', '12h', '24h']"
+        )
+        assert expected in config_js_content
+
+    def test_resolutions_are_frozen(self, config_js_content: str) -> None:
+        """Verify RESOLUTIONS object is frozen."""
+        assert "Object.freeze(CONFIG.RESOLUTIONS)" in config_js_content
+
+    def test_resolution_order_is_frozen(self, config_js_content: str) -> None:
+        """Verify RESOLUTION_ORDER array is frozen."""
+        assert "Object.freeze(CONFIG.RESOLUTION_ORDER)" in config_js_content
+
+    def test_display_names_are_human_readable(self, parsed_resolutions: dict) -> None:
+        """Verify display names are human-readable."""
+        expected_names = {
+            "1m": "1 min",
+            "5m": "5 min",
+            "10m": "10 min",
+            "1h": "1 hour",
+            "3h": "3 hours",
+            "6h": "6 hours",
+            "12h": "12 hours",
+            "24h": "24 hours",
+        }
+        for key, expected_name in expected_names.items():
+            assert parsed_resolutions[key]["displayName"] == expected_name
+
+
+class TestExistingEndpointsUnchanged:
+    """Verify existing endpoints are not modified."""
+
+    @pytest.fixture
+    def config_js_content(self) -> str:
+        """Load config.js content."""
+        config_path = (
+            Path(__file__).parent.parent.parent.parent
+            / "src"
+            / "dashboard"
+            / "config.js"
+        )
+        return config_path.read_text()
+
+    @pytest.mark.parametrize(
+        "endpoint",
+        [
+            "SENTIMENT: '/api/v2/sentiment'",
+            "TRENDS: '/api/v2/trends'",
+            "ARTICLES: '/api/v2/articles'",
+            "METRICS: '/api/v2/metrics'",
+            "STREAM: '/api/v2/stream'",
+        ],
+    )
+    def test_existing_endpoint_unchanged(
+        self, config_js_content: str, endpoint: str
+    ) -> None:
+        """Verify existing endpoint is still present."""
+        assert endpoint in config_js_content


### PR DESCRIPTION
Add resolution configuration for the multi-resolution timeseries feature.

Configuration added:
- RESOLUTIONS object with all 8 resolution levels (1m to 24h)
- Each resolution has: key, displayName, durationSeconds, ttlSeconds
- RESOLUTION_ORDER array for UI display order
- DEFAULT_RESOLUTION constant set to "5m" (per FR-002)
- TIMESERIES endpoint: /api/v2/timeseries
- Object.freeze() on new config objects for immutability

Tests added (14 tests):
- test_all_resolutions_defined: Verify 8 resolutions exist
- test_ttl_matches_python_model: Compare JS TTLs with Python Resolution.ttl_seconds
- test_duration_matches_python_model: Compare JS durations with Python Resolution.duration_seconds
- test_display_names_are_human_readable: Verify user-friendly names
- test_existing_endpoint_unchanged: Verify no regression in existing endpoints

Spec artifacts in specs/1021-dashboard-resolution-config/:
- spec.md: 3 user stories, 6 FRs, 5 SCs
- tasks.md: 15 tasks complete (Phase 1-3)

Parent: 1009-realtime-multi-resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
