### PR TITLE
feat(infra): Add Tiingo/Finnhub secrets to Dashboard Lambda (Feature 1056)

### DIFF
--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -422,6 +422,9 @@ module "dashboard_lambda" {
     TIMESERIES_TABLE = module.dynamodb.timeseries_table_name
     # Feature 1054: JWT secret for auth middleware token validation
     JWT_SECRET = var.jwt_secret
+    # Feature 1056: OHLC data source secrets for Tiingo/Finnhub adapters
+    TIINGO_SECRET_ARN  = module.secrets.tiingo_secret_arn
+    FINNHUB_SECRET_ARN = module.secrets.finnhub_secret_arn
   }
 
   # Function URL with CORS

--- a/infrastructure/terraform/modules/iam/main.tf
+++ b/infrastructure/terraform/modules/iam/main.tf
@@ -378,7 +378,7 @@ resource "aws_iam_role_policy" "dashboard_dynamodb" {
   })
 }
 
-# Dashboard Lambda: Secrets Manager (API key)
+# Dashboard Lambda: Secrets Manager (API key + OHLC data sources)
 resource "aws_iam_role_policy" "dashboard_secrets" {
   name = "${var.environment}-dashboard-secrets-policy"
   role = aws_iam_role.dashboard_lambda.id
@@ -391,7 +391,12 @@ resource "aws_iam_role_policy" "dashboard_secrets" {
         Action = [
           "secretsmanager:GetSecretValue"
         ]
-        Resource = var.dashboard_api_key_secret_arn
+        # Feature 1056: Add Tiingo and Finnhub secrets for OHLC endpoint
+        Resource = [
+          var.dashboard_api_key_secret_arn,
+          var.tiingo_secret_arn,
+          var.finnhub_secret_arn
+        ]
       }
     ]
   })

--- a/specs/1056-dashboard-ohlc-secrets/spec.md
+++ b/specs/1056-dashboard-ohlc-secrets/spec.md
@@ -1,0 +1,104 @@
+# Feature Specification: Dashboard Lambda OHLC Secrets Configuration
+
+**Feature Branch**: `1056-dashboard-ohlc-secrets`
+**Created**: 2025-12-25
+**Status**: Draft
+**Input**: Add TIINGO_SECRET_ARN and FINNHUB_SECRET_ARN environment variables to Dashboard Lambda for OHLC endpoint
+
+## Problem Statement
+
+The Dashboard Lambda OHLC endpoint (`GET /api/v2/tickers/{ticker}/ohlc`) returns HTTP 503 "Tiingo data source unavailable" because the Lambda is missing the `TIINGO_SECRET_ARN` and `FINNHUB_SECRET_ARN` environment variables required to fetch API keys from AWS Secrets Manager.
+
+**Root Cause**: The Ingestion Lambda has these environment variables configured, but the Dashboard Lambda (which also serves OHLC data) does not.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - View OHLC Price Data (Priority: P1)
+
+As a dashboard user, I want to view OHLC (Open/High/Low/Close) candlestick data for stock tickers so I can analyze price movements alongside sentiment data.
+
+**Why this priority**: This is the core functionality - without it, the OHLC chart displays errors instead of data.
+
+**Independent Test**: Can be tested by calling `GET /api/v2/tickers/AAPL/ohlc` and verifying price data is returned instead of 503.
+
+**Acceptance Scenarios**:
+
+1. **Given** the Dashboard Lambda has TIINGO_SECRET_ARN configured, **When** I request OHLC data for a valid ticker, **Then** I receive candlestick price data with open/high/low/close values
+2. **Given** Tiingo API is unavailable, **When** I request OHLC data, **Then** the system falls back to Finnhub for data
+3. **Given** both APIs are unavailable, **When** I request OHLC data, **Then** I receive a graceful error message (not a 503 configuration error)
+
+---
+
+### User Story 2 - Resolution Selection Works (Priority: P1)
+
+As a dashboard user, I want to select different time resolutions (1min, 5min, 15min, 30min, 60min, Daily) and see the chart update with the appropriate candlestick data.
+
+**Why this priority**: Resolution selection is the key feature of the OHLC implementation (Feature 1035).
+
+**Independent Test**: Can be tested by calling `GET /api/v2/tickers/AAPL/ohlc?resolution=5` and verifying 5-minute candles are returned.
+
+**Acceptance Scenarios**:
+
+1. **Given** I select 5-minute resolution, **When** the chart loads, **Then** I see 5-minute candlestick data from Finnhub (intraday source)
+2. **Given** I select Daily resolution, **When** the chart loads, **Then** I see daily candlestick data from Tiingo (daily source)
+
+---
+
+### Edge Cases
+
+- What happens when the secret ARN exists but the secret value is empty? The endpoint returns 503 with clear error message
+- What happens when the IAM role lacks permission to read the secret? Error is logged, endpoint returns 503
+- What happens when the secret JSON is malformed (missing "api_key" field)? Error is logged, endpoint returns 503
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Dashboard Lambda MUST have `TIINGO_SECRET_ARN` environment variable configured pointing to the Tiingo API key secret
+- **FR-002**: Dashboard Lambda MUST have `FINNHUB_SECRET_ARN` environment variable configured pointing to the Finnhub API key secret
+- **FR-003**: Dashboard Lambda IAM role MUST have `secretsmanager:GetSecretValue` permission for both secrets
+- **FR-004**: OHLC endpoint MUST return price data when secrets are properly configured
+- **FR-005**: OHLC endpoint MUST fall back to Finnhub when Tiingo is unavailable
+
+### Key Entities
+
+- **TIINGO_SECRET_ARN**: Environment variable containing the ARN of the Tiingo API key secret in Secrets Manager
+- **FINNHUB_SECRET_ARN**: Environment variable containing the ARN of the Finnhub API key secret in Secrets Manager
+- **Dashboard Lambda**: The Lambda function serving `/api/v2/*` endpoints including OHLC
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: OHLC endpoint returns HTTP 200 with price data (not 503) when called with valid ticker
+- **SC-002**: Dashboard Lambda environment includes both `TIINGO_SECRET_ARN` and `FINNHUB_SECRET_ARN` variables
+- **SC-003**: Dashboard Lambda IAM role policy includes secretsmanager:GetSecretValue for tiingo and finnhub secrets
+- **SC-004**: Resolution selector UI displays candlestick data for all resolutions (1, 5, 15, 30, 60, D)
+
+## Technical Scope
+
+### Files to Modify
+
+1. `infrastructure/terraform/main.tf` - Add environment variables to `module.dashboard_lambda`
+2. `infrastructure/terraform/modules/iam/main.tf` - Ensure Dashboard Lambda role has secrets access (may already exist)
+
+### Pattern Reference
+
+Copy pattern from Ingestion Lambda configuration:
+```hcl
+# From ingestion_lambda (line ~289)
+TIINGO_SECRET_ARN  = module.secrets.tiingo_secret_arn
+FINNHUB_SECRET_ARN = module.secrets.finnhub_secret_arn
+```
+
+## Assumptions
+
+- The secrets (`preprod/sentiment-analyzer/tiingo` and `preprod/sentiment-analyzer/finnhub`) already exist in AWS Secrets Manager
+- The secrets module already outputs `tiingo_secret_arn` and `finnhub_secret_arn`
+- The IAM module may already grant the necessary permissions (needs verification)
+
+## Out of Scope
+
+- Creating the actual secrets in Secrets Manager (admin responsibility)
+- Storing actual API key values (admin responsibility)
+- Modifying the OHLC endpoint code (already works, just needs config)

--- a/specs/1056-dashboard-ohlc-secrets/tasks.md
+++ b/specs/1056-dashboard-ohlc-secrets/tasks.md
@@ -1,0 +1,54 @@
+# Tasks: Dashboard Lambda OHLC Secrets Configuration
+
+**Feature**: 1056-dashboard-ohlc-secrets
+**Spec**: [spec.md](./spec.md)
+
+## Phase 1: Setup
+
+- [ ] T001 Verify secrets module outputs exist in infrastructure/terraform/modules/secrets/outputs.tf
+
+## Phase 2: Infrastructure Changes
+
+- [ ] T002 [P] [US1] Add TIINGO_SECRET_ARN to dashboard_lambda environment_variables in infrastructure/terraform/main.tf
+- [ ] T003 [P] [US1] Add FINNHUB_SECRET_ARN to dashboard_lambda environment_variables in infrastructure/terraform/main.tf
+- [ ] T004 [US1] Verify Dashboard Lambda IAM role has secretsmanager:GetSecretValue in infrastructure/terraform/modules/iam/main.tf
+
+## Phase 3: Validation
+
+- [ ] T005 Run terraform fmt to format changes in infrastructure/terraform/
+- [ ] T006 Run terraform validate to check syntax in infrastructure/terraform/
+
+## Dependencies
+
+```
+T001 → T002, T003 (must verify outputs exist before using them)
+T002, T003 → T004 (env vars first, then IAM)
+T004 → T005, T006 (validate after all changes)
+```
+
+## Parallel Execution
+
+Tasks T002 and T003 can run in parallel [P] as they modify different lines in the same block.
+
+## Implementation Notes
+
+### Pattern to Follow
+
+From the Ingestion Lambda configuration (infrastructure/terraform/main.tf ~line 289):
+```hcl
+TIINGO_SECRET_ARN  = module.secrets.tiingo_secret_arn
+FINNHUB_SECRET_ARN = module.secrets.finnhub_secret_arn
+```
+
+### Target Location
+
+In `module.dashboard_lambda` block, add to `environment_variables`:
+```hcl
+environment_variables = {
+    # ... existing vars ...
+
+    # Feature 1056: OHLC data source secrets for Tiingo/Finnhub adapters
+    TIINGO_SECRET_ARN  = module.secrets.tiingo_secret_arn
+    FINNHUB_SECRET_ARN = module.secrets.finnhub_secret_arn
+}
+```


### PR DESCRIPTION
## Summary

- Add TIINGO_SECRET_ARN and FINNHUB_SECRET_ARN environment variables to Dashboard Lambda module
- Update Dashboard IAM policy to allow reading Tiingo and Finnhub secrets from Secrets Manager
- Enables the OHLC endpoint (GET /api/v2/tickers/{ticker}/ohlc) to fetch price data

## Test Plan

- [ ] Terraform plan shows environment variables added to Dashboard Lambda
- [ ] Terraform apply succeeds in preprod
- [ ] OHLC endpoint returns data instead of "unavailable" error

## Notes

Requires admin action after deploy: Store actual API keys in Secrets Manager:
- preprod/sentiment-analyzer/tiingo: {"api_key": "YOUR_KEY"}
- preprod/sentiment-analyzer/finnhub: {"api_key": "YOUR_KEY"}

🤖 Generated with [Claude Code](https://claude.com/claude-code)