### PR TITLE
fix(dashboard): Handle empty string SSE URLs for same-origin requests (Feature 1068)

### DIFF
--- a/.specify/scripts/bash/create-new-feature.sh
+++ b/.specify/scripts/bash/create-new-feature.sh
@@ -131,8 +131,8 @@ check_existing_branches() {
     local short_name="$1"
     local specs_dir="$2"
 
-    # Fetch all remotes to get latest branch info (suppress errors if no remotes)
-    git fetch --all --prune 2>/dev/null || true
+    # Fetch all remotes to get latest branch info (suppress all output)
+    git fetch --all --prune >/dev/null 2>&1 || true
 
     # Find all branches matching the pattern using git ls-remote (more reliable)
     local remote_branches=$(git ls-remote --heads origin 2>/dev/null | grep -E "refs/heads/[0-9]+-${short_name}$" | sed 's/.*\/\([0-9]*\)-.*/\1/' | sort -n)

--- a/specs/1068-fix-sse-same-origin/spec.md
+++ b/specs/1068-fix-sse-same-origin/spec.md
@@ -1,0 +1,155 @@
+# Feature Specification: Fix SSE Same-Origin Configuration
+
+**Feature Branch**: `1068-fix-sse-same-origin`
+**Created**: 2025-12-26
+**Status**: Draft
+**Input**: User description: "Fix SSE connection failure when same-origin configuration uses empty strings"
+
+## Problem Statement
+
+The SSE (Server-Sent Events) connection fails to establish when `API_BASE_URL` and `SSE_BASE_URL` are configured as empty strings, which is the correct configuration for same-origin requests.
+
+### Root Cause
+
+In `src/dashboard/timeseries.js:575-579`, the check `if (!baseUrl)` treats empty string as falsy, blocking SSE connection:
+
+```javascript
+const baseUrl = this.sseBaseUrl || this.apiBaseUrl;
+if (!baseUrl) {  // BUG: '' is falsy but valid for same-origin
+    console.warn('No SSE base URL configured');
+    return;  // SSE connection blocked!
+}
+```
+
+### Impact
+
+1. Console warning: "No SSE base URL configured"
+2. SSE EventSource never instantiated
+3. Sentiment Trends chart shows initial data but never updates with real-time data
+4. Resolution selector buttons work but SSE reconnection fails silently on switch
+
+### Regression Context
+
+- Introduced in PR #524 (Feature 1064: Unified Resolution Selector)
+- PR #526 and #527 attempted fixes but addressed window exports, not the actual SSE connection issue
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Real-Time Sentiment Updates (Priority: P1)
+
+As a dashboard user, I want to see sentiment data update in real-time so that I can make informed decisions based on current market sentiment.
+
+**Why this priority**: This is the core value proposition of the dashboard - real-time sentiment visualization. Without SSE, the dashboard is static and loses most of its utility.
+
+**Independent Test**: Can be tested by opening the dashboard, observing the console for SSE connection logs, and verifying data updates flow through without page refresh.
+
+**Acceptance Scenarios**:
+
+1. **Given** dashboard loads with same-origin config (empty string URLs), **When** page initialization completes, **Then** SSE connection MUST be established (no "No SSE base URL configured" warning)
+2. **Given** SSE connection is established, **When** sentiment data is published, **Then** the Sentiment Trends chart MUST update without page refresh
+3. **Given** user changes resolution, **When** resolution switch completes, **Then** SSE MUST reconnect with new resolution filter
+
+---
+
+### User Story 2 - Browser Console Clean Startup (Priority: P2)
+
+As a developer debugging the dashboard, I want the console to be free of spurious warnings when the configuration is correct, so I can focus on actual issues.
+
+**Why this priority**: Developer experience and observability. False warnings create noise and mask real problems.
+
+**Independent Test**: Can be tested by opening browser DevTools console during dashboard load and verifying no warnings appear for valid configurations.
+
+**Acceptance Scenarios**:
+
+1. **Given** `CONFIG.SSE_BASE_URL` is empty string (same-origin), **When** `connectSSE()` is called, **Then** no warning MUST be logged
+2. **Given** `CONFIG.SSE_BASE_URL` is `null` or `undefined`, **When** `connectSSE()` is called, **Then** a warning SHOULD be logged (actual config error)
+
+---
+
+### User Story 3 - Cross-Origin SSE Support (Priority: P3)
+
+As a deployment engineer, I want to configure SSE to use a separate Lambda URL when using two-Lambda architecture, so I can scale SSE independently.
+
+**Why this priority**: Important for production deployments but not blocking for basic functionality.
+
+**Independent Test**: Can be tested by setting `CONFIG.SSE_BASE_URL` to a different hostname and verifying SSE connects to that URL.
+
+**Acceptance Scenarios**:
+
+1. **Given** `CONFIG.SSE_BASE_URL` is set to `https://sse-lambda.example.com`, **When** `connectSSE()` is called, **Then** EventSource MUST connect to that URL
+
+---
+
+### Edge Cases
+
+- What happens when `apiBaseUrl` is set but `sseBaseUrl` is empty? (Should use `apiBaseUrl` fallback)
+- What happens when both are explicitly `null`? (Should warn and return early)
+- What happens when SSE URL is invalid? (Should fail gracefully at EventSource level)
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST establish SSE connection when `SSE_BASE_URL` is empty string (same-origin configuration)
+- **FR-002**: System MUST use `apiBaseUrl` as fallback when `sseBaseUrl` is empty string but `apiBaseUrl` is set
+- **FR-003**: System MUST only warn when both URLs are `null` or `undefined` (not just falsy)
+- **FR-004**: System MUST construct valid same-origin URLs (e.g., `/api/v2/stream`) when baseUrl is empty string
+- **FR-005**: System MUST reconnect SSE on resolution switch with new parameters
+
+### Key Entities
+
+- **CONFIG**: Global configuration object with `SSE_BASE_URL` and `API_BASE_URL`
+- **TimeseriesManager**: Class managing SSE connection and sentiment data
+- **EventSource**: Browser API for SSE connection
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: No "No SSE base URL configured" warning in console when using empty string configuration
+- **SC-002**: SSE connection established within 1 second of `connectSSE()` call
+- **SC-003**: Sentiment Trends chart receives real-time updates via SSE `bucket_update` events
+- **SC-004**: Resolution selector changes trigger SSE reconnection without errors
+
+## Technical Approach
+
+### Fix Location
+
+`src/dashboard/timeseries.js`, `connectSSE()` method (lines 569-613)
+
+### Proposed Change
+
+Replace truthy check with explicit null/undefined check:
+
+```javascript
+// Before (buggy)
+const baseUrl = this.sseBaseUrl || this.apiBaseUrl;
+if (!baseUrl) {
+    console.warn('No SSE base URL configured');
+    return;
+}
+
+// After (correct)
+// Get base URL with proper fallback chain
+// Empty string '' is valid for same-origin requests
+const sseUrl = this.sseBaseUrl;
+const apiUrl = this.apiBaseUrl;
+
+// Only warn if both are truly unconfigured (null/undefined), not just empty
+if ((sseUrl === null || sseUrl === undefined) &&
+    (apiUrl === null || apiUrl === undefined)) {
+    console.warn('No SSE base URL configured');
+    return;
+}
+
+// Use nullish coalescing to allow empty string through
+const baseUrl = sseUrl ?? apiUrl ?? '';
+```
+
+### Test Requirements
+
+Unit tests should verify:
+1. SSE connects when both URLs are empty strings
+2. SSE connects when only `sseBaseUrl` is set
+3. SSE connects when only `apiBaseUrl` is set
+4. SSE warns and returns when both are `null`/`undefined`

--- a/src/dashboard/timeseries.js
+++ b/src/dashboard/timeseries.js
@@ -572,11 +572,20 @@ class TimeseriesManager {
             this.eventSource.close();
         }
 
-        const baseUrl = this.sseBaseUrl || this.apiBaseUrl;
-        if (!baseUrl) {
+        // Feature 1068: Fix same-origin configuration handling
+        // Empty string '' is valid for same-origin requests, only warn if truly unconfigured
+        const sseUrl = this.sseBaseUrl;
+        const apiUrl = this.apiBaseUrl;
+
+        // Only warn if both are null/undefined (not just falsy empty strings)
+        if ((sseUrl === null || sseUrl === undefined) &&
+            (apiUrl === null || apiUrl === undefined)) {
             console.warn('No SSE base URL configured');
             return;
         }
+
+        // Use nullish coalescing to allow empty string through for same-origin
+        const baseUrl = sseUrl ?? apiUrl ?? '';
 
         // Connect with resolution filter
         const streamUrl = `${baseUrl}/api/v2/stream?tickers=${this.currentTicker}&resolutions=${this.currentResolution}`;

--- a/tests/unit/dashboard/test_sse_same_origin.py
+++ b/tests/unit/dashboard/test_sse_same_origin.py
@@ -1,0 +1,213 @@
+"""
+SSE Same-Origin Configuration Tests for Dashboard JavaScript.
+
+Feature 1068: Tests that verify the SSE URL handling logic correctly
+treats empty strings as valid same-origin configuration.
+
+These tests use static analysis of JavaScript source code to verify:
+1. The connectSSE function uses explicit null/undefined checks
+2. Empty string '' is NOT treated as "unconfigured"
+3. Nullish coalescing (??) is used instead of logical OR (||)
+
+Run: pytest tests/unit/dashboard/test_sse_same_origin.py -v
+"""
+
+import re
+from pathlib import Path
+
+
+def get_repo_root() -> Path:
+    """Get the repository root directory."""
+    return Path(__file__).parents[3]
+
+
+def read_timeseries_js() -> str:
+    """Read the timeseries.js file content."""
+    repo_root = get_repo_root()
+    timeseries_path = repo_root / "src" / "dashboard" / "timeseries.js"
+    assert timeseries_path.exists(), f"timeseries.js not found at {timeseries_path}"
+    return timeseries_path.read_text()
+
+
+class TestSSEURLHandling:
+    """Test SSE URL handling logic in timeseries.js."""
+
+    def test_file_exists(self) -> None:
+        """Verify timeseries.js exists."""
+        repo_root = get_repo_root()
+        timeseries_path = repo_root / "src" / "dashboard" / "timeseries.js"
+        assert timeseries_path.exists(), "timeseries.js not found"
+
+    def test_connect_sse_method_exists(self) -> None:
+        """Verify connectSSE method exists."""
+        content = read_timeseries_js()
+        assert "connectSSE()" in content, "connectSSE method not found"
+
+    def test_no_truthy_check_for_baseurl(self) -> None:
+        """
+        Verify the code does NOT use truthy check (!baseUrl) for URL validation.
+
+        The bug was: if (!baseUrl) - treats empty string as falsy (invalid)
+        The fix uses explicit null/undefined checks instead.
+        """
+        content = read_timeseries_js()
+
+        # Find the connectSSE function
+        connect_sse_match = re.search(
+            r"connectSSE\(\)\s*\{([\s\S]*?)\n\s{4}\}",
+            content,
+            re.MULTILINE,
+        )
+        assert connect_sse_match, "Could not find connectSSE method body"
+
+        method_body = connect_sse_match.group(1)
+
+        # The bug pattern: using truthy check on baseUrl
+        # This incorrectly treats empty string as "not configured"
+        bug_pattern = r"if\s*\(\s*!baseUrl\s*\)"
+
+        # Should NOT find the bug pattern
+        assert not re.search(bug_pattern, method_body), (
+            "Found truthy check (!baseUrl) in connectSSE - this treats empty string "
+            "as unconfigured. Use explicit null/undefined check instead.\n"
+            f"Method body:\n{method_body[:500]}..."
+        )
+
+    def test_uses_nullish_coalescing_or_explicit_checks(self) -> None:
+        """
+        Verify the code uses nullish coalescing (??) or explicit null checks.
+
+        Correct patterns:
+        - sseUrl ?? apiUrl ?? ''
+        - sseUrl === null || sseUrl === undefined
+        """
+        content = read_timeseries_js()
+
+        # Find the connectSSE function
+        connect_sse_match = re.search(
+            r"connectSSE\(\)\s*\{([\s\S]*?)\n\s{4}\}",
+            content,
+            re.MULTILINE,
+        )
+        assert connect_sse_match, "Could not find connectSSE method body"
+
+        method_body = connect_sse_match.group(1)
+
+        # Should use nullish coalescing (??) instead of logical OR (||)
+        # for baseUrl assignment
+        has_nullish_coalescing = "??" in method_body
+
+        # Or should have explicit null/undefined checks
+        has_explicit_null_check = (
+            "=== null" in method_body or "=== undefined" in method_body
+        )
+
+        assert has_nullish_coalescing or has_explicit_null_check, (
+            "connectSSE should use nullish coalescing (??) or explicit null checks "
+            "to handle empty string same-origin configuration correctly.\n"
+            f"Method body:\n{method_body[:500]}..."
+        )
+
+    def test_has_feature_1068_comment(self) -> None:
+        """Verify the Feature 1068 fix has a comment for traceability."""
+        content = read_timeseries_js()
+
+        # Look for Feature 1068 reference
+        assert "Feature 1068" in content or "1068" in content, (
+            "Missing Feature 1068 reference in timeseries.js. "
+            "The fix should have a comment for traceability."
+        )
+
+    def test_baseurl_fallback_allows_empty_string(self) -> None:
+        """
+        Verify the baseUrl assignment allows empty string through.
+
+        The bug was: const baseUrl = this.sseBaseUrl || this.apiBaseUrl;
+        This treats '' as falsy and skips to the next option.
+
+        The fix should use: const baseUrl = sseUrl ?? apiUrl ?? '';
+        This allows empty string through as a valid value.
+        """
+        content = read_timeseries_js()
+
+        # Find the connectSSE function
+        connect_sse_match = re.search(
+            r"connectSSE\(\)\s*\{([\s\S]*?)\n\s{4}\}",
+            content,
+            re.MULTILINE,
+        )
+        assert connect_sse_match, "Could not find connectSSE method body"
+
+        method_body = connect_sse_match.group(1)
+
+        # Bug pattern: using || which treats empty string as falsy
+        bug_pattern = (
+            r"const\s+baseUrl\s*=\s*this\.sseBaseUrl\s*\|\|\s*this\.apiBaseUrl"
+        )
+
+        assert not re.search(bug_pattern, method_body), (
+            "Found logical OR (||) for baseUrl assignment. This treats empty string "
+            "as falsy. Use nullish coalescing (??) instead:\n"
+            "  Bad:  const baseUrl = this.sseBaseUrl || this.apiBaseUrl\n"
+            "  Good: const baseUrl = sseUrl ?? apiUrl ?? ''\n"
+        )
+
+
+class TestSSEURLEdgeCases:
+    """Test edge case handling documentation in the code."""
+
+    def test_same_origin_comment_exists(self) -> None:
+        """Verify there's a comment explaining same-origin handling."""
+        content = read_timeseries_js()
+
+        # Should have documentation about same-origin behavior
+        same_origin_patterns = [
+            r"same.?origin",
+            r"empty string",
+            r"'' is valid",
+        ]
+
+        has_documentation = any(
+            re.search(pattern, content, re.IGNORECASE)
+            for pattern in same_origin_patterns
+        )
+
+        assert has_documentation, (
+            "Missing documentation about same-origin URL handling. "
+            "Add a comment explaining that empty string is valid for same-origin requests."
+        )
+
+    def test_warning_only_for_null_undefined(self) -> None:
+        """
+        Verify warning is only logged for actual null/undefined values.
+
+        The warning should NOT trigger for empty string (same-origin).
+        """
+        content = read_timeseries_js()
+
+        # Find the connectSSE function
+        connect_sse_match = re.search(
+            r"connectSSE\(\)\s*\{([\s\S]*?)\n\s{4}\}",
+            content,
+            re.MULTILINE,
+        )
+        assert connect_sse_match, "Could not find connectSSE method body"
+
+        method_body = connect_sse_match.group(1)
+
+        # The warning should be preceded by explicit null/undefined check
+        # Look for pattern like:
+        #   if (... === null ... === undefined ...)
+        #   console.warn('No SSE base URL configured')
+        has_warning = "console.warn" in method_body
+
+        if has_warning:
+            # If there's a warning, verify it's guarded by explicit checks
+            has_proper_guard = (
+                "=== null" in method_body and "=== undefined" in method_body
+            )
+            assert has_proper_guard, (
+                "Warning found but without explicit null/undefined checks. "
+                "The warning should only trigger for actually unconfigured URLs, "
+                "not for empty string (same-origin)."
+            )


### PR DESCRIPTION
## Summary

- Fix SSE connection failure when `API_BASE_URL` and `SSE_BASE_URL` are configured as empty strings (same-origin configuration)
- Root cause: In `timeseries.js:575-579`, the check `if (!baseUrl)` treated empty string as falsy, blocking SSE connection
- Empty string `''` is valid for same-origin requests where the browser uses the current host

## Changes

- **timeseries.js**: Replace truthy check with explicit null/undefined check using nullish coalescing (`??`)
- **test_sse_same_origin.py**: Add static analysis tests to prevent regression
- **create-new-feature.sh**: Fix git fetch stdout pollution bug

## Impact

- Console warning "No SSE base URL configured" no longer appears for valid same-origin config
- SSE EventSource connects properly for same-origin deployments
- Sentiment Trends chart receives real-time updates again

## Regression Context

- Introduced in PR #524 (Feature 1064: Unified Resolution Selector)
- PR #526/527 attempted fixes but addressed window exports, not the SSE connection issue

## Test plan

- [x] All 218 dashboard unit tests pass
- [x] New test_sse_same_origin.py tests verify the fix
- [ ] Manual verification: Open dashboard, check no SSE warning in console
- [ ] Manual verification: Sentiment Trends chart updates with real-time data

🤖 Generated with [Claude Code](https://claude.com/claude-code)