### PR TITLE
docs(1035): Mark all tasks complete, fix quickstart test command

### DIFF
--- a/specs/1035-ohlc-resolution-selector/quickstart.md
+++ b/specs/1035-ohlc-resolution-selector/quickstart.md
@@ -80,7 +80,7 @@ Resolution preference is stored in sessionStorage and persists across page navig
 pytest tests/unit/lambdas/dashboard/test_ohlc.py -v
 
 # Frontend
-npm test -- --grep "resolution"
+npm test -- --run -t "resolution"
 ```
 
 ### E2E Tests

--- a/specs/1035-ohlc-resolution-selector/tasks.md
+++ b/specs/1035-ohlc-resolution-selector/tasks.md
@@ -86,8 +86,8 @@
 
 ### Frontend Unit Tests
 
-- [ ] T022 [P] [US1] Add test for resolution selector rendering in frontend/src/__tests__/price-sentiment-chart.test.tsx
-- [ ] T023 [P] [US1] Add test for resolution change triggers data refetch in frontend/src/__tests__/price-sentiment-chart.test.tsx
+- [x] T022 [P] [US1] Add test for resolution selector rendering in frontend/tests/unit/components/charts/price-sentiment-chart.test.tsx
+- [x] T023 [P] [US1] Add test for resolution change triggers data refetch in frontend/tests/unit/components/charts/price-sentiment-chart.test.tsx
 
 **Checkpoint**: User Story 1 complete - users can select resolutions and see chart update with intraday candles
 
@@ -107,8 +107,8 @@
 
 ### Frontend Unit Tests
 
-- [ ] T027 [P] [US2] Add test for resolution preference persistence in frontend/src/__tests__/price-sentiment-chart.test.tsx
-- [ ] T028 [P] [US2] Add test for initial resolution read from sessionStorage in frontend/src/__tests__/price-sentiment-chart.test.tsx
+- [x] T027 [P] [US2] Add test for resolution preference persistence in frontend/tests/unit/components/charts/price-sentiment-chart.test.tsx
+- [x] T028 [P] [US2] Add test for initial resolution read from sessionStorage in frontend/tests/unit/components/charts/price-sentiment-chart.test.tsx
 
 **Checkpoint**: User Story 2 complete - resolution preference persists across navigation
 
@@ -127,7 +127,7 @@
 
 ### Frontend Unit Tests
 
-- [ ] T031 [P] [US3] Add test for synchronized resolution between price and sentiment in frontend/src/__tests__/price-sentiment-chart.test.tsx
+- [x] T031 [P] [US3] Add test for synchronized resolution between price and sentiment in frontend/tests/unit/components/charts/price-sentiment-chart.test.tsx
 
 **Checkpoint**: User Story 3 complete - price and sentiment data synchronized on time axis
 
@@ -138,8 +138,8 @@
 **Purpose**: Final improvements affecting multiple components
 
 - [x] T032 Add error message display when resolution unavailable (fallback to daily) in frontend/src/components/charts/price-sentiment-chart.tsx
-- [ ] T033 [P] Run make validate to ensure code quality in project root
-- [ ] T034 [P] Verify quickstart.md examples work with new resolution parameter
+- [x] T033 [P] Run make validate to ensure code quality in project root
+- [x] T034 [P] Verify quickstart.md examples work with new resolution parameter
 
 ---
 


### PR DESCRIPTION
## Summary
- Mark T022-T023, T027-T028, T031 as complete (frontend tests merged in #484)
- Mark T033-T034 as complete (validation and quickstart verified)
- Fix vitest command in quickstart.md: `--grep` → `-t` (vitest syntax)
- Update test file paths to actual location

## Test plan
- [x] Quickstart test command verified: `npm test -- --run -t "resolution"` runs correctly
- [x] All tasks in tasks.md now marked complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)