### PR TITLE
feat(dashboard): Integrate PriceSentimentChart with OHLC resolution selector

### DIFF
--- a/specs/1038-dashboard-ohlc-integration/plan.md
+++ b/specs/1038-dashboard-ohlc-integration/plan.md
@@ -1,0 +1,80 @@
+# Plan: Dashboard OHLC Integration
+
+**Feature ID**: 1038
+**Spec**: spec.md
+
+## Implementation Strategy
+
+This is a **frontend-only integration** of existing components. No new backend work required.
+
+### Phase 1: Prepare Dashboard Page
+
+**Goal**: Update imports and remove mock data
+
+1. Update imports in `frontend/src/app/(dashboard)/page.tsx`:
+   - Add: `import { PriceSentimentChart } from '@/components/charts'`
+   - Remove: `SentimentChart` dynamic import
+
+2. Remove mock data:
+   - Delete `generateMockData` function
+   - Remove `SentimentTimeSeries` type import if unused
+
+3. Simplify state:
+   - Keep `activeTicker` for current selection
+   - Remove `tickers` array with embedded `data` (chart fetches its own data)
+
+### Phase 2: Integrate PriceSentimentChart
+
+**Goal**: Replace SentimentChart with PriceSentimentChart
+
+1. Replace chart component usage:
+   ```tsx
+   // Before
+   <SentimentChart data={activeTickerData.data} ticker={...} />
+
+   // After
+   <PriceSentimentChart ticker={activeTicker} />
+   ```
+
+2. PriceSentimentChart handles internally:
+   - API data fetching via `useChartData` hook
+   - Resolution selector UI
+   - Time range selector
+   - Loading states
+   - Error handling
+
+### Phase 3: Maintain Ticker Chips (Optional)
+
+**Goal**: Keep multi-ticker chip functionality if desired
+
+1. TickerChipList can remain for quick ticker switching
+2. Active chip triggers `setActiveTicker`
+3. Chart re-fetches data for new ticker automatically
+
+### Phase 4: Unit Tests
+
+**Goal**: Verify integration works
+
+1. Test that PriceSentimentChart renders when ticker selected
+2. Test resolution selector is visible
+3. Test ticker switching updates chart
+
+## File Changes Summary
+
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `frontend/src/app/(dashboard)/page.tsx` | Modify | Replace SentimentChart with PriceSentimentChart |
+| `frontend/src/__tests__/app/dashboard.test.tsx` | Create | Integration tests |
+
+## Execution Sequence
+
+```
+T001: Update imports → T002: Remove mock data → T003: Replace chart component →
+T004: Test manually → T005: Add unit tests → T006: Run make validate
+```
+
+## Rollback Plan
+
+If issues arise:
+- Revert `page.tsx` to use SentimentChart with mock data
+- No backend changes to rollback

--- a/specs/1038-dashboard-ohlc-integration/spec.md
+++ b/specs/1038-dashboard-ohlc-integration/spec.md
@@ -1,0 +1,90 @@
+# Spec: Dashboard OHLC Integration
+
+**Feature ID**: 1038
+**Priority**: P0 (Demo-critical)
+**Status**: Draft
+
+## Problem Statement
+
+The main dashboard page (`frontend/src/app/(dashboard)/page.tsx`) currently uses `SentimentChart` with **mock data**, while `PriceSentimentChart` with full OHLC resolution selector and real API data exists but is not integrated into any user-facing route.
+
+**Current State**:
+- `SentimentChart`: Mock data, sentiment-only, no resolution selector
+- `PriceSentimentChart`: Real OHLC data from Tiingo/Finnhub, 6 resolution options (1m, 5m, 15m, 30m, 1h, D), time range selector, sentiment overlay
+
+**Goal**: Replace mock sentiment chart with real OHLC chart to make dashboard demo-able.
+
+## User Stories
+
+### US1: View Real OHLC Candles on Dashboard (P0)
+**As a** demo viewer
+**I want to** see real candlestick data when I search for a ticker
+**So that** the dashboard demonstrates real financial data analysis
+
+**Acceptance Criteria**:
+- When user searches for a ticker (e.g., AAPL), real OHLC data displays
+- Default resolution is "D" (daily) per existing convention
+- Chart shows candlesticks with price data from Tiingo/Finnhub
+
+### US2: Select Time Resolution (P1)
+**As a** trader
+**I want to** select different time resolutions (1m, 5m, 15m, 30m, 1h, D)
+**So that** I can analyze price patterns at different granularities
+
+**Acceptance Criteria**:
+- Resolution selector buttons visible above chart
+- Clicking resolution triggers data refetch
+- Resolution persists across ticker changes (sessionStorage)
+
+### US3: View Synchronized Sentiment Overlay (P2)
+**As an** analyst
+**I want to** see sentiment line overlaid on price candles
+**So that** I can correlate sentiment with price movements
+
+**Acceptance Criteria**:
+- Sentiment line displays on right Y-axis (-1 to +1)
+- Both layers share time axis at selected resolution
+- Crosshair shows aligned OHLC + sentiment values
+
+## Technical Approach
+
+### Changes Required
+
+1. **Replace SentimentChart import with PriceSentimentChart** in `page.tsx`
+2. **Remove mock data generation** (generateMockData function)
+3. **Pass ticker to PriceSentimentChart** for real API calls
+4. **Handle loading states** properly during API fetches
+
+### Existing Components to Leverage
+
+- `PriceSentimentChart` - Already fully implemented (Feature 1035)
+- `useChartData` hook - Handles OHLC + sentiment fetching
+- `fetchOHLCData` API client - Connects to `/api/v2/tickers/{ticker}/ohlc`
+
+### API Endpoints (Already Working)
+
+- `GET /api/v2/tickers/{ticker}/ohlc` - Returns OHLC candlestick data
+- `GET /api/v2/tickers/{ticker}/sentiment/history` - Returns sentiment time series
+
+## Out of Scope
+
+- New API endpoints (all exist)
+- New backend logic (all implemented in Feature 1035)
+- New chart components (PriceSentimentChart exists)
+
+## Dependencies
+
+- Feature 1035 (OHLC Resolution Selector) - MERGED
+- PR #486 (Dashboard ECR IAM) - MERGED
+
+## Risks
+
+- **Low**: This is primarily a frontend integration of existing components
+- **Medium**: Potential layout issues when swapping chart components
+
+## Success Metrics
+
+- Dashboard displays real OHLC data for any valid ticker
+- Resolution selector visible and functional
+- No console errors or API failures
+- Load time < 2s for initial chart render

--- a/specs/1038-dashboard-ohlc-integration/tasks.md
+++ b/specs/1038-dashboard-ohlc-integration/tasks.md
@@ -1,0 +1,42 @@
+# Tasks: Dashboard OHLC Integration
+
+**Feature ID**: 1038
+**Input**: spec.md, plan.md
+
+## Phase 1: Component Integration
+
+- [ ] T001 Update imports: add PriceSentimentChart, remove SentimentChart dynamic import in frontend/src/app/(dashboard)/page.tsx
+- [ ] T002 Remove generateMockData function and TickerData interface with embedded data in frontend/src/app/(dashboard)/page.tsx
+- [ ] T003 Simplify tickers state to only track symbols (no embedded data) in frontend/src/app/(dashboard)/page.tsx
+- [ ] T004 Replace SentimentChart with PriceSentimentChart, passing activeTicker as ticker prop in frontend/src/app/(dashboard)/page.tsx
+- [ ] T005 Remove refresh button logic (chart handles its own data) in frontend/src/app/(dashboard)/page.tsx
+
+## Phase 2: State Cleanup
+
+- [ ] T006 Update handleTickerSelect to only add symbol to list (no mock data generation) in frontend/src/app/(dashboard)/page.tsx
+- [ ] T007 Update tickerChips useMemo to work with simplified state in frontend/src/app/(dashboard)/page.tsx
+
+## Phase 3: Testing
+
+- [ ] T008 Add unit test for PriceSentimentChart integration in frontend/src/__tests__/app/(dashboard)/page.test.tsx
+- [ ] T009 Run make validate to verify no regressions
+
+## Dependencies
+
+- T001 must complete before T002-T005
+- T006-T007 can run in parallel with T004-T005
+- T008 depends on T001-T007 completion
+- T009 runs last
+
+## Parallel Opportunities
+
+**Parallel Set 1**: After T001 completes
+- T002, T003 (independent cleanup)
+
+**Parallel Set 2**: After basic integration
+- T006, T007 (state cleanup)
+
+## Estimated Complexity
+
+- **Low**: This is primarily removing code and swapping one component for another
+- **Total**: ~100 lines changed (mostly deletions)


### PR DESCRIPTION
## Summary

- Replace mock `SentimentChart` with real `PriceSentimentChart` on main dashboard
- Enable real OHLC candlestick data from Tiingo/Finnhub APIs
- Add 6 resolution options (1m, 5m, 15m, 30m, 1h, Daily) via resolution selector
- Simplify state management - chart handles its own data fetching

## Changes

**frontend/src/app/(dashboard)/page.tsx:**
- Replace `SentimentChart` dynamic import with `PriceSentimentChart`
- Remove `generateMockData` function and mock data generation
- Simplify `TickerInfo` interface (only symbol/name, no embedded data)
- Chart now fetches real OHLC data via `useChartData` hook internally

## Test plan

- [ ] Search for a ticker (e.g., AAPL) - real OHLC candles display
- [ ] Click resolution buttons (1m, 5m, 15m, 30m, 1h, D) - data refreshes
- [ ] Resolution persists across ticker changes (sessionStorage)
- [ ] Crosshair shows OHLC + sentiment values
- [ ] Frontend tests pass (396 tests)
- [ ] Backend tests pass (2350 tests)

## Related

- Feature 1035: OHLC Resolution Selector (already merged)
- Spec: specs/1038-dashboard-ohlc-integration/

🤖 Generated with [Claude Code](https://claude.com/claude-code)