### PR TITLE
fix(dashboard): Add missing window exports for initOHLCChart and updateOHLCTicker

### DIFF
--- a/specs/1066-ohlc-window-exports-fix/plan.md
+++ b/specs/1066-ohlc-window-exports-fix/plan.md
@@ -1,0 +1,60 @@
+# Plan: Feature 1066 - Fix Missing Window Exports in ohlc.js
+
+## Overview
+
+Add missing window exports for `initOHLCChart` and `updateOHLCTicker` functions in `src/dashboard/ohlc.js`.
+
+## Implementation Steps
+
+### Step 1: Add Missing Window Exports
+
+**File**: `src/dashboard/ohlc.js`
+**Location**: After line 724
+
+**Change**:
+```javascript
+// Export functions for external use
+window.setOHLCResolution = setOHLCResolution;
+window.hideOHLCResolutionSelector = hideOHLCResolutionSelector;
+window.loadOHLCSentimentOverlay = loadOHLCSentimentOverlay;
+window.initOHLCChart = initOHLCChart;           // NEW
+window.updateOHLCTicker = updateOHLCTicker;     // NEW
+```
+
+### Step 2: Verify app.js Integration
+
+**File**: `src/dashboard/app.js`
+**Lines**: 283, 321
+
+Confirm these typeof guards will now pass:
+- Line 283: `if (typeof initOHLCChart === 'function')` → true after fix
+- Line 321: `if (typeof updateOHLCTicker === 'function')` → true after fix
+
+No changes needed to app.js - the guards are correct.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/dashboard/ohlc.js` | Add 2 window exports at end of file |
+
+## Testing
+
+1. **Unit**: Verify window exports exist (future Feature 1067)
+2. **Manual**: Load dashboard, verify OHLC chart renders
+3. **Manual**: Verify resolution buttons change chart
+4. **Manual**: Verify ticker input updates chart
+
+## Risk Assessment
+
+- **Low risk**: Simple additive change (2 lines)
+- **No API changes**: Only window exports added
+- **Backward compatible**: Existing functionality unchanged
+
+## Definition of Done
+
+- [ ] `window.initOHLCChart` is exported
+- [ ] `window.updateOHLCTicker` is exported
+- [ ] OHLC chart renders on dashboard load
+- [ ] Resolution buttons update the chart
+- [ ] All existing tests pass

--- a/specs/1066-ohlc-window-exports-fix/spec.md
+++ b/specs/1066-ohlc-window-exports-fix/spec.md
@@ -1,0 +1,93 @@
+# Feature 1066: Fix Missing Window Exports in ohlc.js
+
+## Problem Statement
+
+The OHLC chart and unified resolution selector are broken in production. Resolution buttons render but do not function, and the OHLC chart never initializes.
+
+### Root Cause
+
+In `src/dashboard/ohlc.js`, the functions `initOHLCChart` and `updateOHLCTicker` are defined (lines 628-655) but NOT exported to the window object. The window exports at lines 721-724 only export 3 of 5 required functions:
+
+```javascript
+// Currently exported (lines 721-724):
+window.setOHLCResolution = setOHLCResolution;
+window.hideOHLCResolutionSelector = hideOHLCResolutionSelector;
+window.loadOHLCSentimentOverlay = loadOHLCSentimentOverlay;
+
+// Missing exports:
+// window.initOHLCChart = initOHLCChart;      // NOT EXPORTED
+// window.updateOHLCTicker = updateOHLCTicker; // NOT EXPORTED
+```
+
+### Impact
+
+In `app.js`, the typeof guards silently fail:
+- Line 283: `if (typeof initOHLCChart === 'function')` → returns false
+- Line 321: `if (typeof updateOHLCTicker === 'function')` → returns false
+
+Result: OHLC chart never initializes, resolution buttons render but do nothing.
+
+## Requirements
+
+### R01: Export initOHLCChart to window
+The `initOHLCChart` function must be exported to the window object so `app.js` can call it during session initialization.
+
+### R02: Export updateOHLCTicker to window
+The `updateOHLCTicker` function must be exported to the window object so `app.js` and `timeseries.js` can call it when the ticker changes.
+
+### R03: Maintain backward compatibility
+Existing exports (`setOHLCResolution`, `hideOHLCResolutionSelector`, `loadOHLCSentimentOverlay`) must continue to work.
+
+### R04: Verify integration with app.js
+After adding exports, the typeof guards in `app.js` lines 283 and 321 should evaluate to true, and the chart should initialize on page load.
+
+## Test Requirements
+
+### T01: Verify initOHLCChart export exists
+After loading ohlc.js, `window.initOHLCChart` should be a function.
+
+### T02: Verify updateOHLCTicker export exists
+After loading ohlc.js, `window.updateOHLCTicker` should be a function.
+
+### T03: Verify chart initialization flow
+When `initOHLCChart('AAPL')` is called, it should:
+- Render the OHLC chart container
+- Fetch data from the API
+- Display candlestick chart
+
+### T04: Verify ticker update flow
+When `updateOHLCTicker('MSFT')` is called, it should:
+- Update the chart's ticker
+- Fetch new data
+- Re-render the chart
+
+## Implementation
+
+### File: src/dashboard/ohlc.js
+
+Add the missing exports after line 724:
+
+```javascript
+// Export functions for external use
+window.setOHLCResolution = setOHLCResolution;
+window.hideOHLCResolutionSelector = hideOHLCResolutionSelector;
+window.loadOHLCSentimentOverlay = loadOHLCSentimentOverlay;
+window.initOHLCChart = initOHLCChart;           // ADD THIS
+window.updateOHLCTicker = updateOHLCTicker;     // ADD THIS
+```
+
+## Verification
+
+1. Load the dashboard in a browser
+2. Open console and verify:
+   - `typeof window.initOHLCChart === 'function'` → true
+   - `typeof window.updateOHLCTicker === 'function'` → true
+3. Verify OHLC chart renders with candlesticks
+4. Verify resolution buttons update the chart
+5. Verify ticker input changes the chart symbol
+
+## Related Features
+
+- Feature 1057: Dashboard OHLC Chart (original implementation)
+- Feature 1064: Unified Resolution Selector (added window.setOHLCResolution)
+- Feature 1065: Sentiment-Price Overlay (added window.loadOHLCSentimentOverlay)

--- a/src/dashboard/ohlc.js
+++ b/src/dashboard/ohlc.js
@@ -722,3 +722,5 @@ function hideOHLCResolutionSelector() {
 window.setOHLCResolution = setOHLCResolution;
 window.hideOHLCResolutionSelector = hideOHLCResolutionSelector;
 window.loadOHLCSentimentOverlay = loadOHLCSentimentOverlay;  // Feature 1065
+window.initOHLCChart = initOHLCChart;  // Feature 1066: Fix missing export
+window.updateOHLCTicker = updateOHLCTicker;  // Feature 1066: Fix missing export


### PR DESCRIPTION
## Summary

- Add missing `window.initOHLCChart` export to ohlc.js
- Add missing `window.updateOHLCTicker` export to ohlc.js

## Root Cause

Functions `initOHLCChart` (line 628) and `updateOHLCTicker` (line 651) were defined in `ohlc.js` but NOT exported to the window object. The window exports at lines 721-724 only exported 3 of 5 required functions:

```javascript
// Before: Missing 2 exports
window.setOHLCResolution = setOHLCResolution;
window.hideOHLCResolutionSelector = hideOHLCResolutionSelector;
window.loadOHLCSentimentOverlay = loadOHLCSentimentOverlay;
// initOHLCChart - NOT EXPORTED
// updateOHLCTicker - NOT EXPORTED
```

This caused `app.js` typeof guards at lines 283 and 321 to fail silently:
- Line 283: `if (typeof initOHLCChart === 'function')` → returned false
- Line 321: `if (typeof updateOHLCTicker === 'function')` → returned false

**Impact**: OHLC chart never initialized, resolution buttons rendered but did nothing.

## Fix

Added 2 lines to export the missing functions:

```javascript
window.initOHLCChart = initOHLCChart;  // Feature 1066
window.updateOHLCTicker = updateOHLCTicker;  // Feature 1066
```

## Test Plan

- [x] All 199 dashboard unit tests pass
- [x] All 2363 unit tests pass
- [ ] Manual: Load dashboard, verify OHLC chart renders
- [ ] Manual: Verify resolution buttons change chart
- [ ] Manual: Verify ticker input updates chart

## Related

- Fixes dashboard UI regression after Features 1064/1065
- Spec: `specs/1066-ohlc-window-exports-fix/spec.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)