### PR TITLE
feat(dashboard): Price Chart zoom refinements (#1072)

### DIFF
--- a/specs/1072-price-chart-zoom-refinements/spec.md
+++ b/specs/1072-price-chart-zoom-refinements/spec.md
@@ -1,0 +1,145 @@
+# Feature Specification: Price Chart Zoom Refinements
+
+**Feature Branch**: `1072-price-chart-zoom-refinements`
+**Created**: 2025-12-27
+**Status**: Draft
+**Input**: User description: "Price Chart zoom refinements: 1) Auto-fit data on resolution change, 2) Remove legend, 3) Set min price to $0 when zooming out"
+
+## Problem Statement
+
+The Price Chart has vertical zoom (Feature 1070) and horizontal pan (Feature 1071), but needs refinements for a polished demo experience:
+
+1. When switching resolutions or on first load, the chart should auto-fit all data in the visible area
+2. The chart legend takes up space and is unnecessary since the chart title already shows the ticker
+3. When zooming out, users can currently zoom past $0 which shows negative prices (impossible for stocks)
+
+### Current State
+
+- Chart loads with Chart.js default scale behavior
+- Legend is displayed at the top showing "Price" and "Sentiment" labels
+- No minimum price limit when zooming out (can show negative values)
+
+### Desired State
+
+- Chart auto-fits to show all data within the visible area on load and resolution change
+- No legend displayed (cleaner, more professional appearance)
+- Price Y-axis cannot go below $0 when zooming out
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Auto-Fit on Resolution Change (Priority: P1)
+
+As a trader switching between time resolutions (1m, 5m, 1h, etc.), I want the chart to automatically fit all data in view so I can immediately see the full price range.
+
+**Why this priority**: Core demo experience - users should see all data without manual zoom adjustments.
+
+**Independent Test**: Select a different resolution, chart should display full price range of new data.
+
+**Acceptance Scenarios**:
+
+1. **Given** Price Chart is displayed, **When** user selects a new resolution, **Then** chart MUST auto-fit Y-axis to show full price range of new data
+2. **Given** dashboard first loads, **When** OHLC data is fetched, **Then** chart MUST auto-fit Y-axis to show all candles
+3. **Given** chart is zoomed in, **When** user changes resolution, **Then** zoom MUST reset and chart auto-fits new data
+
+---
+
+### User Story 2 - Remove Legend (Priority: P2)
+
+As a dashboard user, I want a cleaner chart without the legend taking up space, since the chart title already shows what I'm viewing.
+
+**Why this priority**: Visual polish - legend is redundant with chart title "Price Chart AAPL".
+
+**Independent Test**: Load dashboard, chart should display without legend at the top.
+
+**Acceptance Scenarios**:
+
+1. **Given** Price Chart is displayed, **When** user views the chart, **Then** no legend should be visible
+2. **Given** legend is hidden, **When** user hovers over data, **Then** tooltip should still show Price and Sentiment values
+
+---
+
+### User Story 3 - $0 Price Floor on Zoom Out (Priority: P2)
+
+As a trader zooming out to see more price context, I want the chart to stop at $0 since stock prices cannot be negative.
+
+**Why this priority**: Prevents confusing display of impossible price values.
+
+**Independent Test**: Zoom out fully on Price Chart, Y-axis minimum should be $0.
+
+**Acceptance Scenarios**:
+
+1. **Given** Price Chart is zoomed to show price data, **When** user zooms out via scroll wheel, **Then** Y-axis minimum MUST NOT go below $0
+2. **Given** price data range is $100-$150, **When** user zooms out fully, **Then** Y-axis should show range like $0-$200 (not -$50 to $200)
+
+---
+
+### Edge Cases
+
+- What if price data is very low (e.g., penny stock at $0.50)? Y-axis should still start at $0
+- What if all candles have same price? Auto-fit should show a reasonable range around that price
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST auto-fit chart Y-axis to data range on initial load
+- **FR-002**: System MUST auto-fit chart Y-axis when resolution changes
+- **FR-003**: System MUST reset zoom when loading new data
+- **FR-004**: System MUST NOT display chart legend
+- **FR-005**: System MUST maintain tooltip functionality showing Price and Sentiment values
+- **FR-006**: System MUST enforce $0 as minimum Y-axis value when zooming out
+- **FR-007**: Sentiment Y-axis MUST remain fixed at -1 to 1 (already implemented in Feature 1070)
+
+### Key Entities
+
+- **Chart.js legend plugin**: Disabled via `display: false`
+- **Chart.js price scale limits**: Configure `min: 0` in zoom limits
+- **Chart.resetZoom()**: Called after data load to reset view
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Chart displays full data range on initial load without manual zoom
+- **SC-002**: Resolution change resets zoom and shows full new data range
+- **SC-003**: No legend visible on Price Chart
+- **SC-004**: Tooltip still works when hovering over chart
+- **SC-005**: Y-axis never shows negative price values when zooming out
+- **SC-006**: No JavaScript console errors related to chart operations
+
+## Technical Approach
+
+### Implementation Location
+
+`src/dashboard/ohlc.js` - Update chart configuration
+
+### Proposed Changes
+
+1. **Disable legend**:
+```javascript
+legend: {
+    display: false  // Feature 1072: Remove legend for cleaner display
+}
+```
+
+2. **Add $0 floor to zoom limits**:
+```javascript
+limits: {
+    price: {
+        min: 0,        // Feature 1072: Price cannot go below $0
+        minRange: 5    // Existing: Minimum $5 range when zoomed in
+    }
+}
+```
+
+3. **Reset zoom on data load** (in `updateChart` method):
+```javascript
+// Reset zoom to show all new data
+if (this.chart) {
+    this.chart.resetZoom();
+}
+```
+
+### Dependencies
+
+- chartjs-plugin-zoom v2.0.1 (already loaded)

--- a/src/dashboard/ohlc.js
+++ b/src/dashboard/ohlc.js
@@ -385,13 +385,10 @@ class OHLCChart {
                     intersect: false
                 },
                 plugins: {
+                    // Feature 1072: Hide legend for cleaner display
+                    // Tooltip still shows Price and Sentiment values on hover
                     legend: {
-                        display: true,
-                        position: 'top',
-                        labels: {
-                            usePointStyle: true,
-                            padding: 15
-                        }
+                        display: false
                     },
                     tooltip: {
                         callbacks: {
@@ -444,6 +441,7 @@ class OHLCChart {
                         },
                         limits: {
                             price: {
+                                min: 0,      // Feature 1072: Price cannot go below $0
                                 minRange: 5  // Minimum $5 range when zoomed in
                             }
                         }
@@ -539,6 +537,9 @@ class OHLCChart {
 
         // Update sentiment overlay if we have data (Feature 1065)
         this.updateSentimentOverlay();
+
+        // Feature 1072: Reset zoom to show all new data (auto-fit on load/resolution change)
+        this.chart.resetZoom();
 
         this.chart.update('none');
 

--- a/tests/unit/dashboard/test_price_chart_zoom_refinements.py
+++ b/tests/unit/dashboard/test_price_chart_zoom_refinements.py
@@ -1,0 +1,156 @@
+"""
+Price Chart Zoom Refinements Tests for Dashboard JavaScript.
+
+Feature 1072: Tests that verify the Price Chart zoom refinements:
+1. Auto-fit data on resolution change (resetZoom on data load)
+2. Legend removed for cleaner display
+3. $0 price floor when zooming out
+
+These tests use static analysis of JavaScript source code to verify:
+1. chart.resetZoom() is called in updateChart method
+2. legend.display is set to false
+3. zoom limits include min: 0 for price
+
+Run: pytest tests/unit/dashboard/test_price_chart_zoom_refinements.py -v
+"""
+
+import re
+from pathlib import Path
+
+
+def get_repo_root() -> Path:
+    """Get the repository root directory."""
+    return Path(__file__).parents[3]
+
+
+def read_ohlc_js() -> str:
+    """Read the ohlc.js file content."""
+    repo_root = get_repo_root()
+    ohlc_path = repo_root / "src" / "dashboard" / "ohlc.js"
+    assert ohlc_path.exists(), f"ohlc.js not found at {ohlc_path}"
+    return ohlc_path.read_text()
+
+
+class TestAutoFitOnDataLoad:
+    """Test that chart auto-fits data on resolution change and initial load."""
+
+    def test_reset_zoom_called_in_update_chart(self) -> None:
+        """Verify resetZoom is called when updating chart with new data."""
+        content = read_ohlc_js()
+
+        # Find the updateChart method
+        update_chart_match = re.search(
+            r"updateChart\([^)]*\)\s*\{([\s\S]*?)(?=\n    \w+\([^)]*\)\s*\{|\n    \/\*\*|\Z)",
+            content,
+        )
+        assert update_chart_match, "updateChart method not found in ohlc.js"
+
+        method_body = update_chart_match.group(1)
+        assert "this.chart.resetZoom()" in method_body, (
+            "resetZoom not called in updateChart method. "
+            "Add this.chart.resetZoom() to auto-fit data on load."
+        )
+
+    def test_reset_zoom_before_chart_update(self) -> None:
+        """Verify resetZoom is called before chart.update for proper rendering."""
+        content = read_ohlc_js()
+
+        # resetZoom should come before the final chart.update('none')
+        reset_idx = content.find("this.chart.resetZoom()")
+        update_idx = content.rfind("this.chart.update('none')")
+
+        assert reset_idx != -1, "this.chart.resetZoom() not found"
+        assert update_idx != -1, "this.chart.update('none') not found"
+        assert reset_idx < update_idx, (
+            "resetZoom should be called before chart.update('none') "
+            "for proper rendering order."
+        )
+
+    def test_has_feature_1072_comment_for_reset_zoom(self) -> None:
+        """Verify Feature 1072 comment exists near resetZoom call."""
+        content = read_ohlc_js()
+
+        # Check for Feature 1072 comment and resetZoom in same file
+        has_feature_comment = "Feature 1072" in content and "resetZoom" in content
+
+        assert has_feature_comment, (
+            "Missing Feature 1072 reference near resetZoom. "
+            "Add a comment for traceability."
+        )
+
+
+class TestLegendRemoved:
+    """Test that chart legend is disabled for cleaner display."""
+
+    def test_legend_display_false(self) -> None:
+        """Verify legend is disabled in chart options."""
+        content = read_ohlc_js()
+
+        # Look for legend configuration with display: false
+        legend_pattern = r"legend:\s*\{[^}]*display:\s*false"
+        assert re.search(legend_pattern, content, re.DOTALL), (
+            "Legend not disabled. " "Add legend: { display: false } to chart plugins."
+        )
+
+    def test_has_feature_1072_legend_comment(self) -> None:
+        """Verify Feature 1072 comment exists for legend configuration."""
+        content = read_ohlc_js()
+
+        # Look for Feature 1072 comment near legend config
+        has_legend_comment = "Feature 1072" in content and "legend" in content.lower()
+
+        assert has_legend_comment, (
+            "Missing Feature 1072 reference for legend configuration. "
+            "Add a comment for traceability."
+        )
+
+
+class TestPriceFloorLimit:
+    """Test that price axis cannot go below $0 when zooming out."""
+
+    def test_zoom_limits_has_min_zero(self) -> None:
+        """Verify zoom limits include min: 0 for price axis."""
+        content = read_ohlc_js()
+
+        # Look for limits configuration with price min: 0
+        limits_pattern = r"limits:\s*\{[^}]*price:\s*\{[^}]*min:\s*0"
+        assert re.search(limits_pattern, content, re.DOTALL), (
+            "Zoom limits missing min: 0 for price. "
+            "Add limits: { price: { min: 0 } } to prevent negative prices."
+        )
+
+    def test_has_feature_1072_floor_comment(self) -> None:
+        """Verify Feature 1072 comment exists for price floor configuration."""
+        content = read_ohlc_js()
+
+        # Look for Feature 1072 comment near min: 0 or price floor
+        has_floor_comment = "Feature 1072" in content and (
+            "min: 0" in content or "$0" in content or "price" in content.lower()
+        )
+
+        assert has_floor_comment, (
+            "Missing Feature 1072 reference for price floor. "
+            "Add a comment for traceability."
+        )
+
+
+class TestTooltipStillWorks:
+    """Test that tooltip functionality is preserved despite legend removal."""
+
+    def test_tooltip_configuration_exists(self) -> None:
+        """Verify tooltip configuration is still present."""
+        content = read_ohlc_js()
+
+        assert "tooltip:" in content, (
+            "Tooltip configuration not found. "
+            "Tooltip should still work after legend removal."
+        )
+
+    def test_tooltip_callbacks_exist(self) -> None:
+        """Verify tooltip has callbacks for custom display."""
+        content = read_ohlc_js()
+
+        assert "callbacks:" in content, (
+            "Tooltip callbacks not found. "
+            "Tooltip needs callbacks to display OHLC and sentiment values."
+        )


### PR DESCRIPTION
## Summary

Feature 1072: Price Chart zoom refinements for polished demo experience:

- **Auto-fit on data load**: `chart.resetZoom()` in `updateChart` method resets zoom when resolution changes or data loads
- **Legend removed**: `legend.display = false` for cleaner appearance (tooltip still works)
- **$0 price floor**: `limits.price.min = 0` prevents negative prices when zooming out

## Test Plan

- [ ] Load dashboard - chart shows all data without manual zoom adjustment
- [ ] Change resolution - chart auto-fits to new data range
- [ ] Verify no legend visible at top of Price Chart
- [ ] Hover over chart - tooltip shows Price and Sentiment values
- [ ] Zoom out fully - Y-axis does not go below $0

## Tests

9 static analysis tests validate all requirements:
- `test_price_chart_zoom_refinements.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)