### PR TITLE
feat(sse): Rename timestamp to origin_timestamp for latency measurement (#1042)

### DIFF
--- a/specs/1042-sse-origin-timestamp/checklists/requirements.md
+++ b/specs/1042-sse-origin-timestamp/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: SSE Origin Timestamp for Latency Measurement
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2025-12-23
+**Feature**: [specs/1042-sse-origin-timestamp/spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Specification is ready for `/speckit.plan`
+- All validation items pass
+- Root cause clearly identified (field name mismatch: timestamp vs origin_timestamp)
+- Fix is straightforward: rename or add alias field

--- a/specs/1042-sse-origin-timestamp/data-model.md
+++ b/specs/1042-sse-origin-timestamp/data-model.md
@@ -1,0 +1,69 @@
+# Data Model: SSE Events
+
+**Date**: 2025-12-23
+
+## SSE Event Types
+
+### HeartbeatEventData
+
+Sent every 30 seconds to keep SSE connections alive.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| origin_timestamp | datetime (ISO8601) | Server time when event was generated |
+| connections | int | Number of active SSE connections |
+
+**Before**:
+```python
+class HeartbeatEventData(BaseModel):
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    connections: int = Field(ge=0)
+```
+
+**After**:
+```python
+class HeartbeatEventData(BaseModel):
+    origin_timestamp: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    connections: int = Field(ge=0)
+```
+
+### MetricsEventData
+
+Sent every 60 seconds with aggregated dashboard metrics.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| total | int | Total items analyzed |
+| positive | int | Positive sentiment count |
+| neutral | int | Neutral sentiment count |
+| negative | int | Negative sentiment count |
+| by_tag | dict[str, int] | Counts by tag |
+| rate_last_hour | int | Analysis rate (last hour) |
+| rate_last_24h | int | Analysis rate (last 24h) |
+| origin_timestamp | datetime (ISO8601) | Server time when event was generated |
+
+**Before**:
+```python
+class MetricsEventData(BaseModel):
+    # ... other fields ...
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(UTC))
+```
+
+**After**:
+```python
+class MetricsEventData(BaseModel):
+    # ... other fields ...
+    origin_timestamp: datetime = Field(default_factory=lambda: datetime.now(UTC))
+```
+
+## Client-Side Latency Calculation
+
+The client calculates latency as:
+
+```javascript
+const originTime = new Date(data.origin_timestamp).getTime();
+const receiveTime = Date.now();
+const latencyMs = receiveTime - originTime;
+```
+
+This requires `origin_timestamp` to be present in the JSON payload.

--- a/specs/1042-sse-origin-timestamp/plan.md
+++ b/specs/1042-sse-origin-timestamp/plan.md
@@ -1,0 +1,82 @@
+# Implementation Plan: SSE Origin Timestamp for Latency Measurement
+
+**Branch**: `1042-sse-origin-timestamp` | **Date**: 2025-12-23 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/1042-sse-origin-timestamp/spec.md`
+
+## Summary
+
+Add `origin_timestamp` field to SSE event data models to enable client-side latency measurement. The existing `timestamp` field in HeartbeatEventData and MetricsEventData will be renamed to `origin_timestamp` to match test expectations in `test_live_update_latency.py`.
+
+## Technical Context
+
+**Language/Version**: Python 3.13
+**Primary Dependencies**: FastAPI, sse-starlette, pydantic
+**Storage**: N/A (no database changes)
+**Testing**: pytest (existing E2E tests in tests/e2e/test_live_update_latency.py)
+**Target Platform**: AWS Lambda (containerized)
+**Project Type**: Web application (backend API)
+**Performance Goals**: p95 latency < 3 seconds (existing SLA)
+**Constraints**: Must maintain backward compatibility with existing SSE consumers
+**Scale/Scope**: Minimal change - 2 Pydantic model field renames
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Gate | Status | Notes |
+|------|--------|-------|
+| No quick fixes | PASS | Using full speckit workflow per Amendment 1.6 |
+| No silent failures | PASS | Existing auth handling unchanged |
+| GPG signing | PASS | All commits will be signed |
+| Avoid over-engineering | PASS | Simple field rename, minimal scope |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/1042-sse-origin-timestamp/
+├── spec.md              # Feature specification
+├── plan.md              # This file
+├── research.md          # Phase 0 output (minimal - no unknowns)
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+└── checklists/
+    └── requirements.md  # Specification quality checklist
+```
+
+### Source Code (repository root)
+
+```text
+# Files to modify:
+src/lambdas/dashboard/
+└── sse.py               # SSE event models (HeartbeatEventData, MetricsEventData)
+
+# Tests (already exist, will pass after fix):
+tests/e2e/
+└── test_live_update_latency.py
+```
+
+**Structure Decision**: Backend-only change in existing Lambda code. No new files needed.
+
+## Complexity Tracking
+
+No constitution violations. This is a minimal, focused change.
+
+## Implementation Approach
+
+### Phase 1: Field Rename
+
+1. In `src/lambdas/dashboard/sse.py`:
+   - Rename `timestamp` field to `origin_timestamp` in `HeartbeatEventData` (line 96)
+   - Rename `timestamp` field to `origin_timestamp` in `MetricsEventData` (line 80)
+
+### Phase 2: Validation
+
+1. Run existing E2E tests locally to verify fix
+2. Ensure no other code references the old `timestamp` field name
+
+### Risks
+
+- **Low Risk**: Other code might reference `timestamp` field in SSE event parsing
+- **Mitigation**: Search codebase for SSE event parsing code; if found, update to use `origin_timestamp`

--- a/specs/1042-sse-origin-timestamp/quickstart.md
+++ b/specs/1042-sse-origin-timestamp/quickstart.md
@@ -1,0 +1,37 @@
+# Quickstart: SSE Origin Timestamp
+
+## Overview
+
+This feature renames the `timestamp` field to `origin_timestamp` in SSE event models to enable client-side latency measurement.
+
+## Files Changed
+
+1. `src/lambdas/dashboard/sse.py` - Rename field in 2 Pydantic models
+
+## How to Test
+
+### Run E2E Tests (after implementation)
+
+```bash
+cd /home/traylorre/projects/sentiment-analyzer-gsk
+pytest tests/e2e/test_live_update_latency.py -v
+```
+
+### Expected Results
+
+All 3 tests should pass:
+- `test_live_update_p95_under_3_seconds` - Collects 50+ samples, validates p95 < 3000ms
+- `test_sse_events_include_origin_timestamp` - Verifies `origin_timestamp` field present
+- `test_latency_metrics_exposed_to_window` - Verifies `window.lastLatencyMetrics` populated
+
+## Verification
+
+Before:
+```json
+{"event": "heartbeat", "data": {"timestamp": "2025-12-23T12:00:00Z", "connections": 5}}
+```
+
+After:
+```json
+{"event": "heartbeat", "data": {"origin_timestamp": "2025-12-23T12:00:00Z", "connections": 5}}
+```

--- a/specs/1042-sse-origin-timestamp/research.md
+++ b/specs/1042-sse-origin-timestamp/research.md
@@ -1,0 +1,36 @@
+# Research: SSE Origin Timestamp
+
+**Date**: 2025-12-23
+
+## Summary
+
+No external research required. This is a field naming alignment between backend and frontend.
+
+## Decision: Field Naming Strategy
+
+**Decision**: Rename `timestamp` to `origin_timestamp` in SSE event Pydantic models
+
+**Rationale**:
+- The test code in `test_live_update_latency.py` specifically looks for `origin_timestamp` (line 163)
+- The name `origin_timestamp` clearly indicates this is the server's origin time, not the client's receive time
+- Matches the latency measurement pattern: `latency = receive_time - origin_time`
+
+**Alternatives Considered**:
+1. **Add `origin_timestamp` as alias** - Rejected because it creates redundancy
+2. **Update test to use `timestamp`** - Rejected because `origin_timestamp` is semantically clearer
+3. **Keep both fields** - Rejected because it's over-engineering for this use case
+
+## Backward Compatibility Check
+
+Searched codebase for SSE event timestamp field usage:
+
+```bash
+grep -r "\.timestamp" src/lambdas/dashboard/ --include="*.py"
+```
+
+Results:
+- Only the Pydantic model definitions use the field
+- No parsing code references the `timestamp` field name directly
+- SSE events are JSON-serialized via `model_dump(mode="json")`, so consumers parse JSON
+
+**Conclusion**: Renaming is safe. No backward compatibility concerns.

--- a/specs/1042-sse-origin-timestamp/spec.md
+++ b/specs/1042-sse-origin-timestamp/spec.md
@@ -1,0 +1,84 @@
+# Feature Specification: SSE Origin Timestamp for Latency Measurement
+
+**Feature Branch**: `1042-sse-origin-timestamp`
+**Created**: 2025-12-23
+**Status**: Draft
+**Input**: Add origin_timestamp field to SSE events for end-to-end latency measurement
+
+## Context
+
+Feature 1019 (Validate Live Update Latency) defines E2E tests that measure the latency from SSE event origin to client receipt. These tests expect an `origin_timestamp` field in SSE event data to calculate latency. However, the current SSE implementation uses a `timestamp` field instead, causing test failures because the client-side JavaScript cannot find the expected field name.
+
+**Problem Evidence**:
+- `tests/e2e/test_live_update_latency.py` line 163: `if (data.origin_timestamp)`
+- `src/lambdas/dashboard/sse.py` line 80: `timestamp: datetime = Field(...)`
+- Pipeline failure: 3 tests failing with "No SSE events received with latency metrics"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Dashboard Latency Monitoring (Priority: P1)
+
+As a dashboard user, I expect real-time updates to arrive within a measurable time window so that I can trust the data freshness displayed on my screen.
+
+**Why this priority**: This is the core user value - users need confidence that displayed data is current, not stale. The latency measurement validates this promise.
+
+**Independent Test**: Can be fully tested by connecting to the SSE stream, receiving events, and verifying each event contains the `origin_timestamp` field with a valid ISO8601 timestamp.
+
+**Acceptance Scenarios**:
+
+1. **Given** a browser connected to the SSE stream, **When** a heartbeat event is received, **Then** the event data contains an `origin_timestamp` field in ISO8601 format
+2. **Given** a browser connected to the SSE stream, **When** a metrics event is received, **Then** the event data contains an `origin_timestamp` field in ISO8601 format
+3. **Given** an `origin_timestamp` in the event, **When** the client calculates latency as (receive_time - origin_time), **Then** the result is a positive millisecond value representing actual network latency
+
+---
+
+### User Story 2 - SLA Validation (Priority: P2)
+
+As a platform operator, I need to validate that live updates meet our p95 < 3 second SLA requirement so that I can ensure service quality.
+
+**Why this priority**: SLA validation depends on having measurable latency data. Without origin_timestamp, we cannot validate the SLA.
+
+**Independent Test**: Can be tested by collecting 50+ SSE events with origin_timestamp, calculating p95 latency, and asserting < 3000ms.
+
+**Acceptance Scenarios**:
+
+1. **Given** 50+ SSE events with `origin_timestamp`, **When** p95 latency is calculated, **Then** the value is less than 3000 milliseconds
+2. **Given** SSE events with `origin_timestamp`, **When** client-side metrics are exposed via `window.lastLatencyMetrics`, **Then** the object includes latency_ms, event_type, origin_timestamp, and receive_timestamp fields
+
+---
+
+### Edge Cases
+
+- **Clock skew**: What happens when server and client clocks are not synchronized? The latency may appear negative. System should detect and flag clock skew events.
+- **Missing field**: What if origin_timestamp parsing fails? Client should gracefully skip latency calculation rather than crash.
+- **Timezone handling**: ISO8601 timestamps must include timezone information (UTC preferred) to prevent incorrect latency calculations.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: SSE heartbeat events MUST include an `origin_timestamp` field containing the server's current time when the event was generated
+- **FR-002**: SSE metrics events MUST include an `origin_timestamp` field containing the server's current time when the event was generated
+- **FR-003**: The `origin_timestamp` field MUST be in ISO8601 format with timezone indicator (e.g., `2025-12-23T12:00:00Z` or `2025-12-23T12:00:00+00:00`)
+- **FR-004**: The `origin_timestamp` field name MUST match exactly what the client-side latency tracking code expects (lowercase with underscore)
+- **FR-005**: Existing `timestamp` field MAY be retained for backward compatibility, but `origin_timestamp` takes precedence for latency measurement
+
+### Key Entities
+
+- **SSE Event**: Real-time event sent from server to client containing type (heartbeat/metrics), data payload, and origin_timestamp
+- **Latency Metrics**: Client-side calculated metrics including latency_ms, event_type, origin_timestamp, receive_timestamp, and is_clock_skew flag
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: All 3 tests in `test_live_update_latency.py` pass (test_live_update_p95_under_3_seconds, test_sse_events_include_origin_timestamp, test_latency_metrics_exposed_to_window)
+- **SC-002**: Pipeline passes with no integration test failures related to SSE latency
+- **SC-003**: p95 end-to-end latency remains under 3 seconds (existing SLA maintained)
+- **SC-004**: No breaking changes to existing SSE consumers (timestamp field preserved if used elsewhere)
+
+## Assumptions
+
+- The client-side latency tracking JavaScript is correct and only needs the field name to match
+- Server and client clocks are reasonably synchronized (within seconds, not minutes)
+- Renaming `timestamp` to `origin_timestamp` or adding `origin_timestamp` as an alias will not break existing functionality

--- a/specs/1042-sse-origin-timestamp/tasks.md
+++ b/specs/1042-sse-origin-timestamp/tasks.md
@@ -1,0 +1,91 @@
+# Tasks: SSE Origin Timestamp
+
+**Feature**: 1042-sse-origin-timestamp
+**Date**: 2025-12-23
+
+## Task List
+
+### T001: Rename timestamp to origin_timestamp in HeartbeatEventData
+
+**File**: `src/lambdas/dashboard/sse.py`
+**Line**: ~96
+**Change**: Rename `timestamp` field to `origin_timestamp`
+
+**Before**:
+```python
+class HeartbeatEventData(BaseModel):
+    """Payload for heartbeat events (FR-004)."""
+
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    connections: int = Field(ge=0)
+```
+
+**After**:
+```python
+class HeartbeatEventData(BaseModel):
+    """Payload for heartbeat events (FR-004)."""
+
+    origin_timestamp: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    connections: int = Field(ge=0)
+```
+
+**Acceptance**: Field renamed, model still validates
+
+---
+
+### T002: Rename timestamp to origin_timestamp in MetricsEventData
+
+**File**: `src/lambdas/dashboard/sse.py`
+**Line**: ~80
+**Change**: Rename `timestamp` field to `origin_timestamp`
+
+**Before**:
+```python
+class MetricsEventData(BaseModel):
+    """Payload for metrics events (FR-009)."""
+    # ... other fields ...
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(UTC))
+```
+
+**After**:
+```python
+class MetricsEventData(BaseModel):
+    """Payload for metrics events (FR-009)."""
+    # ... other fields ...
+    origin_timestamp: datetime = Field(default_factory=lambda: datetime.now(UTC))
+```
+
+**Acceptance**: Field renamed, model still validates
+
+---
+
+### T003: Verify no other references to old field name
+
+**Command**:
+```bash
+grep -r "\.timestamp" src/ tests/ --include="*.py" | grep -v origin_timestamp
+```
+
+**Acceptance**: No references to `.timestamp` on SSE event objects remain
+
+---
+
+### T004: Run unit tests
+
+**Command**:
+```bash
+pytest tests/unit/ -v
+```
+
+**Acceptance**: All unit tests pass
+
+---
+
+## Summary
+
+| Task | Description | Status |
+|------|-------------|--------|
+| T001 | Rename HeartbeatEventData.timestamp | pending |
+| T002 | Rename MetricsEventData.timestamp | pending |
+| T003 | Verify no stale references | pending |
+| T004 | Run unit tests | pending |

--- a/src/lambdas/dashboard/sse.py
+++ b/src/lambdas/dashboard/sse.py
@@ -77,7 +77,7 @@ class MetricsEventData(BaseModel):
     by_tag: dict[str, int] = Field(default_factory=dict)
     rate_last_hour: int = 0
     rate_last_24h: int = 0
-    timestamp: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    origin_timestamp: datetime = Field(default_factory=lambda: datetime.now(UTC))
 
 
 class NewItemEventData(BaseModel):
@@ -93,7 +93,7 @@ class NewItemEventData(BaseModel):
 class HeartbeatEventData(BaseModel):
     """Payload for heartbeat events (FR-004)."""
 
-    timestamp: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    origin_timestamp: datetime = Field(default_factory=lambda: datetime.now(UTC))
     connections: int = Field(ge=0)
 
 

--- a/tests/unit/dashboard/test_sse.py
+++ b/tests/unit/dashboard/test_sse.py
@@ -135,7 +135,7 @@ class TestPydanticModels:
         assert data.by_tag == {}
         assert data.rate_last_hour == 0
         assert data.rate_last_24h == 0
-        assert isinstance(data.timestamp, datetime)
+        assert isinstance(data.origin_timestamp, datetime)
 
     def test_metrics_event_data_custom_values(self):
         """MetricsEventData accepts custom values."""
@@ -152,10 +152,10 @@ class TestPydanticModels:
         assert data.by_tag["AAPL"] == 40
 
     def test_heartbeat_event_data(self):
-        """HeartbeatEventData has timestamp and connections."""
+        """HeartbeatEventData has origin_timestamp and connections."""
         data = HeartbeatEventData(connections=5)
         assert data.connections == 5
-        assert isinstance(data.timestamp, datetime)
+        assert isinstance(data.origin_timestamp, datetime)
 
     def test_new_item_event_data(self):
         """NewItemEventData validates sentiment and score."""
@@ -230,7 +230,7 @@ class TestEventGeneration:
 
             # Parse data as JSON
             data = json.loads(event["data"])
-            assert "timestamp" in data
+            assert "origin_timestamp" in data
 
             # Cancel generator
             await gen.aclose()


### PR DESCRIPTION
## Summary

Rename the `timestamp` field to `origin_timestamp` in SSE event models to enable client-side latency measurement as expected by Feature 1019 E2E tests.

### Root Cause
Field naming mismatch between backend (`timestamp`) and test expectations (`origin_timestamp`) in test_live_update_latency.py.

### Changes
- Rename timestamp -> origin_timestamp in HeartbeatEventData (sse.py:96)
- Rename timestamp -> origin_timestamp in MetricsEventData (sse.py:80)
- Update unit tests to use new field name (test_sse.py)
- Add full speckit specification for traceability

### Fixes 3 E2E test failures:
- test_live_update_p95_under_3_seconds
- test_sse_events_include_origin_timestamp
- test_latency_metrics_exposed_to_window

## Test plan
- [x] Unit tests updated and passing
- [ ] E2E tests should now receive origin_timestamp in SSE events

🤖 Generated with [Claude Code](https://claude.com/claude-code)