### PR TITLE
fix(csp): Add cdn.jsdelivr.net to connect-src for Hammer.js source maps

### DIFF
--- a/infrastructure/terraform/modules/cloudfront/variables.tf
+++ b/infrastructure/terraform/modules/cloudfront/variables.tf
@@ -30,7 +30,8 @@ variable "content_security_policy" {
   description = "Content-Security-Policy header value"
   type        = string
   # Updated per 090-security-first-burndown to include CDN domains for Chart.js, DaisyUI, and Tailwind
-  default = "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://cdn.tailwindcss.com https://hcaptcha.com https://*.hcaptcha.com; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://*.amazonaws.com https://*.amazoncognito.com; frame-src https://hcaptcha.com https://*.hcaptcha.com; frame-ancestors 'none';"
+  # Feature 1074: Added cdn.jsdelivr.net to connect-src for Hammer.js source maps
+  default = "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://cdn.tailwindcss.com https://hcaptcha.com https://*.hcaptcha.com; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://*.amazonaws.com https://*.amazoncognito.com https://cdn.jsdelivr.net; frame-src https://hcaptcha.com https://*.hcaptcha.com; frame-ancestors 'none';"
 }
 
 variable "enable_logging" {

--- a/specs/1074-csp-jsdelivr-connect/spec.md
+++ b/specs/1074-csp-jsdelivr-connect/spec.md
@@ -1,0 +1,56 @@
+# Feature Specification: CSP jsdelivr.net connect-src
+
+**Feature Branch**: `1074-csp-jsdelivr-connect`
+**Created**: 2025-12-27
+**Status**: Implementation Complete
+**Input**: Fix CSP blocking Hammer.js source maps from cdn.jsdelivr.net
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Price Chart Pan Gestures Work (Priority: P1)
+
+As a user viewing the Price Chart, I want left-click-drag pan functionality to work without browser console errors, so I can navigate through historical price data.
+
+**Why this priority**: Pan gestures (Feature 1071) require Hammer.js which loads from cdn.jsdelivr.net. The browser's CSP currently blocks source map requests to this CDN, causing console errors and potentially impacting gesture recognition.
+
+**Independent Test**: Can be fully tested by opening the dashboard in a browser, checking the console for CSP violations, and verifying pan gestures work on the Price Chart.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user loads the dashboard, **When** Hammer.js attempts to load source maps, **Then** no CSP violation errors appear in the console
+2. **Given** a user views the Price Chart, **When** they left-click and drag, **Then** the chart pans horizontally through the data
+
+---
+
+### Edge Cases
+
+- If cdn.jsdelivr.net is unreachable, the page still loads (scripts have crossorigin="anonymous")
+- Source maps are optional for functionality; this fix improves debugging experience
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: CloudFront CSP `connect-src` directive MUST include `https://cdn.jsdelivr.net`
+- **FR-002**: Existing CSP directives (script-src, style-src, etc.) MUST remain unchanged
+- **FR-003**: Browser console MUST NOT show CSP violation errors for cdn.jsdelivr.net
+
+### Key Entities
+
+- **CloudFront Distribution**: Response headers include CSP policy
+- **CSP Header**: `content_security_policy` Terraform variable in cloudfront module
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Zero CSP violation errors in browser console when loading dashboard
+- **SC-002**: Hammer.js source maps load without blocking (visible in Network tab)
+- **SC-003**: Pan gestures functional on Price Chart (left-click-drag moves chart)
+
+## Implementation Notes
+
+The fix adds `https://cdn.jsdelivr.net` to the `connect-src` directive in:
+- `infrastructure/terraform/modules/cloudfront/variables.tf` line 34
+
+This allows browsers to make source map requests to the CDN without CSP violations.


### PR DESCRIPTION
## Summary

- Add `https://cdn.jsdelivr.net` to CSP `connect-src` directive to allow Hammer.js source map requests
- Fixes browser console CSP violation errors when loading the dashboard

## Context

Feature 1073 added Hammer.js for pan gestures, but the CloudFront CSP policy was blocking source map requests to `cdn.jsdelivr.net`. This caused console errors and potentially impacted gesture recognition.

## Changes

- `infrastructure/terraform/modules/cloudfront/variables.tf`: Added `https://cdn.jsdelivr.net` to `connect-src`

## Test Plan

- [ ] Deploy to preprod
- [ ] Load dashboard in browser
- [ ] Verify no CSP violation errors in console for cdn.jsdelivr.net
- [ ] Verify pan gestures work on Price Chart (left-click-drag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)