### PR TITLE
fix(ci): Align warmup to use session auth (Feature 1047)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1241,18 +1241,14 @@ jobs:
         env:
           DASHBOARD_URL: ${{ needs.deploy-preprod.outputs.dashboard_url }}
           SSE_LAMBDA_URL: ${{ needs.deploy-preprod.outputs.sse_lambda_url }}
-          API_KEY: ${{ secrets.DASHBOARD_API_KEY }}
         run: |
           echo "🔥 Warming up Lambdas to generate CloudWatch metrics..."
           echo "This ensures observability tests have real metrics to validate."
           echo ""
 
-          # Validate API_KEY is set (Feature 1042: No silent auth failures)
-          if [ -z "${API_KEY}" ]; then
-            echo "❌ ERROR: DASHBOARD_API_KEY secret is not set or empty"
-            echo "Authenticated warmup calls will fail. Please configure the secret."
-            exit 1
-          fi
+          # Feature 1047: Use X-User-ID for session auth (consistent with all endpoints)
+          # API key auth was removed in Feature 1039 - all endpoints now use session auth
+          WARMUP_USER_ID="ci-warmup-$(date +%s)"
 
           # Invoke dashboard Lambda multiple times to generate metrics
           echo "1. Invoking Dashboard Lambda /health endpoint..."
@@ -1262,23 +1258,22 @@ jobs:
             echo "  ⚠️ Health endpoint returned $HTTP_CODE (continuing, may be cold start)"
           fi
 
-          # Feature 1042: Use Bearer prefix and fail on auth errors (no silent fallback)
-          echo "2. Invoking /api/v2/metrics endpoint (authenticated)..."
+          # Feature 1047: Use X-User-ID header for session auth
+          echo "2. Invoking /api/v2/metrics endpoint (session auth)..."
           HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
-            -H "Authorization: Bearer ${API_KEY}" \
+            -H "X-User-ID: ${WARMUP_USER_ID}" \
             "${DASHBOARD_URL}/api/v2/metrics" || echo "000")
           echo "  HTTP $HTTP_CODE"
           if [ "$HTTP_CODE" != "200" ]; then
             echo "❌ ERROR: /api/v2/metrics returned HTTP $HTTP_CODE (expected 200)"
-            echo "Check DASHBOARD_API_KEY secret matches API_KEY in Lambda environment"
+            echo "Check extract_auth_context() in auth_middleware.py and Lambda logs"
             exit 1
           fi
 
-          # Note: Sentiment endpoints require X-User-ID header, not Authorization.
-          # Warmup for sentiment is non-critical since metrics warmup tests the Lambda.
+          # All endpoints now use X-User-ID header for session auth
           echo "3. Invoking /api/v2/tickers/AAPL/sentiment/history endpoint (warmup only)..."
           HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
-            -H "X-User-ID: warmup-test-user" \
+            -H "X-User-ID: ${WARMUP_USER_ID}" \
             "${DASHBOARD_URL}/api/v2/tickers/AAPL/sentiment/history" || echo "000")
           echo "  HTTP $HTTP_CODE (non-critical warmup, any response is acceptable)"
 
@@ -1450,7 +1445,7 @@ jobs:
           echo "Common causes:"
           echo "  - Timeout: Lambda cold start taking too long, increase warmup time"
           echo "  - Failed: Check test output above for specific failures"
-          echo "  - Auth: Verify DASHBOARD_API_KEY secret is set correctly"
+          echo "  - Auth: Endpoints use session auth (X-User-ID header), not API key (Feature 1039)"
           exit 1
 
       - name: Create Validation Metadata
@@ -1917,13 +1912,12 @@ jobs:
         run: |
           # Use API Gateway URL for health check (more reliable than CloudFront for canary)
           API_URL="${{ needs.deploy-prod.outputs.api_url }}"
-          API_KEY="${{ secrets.DASHBOARD_API_KEY }}"
 
           echo "🔍 Running canary test against: ${API_URL}"
 
+          # Feature 1047: Health endpoint is unauthenticated (no API key needed)
           response=$(curl -f -s -w "\n%{http_code}" \
-            "${API_URL}/health" \
-            -H "X-API-Key: ${API_KEY}" || echo "FAILED")
+            "${API_URL}/health" || echo "FAILED")
 
           http_code=$(echo "$response" | tail -1)
           body=$(echo "$response" | head -n -1)

--- a/specs/1047-fix-warmup-session-auth/spec.md
+++ b/specs/1047-fix-warmup-session-auth/spec.md
@@ -1,0 +1,110 @@
+# Spec: CI Warmup Session Auth Alignment
+
+**Feature ID**: 1047
+**Priority**: P0 (Pipeline Blocker)
+**Status**: Draft
+
+## Problem Statement
+
+PR #499 (Feature 1039) unified all dashboard endpoints to use session-based authentication, removing API key authentication. However, the CI warmup script in `deploy.yml` still uses `Authorization: Bearer ${API_KEY}` which is no longer valid.
+
+**Current Behavior (BROKEN)**:
+- CI warmup calls `/api/v2/metrics` with `Authorization: Bearer ${API_KEY}`
+- Dashboard Lambda rejects this (API_KEY is not a UUID or JWT)
+- Pipeline fails with HTTP 401
+
+**Root Cause**:
+- `extract_auth_context()` in `auth_middleware.py` expects:
+  1. Bearer token to be a valid UUID (anonymous session) OR
+  2. Bearer token to be a valid JWT (authenticated session)
+- API_KEY secret is neither - it's an arbitrary string
+
+## Solution
+
+Align CI warmup to use session auth pattern: `X-User-ID: {uuid}` header.
+
+This matches:
+- Line 1281-1282 in deploy.yml which already correctly uses `X-User-ID` for sentiment endpoint
+- The hybrid auth pattern documented in `auth_middleware.py`
+
+## Changes Required
+
+### File: `.github/workflows/deploy.yml`
+
+**Line 1244**: Remove `API_KEY` env var (no longer needed for warmup)
+
+**Lines 1250-1255**: Remove API_KEY validation block
+
+**Lines 1265-1275**: Change from:
+```bash
+echo "2. Invoking /api/v2/metrics endpoint (authenticated)..."
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+  -H "Authorization: Bearer ${API_KEY}" \
+  "${DASHBOARD_URL}/api/v2/metrics" || echo "000")
+echo "  HTTP $HTTP_CODE"
+if [ "$HTTP_CODE" != "200" ]; then
+  echo "❌ ERROR: /api/v2/metrics returned HTTP $HTTP_CODE (expected 200)"
+  echo "Check DASHBOARD_API_KEY secret matches API_KEY in Lambda environment"
+  exit 1
+fi
+```
+
+To:
+```bash
+echo "2. Invoking /api/v2/metrics endpoint (session auth)..."
+# Feature 1047: Use X-User-ID header for session auth (consistent with sentiment warmup)
+WARMUP_USER_ID="ci-warmup-$(date +%s)"
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+  -H "X-User-ID: ${WARMUP_USER_ID}" \
+  "${DASHBOARD_URL}/api/v2/metrics" || echo "000")
+echo "  HTTP $HTTP_CODE"
+if [ "$HTTP_CODE" != "200" ]; then
+  echo "❌ ERROR: /api/v2/metrics returned HTTP $HTTP_CODE (expected 200)"
+  echo "This is a session auth failure. Check extract_auth_context() in auth_middleware.py"
+  exit 1
+fi
+```
+
+**Also update lines 1389-1395**: Remove `DASHBOARD_API_KEY` and `API_KEY` env vars from preprod-integration-tests job since they're no longer needed.
+
+**Lines 1920-1926 (prod canary)**: Remove unnecessary `X-API-Key` header since `/health` is unauthenticated:
+```bash
+# Before
+API_KEY="${{ secrets.DASHBOARD_API_KEY }}"
+response=$(curl -f -s -w "\n%{http_code}" \
+  "${API_URL}/health" \
+  -H "X-API-Key: ${API_KEY}" || echo "FAILED")
+
+# After
+response=$(curl -f -s -w "\n%{http_code}" \
+  "${API_URL}/health" || echo "FAILED")
+```
+
+**Line 1453**: Update error message to reference session auth instead of API key.
+
+## Acceptance Criteria
+
+1. CI warmup succeeds with HTTP 200 on `/api/v2/metrics`
+2. All endpoints use consistent auth pattern (X-User-ID or Bearer UUID/JWT)
+3. No `API_KEY` references in warmup logic
+4. Pipeline passes on main
+
+## Out of Scope
+
+- Removing `DASHBOARD_API_KEY` secret from GitHub (may be used elsewhere)
+- Changes to Lambda code (already correct)
+- Frontend changes (already correct)
+
+## Testing
+
+- Deploy to preprod should succeed
+- Warmup step should log HTTP 200 for metrics endpoint
+- Preprod integration tests should pass
+
+## Dependencies
+
+- Feature 1039 (Unified Session Auth) - MERGED
+
+## Risks
+
+- **Low**: Simple header change, auth middleware already supports X-User-ID


### PR DESCRIPTION
## Summary

- Removes `Authorization: Bearer ${API_KEY}` from CI warmup (no longer valid after Feature 1039)
- Uses `X-User-ID: ci-warmup-{timestamp}` header for session auth consistency
- Fixes pipeline failure on main caused by 401 errors on `/api/v2/metrics`
- Removes unnecessary API key from prod canary (health endpoint is unauthenticated)

## Root Cause

PR #499 (Feature 1039) unified all dashboard endpoints to session auth, but the CI warmup script still used API key auth which is now rejected.

## Changes

- `.github/workflows/deploy.yml`: Use X-User-ID header instead of Bearer token for all warmup calls

## Test Plan

- [ ] Pipeline passes on preprod
- [ ] Warmup step logs HTTP 200 for `/api/v2/metrics`
- [ ] Preprod integration tests pass

Fixes the pipeline failure from PR #499.

🤖 Generated with [Claude Code](https://claude.com/claude-code)