### PR TITLE
fix(dashboard): Add session auth to timeseries.js for OHLC endpoints (Feature 1051)

### DIFF
--- a/specs/1051-fix-timeseries-session-auth/spec.md
+++ b/specs/1051-fix-timeseries-session-auth/spec.md
@@ -1,0 +1,75 @@
+# Feature Specification: Fix Timeseries Module Auth
+
+**Feature Branch**: `1051-fix-timeseries-session-auth`
+**Created**: 2024-12-24
+**Status**: Draft
+**Input**: "Fix 401 on /api/v2/timeseries by adding X-User-ID header to timeseries.js"
+
+## Problem Statement
+
+Feature 1050 fixed auth for `fetchMetrics()` in `app.js`, but the `timeseries.js` module also makes API calls without auth headers. The resolution selector and OHLC chart functionality exists but is broken due to 401 errors.
+
+**Related**: Feature 1050 (PR #505)
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 - OHLC Chart Loads Successfully (Priority: P1)
+
+User can view the OHLC timeseries chart with sentiment data for any ticker.
+
+**Why this priority**: Core functionality - without this fix, the resolution selector and chart are unusable.
+
+**Independent Test**: Load dashboard, enter a ticker (e.g., AAPL), verify chart displays without 401 errors.
+
+**Acceptance Scenarios**:
+
+1. **Given** session is initialized, **When** timeseries data is requested, **Then** data loads without 401 error
+2. **Given** user switches resolution, **When** new data is fetched, **Then** fetch includes X-User-ID header
+
+---
+
+### User Story 2 - Resolution Switching Works (Priority: P1)
+
+User can switch between time resolutions (1m, 5m, 10m, 1h, etc.) and see updated chart.
+
+**Acceptance Scenarios**:
+
+1. **Given** chart is displaying data, **When** user clicks different resolution, **Then** chart updates with correct data
+
+---
+
+### Edge Cases
+
+- timeseries.js must wait for session from app.js (race condition)
+- Multi-ticker batch endpoint also needs auth
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+- **FR-001**: timeseries.js MUST use session UUID from app.js for all API calls
+- **FR-002**: All fetch requests in timeseries.js MUST include `X-User-ID: {uuid}` header
+- **FR-003**: timeseries.js MUST wait for session initialization before making API calls
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**: No 401 errors on `/api/v2/timeseries/*` endpoints
+- **SC-002**: Resolution selector UI works (clicking buttons updates chart)
+- **SC-003**: Multi-ticker comparison view loads all tickers
+
+## Technical Context
+
+### Files to Modify
+
+1. `src/dashboard/timeseries.js` - Add sessionUserId to all fetch calls
+
+### Pattern from Feature 1050
+
+Use the `sessionUserId` variable from `app.js` (now global after Feature 1050):
+```javascript
+headers: {
+    'X-User-ID': sessionUserId
+}
+```

--- a/src/dashboard/timeseries.js
+++ b/src/dashboard/timeseries.js
@@ -351,13 +351,19 @@ class TimeseriesManager {
      * Load timeseries data from API
      *
      * Feature 1021 (T015): Hide skeleton when data arrives
+     * Feature 1051: Added X-User-ID header for session auth
      */
     async loadData() {
         try {
             const url = `${this.apiBaseUrl}/api/v2/timeseries/${this.currentTicker}?resolution=${this.currentResolution}`;
             console.log(`Fetching: ${url}`);
 
-            const response = await fetch(url);
+            // Feature 1051: Include X-User-ID header for authentication
+            const response = await fetch(url, {
+                headers: {
+                    'X-User-ID': sessionUserId
+                }
+            });
             if (!response.ok) {
                 throw new Error(`HTTP ${response.status}: ${response.statusText}`);
             }
@@ -880,6 +886,7 @@ class MultiTickerManager {
 
     /**
      * Load all ticker data using batch API (SC-006: <1s for 10 tickers)
+     * Feature 1051: Added X-User-ID header for session auth
      */
     async loadAllData() {
         const startTime = performance.now();
@@ -890,7 +897,12 @@ class MultiTickerManager {
             const url = `${this.apiBaseUrl}/api/v2/timeseries/batch?tickers=${tickersParam}&resolution=${this.currentResolution}`;
             console.log(`Batch fetching: ${url}`);
 
-            const response = await fetch(url);
+            // Feature 1051: Include X-User-ID header for authentication
+            const response = await fetch(url, {
+                headers: {
+                    'X-User-ID': sessionUserId
+                }
+            });
             if (!response.ok) {
                 throw new Error(`HTTP ${response.status}: ${response.statusText}`);
             }
@@ -930,6 +942,7 @@ class MultiTickerManager {
 
     /**
      * Fallback: load data individually if batch fails
+     * Feature 1051: Added X-User-ID header for session auth
      */
     async loadAllDataFallback() {
         console.log('Using fallback individual requests');
@@ -937,7 +950,12 @@ class MultiTickerManager {
         const promises = this.tickers.map(async (ticker) => {
             try {
                 const url = `${this.apiBaseUrl}/api/v2/timeseries/${ticker}?resolution=${this.currentResolution}`;
-                const response = await fetch(url);
+                // Feature 1051: Include X-User-ID header for authentication
+                const response = await fetch(url, {
+                    headers: {
+                        'X-User-ID': sessionUserId
+                    }
+                });
                 if (!response.ok) throw new Error(`HTTP ${response.status}`);
                 const data = await response.json();
                 this.bucketData[ticker] = data.buckets || [];


### PR DESCRIPTION
## Summary

Continuation of Feature 1050. The timeseries.js module also makes API calls without `X-User-ID` headers, causing 401 errors on OHLC/timeseries endpoints.

## Changes

- `timeseries.js loadData()`: Add X-User-ID header for single ticker fetch
- `timeseries.js loadAllData()`: Add X-User-ID header for batch endpoint
- `timeseries.js loadAllDataFallback()`: Add X-User-ID header for fallback fetches

## Impact

This enables the **existing OHLC resolution selector UI** to work:
- Resolution buttons: 1m, 5m, 10m, 1h, 3h, 6h, 12h, 24h
- Ticker search and selection
- Multi-ticker comparison view

## Related

- Feature 1050 (PR #505) - Fixed auth for fetchMetrics()
- Feature 1039 - Unified session auth

## Test plan

- [ ] Load dashboard at CloudFront URL
- [ ] Enter ticker (e.g., AAPL) - verify chart loads
- [ ] Click resolution buttons - verify chart updates
- [ ] No 401 errors in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)