### PR TITLE
fix(dashboard): Normalize timestamp format in sentiment history endpoint

### DIFF
--- a/src/lambdas/dashboard/sentiment.py
+++ b/src/lambdas/dashboard/sentiment.py
@@ -645,7 +645,7 @@ def get_ticker_sentiment_history(
         base_score = 0.5 + (0.1 * (day_offset % 3 - 1))
         history.append(
             {
-                "timestamp": timestamp.isoformat(),
+                "timestamp": timestamp.isoformat().replace("+00:00", "Z"),
                 "score": round(base_score, 4),
                 "source": source or "our_model",
             }
@@ -661,12 +661,14 @@ def get_ticker_sentiment_history(
                         score=history[0]["score"] if history else 0.0,
                         label=_score_to_label(history[0]["score"] if history else 0.0),
                         confidence=0.8,
-                        updated_at=now.isoformat() + "Z",
+                        updated_at=now.isoformat().replace("+00:00", "Z"),
                     )
                 },
             )
         ],
-        last_updated=now.isoformat() + "Z",
-        next_refresh_at=(now + timedelta(seconds=300)).isoformat() + "Z",
+        last_updated=now.isoformat().replace("+00:00", "Z"),
+        next_refresh_at=(now + timedelta(seconds=300))
+        .isoformat()
+        .replace("+00:00", "Z"),
         cache_status="fresh",
     )


### PR DESCRIPTION
## Summary
- Fix inconsistent timestamp formatting in `get_ticker_sentiment_history()` that caused "Invalid Date" display in frontend
- Use `.replace("+00:00", "Z")` pattern consistently (matching other functions in the same file)

## Root Cause
The function was using two different patterns:
1. `timestamp.isoformat()` - produces `2025-01-10T10:30:45+00:00`
2. `now.isoformat() + "Z"` - produces `2025-01-10T10:30:45+00:00Z` (malformed double timezone)

JavaScript's `new Date()` fails to parse these formats, causing `formatDateTime()` to display "Invalid Date".

## Fix
Changed all timestamp formatting to use `.replace("+00:00", "Z")`:
- Line 648: `timestamp.isoformat().replace("+00:00", "Z")`
- Line 664: `now.isoformat().replace("+00:00", "Z")`
- Lines 669-670: Same pattern for `last_updated` and `next_refresh_at`

## Test plan
- [x] All 199 dashboard unit tests pass
- [x] All 2363 total unit tests pass
- [ ] Verify sentiment timeline displays valid dates in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)