### PR TITLE
fix(ci): Increase E2E test timeout from 360s to 480s

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1339,10 +1339,11 @@ jobs:
         run: |
           # Run tests marked as "preprod" (auto-marked by conftest.py for *_preprod.py files)
           # These tests use REAL AWS resources, not moto mocks
-          # Timeout: 360s (6 min) - provides 20% buffer over 279s avg runtime
-          # Previous 300s was at 93% utilization, risking timeout flakiness
+          # Timeout: 480s (8 min) - provides buffer for Playwright tests and Lambda cold starts
+          # Previous 360s was exceeded when E2E test suite grew, causing job-level timeout
+          # See: specs/1029-fix-e2e-test-timeout/spec.md
           set +e  # Don't exit on error
-          timeout 360 pytest tests/ \
+          timeout 480 pytest tests/ \
             -m "preprod" \
             -v \
             --tb=short \
@@ -1354,7 +1355,7 @@ jobs:
             echo "✅ Integration tests passed"
             echo "passed=true" >> $GITHUB_OUTPUT
           elif [ $TEST_EXIT_CODE -eq 124 ]; then
-            echo "⚠️ Integration tests timed out (360s limit)"
+            echo "⚠️ Integration tests timed out (480s limit)"
             echo "passed=false" >> $GITHUB_OUTPUT
             echo "reason=timeout" >> $GITHUB_OUTPUT
           else

--- a/specs/1029-fix-e2e-test-timeout/spec.md
+++ b/specs/1029-fix-e2e-test-timeout/spec.md
@@ -1,0 +1,46 @@
+# Feature 1029: Fix E2E Test Timeout
+
+## Problem Statement
+
+The Preprod Integration Tests job in deploy.yml is timing out at 360 seconds (6 minutes) before pytest can complete, causing:
+- All remaining tests to be marked as incomplete
+- Test results artifact to not be generated (`preprod-test-results.xml`)
+- Pipeline to fail with "timeout" reason instead of showing actual test results
+
+## Evidence
+
+From workflow run 20453562748:
+```
+##[error]Integration tests did not pass: timeout
+##[warning]No files were found with the provided path: preprod-test-results.xml
+```
+
+## Root Cause
+
+The 360s timeout was set with a "20% buffer over 279s avg runtime" but:
+1. Playwright E2E tests add significant overhead (~10s per test for browser startup)
+2. The test suite has grown to include more Playwright-based tests
+3. Lambda cold starts during tests can add unpredictable delays
+
+## Solution
+
+Increase the timeout from 360s to 480s (8 minutes):
+- Provides 33% buffer over current ~360s runtime
+- Allows pytest to complete and generate results even if some tests are slow
+- Ensures test results artifact is always uploaded
+
+## Acceptance Criteria
+
+- [ ] AC-1: Timeout increased to 480s in deploy.yml test-preprod job
+- [ ] AC-2: Comment updated to reflect new timeout rationale
+- [ ] AC-3: Pipeline completes without timeout (tests may still fail, but not due to timeout)
+
+## Files Modified
+
+- `.github/workflows/deploy.yml` - line ~1345, timeout value in test-preprod job
+
+## Risk Assessment
+
+- **Low risk**: This is a simple numeric change
+- Increasing timeout does not fix underlying test failures, it just allows them to be reported properly
+- If tests consistently take >8 minutes, we should investigate root causes (Lambda cold starts, test efficiency)

--- a/specs/1029-fix-e2e-test-timeout/tasks.md
+++ b/specs/1029-fix-e2e-test-timeout/tasks.md
@@ -1,0 +1,13 @@
+# Tasks: Fix E2E Test Timeout
+
+## Completed Tasks
+
+- [x] T-001: Create spec.md with problem analysis
+- [x] T-002: Update timeout from 360s to 480s in deploy.yml
+- [x] T-003: Update comment explaining rationale
+- [x] T-004: Update timeout message in error handling
+
+## Verification
+
+- [ ] T-005: Pipeline runs to completion without job-level timeout
+- [ ] T-006: Test results artifact is generated (preprod-test-results.xml)


### PR DESCRIPTION
## Summary
- Increase Preprod Integration Tests timeout from 360s to 480s
- Ensures pytest completes and generates test results artifact

## Problem
The 360s timeout was exceeded when the E2E test suite grew, causing:
- Job-level timeout before pytest could complete
- No `preprod-test-results.xml` artifact generated
- Actual test failures masked by "timeout" error

## Evidence
From workflow run 20453562748:
```
##[error]Integration tests did not pass: timeout
##[warning]No files were found with the provided path: preprod-test-results.xml
```

## Changes
- `deploy.yml` line 1346: `timeout 360` → `timeout 480`
- Updated comments to explain rationale

## Test plan
- [ ] Next pipeline run completes without job-level timeout
- [ ] `preprod-test-results.xml` artifact is generated
- [ ] Actual test failures are visible (not masked by timeout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)