### PR TITLE
fix(deploy): Use valid UUID for warmup user ID (Feature 1049 followup)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1248,7 +1248,8 @@ jobs:
 
           # Feature 1047: Use X-User-ID for session auth (consistent with all endpoints)
           # API key auth was removed in Feature 1039 - all endpoints now use session auth
-          WARMUP_USER_ID="ci-warmup-$(date +%s)"
+          # Feature 1049: X-User-ID must be a valid UUID format
+          WARMUP_USER_ID="00000000-0000-0000-0000-000000000001"
 
           # Invoke dashboard Lambda multiple times to generate metrics
           echo "1. Invoking Dashboard Lambda /health endpoint..."


### PR DESCRIPTION
## Summary
- Fix warmup script to use valid UUID format for X-User-ID header
- Previous value `ci-warmup-$(date +%s)` fails UUID validation in `auth_middleware.py`

## Root Cause
Feature 1049 standardized auth to require valid UUID format for X-User-ID. The warmup script was using a timestamp-based string which is not a valid UUID, causing `/api/v2/metrics` to return 401 during Lambda warmup.

## Test plan
- [ ] Pipeline warmup step should succeed with HTTP 200 on /api/v2/metrics
- [ ] All integration tests should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)