### PR TITLE
feat(ohlc): Add module-level response cache to prevent 429 rate limit errors (Feature 1076)

### DIFF
--- a/specs/1076-ohlc-response-cache/checklists/requirements.md
+++ b/specs/1076-ohlc-response-cache/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: OHLC Response Cache
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2025-12-27
+**Feature**: [specs/1076-ohlc-response-cache/spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Spec was derived from investigation of existing codebase patterns (sentiment.py module-level cache)
+- TTL values based on data volatility (1m data more volatile than daily)
+- 256 entry limit matches sentiment cache pattern
+- Ready for `/speckit.plan`

--- a/specs/1076-ohlc-response-cache/plan.md
+++ b/specs/1076-ohlc-response-cache/plan.md
@@ -1,0 +1,168 @@
+# Technical Plan: OHLC Response Cache
+
+**Feature Branch**: `1076-ohlc-response-cache`
+**Created**: 2025-12-27
+**Spec**: [spec.md](./spec.md)
+
+## Overview
+
+Add module-level OHLC response caching to the Dashboard Lambda, following the proven pattern from `sentiment.py`. This eliminates 429 rate limit errors when users rapidly switch resolution buckets.
+
+## Architecture
+
+```
+User Click → /api/v2/tickers/{ticker}/ohlc
+                    ↓
+            OHLC Handler (ohlc.py)
+                    ↓
+        [NEW] _get_cached_ohlc()
+              ├── Cache HIT → Return cached response
+              └── Cache MISS → Tiingo Adapter → Cache → Return
+```
+
+## Implementation Tasks
+
+### Task 1: Add Module-Level Cache Infrastructure
+
+**File**: `src/lambdas/dashboard/ohlc.py`
+
+Add at module level (after imports):
+
+```python
+import time
+import os
+
+# Cache configuration (resolution-based TTLs in seconds)
+OHLC_CACHE_TTLS = {
+    "1min": 300,      # 5 minutes for 1-minute resolution
+    "5min": 900,      # 15 minutes for 5-minute resolution
+    "15min": 900,     # 15 minutes for 15-minute resolution
+    "30min": 900,     # 15 minutes for 30-minute resolution
+    "1hour": 1800,    # 30 minutes for hourly resolution
+    "1day": 3600,     # 1 hour for daily resolution
+}
+OHLC_CACHE_DEFAULT_TTL = 300  # 5 minutes default
+OHLC_CACHE_MAX_ENTRIES = int(os.environ.get("OHLC_CACHE_MAX_ENTRIES", "256"))
+
+# Cache storage: {cache_key: (timestamp, response_dict)}
+_ohlc_cache: dict[str, tuple[float, dict]] = {}
+_ohlc_cache_stats = {"hits": 0, "misses": 0, "evictions": 0}
+```
+
+### Task 2: Add Cache Key Generation
+
+**File**: `src/lambdas/dashboard/ohlc.py`
+
+```python
+def _get_ohlc_cache_key(ticker: str, resolution: str, start_date: date, end_date: date) -> str:
+    """Generate cache key for OHLC request."""
+    return f"ohlc:{ticker.upper()}:{resolution}:{start_date.isoformat()}:{end_date.isoformat()}"
+```
+
+### Task 3: Add Cache Get Function
+
+**File**: `src/lambdas/dashboard/ohlc.py`
+
+```python
+def _get_cached_ohlc(cache_key: str, resolution: str) -> dict | None:
+    """Get OHLC response from cache if valid."""
+    if cache_key in _ohlc_cache:
+        timestamp, response = _ohlc_cache[cache_key]
+        ttl = OHLC_CACHE_TTLS.get(resolution, OHLC_CACHE_DEFAULT_TTL)
+        if time.time() - timestamp < ttl:
+            _ohlc_cache_stats["hits"] += 1
+            return response
+        del _ohlc_cache[cache_key]  # Expired, remove
+    _ohlc_cache_stats["misses"] += 1
+    return None
+```
+
+### Task 4: Add Cache Set Function with LRU Eviction
+
+**File**: `src/lambdas/dashboard/ohlc.py`
+
+```python
+def _set_cached_ohlc(cache_key: str, response: dict) -> None:
+    """Store OHLC response in cache with LRU eviction."""
+    global _ohlc_cache
+    if len(_ohlc_cache) >= OHLC_CACHE_MAX_ENTRIES:
+        # Evict oldest entry by timestamp
+        oldest_key = min(_ohlc_cache.keys(), key=lambda k: _ohlc_cache[k][0])
+        del _ohlc_cache[oldest_key]
+        _ohlc_cache_stats["evictions"] += 1
+    _ohlc_cache[cache_key] = (time.time(), response)
+```
+
+### Task 5: Add Cache Stats Function
+
+**File**: `src/lambdas/dashboard/ohlc.py`
+
+```python
+def get_ohlc_cache_stats() -> dict[str, int]:
+    """Return cache statistics for observability."""
+    return _ohlc_cache_stats.copy()
+```
+
+### Task 6: Integrate Cache into get_ohlc Handler
+
+**File**: `src/lambdas/dashboard/ohlc.py`
+
+Modify the `get_ohlc` function to check cache before calling adapters:
+
+```python
+# At start of get_ohlc() function, after input validation:
+cache_key = _get_ohlc_cache_key(ticker, resolution, start_date, end_date)
+cached_response = _get_cached_ohlc(cache_key, resolution)
+if cached_response:
+    logger.info(f"OHLC cache hit for {cache_key}")
+    return JSONResponse(content=cached_response, headers=response_headers)
+
+# ... existing adapter calls ...
+
+# Before returning successful response, cache it:
+response_data = {
+    "ticker": ticker,
+    "resolution": resolution,
+    "data": [c.model_dump() for c in candles],
+    "metadata": {"source": source, ...}
+}
+_set_cached_ohlc(cache_key, response_data)
+```
+
+### Task 7: Add Unit Tests
+
+**File**: `tests/unit/dashboard/test_ohlc_cache.py`
+
+Test cases:
+1. Cache miss on first request
+2. Cache hit on second request
+3. Cache expiry after TTL
+4. LRU eviction when full
+5. Resolution-specific TTL values
+6. Stats tracking accuracy
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/lambdas/dashboard/ohlc.py` | Add caching infrastructure and integrate into handler |
+| `tests/unit/dashboard/test_ohlc_cache.py` | New test file for cache functionality |
+
+## Success Verification
+
+1. Run unit tests: `pytest tests/unit/dashboard/test_ohlc_cache.py -v`
+2. All existing OHLC tests still pass
+3. Manual test: Click 10 resolution buckets in 5 seconds, no 429 errors
+
+## Dependencies
+
+- None (uses only Python stdlib: `time`, `os`)
+- No new packages required
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Memory growth | 256 entry limit with LRU eviction |
+| Stale data | Resolution-specific TTLs based on data volatility |
+| Cold start penalty | First request still slow, but subsequent requests fast |

--- a/specs/1076-ohlc-response-cache/spec.md
+++ b/specs/1076-ohlc-response-cache/spec.md
@@ -1,0 +1,96 @@
+# Feature Specification: OHLC Response Cache
+
+**Feature Branch**: `1076-ohlc-response-cache`
+**Created**: 2025-12-27
+**Status**: Draft
+**Input**: User description: "Add module-level OHLC response cache in Dashboard Lambda to eliminate 429 rate limit errors when users rapidly click resolution buckets"
+
+## Problem Statement
+
+When users rapidly click resolution buckets on the Price Chart (e.g., switching between 1m, 5m, 15m, 1h), they trigger 429 (Too Many Requests) errors. The root cause is that each resolution change calls the Tiingo external API directly, with only a 5-minute adapter-level cache that's lost on Lambda cold starts.
+
+**Comparison with Sentiment API**: The Sentiment API doesn't have this issue because it queries internal DynamoDB data, which has no rate limits. The OHLC API calls external Tiingo API, which has aggressive rate limiting.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Resolution Switching Without Errors (Priority: P1)
+
+As a user viewing the Price Chart, I want to switch between resolution buckets (1m, 5m, 15m, etc.) without encountering rate limit errors, so that I can explore price data at different granularities.
+
+**Why this priority**: Core functionality - users cannot explore price data if they hit 429 errors after 3-5 clicks.
+
+**Independent Test**: Can be tested by clicking 10 resolution buckets in rapid succession and verifying no 429 errors occur.
+
+**Acceptance Scenarios**:
+
+1. **Given** user is viewing AAPL at 1-minute resolution, **When** user clicks 5-minute, 15-minute, 1-hour, 1-day resolution buttons in quick succession (within 5 seconds), **Then** all resolution changes succeed without 429 errors
+2. **Given** a previously viewed ticker+resolution combination exists in cache, **When** user switches back to that combination, **Then** data loads instantly from cache without external API call
+
+---
+
+### User Story 2 - Warm Lambda Response Time (Priority: P2)
+
+As a user, I want repeated chart views to load faster than initial views, so that my experience feels responsive.
+
+**Why this priority**: User experience improvement - cached responses should be noticeably faster.
+
+**Independent Test**: Can be tested by measuring response time for first vs second request for same ticker+resolution.
+
+**Acceptance Scenarios**:
+
+1. **Given** AAPL 5-minute data is already cached from previous request, **When** user requests same ticker+resolution, **Then** response completes in under 50ms (vs 500-2000ms for external API)
+2. **Given** cache is near capacity (256 entries), **When** new data needs caching, **Then** oldest entries are evicted without affecting response time
+
+---
+
+### User Story 3 - Cache Staleness Handling (Priority: P3)
+
+As a user, I expect fresh price data when market conditions change, so that cached data doesn't become misleading.
+
+**Why this priority**: Data freshness matters for informed decisions but less critical than preventing errors.
+
+**Independent Test**: Can be tested by verifying cache entry timestamps and TTL expiration.
+
+**Acceptance Scenarios**:
+
+1. **Given** 1-minute resolution cache entry is older than 5 minutes, **When** user requests that data, **Then** fresh data is fetched from external API
+2. **Given** daily resolution cache entry is older than 1 hour, **When** user requests that data, **Then** fresh data is fetched from external API
+
+---
+
+### Edge Cases
+
+- What happens when cache is full and new data arrives? (LRU eviction)
+- How does system handle concurrent requests for same ticker+resolution? (deduplicate or allow through)
+- What happens when external API is temporarily down? (serve stale cache if available)
+- How does system handle different date ranges for same ticker+resolution? (different cache keys)
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST cache OHLC responses at the Lambda module level (similar to sentiment.py pattern)
+- **FR-002**: System MUST use cache key format: `{ticker}#{resolution}#{start_date}#{end_date}`
+- **FR-003**: System MUST enforce resolution-specific TTLs:
+  - 1-minute: 5 minutes TTL
+  - 5-minute to 30-minute: 15 minutes TTL
+  - Hourly: 30 minutes TTL
+  - Daily: 1 hour TTL
+- **FR-004**: System MUST limit cache to 256 entries maximum
+- **FR-005**: System MUST evict oldest entries when cache reaches capacity (LRU eviction)
+- **FR-006**: System MUST track cache hit/miss statistics for observability
+- **FR-007**: System MUST log cache state periodically for debugging
+
+### Key Entities
+
+- **OHLCCacheEntry**: Represents a cached response with key, value, timestamp, and TTL
+- **CacheStats**: Tracks hits, misses, evictions for monitoring
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Users can switch between 10 resolution buckets in 5 seconds without any 429 errors
+- **SC-002**: Cached responses load in under 50ms (vs 500-2000ms for external API)
+- **SC-003**: Cache hit rate exceeds 80% for typical user session (switching between 5-6 resolutions)
+- **SC-004**: External API call volume reduced by at least 50% for warm Lambda invocations

--- a/specs/1076-ohlc-response-cache/tasks.md
+++ b/specs/1076-ohlc-response-cache/tasks.md
@@ -1,0 +1,18 @@
+# Implementation Tasks: OHLC Response Cache
+
+**Feature Branch**: `1076-ohlc-response-cache`
+**Created**: 2025-12-27
+**Plan**: [plan.md](./plan.md)
+
+## Tasks
+
+- [ ] **Task 1**: Add cache configuration constants (TTLs, max entries)
+- [ ] **Task 2**: Add cache storage dicts and stats tracking
+- [ ] **Task 3**: Add `_get_ohlc_cache_key()` function
+- [ ] **Task 4**: Add `_get_cached_ohlc()` function with TTL check
+- [ ] **Task 5**: Add `_set_cached_ohlc()` function with LRU eviction
+- [ ] **Task 6**: Add `get_ohlc_cache_stats()` function
+- [ ] **Task 7**: Integrate cache check at start of `get_ohlc()` handler
+- [ ] **Task 8**: Integrate cache set before returning success response
+- [ ] **Task 9**: Add unit tests for cache functionality
+- [ ] **Task 10**: Run all OHLC tests to verify no regressions

--- a/tests/unit/dashboard/test_ohlc_cache.py
+++ b/tests/unit/dashboard/test_ohlc_cache.py
@@ -1,0 +1,265 @@
+"""Unit tests for OHLC response cache (Feature 1076).
+
+Tests the module-level caching infrastructure that prevents 429 rate limit
+errors when users rapidly switch resolution buckets.
+"""
+
+import time
+from datetime import date
+from unittest.mock import patch
+
+import pytest
+
+from src.lambdas.dashboard.ohlc import (
+    OHLC_CACHE_DEFAULT_TTL,
+    OHLC_CACHE_MAX_ENTRIES,
+    OHLC_CACHE_TTLS,
+    _get_cached_ohlc,
+    _get_ohlc_cache_key,
+    _set_cached_ohlc,
+    get_ohlc_cache_stats,
+    invalidate_ohlc_cache,
+)
+
+
+@pytest.fixture(autouse=True)
+def clear_cache():
+    """Clear cache before and after each test."""
+    global _ohlc_cache, _ohlc_cache_stats
+    # Import fresh to reset module state
+    import src.lambdas.dashboard.ohlc as ohlc_module
+
+    ohlc_module._ohlc_cache.clear()
+    ohlc_module._ohlc_cache_stats["hits"] = 0
+    ohlc_module._ohlc_cache_stats["misses"] = 0
+    ohlc_module._ohlc_cache_stats["evictions"] = 0
+    yield
+    ohlc_module._ohlc_cache.clear()
+    ohlc_module._ohlc_cache_stats["hits"] = 0
+    ohlc_module._ohlc_cache_stats["misses"] = 0
+    ohlc_module._ohlc_cache_stats["evictions"] = 0
+
+
+class TestOHLCCacheKey:
+    """Tests for cache key generation."""
+
+    def test_generates_deterministic_key(self):
+        """Cache key should be deterministic for same inputs."""
+        key1 = _get_ohlc_cache_key("AAPL", "D", date(2024, 1, 1), date(2024, 1, 31))
+        key2 = _get_ohlc_cache_key("AAPL", "D", date(2024, 1, 1), date(2024, 1, 31))
+        assert key1 == key2
+
+    def test_normalizes_ticker_to_uppercase(self):
+        """Cache key should normalize ticker to uppercase."""
+        key1 = _get_ohlc_cache_key("aapl", "D", date(2024, 1, 1), date(2024, 1, 31))
+        key2 = _get_ohlc_cache_key("AAPL", "D", date(2024, 1, 1), date(2024, 1, 31))
+        assert key1 == key2
+
+    def test_different_resolutions_different_keys(self):
+        """Different resolutions should produce different cache keys."""
+        key_daily = _get_ohlc_cache_key(
+            "AAPL", "D", date(2024, 1, 1), date(2024, 1, 31)
+        )
+        key_5min = _get_ohlc_cache_key("AAPL", "5", date(2024, 1, 1), date(2024, 1, 31))
+        assert key_daily != key_5min
+
+    def test_different_date_ranges_different_keys(self):
+        """Different date ranges should produce different cache keys."""
+        key1 = _get_ohlc_cache_key("AAPL", "D", date(2024, 1, 1), date(2024, 1, 31))
+        key2 = _get_ohlc_cache_key("AAPL", "D", date(2024, 2, 1), date(2024, 2, 28))
+        assert key1 != key2
+
+    def test_key_format(self):
+        """Cache key should have expected format."""
+        key = _get_ohlc_cache_key("MSFT", "15", date(2024, 3, 15), date(2024, 3, 20))
+        assert key == "ohlc:MSFT:15:2024-03-15:2024-03-20"
+
+
+class TestOHLCCacheGetSet:
+    """Tests for cache get/set operations."""
+
+    def test_cache_miss_returns_none(self):
+        """Cache miss should return None and increment misses."""
+        import src.lambdas.dashboard.ohlc as ohlc_module
+
+        result = _get_cached_ohlc("ohlc:AAPL:D:2024-01-01:2024-01-31", "D")
+        assert result is None
+        assert ohlc_module._ohlc_cache_stats["misses"] == 1
+
+    def test_cache_hit_returns_data(self):
+        """Cache hit should return cached data and increment hits."""
+        import src.lambdas.dashboard.ohlc as ohlc_module
+
+        test_data = {"ticker": "AAPL", "candles": [], "count": 0}
+        cache_key = "ohlc:AAPL:D:2024-01-01:2024-01-31"
+
+        _set_cached_ohlc(cache_key, test_data)
+        result = _get_cached_ohlc(cache_key, "D")
+
+        assert result == test_data
+        assert ohlc_module._ohlc_cache_stats["hits"] == 1
+
+    def test_cache_expiry(self):
+        """Expired cache entries should return None."""
+        import src.lambdas.dashboard.ohlc as ohlc_module
+
+        test_data = {"ticker": "AAPL", "candles": []}
+        cache_key = "ohlc:AAPL:1:2024-01-01:2024-01-31"
+
+        _set_cached_ohlc(cache_key, test_data)
+
+        # Mock time to simulate expiry (1-minute TTL is 300s)
+        with patch("src.lambdas.dashboard.ohlc.time.time") as mock_time:
+            # First call at T=0, second call at T=301 (past 5 min TTL)
+            ohlc_module._ohlc_cache[cache_key] = (1000.0, test_data)
+            mock_time.return_value = 1000.0 + 301  # Past 1-minute TTL (300s)
+
+            result = _get_cached_ohlc(cache_key, "1")
+            assert result is None
+            assert cache_key not in ohlc_module._ohlc_cache
+
+
+class TestOHLCCacheTTLs:
+    """Tests for resolution-specific TTLs."""
+
+    def test_ttl_1min_resolution(self):
+        """1-minute resolution should have 5 minute TTL."""
+        assert OHLC_CACHE_TTLS["1"] == 300
+
+    def test_ttl_5min_resolution(self):
+        """5-minute resolution should have 15 minute TTL."""
+        assert OHLC_CACHE_TTLS["5"] == 900
+
+    def test_ttl_15min_resolution(self):
+        """15-minute resolution should have 15 minute TTL."""
+        assert OHLC_CACHE_TTLS["15"] == 900
+
+    def test_ttl_30min_resolution(self):
+        """30-minute resolution should have 15 minute TTL."""
+        assert OHLC_CACHE_TTLS["30"] == 900
+
+    def test_ttl_hourly_resolution(self):
+        """Hourly resolution should have 30 minute TTL."""
+        assert OHLC_CACHE_TTLS["60"] == 1800
+
+    def test_ttl_daily_resolution(self):
+        """Daily resolution should have 1 hour TTL."""
+        assert OHLC_CACHE_TTLS["D"] == 3600
+
+    def test_default_ttl(self):
+        """Default TTL should be 5 minutes."""
+        assert OHLC_CACHE_DEFAULT_TTL == 300
+
+
+class TestOHLCCacheEviction:
+    """Tests for LRU eviction when cache is full."""
+
+    def test_eviction_when_full(self):
+        """Oldest entry should be evicted when cache is full."""
+        import src.lambdas.dashboard.ohlc as ohlc_module
+
+        # Fill cache with MAX_ENTRIES items
+        with patch.object(ohlc_module, "OHLC_CACHE_MAX_ENTRIES", 3):
+            # Add 3 entries
+            for i in range(3):
+                key = f"ohlc:AAPL:{i}:2024-01-01:2024-01-31"
+                ohlc_module._ohlc_cache[key] = (1000.0 + i, {"index": i})
+
+            # Add 4th entry - should evict oldest (index 0)
+            ohlc_module._set_cached_ohlc(
+                "ohlc:AAPL:new:2024-01-01:2024-01-31", {"index": "new"}
+            )
+
+            # Check oldest was evicted
+            assert "ohlc:AAPL:0:2024-01-01:2024-01-31" not in ohlc_module._ohlc_cache
+            # Check new entry exists
+            assert "ohlc:AAPL:new:2024-01-01:2024-01-31" in ohlc_module._ohlc_cache
+            # Check eviction counter
+            assert ohlc_module._ohlc_cache_stats["evictions"] == 1
+
+    def test_max_entries_default(self):
+        """Default max entries should be 256."""
+        assert OHLC_CACHE_MAX_ENTRIES == 256
+
+
+class TestOHLCCacheStats:
+    """Tests for cache statistics."""
+
+    def test_stats_returns_copy(self):
+        """get_ohlc_cache_stats should return a copy, not the original."""
+        import src.lambdas.dashboard.ohlc as ohlc_module
+
+        stats = get_ohlc_cache_stats()
+        stats["hits"] = 999  # Modify the copy
+
+        # Original should be unchanged
+        assert ohlc_module._ohlc_cache_stats["hits"] == 0
+
+    def test_stats_tracks_hits_misses_evictions(self):
+        """Stats should track hits, misses, and evictions."""
+        stats = get_ohlc_cache_stats()
+        assert "hits" in stats
+        assert "misses" in stats
+        assert "evictions" in stats
+
+
+class TestOHLCCacheInvalidation:
+    """Tests for cache invalidation."""
+
+    def test_invalidate_all(self):
+        """invalidate_ohlc_cache() with no args should clear entire cache."""
+        import src.lambdas.dashboard.ohlc as ohlc_module
+
+        # Add some entries
+        ohlc_module._ohlc_cache["ohlc:AAPL:D:2024-01-01:2024-01-31"] = (
+            time.time(),
+            {"ticker": "AAPL"},
+        )
+        ohlc_module._ohlc_cache["ohlc:MSFT:D:2024-01-01:2024-01-31"] = (
+            time.time(),
+            {"ticker": "MSFT"},
+        )
+
+        count = invalidate_ohlc_cache()
+
+        assert count == 2
+        assert len(ohlc_module._ohlc_cache) == 0
+
+    def test_invalidate_by_ticker(self):
+        """invalidate_ohlc_cache(ticker) should only clear that ticker's entries."""
+        import src.lambdas.dashboard.ohlc as ohlc_module
+
+        # Add entries for different tickers
+        ohlc_module._ohlc_cache["ohlc:AAPL:D:2024-01-01:2024-01-31"] = (
+            time.time(),
+            {"ticker": "AAPL"},
+        )
+        ohlc_module._ohlc_cache["ohlc:AAPL:5:2024-01-01:2024-01-31"] = (
+            time.time(),
+            {"ticker": "AAPL"},
+        )
+        ohlc_module._ohlc_cache["ohlc:MSFT:D:2024-01-01:2024-01-31"] = (
+            time.time(),
+            {"ticker": "MSFT"},
+        )
+
+        count = invalidate_ohlc_cache("AAPL")
+
+        assert count == 2
+        assert "ohlc:AAPL:D:2024-01-01:2024-01-31" not in ohlc_module._ohlc_cache
+        assert "ohlc:AAPL:5:2024-01-01:2024-01-31" not in ohlc_module._ohlc_cache
+        assert "ohlc:MSFT:D:2024-01-01:2024-01-31" in ohlc_module._ohlc_cache
+
+    def test_invalidate_ticker_case_insensitive(self):
+        """Ticker invalidation should be case-insensitive."""
+        import src.lambdas.dashboard.ohlc as ohlc_module
+
+        ohlc_module._ohlc_cache["ohlc:AAPL:D:2024-01-01:2024-01-31"] = (
+            time.time(),
+            {"ticker": "AAPL"},
+        )
+
+        count = invalidate_ohlc_cache("aapl")  # lowercase
+
+        assert count == 1
+        assert len(ohlc_module._ohlc_cache) == 0


### PR DESCRIPTION
## Summary

- Add module-level OHLC response cache to prevent 429 rate limit errors when users rapidly switch resolution buckets
- Resolution-specific TTLs: 1m=5min, 5-30m=15min, hourly=30min, daily=1hr
- LRU eviction when cache reaches 256 entries
- Cache hit/miss/eviction tracking for observability

## Problem

When users rapidly click resolution buckets (1m, 5m, 15m, etc.), they trigger 429 rate limit errors from the Tiingo API. The adapter-level 5-minute cache is tied to Lambda execution environment and lost on cold starts.

## Solution

Add module-level caching in `ohlc.py` following the proven pattern from `sentiment.py`:
- Check cache before making external API calls
- Store successful responses with resolution-specific TTLs
- Track cache statistics for monitoring

## Test Plan

- [x] 22 new cache-specific unit tests pass
- [x] All 48 OHLC tests pass (no regressions)
- [x] All 2457 unit tests pass
- [ ] Manual verification: Click 10 resolution buckets in 5 seconds without 429 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)