### PR TITLE
feat(iam): Add KMS decrypt permission to dashboard Lambda secrets policy

### DIFF
--- a/infrastructure/terraform/modules/iam/main.tf
+++ b/infrastructure/terraform/modules/iam/main.tf
@@ -385,7 +385,7 @@ resource "aws_iam_role_policy" "dashboard_secrets" {
 
   policy = jsonencode({
     Version = "2012-10-17"
-    Statement = [
+    Statement = concat([
       {
         Effect = "Allow"
         Action = [
@@ -398,7 +398,17 @@ resource "aws_iam_role_policy" "dashboard_secrets" {
           var.finnhub_secret_arn
         ]
       }
-    ]
+      ],
+      # Feature 1058: KMS decrypt required when secrets use customer-managed KMS keys
+      var.secrets_kms_key_arn != "" ? [
+        {
+          Effect = "Allow"
+          Action = [
+            "kms:Decrypt"
+          ]
+          Resource = var.secrets_kms_key_arn
+        }
+    ] : [])
   })
 }
 

--- a/specs/1058-dashboard-kms-decrypt/checklists/requirements.md
+++ b/specs/1058-dashboard-kms-decrypt/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Dashboard Lambda KMS Decrypt Permission
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2025-12-25
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation. Spec is ready for `/speckit.plan`.
+- Assumptions section documents the pattern to follow (ingestion Lambda KMS decrypt).
+- Single user story is appropriate for this focused infrastructure fix.

--- a/specs/1058-dashboard-kms-decrypt/plan.md
+++ b/specs/1058-dashboard-kms-decrypt/plan.md
@@ -1,0 +1,72 @@
+# Implementation Plan: Dashboard Lambda KMS Decrypt Permission
+
+**Branch**: `1058-dashboard-kms-decrypt` | **Date**: 2025-12-25 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/1058-dashboard-kms-decrypt/spec.md`
+
+## Summary
+
+The dashboard Lambda is missing KMS decrypt permission required to read secrets encrypted with customer-managed KMS keys. The ingestion Lambda has this permission (via conditional block in IAM policy), but the dashboard Lambda's secrets policy only has `secretsmanager:GetSecretValue` without the corresponding `kms:Decrypt`. This blocks the OHLC endpoint from fetching Tiingo/Finnhub API keys, causing the dashboard to display only the sentiment donut chart with no ticker data.
+
+## Technical Context
+
+**Language/Version**: HCL (Terraform) 1.5+
+**Primary Dependencies**: AWS Provider ~> 5.0
+**Storage**: N/A (IAM policy modification)
+**Testing**: terraform validate, terraform plan, IAM validator
+**Target Platform**: AWS Lambda IAM Role
+**Project Type**: Infrastructure as Code (Terraform modules)
+**Performance Goals**: N/A (IAM policy change)
+**Constraints**: Must follow least-privilege (single KMS key resource, not wildcard)
+**Scale/Scope**: Single IAM policy modification in modules/iam/main.tf
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Gate | Status | Evidence |
+|------|--------|----------|
+| Security & Access Control - Least Privilege | PASS | kms:Decrypt scoped to specific KMS key ARN, not wildcard |
+| Security & Access Control - Secrets in managed service | PASS | Using AWS Secrets Manager + KMS |
+| Infrastructure as Code | PASS | Terraform module modification |
+| Testing & Validation | PASS | terraform validate + plan + unit test |
+| No Pipeline Bypass | PASS | Standard PR workflow with CI checks |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/1058-dashboard-kms-decrypt/
+├── spec.md              # Feature specification
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── checklists/
+│   └── requirements.md  # Spec validation checklist
+└── tasks.md             # Phase 2 output (/speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+infrastructure/terraform/modules/iam/
+├── main.tf              # Dashboard secrets policy modification (target)
+└── variables.tf         # Already has secrets_kms_key_arn variable
+```
+
+**Structure Decision**: This is an infrastructure-only change to the IAM module. No application code changes required.
+
+## Complexity Tracking
+
+> No constitution violations. Single, focused IAM policy modification.
+
+## Phase 0: Research
+
+No NEEDS CLARIFICATION markers. The pattern to follow is already established in the ingestion Lambda policy (lines 79-87 in modules/iam/main.tf).
+
+### Research Findings
+
+**Decision**: Add conditional KMS decrypt block to dashboard_secrets policy
+**Rationale**: Exact pattern already exists for ingestion Lambda; proven to work
+**Alternatives Considered**:
+- Shared secrets policy resource: Rejected (violates least-privilege per-role isolation)
+- KMS key policy modification: Rejected (less precise, affects all principals)

--- a/specs/1058-dashboard-kms-decrypt/research.md
+++ b/specs/1058-dashboard-kms-decrypt/research.md
@@ -1,0 +1,60 @@
+# Research: Dashboard Lambda KMS Decrypt Permission
+
+**Feature**: 1058-dashboard-kms-decrypt
+**Date**: 2025-12-25
+
+## Summary
+
+This feature requires adding KMS decrypt permission to the dashboard Lambda's secrets policy. The pattern already exists in the codebase (ingestion Lambda), so no external research was needed.
+
+## Existing Pattern Analysis
+
+### Ingestion Lambda Pattern (modules/iam/main.tf, lines 79-87)
+
+```hcl
+# KMS decrypt required when secrets use customer-managed KMS keys
+var.secrets_kms_key_arn != "" ? [
+  {
+    Effect = "Allow"
+    Action = [
+      "kms:Decrypt"
+    ]
+    Resource = var.secrets_kms_key_arn
+  }
+] : []
+```
+
+**Key Features**:
+1. Conditional on `secrets_kms_key_arn != ""` - graceful handling when KMS not used
+2. Single action: `kms:Decrypt` - minimal permission
+3. Single resource: `var.secrets_kms_key_arn` - least privilege, not wildcard
+4. Empty list when not needed - no unnecessary permissions
+
+### Dashboard Lambda Current State (modules/iam/main.tf, lines 381-403)
+
+The dashboard_secrets policy currently lacks this conditional block, causing GetSecretValue calls to fail when secrets use customer-managed KMS encryption.
+
+## Decision
+
+**Approach**: Replicate the ingestion Lambda pattern in the dashboard_secrets policy.
+
+**Rationale**:
+- Proven pattern already working in production
+- Maintains consistency across Lambda IAM policies
+- Follows AWS best practice for Secrets Manager + KMS
+- Minimal change surface area
+
+## Alternatives Considered
+
+| Alternative | Rejected Because |
+|-------------|------------------|
+| Shared secrets policy | Violates per-role isolation; harder to audit which Lambda has which permissions |
+| KMS key policy grant | Affects all principals with key access; less precise than IAM policy |
+| AWS managed KMS key | Would require changing secrets encryption; larger change scope |
+
+## Validation Strategy
+
+1. **terraform validate** - Syntax check
+2. **terraform plan** - Verify expected policy change
+3. **IAM validator** - Confirm least-privilege compliance
+4. **Unit test** - Verify policy structure

--- a/specs/1058-dashboard-kms-decrypt/spec.md
+++ b/specs/1058-dashboard-kms-decrypt/spec.md
@@ -1,0 +1,61 @@
+# Feature Specification: Dashboard Lambda KMS Decrypt Permission
+
+**Feature Branch**: `1058-dashboard-kms-decrypt`
+**Created**: 2025-12-25
+**Status**: Draft
+**Input**: Dashboard Lambda missing KMS Decrypt permission for Secrets Manager. The dashboard_secrets policy grants secretsmanager:GetSecretValue for tiingo and finnhub secrets but lacks the conditional kms:Decrypt block that ingestion Lambda has. This prevents the OHLC endpoint from fetching API keys.
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 - Dashboard OHLC Data Access (Priority: P1)
+
+As a dashboard user, I want to view OHLC (Open-High-Low-Close) candlestick charts for selected tickers so that I can analyze price movements alongside sentiment data.
+
+**Why this priority**: Without the ability to fetch OHLC data, the dashboard only displays the sentiment donut chart, making the feature incomplete and not demo-able. This is a blocker for the core value proposition of the ONE URL dashboard.
+
+**Independent Test**: Can be fully tested by navigating to the dashboard, entering a ticker symbol (e.g., AAPL), and verifying that candlestick chart data loads and renders. Delivers immediate visual value to users.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user is on the dashboard page with Tiingo/Finnhub API keys configured in Secrets Manager, **When** the user enters a valid ticker symbol, **Then** the OHLC candlestick chart renders with price data within 3 seconds.
+
+2. **Given** the dashboard Lambda attempts to fetch OHLC data, **When** it calls Secrets Manager to retrieve the Tiingo API key, **Then** the decryption succeeds and the API key is returned.
+
+3. **Given** the dashboard Lambda attempts to fetch OHLC data, **When** it calls Secrets Manager to retrieve the Finnhub API key, **Then** the decryption succeeds and the API key is returned.
+
+---
+
+### Edge Cases
+
+- What happens when the KMS key ARN is empty/not configured? The conditional block should evaluate to false and no KMS policy is attached (graceful degradation for non-KMS-encrypted secrets).
+- What happens when the secrets exist but don't have the expected JSON structure? The adapters should return a user-friendly error message indicating misconfiguration.
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+- **FR-001**: Dashboard Lambda IAM role MUST include `kms:Decrypt` permission for the secrets KMS key when customer-managed encryption is used.
+- **FR-002**: The KMS decrypt permission MUST be conditional on `secrets_kms_key_arn` being non-empty (matching the ingestion Lambda pattern).
+- **FR-003**: The permission MUST apply to the same KMS key ARN used to encrypt Tiingo and Finnhub secrets.
+- **FR-004**: The permission MUST be scoped only to the specific KMS key resource (least-privilege principle).
+
+### Key Entities
+
+- **Dashboard Lambda IAM Role**: The execution role for the dashboard Lambda function that requires Secrets Manager access.
+- **Secrets KMS Key**: The customer-managed KMS key used to encrypt Tiingo and Finnhub secrets in Secrets Manager.
+- **Tiingo/Finnhub Secrets**: The Secrets Manager secrets containing API keys for external price data providers.
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**: Dashboard users can view OHLC candlestick charts when entering a valid ticker symbol (feature becomes functional).
+- **SC-002**: The dashboard Lambda can successfully call `GetSecretValue` for Tiingo and Finnhub secrets without access denied errors.
+- **SC-003**: No overly permissive IAM permissions introduced (kms:Decrypt scoped to single KMS key resource, not wildcard).
+- **SC-004**: Terraform plan shows only the expected IAM policy change with no unintended drift.
+
+## Assumptions
+
+- Tiingo and Finnhub secrets use the same customer-managed KMS key as other secrets in the system.
+- The `secrets_kms_key_arn` variable is already passed to the IAM module (verified from existing ingestion Lambda pattern).
+- The ingestion Lambda's conditional KMS decrypt pattern (lines 79-87 in modules/iam/main.tf) is the correct pattern to follow.

--- a/specs/1058-dashboard-kms-decrypt/tasks.md
+++ b/specs/1058-dashboard-kms-decrypt/tasks.md
@@ -1,0 +1,108 @@
+# Tasks: Dashboard Lambda KMS Decrypt Permission
+
+**Feature Branch**: `1058-dashboard-kms-decrypt`
+**Created**: 2025-12-25
+**Spec**: [spec.md](./spec.md)
+**Plan**: [plan.md](./plan.md)
+
+## Summary
+
+Add KMS decrypt permission to the dashboard Lambda's secrets policy, enabling OHLC data fetching by allowing the Lambda to decrypt Tiingo/Finnhub API keys from Secrets Manager.
+
+## Dependency Graph
+
+```
+Phase 1 (Setup) → Phase 2 (Foundational) → Phase 3 (User Story 1) → Phase 4 (Polish)
+```
+
+All phases are sequential for this feature due to single-file modification scope.
+
+---
+
+## Phase 1: Setup
+
+**Goal**: Verify current state and prepare for modification
+
+- [ ] T001 Verify current dashboard_secrets policy structure in infrastructure/terraform/modules/iam/main.tf
+- [ ] T002 Verify secrets_kms_key_arn variable exists in infrastructure/terraform/modules/iam/variables.tf
+
+---
+
+## Phase 2: Foundational
+
+**Goal**: Understand the pattern to replicate
+
+- [ ] T003 Document ingestion Lambda KMS decrypt pattern (lines 79-87) in infrastructure/terraform/modules/iam/main.tf
+
+---
+
+## Phase 3: User Story 1 - Dashboard OHLC Data Access (P1)
+
+**Goal**: Enable dashboard Lambda to decrypt secrets with customer-managed KMS keys
+**Independent Test**: terraform plan shows expected policy modification with kms:Decrypt action
+
+- [ ] T004 [US1] Add conditional KMS decrypt statement to dashboard_secrets policy in infrastructure/terraform/modules/iam/main.tf
+
+Pattern to implement:
+```hcl
+policy = jsonencode({
+  Version = "2012-10-17"
+  Statement = concat([
+    {
+      Effect = "Allow"
+      Action = [
+        "secretsmanager:GetSecretValue"
+      ]
+      Resource = [
+        var.dashboard_api_key_secret_arn,
+        var.tiingo_secret_arn,
+        var.finnhub_secret_arn
+      ]
+    }
+  ],
+  # KMS decrypt required when secrets use customer-managed KMS keys
+  var.secrets_kms_key_arn != "" ? [
+    {
+      Effect = "Allow"
+      Action = [
+        "kms:Decrypt"
+      ]
+      Resource = var.secrets_kms_key_arn
+    }
+  ] : [])
+})
+```
+
+- [ ] T005 [US1] Run terraform fmt on infrastructure/terraform/modules/iam/main.tf
+- [ ] T006 [US1] Run terraform validate in infrastructure/terraform/
+
+---
+
+## Phase 4: Polish & Validation
+
+**Goal**: Ensure change meets quality standards
+
+- [ ] T007 Run make validate in repository root
+- [ ] T008 Run terraform plan to verify expected policy changes
+
+---
+
+## Parallel Execution Examples
+
+Due to single-file scope, sequential execution is required. No parallelization opportunities.
+
+## Implementation Strategy
+
+**MVP Scope**: Phase 3 (User Story 1) - Single policy modification
+**Incremental Delivery**: Complete in one PR
+**Validation**: terraform plan shows only dashboard_secrets policy modification
+
+## Task Count Summary
+
+| Phase | Tasks | Description |
+|-------|-------|-------------|
+| Phase 1 | 2 | Setup verification |
+| Phase 2 | 1 | Pattern documentation |
+| Phase 3 | 3 | User Story 1 implementation |
+| Phase 4 | 2 | Polish & validation |
+| **Total** | **8** | |


### PR DESCRIPTION
## Summary

- Add conditional KMS decrypt permission to dashboard_secrets IAM policy
- Enables dashboard Lambda to decrypt Tiingo/Finnhub API keys from Secrets Manager when using customer-managed KMS keys
- Pattern matches existing ingestion Lambda implementation (lines 79-87)

## Changes

- `infrastructure/terraform/modules/iam/main.tf`: Modified dashboard_secrets policy to use `concat()` with conditional KMS decrypt block

## Root Cause

The OHLC endpoint was returning "unavailable" because the dashboard Lambda could read secrets (`secretsmanager:GetSecretValue`) but couldn't decrypt them when encrypted with a customer-managed KMS key.

## Test plan

- [x] terraform fmt passes
- [x] terraform validate passes  
- [x] make validate passes (2355 unit tests)
- [ ] Deploy to preprod and verify OHLC endpoint returns data

## Spec

See `specs/1058-dashboard-kms-decrypt/` for full specification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)