### PR TITLE
test(dashboard): Add window export validation tests for vanilla JS files

### DIFF
--- a/specs/1067-window-export-tests/plan.md
+++ b/specs/1067-window-export-tests/plan.md
@@ -1,0 +1,97 @@
+# Plan: Feature 1067 - Window Export Validation Tests
+
+## Overview
+
+Add static analysis tests that verify all required window exports exist in vanilla JS dashboard files. Uses regex parsing - no browser required.
+
+## Implementation Steps
+
+### Step 1: Create Window Export Registry
+
+**File**: `tests/unit/dashboard/window_export_registry.py`
+
+Define the expected window exports for each dashboard JS file:
+
+```python
+WINDOW_EXPORT_REGISTRY = {
+    "src/dashboard/ohlc.js": [
+        "initOHLCChart",
+        "updateOHLCTicker",
+        "setOHLCResolution",
+        "hideOHLCResolutionSelector",
+        "loadOHLCSentimentOverlay",
+    ],
+    "src/dashboard/timeseries.js": [
+        "initTimeseriesChart",
+        "updateTimeseriesTicker",
+    ],
+    "src/dashboard/unified-resolution.js": [
+        "initUnifiedResolutionSelector",
+        "setResolution",
+    ],
+}
+```
+
+### Step 2: Create Window Export Validator
+
+**File**: `tests/unit/dashboard/test_window_exports.py`
+
+```python
+import re
+from pathlib import Path
+import pytest
+from .window_export_registry import WINDOW_EXPORT_REGISTRY
+
+def find_window_exports(js_content: str) -> set[str]:
+    """Parse JS file to find window.X = X export patterns."""
+    pattern = r'window\.(\w+)\s*=\s*\1\s*[;,]?'
+    return set(re.findall(pattern, js_content))
+
+@pytest.mark.parametrize("js_file,expected_exports", WINDOW_EXPORT_REGISTRY.items())
+def test_window_exports_exist(js_file: str, expected_exports: list[str]):
+    """Verify all required window exports exist in JS file."""
+    repo_root = Path(__file__).parents[3]
+    js_path = repo_root / js_file
+
+    assert js_path.exists(), f"JS file not found: {js_file}"
+
+    content = js_path.read_text()
+    actual_exports = find_window_exports(content)
+
+    missing = set(expected_exports) - actual_exports
+    assert not missing, (
+        f"Missing window exports in {js_file}:\n"
+        f"  Expected: window.{', window.'.join(sorted(missing))}\n"
+        f"  Pattern: window.<name> = <name>;"
+    )
+```
+
+### Step 3: Verify with Current State
+
+Run tests to confirm they pass with Feature 1066 fix in place.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `tests/unit/dashboard/window_export_registry.py` | NEW - Export registry |
+| `tests/unit/dashboard/test_window_exports.py` | NEW - Validation tests |
+
+## Testing
+
+1. Run: `pytest tests/unit/dashboard/test_window_exports.py -v`
+2. Verify all parametrized tests pass
+3. Temporarily remove an export to verify test catches it
+
+## Risk Assessment
+
+- **Low risk**: Read-only tests, no production code changes
+- **Fast feedback**: Static analysis, no browser needed
+- **Regression prevention**: Would have caught Feature 1066
+
+## Definition of Done
+
+- [ ] Window export registry defines all exports
+- [ ] Tests pass for all dashboard JS files
+- [ ] Tests run in < 1 second (static analysis)
+- [ ] Error messages clearly identify missing exports

--- a/specs/1067-window-export-tests/spec.md
+++ b/specs/1067-window-export-tests/spec.md
@@ -1,0 +1,103 @@
+# Feature 1067: Window Export Validation Tests
+
+## Problem Statement
+
+The vanilla JavaScript dashboard files (`src/dashboard/*.js`) have NO automated tests despite being critical for chart initialization and user interaction. This test coverage gap allowed Feature 1066's regression (missing window exports) to slip through to production.
+
+### Background
+
+- Backend API tests exist (`tests/unit/dashboard/test_ohlc.py` - 200+ lines)
+- React frontend tests exist (`frontend/src/components/charts/*.test.tsx`)
+- **Gap**: NO tests for `src/dashboard/*.js` vanilla JS files
+- Silent failures from `typeof X === 'function'` guards hide missing exports
+
+### Impact
+
+Without window export validation tests:
+- Missing exports are not detected until manual testing
+- Silent failures in `app.js` go unnoticed
+- Regressions like Feature 1066 reach production
+
+## Requirements
+
+### R01: Static Window Export Verification
+
+Create tests that verify all required window exports exist in each dashboard JS file by parsing the source code.
+
+**Files to validate:**
+- `src/dashboard/ohlc.js` - OHLC chart functions
+- `src/dashboard/timeseries.js` - Timeseries chart functions
+- `src/dashboard/unified-resolution.js` - Resolution selector functions
+- `src/dashboard/app.js` - App initialization functions
+
+### R02: Export Registry Definition
+
+Define an explicit registry of required window exports per file. This makes the contract explicit and prevents accidental removal.
+
+**Expected exports:**
+```
+ohlc.js:
+  - initOHLCChart
+  - updateOHLCTicker
+  - setOHLCResolution
+  - hideOHLCResolutionSelector
+  - loadOHLCSentimentOverlay
+
+timeseries.js:
+  - initTimeseriesChart
+  - updateTimeseriesTicker
+  - setTimeseriesResolution (if exists)
+
+unified-resolution.js:
+  - initUnifiedResolutionSelector
+  - setResolution
+
+app.js:
+  - initDashboard (if exists)
+```
+
+### R03: Fast Feedback
+
+Tests must run as part of the standard `pytest` test suite without requiring a browser. Use static analysis (regex parsing) of JavaScript source files.
+
+### R04: Clear Error Messages
+
+When an export is missing, the test failure message must clearly identify:
+- Which file is missing the export
+- Which function is not exported
+- The expected export pattern
+
+## Test Requirements
+
+### T01: Test detects missing export
+
+Given ohlc.js WITHOUT `window.initOHLCChart = initOHLCChart`, the test MUST fail with a clear message.
+
+### T02: Test passes with all exports
+
+Given ohlc.js WITH all 5 required exports, the test MUST pass.
+
+### T03: Test catches partial exports
+
+If a file has some but not all required exports, the test MUST identify which specific exports are missing.
+
+## Implementation Notes
+
+- Use Python regex to parse JS files for `window.X = X` patterns
+- Test file location: `tests/unit/dashboard/test_window_exports.py`
+- No browser/Playwright required for static validation
+- Run with standard pytest markers
+
+## Definition of Done
+
+- [ ] All dashboard JS files have explicit export registries
+- [ ] Tests verify all exports exist via static analysis
+- [ ] Tests run as part of `pytest tests/unit/dashboard/`
+- [ ] Clear error messages identify missing exports
+- [ ] Tests would have caught Feature 1066 regression
+
+## Related Features
+
+- Feature 1066: Fix Missing Window Exports (the bug this prevents)
+- Feature 1064: Unified Resolution Selector
+- Feature 1065: Sentiment-Price Overlay

--- a/tests/unit/dashboard/test_window_exports.py
+++ b/tests/unit/dashboard/test_window_exports.py
@@ -1,0 +1,157 @@
+"""
+Window Export Validation Tests for Dashboard JavaScript Files.
+
+These tests verify that all required window exports exist in vanilla JS dashboard files
+via static analysis (regex parsing). No browser required.
+
+This test module prevents regressions like Feature 1066 where functions were defined
+but not exported to the window object, causing silent failures in app.js.
+
+Run: pytest tests/unit/dashboard/test_window_exports.py -v
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+from tests.unit.dashboard.window_export_registry import WINDOW_EXPORT_REGISTRY
+
+
+def find_window_exports(js_content: str) -> set[str]:
+    """
+    Parse JavaScript file content to find window.X = X export patterns.
+
+    Matches patterns like:
+        window.functionName = functionName;
+        window.ClassName = ClassName;
+        window.varName = varName
+
+    Args:
+        js_content: JavaScript source code as string
+
+    Returns:
+        Set of exported function/variable names
+    """
+    # Pattern: window.<name> = <name> with optional semicolon/comma and comments
+    # Handles:
+    #   window.foo = foo;
+    #   window.foo = foo  // comment
+    #   window.foo = foo,
+    pattern = r"window\.(\w+)\s*=\s*\1\s*[;,]?\s*(?://.*)?$"
+    return set(re.findall(pattern, js_content, re.MULTILINE))
+
+
+def get_repo_root() -> Path:
+    """Get the repository root directory."""
+    # Navigate up from tests/unit/dashboard/ to repo root
+    return Path(__file__).parents[3]
+
+
+class TestWindowExportsExist:
+    """Test that all required window exports exist in dashboard JS files."""
+
+    @pytest.mark.parametrize(
+        "js_file,expected_exports",
+        list(WINDOW_EXPORT_REGISTRY.items()),
+        ids=lambda x: x if isinstance(x, str) else None,
+    )
+    def test_window_exports_exist(
+        self, js_file: str, expected_exports: list[str]
+    ) -> None:
+        """
+        Verify all required window exports exist in the specified JS file.
+
+        Args:
+            js_file: Relative path to JavaScript file from repo root
+            expected_exports: List of function names that must be exported
+        """
+        repo_root = get_repo_root()
+        js_path = repo_root / js_file
+
+        # Verify file exists
+        assert js_path.exists(), (
+            f"JavaScript file not found: {js_file}\n"
+            f"Expected at: {js_path}\n"
+            f"Repo root: {repo_root}"
+        )
+
+        # Parse file content
+        content = js_path.read_text()
+        actual_exports = find_window_exports(content)
+
+        # Find missing exports
+        missing = set(expected_exports) - actual_exports
+
+        # Provide clear error message
+        assert not missing, (
+            f"\nMissing window exports in {js_file}:\n"
+            f"  Missing: {', '.join(sorted(missing))}\n"
+            f"  Expected pattern: window.<name> = <name>;\n"
+            f"\n"
+            f"  Found exports: {', '.join(sorted(actual_exports)) or '(none)'}\n"
+            f"\n"
+            f"  Fix: Add the following lines to {js_file}:\n"
+            + "\n".join(f"    window.{name} = {name};" for name in sorted(missing))
+        )
+
+    def test_registry_has_entries(self) -> None:
+        """Verify the registry is not empty."""
+        assert WINDOW_EXPORT_REGISTRY, "Window export registry is empty"
+        assert (
+            len(WINDOW_EXPORT_REGISTRY) >= 3
+        ), f"Expected at least 3 files in registry, found {len(WINDOW_EXPORT_REGISTRY)}"
+
+
+class TestWindowExportPattern:
+    """Test the window export pattern matching logic."""
+
+    def test_finds_simple_export(self) -> None:
+        """Test finding a simple window.foo = foo; pattern."""
+        js = "window.myFunc = myFunc;"
+        exports = find_window_exports(js)
+        assert "myFunc" in exports
+
+    def test_finds_export_without_semicolon(self) -> None:
+        """Test finding export without trailing semicolon."""
+        js = "window.myFunc = myFunc"
+        exports = find_window_exports(js)
+        assert "myFunc" in exports
+
+    def test_finds_export_with_comment(self) -> None:
+        """Test finding export with trailing comment."""
+        js = "window.myFunc = myFunc;  // Feature 1065"
+        exports = find_window_exports(js)
+        assert "myFunc" in exports
+
+    def test_ignores_different_assignment(self) -> None:
+        """Test that window.foo = bar (different names) is not matched."""
+        js = "window.myFunc = otherFunc;"
+        exports = find_window_exports(js)
+        assert "myFunc" not in exports
+
+    def test_finds_multiple_exports(self) -> None:
+        """Test finding multiple exports."""
+        js = """
+window.func1 = func1;
+window.func2 = func2;
+window.func3 = func3;
+"""
+        exports = find_window_exports(js)
+        assert exports == {"func1", "func2", "func3"}
+
+    def test_handles_empty_file(self) -> None:
+        """Test handling empty file content."""
+        exports = find_window_exports("")
+        assert exports == set()
+
+    def test_handles_no_exports(self) -> None:
+        """Test handling file with no window exports."""
+        js = """
+function myFunc() {
+    console.log("hello");
+}
+const x = 5;
+"""
+        exports = find_window_exports(js)
+        assert exports == set()

--- a/tests/unit/dashboard/window_export_registry.py
+++ b/tests/unit/dashboard/window_export_registry.py
@@ -1,0 +1,44 @@
+"""
+Window Export Registry for Dashboard JavaScript Files.
+
+This registry defines the required window exports for each vanilla JS dashboard file.
+Tests validate that all exports exist via static analysis (regex parsing).
+
+This prevents regressions like Feature 1066 where functions were defined but not exported.
+
+Usage:
+    from tests.unit.dashboard.window_export_registry import WINDOW_EXPORT_REGISTRY
+"""
+
+# Registry of required window exports per file
+# Format: { "relative/path/to/file.js": ["export1", "export2", ...] }
+WINDOW_EXPORT_REGISTRY: dict[str, list[str]] = {
+    # OHLC Chart - candlestick visualization with sentiment overlay
+    "src/dashboard/ohlc.js": [
+        "OHLCChart",  # Class export
+        "setOHLCResolution",  # Change chart resolution
+        "hideOHLCResolutionSelector",  # Hide resolution UI
+        "loadOHLCSentimentOverlay",  # Load sentiment data on chart
+        "initOHLCChart",  # Initialize chart (Feature 1066 fix)
+        "updateOHLCTicker",  # Update ticker symbol (Feature 1066 fix)
+    ],
+    # Timeseries Chart - sentiment trends over time
+    "src/dashboard/timeseries.js": [
+        "setSentimentResolution",  # Change resolution
+        "hideSentimentResolutionSelector",  # Hide resolution UI
+        "getTimeseriesManager",  # Get chart manager instance
+    ],
+    # Unified Resolution Selector - shared resolution control
+    "src/dashboard/unified-resolution.js": [
+        "initUnifiedResolution",  # Initialize selector
+        "getUnifiedResolution",  # Get current resolution
+    ],
+}
+
+# Files that are intentionally exempt from export validation
+# (e.g., utility files, config files, internal modules)
+EXEMPT_FILES: set[str] = {
+    "src/dashboard/cache.js",  # Internal caching utility
+    "src/dashboard/config.js",  # Configuration constants
+    "src/dashboard/app.js",  # Consumer, not exporter
+}


### PR DESCRIPTION
## Summary

- Add static analysis tests that verify all required window exports exist in dashboard JS files
- Add window export registry defining expected exports per file
- Prevents regressions like Feature 1066 where functions were defined but not exported

## Files Added

- `tests/unit/dashboard/window_export_registry.py` - Registry of required exports
- `tests/unit/dashboard/test_window_exports.py` - 11 validation tests
- `specs/1067-window-export-tests/` - Specification and plan

## Validation Coverage

| File | Required Exports |
|------|-----------------|
| `src/dashboard/ohlc.js` | 6 exports (OHLCChart, initOHLCChart, updateOHLCTicker, setOHLCResolution, hideOHLCResolutionSelector, loadOHLCSentimentOverlay) |
| `src/dashboard/timeseries.js` | 3 exports (setSentimentResolution, hideSentimentResolutionSelector, getTimeseriesManager) |
| `src/dashboard/unified-resolution.js` | 2 exports (initUnifiedResolution, getUnifiedResolution) |

## Test Plan

- [x] All 11 window export tests pass
- [x] All 2374 unit tests pass
- [x] Pattern matching correctly identifies exports
- [x] Clear error messages when exports missing

## Why This Matters

This test would have caught Feature 1066's regression where `initOHLCChart` and `updateOHLCTicker` were defined but not exported to window object, causing silent failures.

## Related

- Feature 1066: Fix Missing Window Exports (the bug this prevents)
- Spec: `specs/1067-window-export-tests/spec.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)