### PR TITLE
feat(dashboard): Add vertical zoom to Price Chart (Feature 1070)

### DIFF
--- a/specs/1070-price-chart-vertical-zoom/spec.md
+++ b/specs/1070-price-chart-vertical-zoom/spec.md
@@ -1,0 +1,148 @@
+# Feature Specification: Price Chart Vertical Zoom
+
+**Feature Branch**: `1070-price-chart-vertical-zoom`
+**Created**: 2025-12-27
+**Status**: Draft
+**Input**: User description: "Add vertical zoom-in and zoom-out functionality to Price Chart with mouse scroll-wheel, focused around where mouse is pointing, because it is very hard to interpret stock prices when zoomed-out. Zoom should work with Price (left Y-axis), Sentiment (right Y-axis) is normalized to -1 to 1 so can remain fixed."
+
+## Problem Statement
+
+The Price Chart displays OHLC candlestick data with a left Y-axis showing price values. When the price range is large (e.g., $100-$250), small price movements are difficult to see. Users cannot zoom in on specific price ranges to analyze price action in detail.
+
+### Current State
+
+- Chart displays full price range from min to max values
+- No zoom functionality exists
+- Users cannot focus on specific price regions
+- Small percentage moves are invisible on charts with large ranges
+- chartjs-plugin-zoom is NOT currently loaded in index.html
+
+### Desired State
+
+- Users can scroll mouse wheel to zoom in/out on Y-axis (price)
+- Zoom centers around mouse cursor position
+- Sentiment Y-axis (-1 to 1) remains fixed (already normalized)
+- Double-click resets zoom to default view
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Zoom In on Price Range (Priority: P1)
+
+As a trader analyzing price charts, I want to zoom in on the Y-axis (price) using my mouse scroll wheel so that I can see small price movements that are otherwise invisible when the full range is displayed.
+
+**Why this priority**: Core purpose of the feature - without this, the Price Chart is hard to interpret for detailed analysis.
+
+**Independent Test**: Open dashboard, hover over Price Chart, scroll mouse wheel up - chart Y-axis should zoom in around cursor position.
+
+**Acceptance Scenarios**:
+
+1. **Given** Price Chart is displayed with OHLC data, **When** user hovers over chart and scrolls wheel up, **Then** Y-axis (price) MUST zoom in, centered around cursor position
+2. **Given** Price Chart is zoomed in, **When** user scrolls wheel down, **Then** Y-axis MUST zoom out toward original view
+3. **Given** zoom is active, **When** cursor is at bottom of chart and user zooms in, **Then** zoom center MUST be at lower price levels
+4. **Given** zoom is active, **When** cursor is at top of chart and user zooms in, **Then** zoom center MUST be at higher price levels
+
+---
+
+### User Story 2 - Reset Zoom to Default (Priority: P2)
+
+As a trader who has zoomed into a specific price range, I want to quickly reset the zoom to see the full picture again.
+
+**Why this priority**: Essential for workflow - users need to zoom out after detailed analysis.
+
+**Independent Test**: Zoom into chart, then double-click to reset - chart should return to showing full price range.
+
+**Acceptance Scenarios**:
+
+1. **Given** Price Chart is zoomed in, **When** user double-clicks on chart, **Then** zoom MUST reset to original (full range) view
+2. **Given** Price Chart is at default zoom, **When** user double-clicks, **Then** nothing should change (already at default)
+
+---
+
+### User Story 3 - Sentiment Axis Remains Fixed (Priority: P3)
+
+As a dashboard user, I want the Sentiment Y-axis (right side) to remain fixed at -1 to 1 regardless of zoom, because sentiment values are already normalized.
+
+**Why this priority**: Prevents confusion - zooming sentiment axis would make the scale meaningless.
+
+**Independent Test**: Zoom price axis in/out, verify sentiment axis remains -1 to 1.
+
+**Acceptance Scenarios**:
+
+1. **Given** Price Chart with sentiment overlay, **When** user zooms price axis, **Then** sentiment Y-axis MUST remain fixed at -1.0 to 1.0
+2. **Given** sentiment line is displayed, **When** price axis zooms, **Then** sentiment line position relative to its axis MUST not change
+
+---
+
+### Edge Cases
+
+- What happens when chart has no data? (Zoom should be disabled or no-op)
+- What happens when user zooms in extremely far? (Should have reasonable min/max limits)
+- What happens on touch devices? (Pinch-to-zoom for mobile, but not blocking for MVP)
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST load chartjs-plugin-zoom library via CDN in index.html
+- **FR-002**: System MUST enable Y-axis zoom on mouse wheel scroll
+- **FR-003**: System MUST zoom centered around mouse cursor position (mode: 'y')
+- **FR-004**: System MUST allow zoom reset on double-click
+- **FR-005**: System MUST only zoom the 'price' Y-axis (left side)
+- **FR-006**: System MUST NOT zoom the 'sentiment' Y-axis (right side, keep fixed -1 to 1)
+- **FR-007**: System MUST set reasonable zoom limits (e.g., min 50%, max 1000% of original range)
+
+### Key Entities
+
+- **Chart.js Price Axis**: Left Y-axis showing dollar prices, subject to zoom
+- **Chart.js Sentiment Axis**: Right Y-axis (-1 to 1), fixed and not zoomable
+- **chartjs-plugin-zoom**: Chart.js plugin that provides zoom/pan functionality
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Mouse wheel scroll over Price Chart zooms Y-axis in/out
+- **SC-002**: Zoom center follows mouse cursor position
+- **SC-003**: Double-click resets zoom to full price range
+- **SC-004**: Sentiment axis remains fixed at -1.0 to 1.0 during all zoom operations
+- **SC-005**: No JavaScript errors in console related to zoom functionality
+
+## Technical Approach
+
+### Implementation Location
+
+`src/dashboard/index.html` - Add chartjs-plugin-zoom CDN
+`src/dashboard/ohlc.js` - Configure zoom options in `initChart()` method
+
+### Proposed Change
+
+1. Add to index.html (after chart.js):
+```html
+<script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-zoom@2.0.1/dist/chartjs-plugin-zoom.min.js"
+        integrity="sha384-..."
+        crossorigin="anonymous"></script>
+```
+
+2. Update ohlc.js `initChart()` options:
+```javascript
+options: {
+  plugins: {
+    zoom: {
+      zoom: {
+        wheel: { enabled: true },
+        mode: 'y',
+        scaleMode: 'y',
+        // Only allow zooming the price axis
+        overScaleMode: 'y'
+      },
+      limits: {
+        y: { minRange: 10 }  // Minimum price range when zoomed in
+      }
+    }
+  }
+}
+```
+
+### Dependencies
+
+- chartjs-plugin-zoom v2.0.1 (compatible with Chart.js 4.x)

--- a/src/dashboard/index.html
+++ b/src/dashboard/index.html
@@ -8,6 +8,10 @@
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"
             integrity="sha384-e6nUZLBkQ86NJ6TVVKAeSaK8jWa3NhkYWZFomE39AvDbQWeie9PlQqM3pmYW5d1g"
             crossorigin="anonymous"></script>
+    <!-- Feature 1070: Chart.js zoom plugin for vertical zoom on Price Chart -->
+    <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-zoom@2.0.1/dist/chartjs-plugin-zoom.min.js"
+            integrity="sha384-zPzbVRXfR492Sd5D+HydTYCxxgHAfgVO8KERbLlpeH5unsmbAEXrscGUUqLZG9BM"
+            crossorigin="anonymous"></script>
 </head>
 <body>
     <header>

--- a/src/dashboard/ohlc.js
+++ b/src/dashboard/ohlc.js
@@ -136,7 +136,7 @@ class OHLCChart {
     }
 
     /**
-     * Bind event handlers for resolution buttons
+     * Bind event handlers for resolution buttons and chart interactions
      */
     bindEvents() {
         // Resolution button clicks
@@ -148,6 +148,24 @@ class OHLCChart {
                 }
             });
         });
+
+        // Feature 1070: Double-click to reset zoom
+        const canvas = document.getElementById('ohlc-chart');
+        if (canvas) {
+            canvas.addEventListener('dblclick', () => {
+                this.resetZoom();
+            });
+        }
+    }
+
+    /**
+     * Feature 1070: Reset chart zoom to default view
+     */
+    resetZoom() {
+        if (this.chart) {
+            this.chart.resetZoom();
+            console.log('OHLC: Zoom reset to default');
+        }
     }
 
     /**
@@ -400,6 +418,33 @@ class OHLCChart {
                                     return 'Sentiment: N/A';
                                 }
                                 return '';
+                            }
+                        }
+                    },
+                    // Feature 1070: Vertical zoom for Price Chart
+                    // Allows mouse wheel zoom on Y-axis (price) centered around cursor
+                    // Sentiment axis (right, -1 to 1) remains fixed
+                    zoom: {
+                        zoom: {
+                            wheel: {
+                                enabled: true,
+                                speed: 0.1
+                            },
+                            mode: 'y',
+                            // Only zoom the price axis, not sentiment
+                            scaleMode: 'y',
+                            onZoom: ({ chart }) => {
+                                // Restore sentiment axis to fixed -1 to 1 range
+                                const sentimentScale = chart.scales.sentiment;
+                                if (sentimentScale) {
+                                    sentimentScale.options.min = overlayConfig.yAxisMin || -1.0;
+                                    sentimentScale.options.max = overlayConfig.yAxisMax || 1.0;
+                                }
+                            }
+                        },
+                        limits: {
+                            price: {
+                                minRange: 5  // Minimum $5 range when zoomed in
                             }
                         }
                     }

--- a/tests/unit/dashboard/test_price_chart_zoom.py
+++ b/tests/unit/dashboard/test_price_chart_zoom.py
@@ -1,0 +1,204 @@
+"""
+Price Chart Vertical Zoom Tests for Dashboard JavaScript.
+
+Feature 1070: Tests that verify the Price Chart has vertical zoom
+functionality enabled via chartjs-plugin-zoom.
+
+These tests use static analysis of JavaScript/HTML source code to verify:
+1. chartjs-plugin-zoom is loaded in index.html
+2. Zoom configuration exists in ohlc.js initChart() method
+3. Zoom is configured for Y-axis only (mode: 'y')
+4. Double-click reset handler is bound
+
+Run: pytest tests/unit/dashboard/test_price_chart_zoom.py -v
+"""
+
+import re
+from pathlib import Path
+
+
+def get_repo_root() -> Path:
+    """Get the repository root directory."""
+    return Path(__file__).parents[3]
+
+
+def read_index_html() -> str:
+    """Read the index.html file content."""
+    repo_root = get_repo_root()
+    index_path = repo_root / "src" / "dashboard" / "index.html"
+    assert index_path.exists(), f"index.html not found at {index_path}"
+    return index_path.read_text()
+
+
+def read_ohlc_js() -> str:
+    """Read the ohlc.js file content."""
+    repo_root = get_repo_root()
+    ohlc_path = repo_root / "src" / "dashboard" / "ohlc.js"
+    assert ohlc_path.exists(), f"ohlc.js not found at {ohlc_path}"
+    return ohlc_path.read_text()
+
+
+class TestZoomPluginLoaded:
+    """Test that chartjs-plugin-zoom is loaded in index.html."""
+
+    def test_chartjs_plugin_zoom_script_tag(self) -> None:
+        """Verify chartjs-plugin-zoom is included via CDN."""
+        content = read_index_html()
+
+        assert "chartjs-plugin-zoom" in content, (
+            "chartjs-plugin-zoom not found in index.html. "
+            "Add the plugin via CDN for zoom functionality."
+        )
+
+    def test_chartjs_plugin_zoom_has_integrity(self) -> None:
+        """Verify chartjs-plugin-zoom has SRI integrity hash."""
+        content = read_index_html()
+
+        # Find the chartjs-plugin-zoom script tag
+        zoom_pattern = r"<script[^>]*chartjs-plugin-zoom[^>]*>"
+        match = re.search(zoom_pattern, content)
+        assert match, "chartjs-plugin-zoom script tag not found"
+
+        script_tag = match.group(0)
+        assert "integrity=" in script_tag, (
+            "chartjs-plugin-zoom missing SRI integrity hash. "
+            "Add integrity attribute for security."
+        )
+
+    def test_chartjs_plugin_zoom_version(self) -> None:
+        """Verify chartjs-plugin-zoom uses compatible version with Chart.js 4.x."""
+        content = read_index_html()
+
+        # Should use v2.x for Chart.js 4.x compatibility
+        assert "chartjs-plugin-zoom@2" in content, (
+            "chartjs-plugin-zoom should use v2.x for Chart.js 4.x compatibility. "
+            "Found different version or pattern."
+        )
+
+    def test_has_feature_1070_comment(self) -> None:
+        """Verify Feature 1070 comment exists in index.html or ohlc.js."""
+        html_content = read_index_html()
+        js_content = read_ohlc_js()
+
+        has_comment = "Feature 1070" in html_content or "1070" in js_content
+
+        assert has_comment, (
+            "Missing Feature 1070 reference. " "Add a comment for traceability."
+        )
+
+
+class TestZoomConfiguration:
+    """Test that zoom is properly configured in ohlc.js."""
+
+    def test_zoom_plugin_in_chart_options(self) -> None:
+        """Verify zoom plugin is configured in chart options."""
+        content = read_ohlc_js()
+
+        # Find the initChart method and look for zoom configuration
+        assert "plugins:" in content, "Chart plugins configuration not found"
+        assert "zoom:" in content, (
+            "Zoom plugin configuration not found in chart options. "
+            "Add zoom: { ... } to plugins section."
+        )
+
+    def test_zoom_wheel_enabled(self) -> None:
+        """Verify mouse wheel zoom is enabled."""
+        content = read_ohlc_js()
+
+        # Look for wheel configuration
+        wheel_pattern = r"wheel:\s*\{\s*enabled:\s*true"
+        assert re.search(wheel_pattern, content), (
+            "Mouse wheel zoom not enabled. "
+            "Add wheel: { enabled: true } to zoom configuration."
+        )
+
+    def test_zoom_mode_y_axis(self) -> None:
+        """Verify zoom is configured for Y-axis only (vertical zoom)."""
+        content = read_ohlc_js()
+
+        # Look for mode: 'y' configuration
+        mode_pattern = r"mode:\s*['\"]y['\"]"
+        assert re.search(mode_pattern, content), (
+            "Zoom mode not set to 'y'. " "Use mode: 'y' for vertical-only zoom."
+        )
+
+
+class TestZoomResetFunctionality:
+    """Test that zoom reset is properly implemented."""
+
+    def test_reset_zoom_method_exists(self) -> None:
+        """Verify resetZoom method exists in OHLCChart class."""
+        content = read_ohlc_js()
+
+        assert "resetZoom()" in content, (
+            "resetZoom method not found in OHLCChart class. "
+            "Add method to reset chart zoom to default."
+        )
+
+    def test_double_click_handler_bound(self) -> None:
+        """Verify double-click event listener is bound for zoom reset."""
+        content = read_ohlc_js()
+
+        assert "dblclick" in content, (
+            "Double-click event handler not found. "
+            "Add dblclick listener to reset zoom."
+        )
+
+    def test_reset_zoom_calls_chart_method(self) -> None:
+        """Verify resetZoom uses Chart.js resetZoom method."""
+        content = read_ohlc_js()
+
+        # Find the resetZoom method
+        reset_match = re.search(
+            r"resetZoom\(\)\s*\{([^}]+)\}",
+            content,
+            re.DOTALL,
+        )
+        assert reset_match, "Could not find resetZoom method body"
+
+        method_body = reset_match.group(1)
+        assert "this.chart.resetZoom()" in method_body, (
+            "resetZoom should call this.chart.resetZoom() to reset zoom. "
+            "This is the Chart.js zoom plugin method."
+        )
+
+
+class TestSentimentAxisFixed:
+    """Test that sentiment axis remains fixed during zoom."""
+
+    def test_sentiment_axis_has_fixed_min_max(self) -> None:
+        """Verify sentiment Y-axis has fixed min/max in scale configuration."""
+        content = read_ohlc_js()
+
+        # Look for sentiment scale with fixed min and max
+        sentiment_min_pattern = r"sentiment:\s*\{[^}]*min:"
+        sentiment_max_pattern = r"sentiment:\s*\{[^}]*max:"
+
+        # Need to find both min and max in the scales section
+        assert re.search(sentiment_min_pattern, content, re.DOTALL), (
+            "Sentiment axis missing min configuration. "
+            "Add min: -1.0 to sentiment scale."
+        )
+        assert re.search(sentiment_max_pattern, content, re.DOTALL), (
+            "Sentiment axis missing max configuration. "
+            "Add max: 1.0 to sentiment scale."
+        )
+
+    def test_zoom_on_zoom_callback_restores_sentiment(self) -> None:
+        """Verify onZoom callback restores sentiment axis bounds."""
+        content = read_ohlc_js()
+
+        # Look for onZoom callback that handles sentiment axis
+        has_on_zoom = "onZoom:" in content
+        has_sentiment_scale_restore = (
+            "sentimentScale" in content or "scales.sentiment" in content
+        )
+
+        assert has_on_zoom, (
+            "Missing onZoom callback. "
+            "Add callback to restore sentiment axis after zoom."
+        )
+        assert has_sentiment_scale_restore, (
+            "onZoom callback should reference sentiment scale "
+            "to prevent it from zooming."
+        )


### PR DESCRIPTION
## Summary

- Add mouse wheel zoom on the Y-axis (price) of the OHLC Price Chart
- Zoom centers around mouse cursor position for focused analysis
- Double-click to reset zoom to default view
- Sentiment axis (right side, -1 to 1) remains fixed during zoom

## Changes

- `src/dashboard/index.html`: Add chartjs-plugin-zoom v2.0.1 via CDN with SRI hash
- `src/dashboard/ohlc.js`: Configure zoom plugin with mode 'y' for vertical-only zoom
- `src/dashboard/ohlc.js`: Add onZoom callback to keep sentiment axis fixed
- `src/dashboard/ohlc.js`: Add resetZoom() method and double-click handler
- Add 12 static analysis tests validating zoom implementation

## Usage

- Scroll wheel up/down over Price Chart to zoom in/out on Y-axis
- Zoom centers around mouse cursor position
- Double-click to reset zoom to default view

## Test plan

- [x] All 12 new tests pass (`pytest tests/unit/dashboard/test_price_chart_zoom.py`)
- [x] Pre-commit hooks pass
- [ ] Verify zoom functionality in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)