### PR TITLE
chore(ci): Fix deploy workflow visual grouping (Feature 1052)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1945,7 +1945,7 @@ jobs:
   # ========================================================================
   summary:
     name: Deployment Summary
-    needs: [build, test, build-sse-image-preprod, build-analysis-image-preprod, deploy-preprod, test-preprod]
+    needs: [build, test, build-sse-image-preprod, build-analysis-image-preprod, build-dashboard-image-preprod, deploy-preprod, test-preprod]
     if: always()
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## Summary

- Added `build-dashboard-image-preprod` to summary job's `needs` array
- Fixes visual inconsistency where Dashboard Lambda was rendered in a separate box from SSE/Analysis Lambdas

## Impact

**Cosmetic only** - no functional change. The summary job already waited for Dashboard Lambda transitively through `deploy-preprod`.

## Before/After

Before: Dashboard Lambda in separate visual box
After: All three Lambda builds grouped together

🤖 Generated with [Claude Code](https://claude.com/claude-code)