### PR TITLE
fix(ohlc): Normalize cache keys to use time_range instead of dates (Feature 1078)

### DIFF
--- a/specs/1078-ohlc-cache-key-normalization/spec.md
+++ b/specs/1078-ohlc-cache-key-normalization/spec.md
@@ -1,0 +1,63 @@
+# Feature Specification: OHLC Cache Key Normalization
+
+**Feature Branch**: `1078-ohlc-cache-key-normalization`
+**Created**: 2025-12-28
+**Status**: Draft
+
+## Problem Statement
+
+The OHLC response cache (Feature 1076) has 0% cache hit rate because the cache key includes dynamically calculated dates. Every request generates a unique cache key, causing all requests to miss the cache and hit the Tiingo API, resulting in 429 rate limit errors after ~10 resolution clicks.
+
+**Root Cause**: When users don't provide custom dates, `end_date = date.today()` is calculated fresh on every request. Combined with resolution and ticker, this creates unique cache keys.
+
+**Example**:
+- Request at 10:00: `ohlc:AAPL:5:2024-10-28:2024-11-27`
+- Request at 10:01: `ohlc:AAPL:5:2024-10-28:2024-11-27` (same, but...)
+- Request next day: `ohlc:AAPL:5:2024-10-29:2024-11-28` (DIFFERENT!)
+
+## User Scenarios & Testing
+
+### User Story 1 - Rapid Resolution Switching Without 429 (Priority: P1)
+
+As a user, I want to switch between resolution buckets rapidly without triggering rate limit errors, so I can explore price data at different granularities.
+
+**Acceptance Scenarios**:
+
+1. **Given** user is viewing AAPL chart, **When** user clicks 10 different resolution buttons in 10 seconds, **Then** no 429 errors occur
+2. **Given** user clicked 5m resolution earlier, **When** user clicks 5m again, **Then** data loads from cache (fast response)
+
+---
+
+### User Story 2 - Cache Hits for Same Resolution (Priority: P1)
+
+As a user, I expect switching back to a previously viewed resolution to be instant, since the data was already fetched.
+
+**Acceptance Scenarios**:
+
+1. **Given** user viewed AAPL at 5m resolution, **When** user switches to 15m then back to 5m, **Then** 5m data loads instantly from cache
+
+---
+
+### Edge Cases
+
+- What happens when cache key normalization crosses date boundaries? (Use UTC date for consistency)
+- What if user provides custom date range? (Use exact dates for cache key, not normalized)
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: System MUST normalize cache keys to use ticker + resolution only (not date range)
+- **FR-002**: System MUST use separate cache entries for custom date ranges vs predefined ranges
+- **FR-003**: System MUST use UTC date for cache key consistency across time zones
+- **FR-004**: Cache hit rate SHOULD be > 80% for repeated resolution switches
+
+### Key Entities
+
+- **CacheKey**: `ohlc:{ticker}:{resolution}:{range_type}` where range_type is `1W|1M|3M|6M|1Y|custom:{start}:{end}`
+
+## Success Criteria
+
+- **SC-001**: Users can click 10 resolution buckets in 10 seconds without 429 errors
+- **SC-002**: Cache hit rate > 80% for session with multiple resolution switches
+- **SC-003**: Repeated clicks on same resolution load from cache (<50ms response)

--- a/tests/integration/ohlc/test_error_resilience.py
+++ b/tests/integration/ohlc/test_error_resilience.py
@@ -42,6 +42,26 @@ from tests.fixtures.mocks.mock_finnhub import MockFinnhubAdapter
 from tests.fixtures.mocks.mock_tiingo import MockTiingoAdapter
 
 
+@pytest.fixture(autouse=True)
+def clear_ohlc_cache():
+    """Clear OHLC cache before and after each test to ensure test isolation.
+
+    Feature 1078: Cache keys now use time_range instead of dates, so cache
+    persists across tests unless explicitly cleared.
+    """
+    import src.lambdas.dashboard.ohlc as ohlc_module
+
+    ohlc_module._ohlc_cache.clear()
+    ohlc_module._ohlc_cache_stats["hits"] = 0
+    ohlc_module._ohlc_cache_stats["misses"] = 0
+    ohlc_module._ohlc_cache_stats["evictions"] = 0
+    yield
+    ohlc_module._ohlc_cache.clear()
+    ohlc_module._ohlc_cache_stats["hits"] = 0
+    ohlc_module._ohlc_cache_stats["misses"] = 0
+    ohlc_module._ohlc_cache_stats["evictions"] = 0
+
+
 @pytest.fixture
 def auth_headers():
     """Headers with valid authentication (Feature 1049: valid UUID required)."""

--- a/tests/unit/dashboard/test_ohlc.py
+++ b/tests/unit/dashboard/test_ohlc.py
@@ -12,6 +12,22 @@ from src.lambdas.shared.adapters.base import OHLCCandle
 from src.lambdas.shared.models import RESOLUTION_MAX_DAYS, OHLCResolution, TimeRange
 
 
+@pytest.fixture(autouse=True)
+def clear_ohlc_cache():
+    """Clear OHLC cache before and after each test to ensure test isolation."""
+    import src.lambdas.dashboard.ohlc as ohlc_module
+
+    ohlc_module._ohlc_cache.clear()
+    ohlc_module._ohlc_cache_stats["hits"] = 0
+    ohlc_module._ohlc_cache_stats["misses"] = 0
+    ohlc_module._ohlc_cache_stats["evictions"] = 0
+    yield
+    ohlc_module._ohlc_cache.clear()
+    ohlc_module._ohlc_cache_stats["hits"] = 0
+    ohlc_module._ohlc_cache_stats["misses"] = 0
+    ohlc_module._ohlc_cache_stats["evictions"] = 0
+
+
 # Test helpers
 def _create_ohlc_candles(
     count: int, start_date: date | None = None


### PR DESCRIPTION
## Summary

- Fix 0% cache hit rate by using time_range string ("1M", "1W") instead of actual dates in cache keys
- Add autouse fixture to clear cache between tests for proper isolation
- Enable actual cache hits when users switch resolutions rapidly

## Problem

Cache keys included dynamically calculated dates (`end_date = date.today()`), so every request generated a unique key. After ~10 resolution clicks, Tiingo API rate limit was hit (429 error).

**Before**: `ohlc:AAPL:5:2024-10-28:2024-11-27` (changes daily)
**After**: `ohlc:AAPL:5:1M` (stable for same range type)

## Solution

Use `time_range_str` for predefined ranges, and only include actual dates for custom ranges:
- Predefined: `ohlc:AAPL:5:1M`
- Custom: `ohlc:AAPL:5:custom:2024-01-01:2024-01-31`

## Test Plan

- [x] All 51 OHLC tests pass (25 endpoint + 26 cache)
- [x] All 2460 unit tests pass
- [ ] Manual: Click 10 resolution buckets in 10 seconds without 429 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)