### PR TITLE
chore(tests): Apply ruff format to 33 test files (T070)

### DIFF
--- a/tests/e2e/test_multi_resolution_dashboard.py
+++ b/tests/e2e/test_multi_resolution_dashboard.py
@@ -391,10 +391,7 @@ class TestLiveUpdates:
 
         # Check for partial bucket indicator
         partial_indicator = page.locator(
-            ".partial-bucket, "
-            "[data-partial='true'], "
-            ".in-progress, "
-            "[class*='partial']"
+            ".partial-bucket, [data-partial='true'], .in-progress, [class*='partial']"
         )
 
         # Also check in JavaScript state

--- a/tests/unit/dashboard/test_config_resolution.py
+++ b/tests/unit/dashboard/test_config_resolution.py
@@ -57,10 +57,9 @@ class TestResolutionConfig:
         for resolution in Resolution:
             js_ttl = parsed_resolutions[resolution.value]["ttlSeconds"]
             python_ttl = resolution.ttl_seconds
-            assert js_ttl == python_ttl, (
-                f"TTL mismatch for {resolution.value}: "
-                f"JS={js_ttl}, Python={python_ttl}"
-            )
+            assert (
+                js_ttl == python_ttl
+            ), f"TTL mismatch for {resolution.value}: JS={js_ttl}, Python={python_ttl}"
 
     def test_duration_matches_python_model(self, parsed_resolutions: dict) -> None:
         """Verify duration values match Resolution.duration_seconds."""


### PR DESCRIPTION
Ran make validate which triggered ruff format, auto-formatting:
- tests/e2e/*.py (21 files)
- tests/integration/*.py (8 files)
- tests/unit/*.py (4 files)

No functional changes, only formatting adjustments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
