### PR TITLE
fix(dashboard): Use correct timestamp field for sentiment overlay (Feature 1069)

### DIFF
--- a/specs/1069-fix-sentiment-overlay-timestamp/spec.md
+++ b/specs/1069-fix-sentiment-overlay-timestamp/spec.md
@@ -1,0 +1,112 @@
+# Feature Specification: Fix Sentiment Overlay Timestamp Field Mismatch
+
+**Feature Branch**: `1069-fix-sentiment-overlay-timestamp`
+**Created**: 2025-12-27
+**Status**: Draft
+**Input**: User description: "fix-sentiment-overlay-timestamp"
+
+## Problem Statement
+
+The Price Chart shows the blue "Sentiment" line in the legend, but no actual sentiment data points appear on the chart.
+
+### Root Cause
+
+In `src/dashboard/ohlc.js:564`, the code looks for timestamp with wrong field names:
+
+```javascript
+const ts = bucket.bucket_timestamp || bucket.SK;  // WRONG
+```
+
+The API (`/api/v2/timeseries/{ticker}`) returns buckets with `timestamp` field:
+```json
+{
+  "buckets": [
+    {
+      "timestamp": "2025-12-27T10:00:00+00:00",
+      "avg": 0.45,
+      ...
+    }
+  ]
+}
+```
+
+The field name mismatch causes `ts` to be `undefined`, resulting in no sentiment data being mapped.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - View Sentiment Overlay on Price Chart (Priority: P1)
+
+As a dashboard user, I want to see the sentiment line overlaid on the OHLC price chart so that I can correlate price movements with market sentiment.
+
+**Why this priority**: This is the core purpose of Feature 1065 (sentiment-price overlay). The chart currently shows the legend but no data, making the feature broken.
+
+**Independent Test**: Open dashboard, observe Price Chart - blue sentiment line should appear with actual data points aligned to OHLC candles.
+
+**Acceptance Scenarios**:
+
+1. **Given** Price Chart displays OHLC candles for AAPL, **When** sentiment data exists for the time period, **Then** blue sentiment line MUST appear with data points
+2. **Given** sentiment API returns buckets with `timestamp` field, **When** chart parses the response, **Then** all bucket timestamps MUST be correctly extracted
+3. **Given** resolution switch from 1h to 5m, **When** chart reloads sentiment data, **Then** new sentiment data MUST be correctly aligned to new OHLC candles
+
+---
+
+### User Story 2 - Console Logging for Debugging (Priority: P2)
+
+As a developer debugging the dashboard, I want clear console logs showing how many sentiment points were aligned, so I can verify the overlay is working.
+
+**Why this priority**: Observability for ongoing maintenance.
+
+**Independent Test**: Open browser DevTools, switch resolutions, verify log messages show non-zero aligned points.
+
+**Acceptance Scenarios**:
+
+1. **Given** sentiment data loads successfully, **When** updateSentimentOverlay() runs, **Then** console MUST log "Updated sentiment overlay with N aligned points" where N > 0
+
+---
+
+### Edge Cases
+
+- What happens when API returns empty buckets array? (Clear overlay, no error)
+- What happens when bucket has no timestamp field at all? (Skip that bucket, log warning)
+- What happens when OHLC and sentiment have no overlapping timestamps? (Show empty overlay, log warning)
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST read `bucket.timestamp` as the primary timestamp field
+- **FR-002**: System MUST fallback to `bucket.bucket_timestamp` then `bucket.SK` for backwards compatibility
+- **FR-003**: System MUST align sentiment data points to OHLC candle timestamps within 1 hour tolerance
+- **FR-004**: System MUST update chart dataset[1] with aligned sentiment values
+
+### Key Entities
+
+- **SentimentBucket**: API response with `timestamp`, `avg`, `count`, `label_counts`
+- **OHLCCandle**: Price data with `date`, `open`, `high`, `low`, `close`
+- **Chart.js Dataset[1]**: Sentiment overlay line data array
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Sentiment overlay shows non-zero aligned points in console log
+- **SC-002**: Blue sentiment line visible on Price Chart when sentiment data exists
+- **SC-003**: No JavaScript errors in console related to undefined timestamp
+
+## Technical Approach
+
+### Fix Location
+
+`src/dashboard/ohlc.js`, `updateSentimentOverlay()` method, line 564
+
+### Proposed Change
+
+```javascript
+// Before (buggy)
+const ts = bucket.bucket_timestamp || bucket.SK;
+
+// After (correct)
+const ts = bucket.timestamp || bucket.bucket_timestamp || bucket.SK;
+```
+
+This adds `bucket.timestamp` as the primary field, with fallbacks for any legacy data formats.

--- a/src/dashboard/ohlc.js
+++ b/src/dashboard/ohlc.js
@@ -561,7 +561,8 @@ class OHLCChart {
         // Build a map of sentiment by timestamp for alignment
         const sentimentByTime = new Map();
         this.sentimentData.forEach(bucket => {
-            const ts = bucket.bucket_timestamp || bucket.SK;
+            // Feature 1069: Fix field name - API returns 'timestamp', not 'bucket_timestamp' or 'SK'
+            const ts = bucket.timestamp || bucket.bucket_timestamp || bucket.SK;
             if (ts) {
                 // Parse and normalize to date string for matching
                 const date = new Date(ts);

--- a/tests/unit/dashboard/test_sentiment_overlay_fields.py
+++ b/tests/unit/dashboard/test_sentiment_overlay_fields.py
@@ -1,0 +1,130 @@
+"""
+Sentiment Overlay Field Validation Tests for Dashboard JavaScript.
+
+Feature 1069: Tests that verify the sentiment overlay code uses correct
+field names to extract timestamps from API responses.
+
+The API returns buckets with 'timestamp' field, not 'bucket_timestamp' or 'SK'.
+This test ensures the JavaScript code checks 'timestamp' first.
+
+Run: pytest tests/unit/dashboard/test_sentiment_overlay_fields.py -v
+"""
+
+import re
+from pathlib import Path
+
+
+def get_repo_root() -> Path:
+    """Get the repository root directory."""
+    return Path(__file__).parents[3]
+
+
+def read_ohlc_js() -> str:
+    """Read the ohlc.js file content."""
+    repo_root = get_repo_root()
+    ohlc_path = repo_root / "src" / "dashboard" / "ohlc.js"
+    assert ohlc_path.exists(), f"ohlc.js not found at {ohlc_path}"
+    return ohlc_path.read_text()
+
+
+class TestSentimentOverlayFields:
+    """Test that sentiment overlay uses correct API field names."""
+
+    def test_file_exists(self) -> None:
+        """Verify ohlc.js exists."""
+        repo_root = get_repo_root()
+        ohlc_path = repo_root / "src" / "dashboard" / "ohlc.js"
+        assert ohlc_path.exists(), "ohlc.js not found"
+
+    def test_update_sentiment_overlay_method_exists(self) -> None:
+        """Verify updateSentimentOverlay method exists."""
+        content = read_ohlc_js()
+        assert (
+            "updateSentimentOverlay()" in content
+        ), "updateSentimentOverlay method not found"
+
+    def test_uses_timestamp_field_first(self) -> None:
+        """
+        Verify the code checks bucket.timestamp as the primary field.
+
+        The API returns SentimentBucketResponse with 'timestamp' field.
+        The JS code must check this field first, before legacy fallbacks.
+        """
+        content = read_ohlc_js()
+
+        # Find the updateSentimentOverlay function
+        overlay_match = re.search(
+            r"updateSentimentOverlay\(\)\s*\{([\s\S]*?)\n\s{4}\}",
+            content,
+            re.MULTILINE,
+        )
+        assert overlay_match, "Could not find updateSentimentOverlay method body"
+
+        method_body = overlay_match.group(1)
+
+        # The correct pattern: bucket.timestamp should appear first
+        # Pattern should be: bucket.timestamp || bucket.bucket_timestamp || bucket.SK
+        correct_pattern = r"bucket\.timestamp\s*\|\|"
+
+        assert re.search(correct_pattern, method_body), (
+            "Sentiment overlay must check bucket.timestamp first.\n"
+            "The API returns SentimentBucketResponse with 'timestamp' field, "
+            "not 'bucket_timestamp' or 'SK'.\n"
+            "Expected pattern: bucket.timestamp || bucket.bucket_timestamp || bucket.SK"
+        )
+
+    def test_has_feature_1069_comment(self) -> None:
+        """Verify the Feature 1069 fix has a comment for traceability."""
+        content = read_ohlc_js()
+
+        # Look for Feature 1069 reference
+        assert "Feature 1069" in content or "1069" in content, (
+            "Missing Feature 1069 reference in ohlc.js. "
+            "The fix should have a comment for traceability."
+        )
+
+    def test_does_not_skip_timestamp_field(self) -> None:
+        """
+        Verify the code does NOT only check bucket_timestamp or SK.
+
+        Bug was: const ts = bucket.bucket_timestamp || bucket.SK;
+        This skips the actual 'timestamp' field that the API returns.
+        """
+        content = read_ohlc_js()
+
+        # Find the updateSentimentOverlay function
+        overlay_match = re.search(
+            r"updateSentimentOverlay\(\)\s*\{([\s\S]*?)\n\s{4}\}",
+            content,
+            re.MULTILINE,
+        )
+        assert overlay_match, "Could not find updateSentimentOverlay method body"
+
+        method_body = overlay_match.group(1)
+
+        # Bug pattern: starting with bucket_timestamp, skipping timestamp
+        bug_pattern = r"=\s*bucket\.bucket_timestamp\s*\|\|\s*bucket\.SK\s*;"
+
+        assert not re.search(bug_pattern, method_body), (
+            "Found bug pattern: bucket.bucket_timestamp || bucket.SK\n"
+            "This skips the 'timestamp' field that the API actually returns.\n"
+            "Fix: bucket.timestamp || bucket.bucket_timestamp || bucket.SK"
+        )
+
+
+class TestSentimentApiFieldNames:
+    """Test that we document the expected API field names."""
+
+    def test_load_sentiment_data_method_exists(self) -> None:
+        """Verify loadSentimentData method exists."""
+        content = read_ohlc_js()
+        assert "loadSentimentData" in content, "loadSentimentData method not found"
+
+    def test_uses_buckets_array(self) -> None:
+        """Verify the code accesses data.buckets from API response."""
+        content = read_ohlc_js()
+
+        # The API returns { buckets: [...] }
+        assert (
+            "data.buckets" in content
+        ), "Code should access data.buckets from API response"


### PR DESCRIPTION
## Summary

- Fix sentiment overlay showing legend but no data points on Price Chart
- Root cause: API returns `bucket.timestamp` but JS code looked for `bucket.bucket_timestamp` or `bucket.SK`

## Changes

- **ohlc.js**: Add `bucket.timestamp` as primary field with fallbacks for backwards compatibility
- **test_sentiment_overlay_fields.py**: Static analysis tests to prevent regression

## Impact

- Blue sentiment line now renders actual data points on Price Chart
- Enables price-sentiment correlation analysis (Feature 1065 intent)

## Test plan

- [x] All 2389 unit tests pass (including 7 new tests)
- [ ] Manual verification: Open Price Chart, verify blue sentiment line shows data

🤖 Generated with [Claude Code](https://claude.com/claude-code)