### PR TITLE
feat(dashboard): Add sentiment overlay to OHLC price chart (Feature 1065)

### DIFF
--- a/specs/1065-sentiment-price-overlay/plan.md
+++ b/specs/1065-sentiment-price-overlay/plan.md
@@ -1,0 +1,107 @@
+# Implementation Plan: Sentiment-Price Overlay Chart
+
+**Feature**: 1065-sentiment-price-overlay
+**Created**: 2025-12-27
+**Status**: Ready for implementation
+
+## Technical Context
+
+- **Frontend Framework**: Vanilla JavaScript with Chart.js
+- **OHLC Chart**: `src/dashboard/ohlc.js` - Uses Chart.js bar chart simulating candlesticks
+- **Sentiment Chart**: `src/dashboard/timeseries.js` - Uses Chart.js line chart
+- **Unified Resolution**: `src/dashboard/unified-resolution.js` - Feature 1064, already provides resolution sync
+- **API Endpoints**:
+  - OHLC: `/api/v2/tickers/{ticker}/ohlc?resolution=D`
+  - Sentiment: `/api/v2/timeseries/{ticker}?resolution=1h`
+
+## Architecture Decision
+
+**Approach**: Extend the OHLC chart to include a second dataset for sentiment overlay.
+
+The OHLC chart already uses Chart.js which supports:
+- Multiple datasets on the same chart
+- Dual Y-axes (left for price, right for sentiment)
+- Mixed chart types (bar for OHLC, line for sentiment)
+
+This avoids creating a separate overlay module and leverages existing Chart.js infrastructure.
+
+## Implementation Tasks
+
+### Phase 1: Config Update
+
+**T001**: Add overlay configuration to `config.js`
+- Add `SENTIMENT_OVERLAY_COLOR` to CONFIG.COLORS
+- Add `OVERLAY_ENABLED` boolean config
+
+### Phase 2: OHLC Chart Extension
+
+**T002**: Extend OHLCChart class in `ohlc.js` for dual-axis support
+- Add second Y-axis (yAxisID: 'sentiment') with -1 to +1 scale
+- Position price Y-axis on left (not right as currently)
+- Add sentiment dataset slot to chart.data.datasets
+
+**T003**: Add sentiment data fetching to OHLCChart
+- Add `loadSentimentData()` method to fetch from timeseries endpoint
+- Store sentiment data in `this.sentimentData` property
+- Call loadSentimentData() in parallel with loadData()
+
+**T004**: Add sentiment overlay rendering to chart
+- Add `updateSentimentOverlay()` method to update dataset[1]
+- Align sentiment data points with OHLC candles by timestamp
+- Handle missing data gracefully (nulls for gaps)
+
+**T005**: Update tooltip callback to show both OHLC and sentiment
+- Extend tooltip label callback to include sentiment score
+- Format: "Sentiment: +0.45" or "Sentiment: N/A"
+
+### Phase 3: Legend and Visual Polish
+
+**T006**: Enable legend in chart options
+- Show legend with "Price" and "Sentiment" labels
+- Use contrasting colors (green/red for candles, blue for sentiment)
+
+**T007**: Add CSS styles for overlay indicators
+- Style any fallback messages
+- Style legend positioning
+
+### Phase 4: Integration
+
+**T008**: Update unified resolution callback in `app.js`
+- When resolution changes, reload both OHLC and sentiment data
+- Ensure both datasets update together
+
+## File Changes Summary
+
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `src/dashboard/config.js` | Modify | Add overlay color config |
+| `src/dashboard/ohlc.js` | Modify | Add dual-axis, sentiment fetch, overlay render |
+| `src/dashboard/styles.css` | Modify | Add legend styles if needed |
+| `src/dashboard/app.js` | Modify | Update resolution callback |
+
+## Data Alignment Strategy
+
+OHLC data format:
+```javascript
+{ date: "2025-12-27T10:00:00Z", open: 150.0, high: 152.0, low: 149.0, close: 151.0 }
+```
+
+Sentiment data format:
+```javascript
+{ bucket_timestamp: "2025-12-27T10:00:00Z", avg: 0.45, count: 12, ... }
+```
+
+Alignment approach:
+1. Parse both datasets by timestamp
+2. Create a unified timeline from OHLC dates
+3. For each OHLC candle date, find matching or nearest sentiment bucket
+4. Use null for sentiment where no data exists
+
+## Success Validation
+
+- [ ] OHLC chart shows price candles on left Y-axis
+- [ ] Sentiment line appears overlaid on right Y-axis (-1 to +1)
+- [ ] Tooltip shows both OHLC values and sentiment score
+- [ ] Resolution changes update both datasets
+- [ ] Legend clearly labels both data series
+- [ ] Blue sentiment line contrasts with green/red candles

--- a/specs/1065-sentiment-price-overlay/spec.md
+++ b/specs/1065-sentiment-price-overlay/spec.md
@@ -1,0 +1,106 @@
+# Feature Specification: Sentiment-Price Overlay Chart
+
+**Feature Branch**: `1065-sentiment-price-overlay`
+**Created**: 2025-12-27
+**Status**: Draft
+**Input**: User description: "Overlay sentiment trend line on OHLC price chart - combine sentiment data visualization with price candlesticks on a single dual-axis Chart.js chart"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - View Sentiment Overlay on Price Chart (Priority: P1)
+
+As an investor using the sentiment analyzer dashboard, I want to see the sentiment trend line overlaid directly on top of the OHLC price candlestick chart so that I can immediately identify correlations between news sentiment and price movements without switching between charts.
+
+**Why this priority**: This is the core value proposition. Currently, the dashboard shows OHLC and sentiment as separate charts, requiring mental context-switching. A unified dual-axis chart enables instant pattern recognition - the key insight users need for trading decisions.
+
+**Independent Test**: Can be fully tested by viewing the OHLC chart and verifying the sentiment line appears overlaid with correct scaling on the right Y-axis. Delivers immediate correlation insight.
+
+**Acceptance Scenarios**:
+
+1. **Given** the OHLC chart is rendered with price data, **When** sentiment data is available for the same ticker and resolution, **Then** a sentiment trend line appears overlaid on the chart with sentiment scale on the right Y-axis
+2. **Given** the overlay chart is displayed, **When** I hover over any data point, **Then** I see a tooltip showing: date/time, OHLC prices (Open, High, Low, Close), and sentiment score
+3. **Given** the overlay chart is rendered, **When** I look at the Y-axes, **Then** I see price scale (dollars) on the left axis and sentiment scale (-1.0 to +1.0) on the right axis
+4. **Given** I change the resolution via the unified selector, **When** the chart updates, **Then** both price candles and sentiment line update to match the new resolution
+
+---
+
+### User Story 2 - Visual Distinction Between Data Types (Priority: P1)
+
+As a user analyzing the combined chart, I want the sentiment line to be visually distinct from the price candlesticks so that I can easily differentiate between the two data types at a glance.
+
+**Why this priority**: Equal priority with overlay display - without visual distinction, the overlay becomes confusing rather than helpful. Color coding and styling are essential for usability.
+
+**Independent Test**: Can be tested by rendering the overlay and verifying the sentiment line has a distinct color and style (smooth line vs block candles).
+
+**Acceptance Scenarios**:
+
+1. **Given** the overlay chart is displayed, **When** I view the chart, **Then** the sentiment line is rendered in a distinctive color (blue) that contrasts with bullish (green) and bearish (red) candles
+2. **Given** the overlay chart has data, **When** I view the chart legend, **Then** it clearly labels "Price" and "Sentiment" with their respective colors
+3. **Given** the sentiment line crosses through candle regions, **When** I view the overlap area, **Then** the sentiment line remains visible with appropriate opacity/z-index
+
+---
+
+### User Story 3 - Handle Data Alignment (Priority: P2)
+
+As a user viewing the overlay chart, I want price and sentiment data to be properly aligned by timestamp so that correlations are accurate even when one dataset has gaps.
+
+**Why this priority**: Important for accuracy but not blocking basic visualization. Users can get value from approximate alignment initially.
+
+**Independent Test**: Can be tested by displaying data with known gaps and verifying points align correctly by timestamp.
+
+**Acceptance Scenarios**:
+
+1. **Given** sentiment data exists for times when no price data exists (weekends/holidays), **When** the chart renders, **Then** the sentiment line continues but price candles are absent for those periods
+2. **Given** price data exists for times when no sentiment data exists, **When** the chart renders, **Then** price candles appear but the sentiment line has gaps
+3. **Given** both datasets are available, **When** the chart renders, **Then** data points align by their timestamp, not by array index
+
+---
+
+### Edge Cases
+
+- What happens when sentiment data is completely unavailable for a ticker? Display OHLC chart normally with a message indicating sentiment data is unavailable.
+- What happens when price data is unavailable but sentiment exists? Display a degraded chart with only the sentiment line visible and a message.
+- How does the chart handle extreme sentiment values near +1.0 or -1.0? Right Y-axis should always show the full -1.0 to +1.0 range to maintain consistent visual reference.
+- What happens when both datasets have very different time ranges? Display the intersection of both ranges, with indicators showing data availability boundaries.
+- How does the chart handle rapid resolution changes? Use debouncing (existing 300ms debounce) to prevent excessive API calls.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST overlay sentiment data as a line chart on top of the existing OHLC candlestick chart
+- **FR-002**: System MUST display the right Y-axis with sentiment scale from -1.0 to +1.0
+- **FR-003**: System MUST display the left Y-axis with price scale (auto-scaled to data)
+- **FR-004**: System MUST render the sentiment line in a contrasting color (#3b82f6 blue)
+- **FR-005**: System MUST fetch sentiment data from the existing timeseries API endpoint
+- **FR-006**: System MUST align sentiment and price data by timestamp
+- **FR-007**: System MUST update tooltips to show both price (OHLC) and sentiment values
+- **FR-008**: System MUST handle resolution changes from the unified selector (Feature 1064)
+- **FR-009**: System MUST display loading state while fetching sentiment data
+- **FR-010**: System MUST gracefully degrade when sentiment data is unavailable (show OHLC only)
+- **FR-011**: System MUST include a legend showing both data series
+- **FR-012**: System MUST preserve existing OHLC chart functionality (candle colors, tooltips, etc.)
+
+### Key Entities
+
+- **SentimentDataPoint**: Represents a single sentiment reading - contains timestamp, average_score (float -1.0 to +1.0), and item_count
+- **OHLCCandle**: Existing - contains date, open, high, low, close
+- **OverlayDataset**: Combined visualization data - contains aligned arrays of candles and sentiment points
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Users can view both price and sentiment data on a single chart without scrolling or switching views
+- **SC-002**: Chart tooltip displays complete information (date, OHLC, sentiment) within 200ms of hover
+- **SC-003**: Sentiment line is visually distinguishable from price candles at any zoom level
+- **SC-004**: Resolution changes via unified selector update both datasets within 3 seconds
+- **SC-005**: Chart renders correctly on desktop viewports (1024px+)
+- **SC-006**: Users can identify correlation patterns between sentiment spikes and price movements
+
+## Assumptions
+
+- The existing OHLC chart (ohlc.js) uses Chart.js which supports multiple datasets and dual Y-axes
+- The timeseries API endpoint already provides sentiment data in the required format
+- The unified resolution selector (Feature 1064) is already integrated and functional
+- Session authentication (X-User-ID) is already implemented and working

--- a/src/dashboard/app.js
+++ b/src/dashboard/app.js
@@ -291,13 +291,15 @@ async function initDashboard() {
     }
 
     // Feature 1064: Initialize Unified Resolution Selector
+    // Feature 1065: onOhlcChange now receives sentiment resolution for overlay
     if (typeof initUnifiedResolution === 'function') {
         try {
             initUnifiedResolution({
                 containerId: 'unified-resolution-selector',
-                onOhlcChange: async (resolution, isFallback) => {
+                onOhlcChange: async (resolution, isFallback, sentimentResolution) => {
                     if (typeof setOHLCResolution === 'function') {
-                        await setOHLCResolution(resolution, isFallback);
+                        // Feature 1065: Pass sentiment resolution for overlay
+                        await setOHLCResolution(resolution, isFallback, sentimentResolution);
                     }
                 },
                 onSentimentChange: async (resolution, isFallback) => {
@@ -315,14 +317,23 @@ async function initDashboard() {
                     if (e.key === 'Enter') {
                         const ticker = tickerInput.value.toUpperCase().trim();
                         if (ticker) {
-                            // Update both charts
+                            // Update OHLC chart
                             if (typeof updateOHLCTicker === 'function') {
                                 await updateOHLCTicker(ticker);
                             }
+                            // Update sentiment timeseries chart
                             if (typeof getTimeseriesManager === 'function') {
                                 const tsManager = getTimeseriesManager();
                                 if (tsManager && typeof tsManager.switchTicker === 'function') {
                                     await tsManager.switchTicker(ticker);
+                                }
+                            }
+                            // Feature 1065: Reload sentiment overlay for new ticker
+                            if (typeof loadOHLCSentimentOverlay === 'function' &&
+                                typeof getUnifiedResolution === 'function') {
+                                const res = getUnifiedResolution();
+                                if (res && res.sentiment) {
+                                    await loadOHLCSentimentOverlay(res.sentiment);
                                 }
                             }
                         }

--- a/src/dashboard/config.js
+++ b/src/dashboard/config.js
@@ -137,7 +137,19 @@ const CONFIG = {
         positive: '#22c55e',
         neutral: '#6b7280',
         negative: '#ef4444',
-        primary: '#3b82f6'
+        primary: '#3b82f6',
+        sentiment: '#3b82f6'  // Feature 1065: Blue for sentiment overlay
+    },
+
+    // Feature 1065: Sentiment-Price Overlay configuration
+    OVERLAY: {
+        enabled: true,
+        sentimentColor: '#3b82f6',       // Blue line
+        sentimentColorBg: 'rgba(59, 130, 246, 0.15)',  // Light blue fill
+        lineWidth: 2,
+        pointRadius: 3,
+        yAxisMin: -1.0,
+        yAxisMax: 1.0
     },
 
     // Chart background colors (with transparency)
@@ -218,3 +230,5 @@ Object.freeze(CONFIG.OHLC_COLORS);
 // Feature 1064: Freeze unified resolution config
 Object.freeze(CONFIG.UNIFIED_RESOLUTIONS);
 CONFIG.UNIFIED_RESOLUTIONS.forEach(r => Object.freeze(r));
+// Feature 1065: Freeze overlay config
+Object.freeze(CONFIG.OVERLAY);

--- a/src/dashboard/ohlc.js
+++ b/src/dashboard/ohlc.js
@@ -1,8 +1,9 @@
 /**
- * OHLC Chart Module (Feature 1057)
- * ================================
+ * OHLC Chart Module (Feature 1057, 1065)
+ * ======================================
  *
  * Displays OHLC candlestick price data with time resolution selector.
+ * Feature 1065: Overlays sentiment trend line on the price chart.
  * Integrates with existing dashboard session auth and ticker input.
  *
  * Dependencies:
@@ -28,6 +29,11 @@ class OHLCChart {
         this.isLoading = false;
         this.lastError = null;
         this.fallbackMessage = null;
+
+        // Feature 1065: Sentiment overlay state
+        this.sentimentData = [];
+        this.sentimentResolution = null;  // Mapped from unified resolution
+        this.ohlcCandles = [];  // Store raw candle data for alignment
 
         // Callbacks
         this.onTickerChange = options.onTickerChange || null;
@@ -307,7 +313,7 @@ class OHLCChart {
     }
 
     /**
-     * Initialize Chart.js chart
+     * Initialize Chart.js chart with dual Y-axes (Feature 1065)
      */
     initChart() {
         const canvas = document.getElementById('ohlc-chart');
@@ -317,42 +323,81 @@ class OHLCChart {
         }
 
         const ctx = canvas.getContext('2d');
+        const overlayConfig = CONFIG.OVERLAY || {};
 
-        // Create line chart (Chart.js doesn't have native candlestick)
-        // We'll use a bar chart with custom styling to simulate candlesticks
+        // Create chart with OHLC bars and sentiment line overlay
         this.chart = new Chart(ctx, {
             type: 'bar',
             data: {
                 labels: [],
                 datasets: [
                     {
-                        label: 'Price Range',
+                        // Dataset 0: OHLC price bars
+                        label: 'Price',
                         data: [],
                         backgroundColor: [],
                         borderColor: [],
                         borderWidth: 1,
-                        barPercentage: 0.8
+                        barPercentage: 0.8,
+                        yAxisID: 'price',
+                        order: 2  // Render behind sentiment line
+                    },
+                    {
+                        // Dataset 1: Sentiment overlay line (Feature 1065)
+                        label: 'Sentiment',
+                        data: [],
+                        type: 'line',
+                        borderColor: overlayConfig.sentimentColor || '#3b82f6',
+                        backgroundColor: overlayConfig.sentimentColorBg || 'rgba(59, 130, 246, 0.15)',
+                        borderWidth: overlayConfig.lineWidth || 2,
+                        pointRadius: overlayConfig.pointRadius || 3,
+                        pointBackgroundColor: overlayConfig.sentimentColor || '#3b82f6',
+                        tension: 0.3,
+                        fill: true,
+                        yAxisID: 'sentiment',
+                        order: 1  // Render on top of price bars
                     }
                 ]
             },
             options: {
                 responsive: true,
                 maintainAspectRatio: false,
+                interaction: {
+                    mode: 'index',
+                    intersect: false
+                },
                 plugins: {
                     legend: {
-                        display: false
+                        display: true,
+                        position: 'top',
+                        labels: {
+                            usePointStyle: true,
+                            padding: 15
+                        }
                     },
                     tooltip: {
                         callbacks: {
                             label: (context) => {
-                                const candle = context.raw;
-                                if (candle && candle.ohlc) {
-                                    return [
-                                        `Open: $${candle.ohlc.open.toFixed(2)}`,
-                                        `High: $${candle.ohlc.high.toFixed(2)}`,
-                                        `Low: $${candle.ohlc.low.toFixed(2)}`,
-                                        `Close: $${candle.ohlc.close.toFixed(2)}`
-                                    ];
+                                // Handle OHLC dataset
+                                if (context.datasetIndex === 0) {
+                                    const candle = context.raw;
+                                    if (candle && candle.ohlc) {
+                                        return [
+                                            `Open: $${candle.ohlc.open.toFixed(2)}`,
+                                            `High: $${candle.ohlc.high.toFixed(2)}`,
+                                            `Low: $${candle.ohlc.low.toFixed(2)}`,
+                                            `Close: $${candle.ohlc.close.toFixed(2)}`
+                                        ];
+                                    }
+                                }
+                                // Handle sentiment dataset (Feature 1065)
+                                if (context.datasetIndex === 1) {
+                                    const value = context.raw;
+                                    if (value !== null && value !== undefined) {
+                                        const sign = value >= 0 ? '+' : '';
+                                        return `Sentiment: ${sign}${value.toFixed(3)}`;
+                                    }
+                                    return 'Sentiment: N/A';
                                 }
                                 return '';
                             }
@@ -370,13 +415,36 @@ class OHLCChart {
                             maxTicksLimit: 10
                         }
                     },
-                    y: {
-                        position: 'right',
+                    // Left Y-axis: Price (Feature 1065: moved to left)
+                    price: {
+                        type: 'linear',
+                        position: 'left',
                         grid: {
                             color: 'rgba(107, 114, 128, 0.2)'
                         },
                         ticks: {
                             callback: (value) => `$${value.toFixed(0)}`
+                        },
+                        title: {
+                            display: true,
+                            text: 'Price ($)'
+                        }
+                    },
+                    // Right Y-axis: Sentiment (Feature 1065)
+                    sentiment: {
+                        type: 'linear',
+                        position: 'right',
+                        min: overlayConfig.yAxisMin || -1.0,
+                        max: overlayConfig.yAxisMax || 1.0,
+                        grid: {
+                            display: false  // Don't duplicate gridlines
+                        },
+                        ticks: {
+                            callback: (value) => value.toFixed(1)
+                        },
+                        title: {
+                            display: true,
+                            text: 'Sentiment'
                         }
                     }
                 }
@@ -392,9 +460,13 @@ class OHLCChart {
 
         this.hideError();
 
+        // Store raw candles for sentiment alignment (Feature 1065)
+        this.ohlcCandles = candles || [];
+
         if (!candles || candles.length === 0) {
             this.chart.data.labels = [];
             this.chart.data.datasets[0].data = [];
+            this.chart.data.datasets[1].data = [];  // Clear sentiment too
             this.chart.update('none');
             return;
         }
@@ -420,9 +492,113 @@ class OHLCChart {
         this.chart.data.datasets[0].backgroundColor = colors;
         this.chart.data.datasets[0].borderColor = colors;
 
+        // Update sentiment overlay if we have data (Feature 1065)
+        this.updateSentimentOverlay();
+
         this.chart.update('none');
 
         console.log(`OHLC: Updated chart with ${candles.length} candles`);
+    }
+
+    /**
+     * Feature 1065: Load sentiment data from timeseries API
+     * @param {string} resolution - Sentiment resolution (e.g., '1h', '5m')
+     */
+    async loadSentimentData(resolution) {
+        if (!CONFIG.OVERLAY?.enabled) {
+            console.log('OHLC: Sentiment overlay disabled');
+            return;
+        }
+
+        this.sentimentResolution = resolution;
+
+        try {
+            const url = `${this.apiBaseUrl}${CONFIG.ENDPOINTS.TIMESERIES}/${this.currentTicker}?resolution=${resolution}`;
+            console.log(`OHLC: Fetching sentiment overlay ${url}`);
+
+            const response = await fetch(url, {
+                headers: {
+                    'Accept': 'application/json',
+                    'X-User-ID': sessionUserId
+                }
+            });
+
+            if (!response.ok) {
+                console.warn(`OHLC: Sentiment fetch failed: ${response.status}`);
+                this.sentimentData = [];
+                this.updateSentimentOverlay();
+                return;
+            }
+
+            const data = await response.json();
+            this.sentimentData = data.buckets || [];
+
+            console.log(`OHLC: Loaded ${this.sentimentData.length} sentiment buckets`);
+
+            // Update the overlay on the chart
+            this.updateSentimentOverlay();
+
+        } catch (error) {
+            console.error('OHLC: Failed to load sentiment data:', error);
+            this.sentimentData = [];
+            this.updateSentimentOverlay();
+        }
+    }
+
+    /**
+     * Feature 1065: Update sentiment line overlay on chart
+     * Aligns sentiment data with OHLC candle timestamps
+     */
+    updateSentimentOverlay() {
+        if (!this.chart || !this.chart.data.datasets[1]) return;
+
+        // If no sentiment data, clear the overlay
+        if (!this.sentimentData || this.sentimentData.length === 0) {
+            this.chart.data.datasets[1].data = [];
+            return;
+        }
+
+        // Build a map of sentiment by timestamp for alignment
+        const sentimentByTime = new Map();
+        this.sentimentData.forEach(bucket => {
+            const ts = bucket.bucket_timestamp || bucket.SK;
+            if (ts) {
+                // Parse and normalize to date string for matching
+                const date = new Date(ts);
+                const normalized = date.toISOString();
+                sentimentByTime.set(normalized, bucket.avg !== undefined ? bucket.avg : (bucket.sum / bucket.count) || 0);
+            }
+        });
+
+        // Align sentiment values to OHLC candle timestamps
+        const alignedSentiment = this.ohlcCandles.map(candle => {
+            const candleDate = new Date(candle.date);
+
+            // Try exact match first
+            const exactKey = candleDate.toISOString();
+            if (sentimentByTime.has(exactKey)) {
+                return sentimentByTime.get(exactKey);
+            }
+
+            // Find nearest sentiment bucket within 1 hour
+            let nearestValue = null;
+            let nearestDelta = Infinity;
+            const candleTime = candleDate.getTime();
+
+            for (const [ts, value] of sentimentByTime.entries()) {
+                const sentimentTime = new Date(ts).getTime();
+                const delta = Math.abs(candleTime - sentimentTime);
+                if (delta < nearestDelta && delta < 3600000) {  // Within 1 hour
+                    nearestDelta = delta;
+                    nearestValue = value;
+                }
+            }
+
+            return nearestValue;  // null if no match found
+        });
+
+        this.chart.data.datasets[1].data = alignedSentiment;
+        console.log(`OHLC: Updated sentiment overlay with ${alignedSentiment.filter(v => v !== null).length} aligned points`);
     }
 
     /**
@@ -483,8 +659,9 @@ async function updateOHLCTicker(ticker) {
  * Called from unified-resolution.js to update OHLC chart resolution
  * @param {string} resolution - OHLC resolution value ('1', '5', '15', '30', '60', 'D')
  * @param {boolean} isFallback - True if this is a fallback from a different unified resolution
+ * @param {string} sentimentResolution - Optional sentiment resolution to load for overlay (Feature 1065)
  */
-async function setOHLCResolution(resolution, isFallback = false) {
+async function setOHLCResolution(resolution, isFallback = false, sentimentResolution = null) {
     if (!ohlcChartInstance) {
         console.warn('OHLC chart not initialized');
         return;
@@ -492,6 +669,10 @@ async function setOHLCResolution(resolution, isFallback = false) {
 
     // Skip if already at this resolution
     if (ohlcChartInstance.currentResolution === resolution) {
+        // Still load sentiment if provided (Feature 1065)
+        if (sentimentResolution) {
+            await ohlcChartInstance.loadSentimentData(sentimentResolution);
+        }
         return;
     }
 
@@ -501,11 +682,29 @@ async function setOHLCResolution(resolution, isFallback = false) {
     ohlcChartInstance.showLoading();
     await ohlcChartInstance.loadData();
 
+    // Feature 1065: Load sentiment overlay data if resolution provided
+    if (sentimentResolution) {
+        await ohlcChartInstance.loadSentimentData(sentimentResolution);
+    }
+
     // Show fallback indicator if needed
     if (isFallback) {
         ohlcChartInstance.fallbackMessage = 'Resolution mapped from unified selector';
         ohlcChartInstance.showFallbackMessage();
     }
+}
+
+/**
+ * Feature 1065: Load sentiment overlay for OHLC chart
+ * Called from unified-resolution.js to update sentiment overlay
+ * @param {string} sentimentResolution - Sentiment resolution (e.g., '1h', '5m')
+ */
+async function loadOHLCSentimentOverlay(sentimentResolution) {
+    if (!ohlcChartInstance) {
+        console.warn('OHLC chart not initialized');
+        return;
+    }
+    await ohlcChartInstance.loadSentimentData(sentimentResolution);
 }
 
 /**
@@ -522,3 +721,4 @@ function hideOHLCResolutionSelector() {
 // Export functions for external use
 window.setOHLCResolution = setOHLCResolution;
 window.hideOHLCResolutionSelector = hideOHLCResolutionSelector;
+window.loadOHLCSentimentOverlay = loadOHLCSentimentOverlay;  // Feature 1065

--- a/src/dashboard/unified-resolution.js
+++ b/src/dashboard/unified-resolution.js
@@ -1,15 +1,17 @@
 /**
- * Unified Resolution Selector (Feature 1064)
- * ==========================================
+ * Unified Resolution Selector (Feature 1064, 1065)
+ * =================================================
  *
  * Single resolution selector that controls both OHLC price chart and sentiment
  * trend chart. Uses resolution mapping to handle different supported values
  * between the two chart types.
  *
+ * Feature 1065: Also passes sentiment resolution to OHLC chart for overlay.
+ *
  * Dependencies:
  *   - config.js: CONFIG.UNIFIED_RESOLUTIONS, CONFIG.DEFAULT_UNIFIED_RESOLUTION
- *   - ohlc.js: ohlcChartInstance.setResolution()
- *   - timeseries.js: timeseriesChartInstance.setResolution()
+ *   - ohlc.js: setOHLCResolution(ohlcRes, isFallback, sentimentRes)
+ *   - timeseries.js: setSentimentResolution(sentimentRes, isFallback)
  */
 
 /**
@@ -157,14 +159,15 @@ class UnifiedResolutionSelector {
 
     /**
      * Apply resolution to both charts via callbacks
+     * Feature 1065: Also passes sentiment resolution to OHLC for overlay
      */
     applyResolution(resolution) {
         const resConfig = CONFIG.UNIFIED_RESOLUTIONS.find(r => r.key === resolution);
         if (!resConfig) return;
 
-        // Notify OHLC chart
+        // Notify OHLC chart (Feature 1065: include sentiment resolution for overlay)
         if (this.onOhlcChange) {
-            this.onOhlcChange(resConfig.ohlc, !resConfig.exact);
+            this.onOhlcChange(resConfig.ohlc, !resConfig.exact, resConfig.sentiment);
         }
 
         // Notify sentiment chart


### PR DESCRIPTION
## Summary
- Overlays sentiment trend line on the OHLC candlestick chart for correlation analysis
- Blue sentiment line (#3b82f6) appears over price candles
- Dual Y-axes: price (left), sentiment -1.0 to +1.0 (right)
- Tooltip shows both OHLC values and sentiment score on hover
- Legend displays "Price" and "Sentiment" with colors

## Changes
- `config.js`: Add OVERLAY config for sentiment line styling
- `ohlc.js`: Extend chart with dual Y-axes, add sentiment data loading
- `unified-resolution.js`: Pass sentiment resolution to OHLC callback
- `app.js`: Update callbacks for sentiment overlay integration

## Test plan
- [ ] Verify OHLC chart renders with price candles
- [ ] Verify blue sentiment line overlays on chart
- [ ] Verify tooltip shows both OHLC and sentiment values
- [ ] Verify resolution changes update both datasets
- [ ] Verify ticker changes reload sentiment overlay

🤖 Generated with [Claude Code](https://claude.com/claude-code)