### PR TITLE
fix(timeseries): Fix DynamoDB key case mismatch causing 500 errors

### DIFF
--- a/specs/1063-fix-timeseries-pk-sk-case/spec.md
+++ b/specs/1063-fix-timeseries-pk-sk-case/spec.md
@@ -1,0 +1,117 @@
+# Feature Specification: Fix Timeseries API DynamoDB Key Case Mismatch
+
+**Feature Branch**: `1063-fix-timeseries-pk-sk-case`
+**Created**: 2025-12-26
+**Status**: Draft
+**Input**: Investigation of 500 errors on `/api/v2/timeseries/{ticker}?resolution=6h`
+
+## Problem Statement
+
+The timeseries API endpoint returns HTTP 500 Internal Server Error for all resolution values. CloudWatch logs show:
+
+```
+botocore.exceptions.ClientError: An error occurred (ValidationException) when calling the Query operation: Query condition missed key schema element: PK
+```
+
+**Root Cause**: The `timeseries.py` query code uses lowercase attribute names (`pk`, `sk`) in the KeyConditionExpression and ExclusiveStartKey, but the `preprod-sentiment-timeseries` DynamoDB table uses uppercase attribute names (`PK`, `SK`).
+
+**Evidence**:
+- Table schema: `{"AttributeName": "PK", "KeyType": "HASH"}, {"AttributeName": "SK", "KeyType": "RANGE"}`
+- Sample item: `"PK": {"S": "TSM#12h"}, "SK": {"S": "2025-12-15T00:00:00+00:00"}`
+- Code at timeseries.py:254: `key_condition = "pk = :pk"` (lowercase)
+- Code at timeseries.py:285: `{"pk": pk, "sk": cursor}` (lowercase)
+
+## User Scenarios & Testing
+
+### User Story 1 - View Sentiment Timeseries (Priority: P1)
+
+As a user viewing the sentiment dashboard, I want to see sentiment trend data for any ticker at various time resolutions so that I can analyze sentiment patterns over time.
+
+**Why this priority**: This is a blocking bug preventing the demo URL from displaying any sentiment trend data.
+
+**Independent Test**: Make API requests to `/api/v2/timeseries/AAPL?resolution=6h` and verify 200 response.
+
+**Acceptance Scenarios**:
+
+1. **Given** the timeseries endpoint is deployed, **When** I request `/api/v2/timeseries/AAPL?resolution=6h` with valid auth, **Then** I receive HTTP 200 with sentiment bucket data
+2. **Given** the timeseries endpoint is deployed, **When** I request `/api/v2/timeseries/AAPL?resolution=1h` with valid auth, **Then** I receive HTTP 200 with sentiment bucket data
+3. **Given** there is no data for a ticker, **When** I request `/api/v2/timeseries/INVALID?resolution=6h`, **Then** I receive HTTP 200 with empty buckets array
+
+---
+
+### User Story 2 - Frontend Sentiment Trend Chart (Priority: P1)
+
+As a user on the frontend dashboard, I want to see the Sentiment Trend chart populate with data when I select different resolutions.
+
+**Why this priority**: The frontend component is built but shows "Failed to load timeseries data: Error: HTTP 500".
+
+**Independent Test**: Load the dashboard and verify the sentiment trend chart displays data.
+
+**Acceptance Scenarios**:
+
+1. **Given** I am on the dashboard, **When** the page loads, **Then** the sentiment trend chart displays data without errors
+2. **Given** I am on the dashboard, **When** I change the resolution selector, **Then** the chart refreshes with the new resolution data
+
+---
+
+### Edge Cases
+
+- What happens when cursor pagination is used? - Fix ExclusiveStartKey to use uppercase keys
+- What happens when time range filtering is used? - Should work since filter uses expression values, not attribute names
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: System MUST query DynamoDB using correct uppercase attribute names `PK` and `SK`
+- **FR-002**: System MUST support all resolution values: 1m, 5m, 10m, 1h, 3h, 6h, 12h, 24h
+- **FR-003**: System MUST support pagination with cursor parameter
+- **FR-004**: System MUST return empty buckets array (not error) when no data exists
+
+### Technical Requirements
+
+- **TR-001**: Update KeyConditionExpression at timeseries.py:254 to use `PK` instead of `pk`
+- **TR-002**: Update ExclusiveStartKey at timeseries.py:285 to use `{"PK": pk, "SK": cursor}`
+- **TR-003**: Verify `_item_to_bucket` function reads items correctly (may use lowercase internally)
+- **TR-004**: Add unit test coverage for DynamoDB query construction
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: API requests with any resolution return HTTP 200 (currently returns 500)
+- **SC-002**: All supported resolutions (1m, 5m, 10m, 1h, 3h, 6h, 12h, 24h) return valid responses
+- **SC-003**: Pagination with cursor parameter works correctly
+- **SC-004**: Unit tests pass for query construction
+- **SC-005**: Frontend sentiment trend chart displays data
+
+## Implementation Notes
+
+The fix requires changing the key names in the query:
+
+```python
+# Line 254 - KeyConditionExpression
+# Current (broken):
+key_condition = "pk = :pk"
+# Fixed:
+key_condition = "PK = :pk"
+
+# Lines 261, 266, 270 - Sort key conditions
+# Current (broken):
+key_condition += " AND sk BETWEEN :start AND :end"
+# Fixed:
+key_condition += " AND SK BETWEEN :start AND :end"
+
+# Line 285 - ExclusiveStartKey
+# Current (broken):
+query_kwargs["ExclusiveStartKey"] = {"pk": pk, "sk": cursor}
+# Fixed:
+query_kwargs["ExclusiveStartKey"] = {"PK": pk, "SK": cursor}
+```
+
+Note: The `_item_to_bucket` function at line 294 reads items using lowercase keys from the response - this may also need updating if DynamoDB returns uppercase keys.
+
+## Files to Modify
+
+- `src/lambdas/dashboard/timeseries.py` - Fix key case at lines 254, 261, 266, 270, 285, and verify _item_to_bucket
+- `tests/unit/dashboard/test_timeseries.py` - Add/update tests for DynamoDB query construction

--- a/tests/unit/test_multi_ticker_query.py
+++ b/tests/unit/test_multi_ticker_query.py
@@ -53,12 +53,13 @@ class TestMultiTickerQuery:
         score: float = 0.5,
         count: int = 10,
     ) -> dict[str, Any]:
-        """Create a mock DynamoDB bucket item."""
+        """Create a mock DynamoDB bucket item.
+
+        Note: Uses uppercase PK and SK to match production schema.
+        """
         return {
-            "pk": f"{ticker}#{resolution}",
-            "sk": timestamp,
-            "ticker": ticker,
-            "resolution": resolution,
+            "PK": f"{ticker}#{resolution}",
+            "SK": timestamp,
             "open": Decimal(str(score)),
             "high": Decimal(str(score + 0.1)),
             "low": Decimal(str(score - 0.1)),
@@ -208,13 +209,12 @@ class TestMultiTickerQueryPerformance:
             mock_dynamodb.Table.return_value = mock_table
 
             # Fast response (no actual I/O)
+            # Note: Uses uppercase PK and SK to match production schema
             mock_table.query.return_value = {
                 "Items": [
                     {
-                        "pk": "AAPL#5m",
-                        "sk": "2025-12-22T10:00:00Z",
-                        "ticker": "AAPL",
-                        "resolution": "5m",
+                        "PK": "AAPL#5m",
+                        "SK": "2025-12-22T10:00:00Z",
                         "open": Decimal("0.5"),
                         "high": Decimal("0.6"),
                         "low": Decimal("0.4"),

--- a/tests/unit/test_shared_cache.py
+++ b/tests/unit/test_shared_cache.py
@@ -238,13 +238,12 @@ class TestCacheWithQueryService:
             mock_dynamodb.Table.return_value = mock_table
 
             # First query (cache miss)
+            # Note: Uses uppercase PK and SK to match production schema
             mock_table.query.return_value = {
                 "Items": [
                     {
-                        "pk": "AAPL#5m",
-                        "sk": "2025-12-22T10:00:00Z",
-                        "ticker": "AAPL",
-                        "resolution": "5m",
+                        "PK": "AAPL#5m",
+                        "SK": "2025-12-22T10:00:00Z",
                         "open": 0.5,
                         "high": 0.6,
                         "low": 0.4,

--- a/tests/unit/test_timeseries_pagination.py
+++ b/tests/unit/test_timeseries_pagination.py
@@ -46,10 +46,8 @@ class TestTimeseriesPagination:
             ts = base_time.replace(minute=i % 60, hour=10 + i // 60)
             items.append(
                 {
-                    "pk": "AAPL#1m",
-                    "sk": ts.isoformat().replace("+00:00", "Z"),
-                    "ticker": "AAPL",
-                    "resolution": "1m",
+                    "PK": "AAPL#1m",
+                    "SK": ts.isoformat().replace("+00:00", "Z"),
                     "open": Decimal("0.65"),
                     "high": Decimal("0.85"),
                     "low": Decimal("0.55"),
@@ -75,10 +73,8 @@ class TestTimeseriesPagination:
         mock_dynamodb_table.query.return_value = {
             "Items": [
                 {
-                    "pk": "AAPL#1m",
-                    "sk": f"2025-12-21T10:{i:02d}:00Z",
-                    "ticker": "AAPL",
-                    "resolution": "1m",
+                    "PK": "AAPL#1m",
+                    "SK": f"2025-12-21T10:{i:02d}:00Z",
                     "open": Decimal("0.65"),
                     "high": Decimal("0.85"),
                     "low": Decimal("0.55"),
@@ -90,7 +86,7 @@ class TestTimeseriesPagination:
                 }
                 for i in range(20)
             ],
-            "LastEvaluatedKey": {"pk": "AAPL#1m", "sk": "2025-12-21T10:19:00Z"},
+            "LastEvaluatedKey": {"PK": "AAPL#1m", "SK": "2025-12-21T10:19:00Z"},
         }
 
         with patch("boto3.resource") as mock_boto:
@@ -121,10 +117,8 @@ class TestTimeseriesPagination:
         mock_dynamodb_table.query.return_value = {
             "Items": [
                 {
-                    "pk": "AAPL#1m",
-                    "sk": f"2025-12-21T10:{20 + i:02d}:00Z",
-                    "ticker": "AAPL",
-                    "resolution": "1m",
+                    "PK": "AAPL#1m",
+                    "SK": f"2025-12-21T10:{20 + i:02d}:00Z",
                     "open": Decimal("0.65"),
                     "high": Decimal("0.85"),
                     "low": Decimal("0.55"),
@@ -136,7 +130,7 @@ class TestTimeseriesPagination:
                 }
                 for i in range(20)
             ],
-            "LastEvaluatedKey": {"pk": "AAPL#1m", "sk": "2025-12-21T10:39:00Z"},
+            "LastEvaluatedKey": {"PK": "AAPL#1m", "SK": "2025-12-21T10:39:00Z"},
         }
 
         with patch("boto3.resource") as mock_boto:
@@ -154,7 +148,7 @@ class TestTimeseriesPagination:
             mock_dynamodb_table.query.assert_called_once()
             call_kwargs = mock_dynamodb_table.query.call_args.kwargs
             assert "ExclusiveStartKey" in call_kwargs
-            assert call_kwargs["ExclusiveStartKey"]["sk"] == "2025-12-21T10:19:00Z"
+            assert call_kwargs["ExclusiveStartKey"]["SK"] == "2025-12-21T10:19:00Z"
 
             # Verify response
             assert len(response.buckets) == 20
@@ -173,10 +167,8 @@ class TestTimeseriesPagination:
         mock_dynamodb_table.query.return_value = {
             "Items": [
                 {
-                    "pk": "AAPL#1m",
-                    "sk": f"2025-12-21T10:{i:02d}:00Z",
-                    "ticker": "AAPL",
-                    "resolution": "1m",
+                    "PK": "AAPL#1m",
+                    "SK": f"2025-12-21T10:{i:02d}:00Z",
                     "open": Decimal("0.65"),
                     "high": Decimal("0.85"),
                     "low": Decimal("0.55"),
@@ -221,10 +213,8 @@ class TestTimeseriesPagination:
         mock_dynamodb_table.query.return_value = {
             "Items": [
                 {
-                    "pk": "AAPL#1m",
-                    "sk": f"2025-12-21T10:{i:02d}:00Z",
-                    "ticker": "AAPL",
-                    "resolution": "1m",
+                    "PK": "AAPL#1m",
+                    "SK": f"2025-12-21T10:{i:02d}:00Z",
                     "open": Decimal("0.65"),
                     "high": Decimal("0.85"),
                     "low": Decimal("0.55"),
@@ -236,7 +226,7 @@ class TestTimeseriesPagination:
                 }
                 for i in range(30)
             ],
-            "LastEvaluatedKey": {"pk": "AAPL#1m", "sk": "2025-12-21T10:29:00Z"},
+            "LastEvaluatedKey": {"PK": "AAPL#1m", "SK": "2025-12-21T10:29:00Z"},
         }
 
         with patch("boto3.resource") as mock_boto:

--- a/tests/unit/test_timeseries_query.py
+++ b/tests/unit/test_timeseries_query.py
@@ -41,16 +41,19 @@ def clear_global_cache() -> None:
 
 
 def create_test_table(dynamodb_client: Any, table_name: str) -> None:
-    """Create DynamoDB timeseries table for testing."""
+    """Create DynamoDB timeseries table for testing.
+
+    Note: Uses uppercase PK and SK to match production schema.
+    """
     dynamodb_client.create_table(
         TableName=table_name,
         KeySchema=[
-            {"AttributeName": "pk", "KeyType": "HASH"},
-            {"AttributeName": "sk", "KeyType": "RANGE"},
+            {"AttributeName": "PK", "KeyType": "HASH"},
+            {"AttributeName": "SK", "KeyType": "RANGE"},
         ],
         AttributeDefinitions=[
-            {"AttributeName": "pk", "AttributeType": "S"},
-            {"AttributeName": "sk", "AttributeType": "S"},
+            {"AttributeName": "PK", "AttributeType": "S"},
+            {"AttributeName": "SK", "AttributeType": "S"},
         ],
         BillingMode="PAY_PER_REQUEST",
     )
@@ -70,14 +73,15 @@ def insert_bucket(
     sum_val: float = 6.0,
     is_partial: bool = False,
 ) -> None:
-    """Insert a sentiment bucket into DynamoDB."""
+    """Insert a sentiment bucket into DynamoDB.
+
+    Note: Uses uppercase PK and SK to match production schema.
+    """
     pk = f"{ticker}#{resolution}"
     table.put_item(
         Item={
-            "pk": pk,
-            "sk": timestamp,
-            "ticker": ticker,
-            "resolution": resolution,
+            "PK": pk,
+            "SK": timestamp,
             "open": Decimal(str(open_val)),
             "high": Decimal(str(high)),
             "low": Decimal(str(low)),


### PR DESCRIPTION
## Summary

- Fix DynamoDB key case mismatch in timeseries query service
- Production table uses uppercase `PK` and `SK` keys, code was using lowercase
- Root cause of all Sentiment Trend 500 errors

## Changes

- `src/lambdas/dashboard/timeseries.py`: Fix key references to use uppercase PK/SK
- Updated `_item_to_bucket` to parse ticker/resolution from composite PK
- Fixed pagination cursor handling to use uppercase SK
- Updated all related unit tests to use correct key schema

## Test plan

- [x] All 2363 unit tests pass
- [ ] Pipeline passes
- [ ] Verify Sentiment Trend endpoint returns data after deploy

## Root Cause

CloudWatch logs showed:
```
botocore.exceptions.ClientError: Query condition missed key schema element: PK
```

DynamoDB table schema: `PK` (HASH), `SK` (RANGE) - uppercase
Code was querying with: `pk`, `sk` - lowercase

🤖 Generated with [Claude Code](https://claude.com/claude-code)