### PR TITLE
fix(sse): Update polling.py to use SENTIMENTS_TABLE env var

### DIFF
--- a/specs/1045-sse-env-var-fix/spec.md
+++ b/specs/1045-sse-env-var-fix/spec.md
@@ -1,0 +1,102 @@
+# Feature Specification: Fix SSE Lambda Environment Variable Mismatch
+
+**Feature Branch**: `1045-sse-env-var-fix`
+**Created**: 2025-12-24
+**Status**: Draft
+**Input**: Pipeline failure - SSE Lambda fails with `ValueError: DYNAMODB_TABLE environment variable is required`
+
+## Problem Statement
+
+The SSE Lambda (`preprod-sentiment-sse-streaming`) is failing all streaming endpoint calls with:
+
+```
+ValueError: DYNAMODB_TABLE environment variable is required (no fallback - Amendment 1.15)
+```
+
+**Root Cause**: PR #495 renamed environment variables from `DATABASE_TABLE`/`DYNAMODB_TABLE` to `USERS_TABLE`/`SENTIMENTS_TABLE` across the dashboard Lambda and Terraform, but the SSE Lambda's `polling.py` was not updated.
+
+**Current State**:
+- Terraform sets: `SENTIMENTS_TABLE = "preprod-sentiment-items"`
+- SSE Lambda reads: `os.environ.get("DYNAMODB_TABLE")` → returns `None` → raises `ValueError`
+
+**Impact**:
+- All SSE streaming endpoints return 500 errors
+- 9 E2E tests failing in CI pipeline
+- Main branch deployment blocked
+
+## User Scenarios & Testing
+
+### User Story 1 - SSE Streaming Works (Priority: P0)
+
+As a dashboard user, I want SSE streaming to connect successfully so that I receive real-time sentiment updates.
+
+**Acceptance Scenarios**:
+
+1. **Given** the SSE Lambda is deployed, **When** I connect to `/api/v2/stream`, **Then** I receive heartbeat events within 30 seconds
+2. **Given** the SSE Lambda is deployed, **When** I request stream status at `/api/v2/stream/status`, **Then** I receive a valid connection status response
+
+### Edge Cases
+
+- What happens if `SENTIMENTS_TABLE` is not set? The existing ValueError is raised (per Amendment 1.15 - no silent fallbacks)
+
+## Requirements
+
+### Functional Requirements
+
+| ID | Requirement | Priority |
+|----|-------------|----------|
+| FR-001 | SSE Lambda must read sentiment items table from `SENTIMENTS_TABLE` env var | P0 |
+| FR-002 | Error message must reflect new env var name if missing | P0 |
+
+### Non-Functional Requirements
+
+| ID | Requirement | Priority |
+|----|-------------|----------|
+| NFR-001 | Change must not affect behavior when env var is correctly set | P0 |
+
+## Technical Approach
+
+### Files to Modify
+
+1. `src/lambdas/sse_streaming/polling.py:42` - Change `DYNAMODB_TABLE` to `SENTIMENTS_TABLE`
+2. `src/lambdas/sse_streaming/polling.py:44-47` - Update error message to reference `SENTIMENTS_TABLE`
+
+### Changes Required
+
+```python
+# Before (line 42)
+self._table_name = table_name or os.environ.get("DYNAMODB_TABLE")
+
+# After
+self._table_name = table_name or os.environ.get("SENTIMENTS_TABLE")
+```
+
+```python
+# Before (lines 44-47)
+raise ValueError(
+    "DYNAMODB_TABLE environment variable is required "
+    "(no fallback - Amendment 1.15)"
+)
+
+# After
+raise ValueError(
+    "SENTIMENTS_TABLE environment variable is required "
+    "(no fallback - Amendment 1.15)"
+)
+```
+
+## Verification
+
+1. Run SSE Lambda unit tests
+2. Verify Terraform config still provides `SENTIMENTS_TABLE`
+3. E2E tests should pass after deployment
+
+## Dependencies
+
+- PR #495 (env var rename) - Already merged
+- No other dependencies
+
+## Risks
+
+- **Low Risk**: This is a 2-line change with clear semantics
+- **Mitigation**: Unit tests will verify behavior

--- a/specs/1045-sse-env-var-fix/tasks.md
+++ b/specs/1045-sse-env-var-fix/tasks.md
@@ -1,0 +1,34 @@
+# Tasks: Fix SSE Lambda Environment Variable Mismatch
+
+**Feature ID**: 1045
+**Input**: spec.md
+
+## Phase 1: Code Fix
+
+- [x] T001 Update polling.py line 42: change `DYNAMODB_TABLE` to `SENTIMENTS_TABLE`
+- [x] T002 Update polling.py lines 44-47: change error message to reference `SENTIMENTS_TABLE`
+- [x] T003 Update polling.py line 247: fix comment to reference `SENTIMENTS_TABLE`
+
+## Phase 2: Test Updates
+
+- [x] T004 Update test_polling.py: change env var patches from `DYNAMODB_TABLE` to `SENTIMENTS_TABLE`
+- [x] T005 Update test_polling.py: rename test `test_missing_dynamodb_table_raises_error` to `test_missing_sentiments_table_raises_error`
+- [x] T006 Run SSE Lambda unit tests: 183 passed
+
+## Phase 3: Deployment
+
+- [ ] T007 Commit and push changes
+- [ ] T008 Create PR with auto-merge
+- [ ] T009 Verify E2E tests pass after deployment
+
+## Dependencies
+
+- T001-T003 are the code changes
+- T004-T005 are the test updates
+- T006 verifies the changes
+- T007-T009 are sequential deployment steps
+
+## Estimated Complexity
+
+- **Very Low**: 6 lines of code changed, 4 test lines updated
+- **Files Modified**: 2 (polling.py, test_polling.py)

--- a/src/lambdas/sse_streaming/polling.py
+++ b/src/lambdas/sse_streaming/polling.py
@@ -32,17 +32,17 @@ class PollingService:
 
         Args:
             table_name: DynamoDB table name.
-                       Defaults to DYNAMODB_TABLE env var.
+                       Defaults to SENTIMENTS_TABLE env var.
             poll_interval: Poll interval in seconds.
                           Defaults to SSE_POLL_INTERVAL env var or 5.
 
         Raises:
-            ValueError: If DYNAMODB_TABLE env var is not set and no table_name provided.
+            ValueError: If SENTIMENTS_TABLE env var is not set and no table_name provided.
         """
-        self._table_name = table_name or os.environ.get("DYNAMODB_TABLE")
+        self._table_name = table_name or os.environ.get("SENTIMENTS_TABLE")
         if not self._table_name:
             raise ValueError(
-                "DYNAMODB_TABLE environment variable is required "
+                "SENTIMENTS_TABLE environment variable is required "
                 "(no fallback - Amendment 1.15)"
             )
         self._poll_interval = poll_interval or int(
@@ -244,7 +244,7 @@ _polling_service: PollingService | None = None
 def get_polling_service() -> PollingService:
     """Get or create the global polling service instance.
 
-    Uses lazy initialization to defer creation until DYNAMODB_TABLE
+    Uses lazy initialization to defer creation until SENTIMENTS_TABLE
     environment variable is available (at Lambda runtime, not import time).
     """
     global _polling_service

--- a/tests/unit/sse_streaming/test_polling.py
+++ b/tests/unit/sse_streaming/test_polling.py
@@ -98,7 +98,9 @@ class TestPollingInterval:
         from src.lambdas.sse_streaming.polling import PollingService
 
         with patch.object(PollingService, "_get_table", return_value=MagicMock()):
-            with patch.dict("os.environ", {"DYNAMODB_TABLE": "test-table"}, clear=True):
+            with patch.dict(
+                "os.environ", {"SENTIMENTS_TABLE": "test-table"}, clear=True
+            ):
                 service = PollingService()
 
         assert service.poll_interval == 5
@@ -110,18 +112,18 @@ class TestPollingInterval:
         with patch.object(PollingService, "_get_table", return_value=MagicMock()):
             with patch.dict(
                 "os.environ",
-                {"DYNAMODB_TABLE": "test-table", "SSE_POLL_INTERVAL": "10"},
+                {"SENTIMENTS_TABLE": "test-table", "SSE_POLL_INTERVAL": "10"},
             ):
                 service = PollingService()
 
         assert service.poll_interval == 10
 
-    def test_missing_dynamodb_table_raises_error(self):
-        """Should raise ValueError if DYNAMODB_TABLE not set."""
+    def test_missing_sentiments_table_raises_error(self):
+        """Should raise ValueError if SENTIMENTS_TABLE not set."""
         from src.lambdas.sse_streaming.polling import PollingService
 
         with patch.dict("os.environ", {}, clear=True):
-            with pytest.raises(ValueError, match="DYNAMODB_TABLE.*required"):
+            with pytest.raises(ValueError, match="SENTIMENTS_TABLE.*required"):
                 PollingService()
 
 


### PR DESCRIPTION
## Summary

- Updates SSE Lambda `polling.py` to use `SENTIMENTS_TABLE` environment variable instead of deprecated `DYNAMODB_TABLE`
- Aligns with PR #496 which renamed Terraform env vars from `DATABASE_TABLE`/`DYNAMODB_TABLE` to `USERS_TABLE`/`SENTIMENTS_TABLE`

## Root Cause

PR #496 updated Terraform to set `SENTIMENTS_TABLE` env var, but the SSE Lambda code was still looking for `DYNAMODB_TABLE`, causing `ValueError: DYNAMODB_TABLE environment variable is required` on every Lambda invocation.

## Impact

- All deploys since Dec 22 have been failing at preprod integration tests
- SSE Lambda returns 500 errors due to missing env var
- OHLC demo URL is blocked until this is merged

## Test Plan

- [x] All 2351 unit tests pass
- [ ] Preprod integration tests pass after deploy
- [ ] SSE streaming works with real DynamoDB data

🤖 Generated with [Claude Code](https://claude.com/claude-code)