### PR TITLE
fix(ohlc): Enable bi-directional pan with X-axis limits (Feature 1080)

### DIFF
--- a/specs/1080-ohlc-pan-limits/checklists/requirements.md
+++ b/specs/1080-ohlc-pan-limits/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: OHLC Pan Limits Fix
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2025-12-28
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Requirements are testable and unambiguous
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] User scenarios cover primary flows
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- Root cause identified: missing X-axis limits and X-only pan mode
+- Small fix scope: 2 changes in ohlc.js zoom plugin config

--- a/specs/1080-ohlc-pan-limits/plan.md
+++ b/specs/1080-ohlc-pan-limits/plan.md
@@ -1,0 +1,54 @@
+# Implementation Plan: OHLC Pan Limits Fix
+
+**Branch**: `1080-ohlc-pan-limits` | **Date**: 2025-12-28 | **Spec**: [spec.md](spec.md)
+
+## Summary
+
+Fix pan functionality by adding X-axis limits and enabling bi-directional (XY) pan mode.
+
+## Technical Context
+
+**Language/Version**: JavaScript (ES6+)
+**Primary Dependencies**: Chart.js v4.x, chartjs-plugin-zoom
+**Storage**: N/A (frontend-only fix)
+**Testing**: Browser manual testing
+**Target Platform**: Web browser
+**Project Type**: Web application (frontend fix only)
+**Scale/Scope**: Single file change (ohlc.js)
+
+## Implementation Details
+
+### Change 1: Add X-axis limits
+
+Add `x` key to the `limits` object in zoom plugin configuration:
+
+```javascript
+limits: {
+    x: {
+        min: 'original',      // Use original data range minimum
+        max: 'original',      // Use original data range maximum
+        minRange: 60000       // Minimum 1 minute visible (ms)
+    },
+    price: { min: 'original', minRange: 5 },
+    sentiment: { min: -1, max: 1, minRange: 2 }
+}
+```
+
+### Change 2: Enable XY pan mode
+
+Change `mode: 'x'` to `mode: 'xy'`:
+
+```javascript
+pan: {
+    enabled: true,
+    mode: 'xy',    // Allow both horizontal and vertical panning
+    threshold: 5,
+    modifierKey: null,
+    onPanStart: ({ chart }) => { chart.canvas.style.cursor = 'grabbing'; },
+    onPanComplete: ({ chart }) => { chart.canvas.style.cursor = 'grab'; }
+}
+```
+
+## File Changes
+
+- `src/dashboard/ohlc.js`: Lines ~446 (pan mode) and ~476 (limits)

--- a/specs/1080-ohlc-pan-limits/spec.md
+++ b/specs/1080-ohlc-pan-limits/spec.md
@@ -1,0 +1,91 @@
+# Feature Specification: OHLC Pan Limits Fix
+
+**Feature Branch**: `1080-ohlc-pan-limits`
+**Created**: 2025-12-28
+**Status**: Draft
+
+## Problem Statement
+
+Pan functionality on the OHLC Price Chart doesn't work despite cursor changing to grab/grabbing:
+
+1. **Left-right pan doesn't work**: X-axis (time) has no limits configuration in zoom plugin
+2. **Up-down pan doesn't work after zoom**: Pan mode is `'x'` only, restricting to horizontal
+
+**Root Cause Analysis**:
+
+Current zoom.limits config (ohlc.js ~line 476):
+```javascript
+limits: {
+    price: { min: 'original', minRange: 5 },
+    sentiment: { min: -1, max: 1, minRange: 2 }
+}
+// MISSING: x: { ... } for time axis limits
+```
+
+Current pan mode (ohlc.js ~line 446):
+```javascript
+pan: {
+    enabled: true,
+    mode: 'x',  // Only allows horizontal, blocks vertical
+    ...
+}
+```
+
+## User Scenarios & Testing
+
+### User Story 1 - Horizontal Pan (Left-Right Time Navigation) (Priority: P1)
+
+As a user viewing the Price Chart, I want to left-click and drag horizontally to navigate through time.
+
+**Why this priority**: Core pan functionality that users expect from any chart.
+
+**Independent Test**: Load chart, left-click-drag horizontally, verify chart pans through time.
+
+**Acceptance Scenarios**:
+
+1. **Given** OHLC chart displays data, **When** user left-click-drags left, **Then** chart shows earlier candles
+2. **Given** OHLC chart displays data, **When** user left-click-drags right, **Then** chart shows later candles
+3. **Given** user is at data boundary, **When** user tries to pan beyond data, **Then** pan stops at boundary
+
+---
+
+### User Story 2 - Vertical Pan After Zoom (Priority: P1)
+
+As a user who has zoomed into price data, I want to pan vertically to see candles that went out of view.
+
+**Why this priority**: After zooming, candlesticks often go out of view and users need to pan to see them.
+
+**Independent Test**: Zoom into chart, then left-click-drag vertically, verify chart pans up/down.
+
+**Acceptance Scenarios**:
+
+1. **Given** user has zoomed in on price axis, **When** user left-click-drags up, **Then** chart shows higher prices
+2. **Given** user has zoomed in on price axis, **When** user left-click-drags down, **Then** chart shows lower prices
+3. **Given** user pans vertically, **When** sentiment axis is visible, **Then** sentiment axis remains fixed at -1 to 1
+
+---
+
+### Edge Cases
+
+- What happens when panning beyond data range? (Stop at data boundaries)
+- What happens to sentiment axis during vertical pan? (Remains fixed per design)
+- What happens with diagonal drag? (Both axes pan simultaneously)
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: System MUST add X-axis limits to zoom plugin configuration
+- **FR-002**: System MUST use 'original' data range for X-axis limits
+- **FR-003**: System MUST change pan mode from 'x' to 'xy' for bi-directional panning
+- **FR-004**: System MUST keep sentiment axis fixed during vertical pan (min: -1, max: 1)
+- **FR-005**: System MUST maintain grab/grabbing cursor feedback during pan
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: Left-click-drag horizontally pans chart through time
+- **SC-002**: Left-click-drag vertically pans chart through price range (after zoom)
+- **SC-003**: Pan stops at data boundaries (cannot pan beyond available data)
+- **SC-004**: Sentiment axis (-1 to 1) remains fixed during vertical pan

--- a/specs/1080-ohlc-pan-limits/tasks.md
+++ b/specs/1080-ohlc-pan-limits/tasks.md
@@ -1,0 +1,25 @@
+# Implementation Tasks: OHLC Pan Limits Fix
+
+**Branch**: `1080-ohlc-pan-limits` | **Created**: 2025-12-28
+
+## Phase 1: Implementation
+
+- [X] T001 [US1] [US2] Add X-axis limits to zoom plugin config in src/dashboard/ohlc.js
+- [X] T002 [US2] Change pan mode from 'x' to 'xy' in src/dashboard/ohlc.js
+
+## Phase 2: Verification
+
+- [ ] T003 Deploy and verify horizontal pan works (left-right time navigation)
+- [ ] T004 Verify vertical pan works after zoom (up-down price navigation)
+- [ ] T005 Verify sentiment axis remains fixed at -1 to 1 during vertical pan
+
+## Dependencies
+
+```text
+T001 + T002 (parallel) → T003 → T004 → T005
+```
+
+## Notes
+
+- Both T001 and T002 modify same file but different sections
+- Can be done in single edit

--- a/src/dashboard/ohlc.js
+++ b/src/dashboard/ohlc.js
@@ -445,7 +445,7 @@ class OHLCChart {
                         // Feature 1071: Pan configuration for horizontal navigation
                         pan: {
                             enabled: true,
-                            mode: 'x',           // Pan only on X-axis (time)
+                            mode: 'xy',          // Feature 1080: Allow both X (time) and Y (price) panning
                             threshold: 5,        // Minimum pan distance before action
                             modifierKey: null,   // No modifier key required (plain left-click)
                             // Feature 1077: Cursor feedback during pan
@@ -473,8 +473,13 @@ class OHLCChart {
                                 }
                             }
                         },
-                        // Feature 1073: Fixed limits configuration
+                        // Feature 1073/1080: Fixed limits configuration with X-axis support
                         limits: {
+                            x: {
+                                min: 'original',  // Feature 1080: Use original data range for time axis
+                                max: 'original',
+                                minRange: 60000   // Minimum 1 minute visible (60 seconds * 1000ms)
+                            },
                             price: {
                                 min: 'original',  // Use data range, not $0 floor
                                 minRange: 5       // Minimum $5 range when zoomed in

--- a/tests/unit/dashboard/test_price_chart_interaction_fixes.py
+++ b/tests/unit/dashboard/test_price_chart_interaction_fixes.py
@@ -211,11 +211,24 @@ class TestPanConfiguration:
             pan_enabled_pattern, content
         ), "Pan not enabled. Add pan: { enabled: true } to zoom config."
 
-    def test_pan_mode_x(self) -> None:
-        """Verify pan mode is 'x' for horizontal navigation."""
+    def test_pan_mode_xy(self) -> None:
+        """Verify pan mode is 'xy' for bi-directional navigation (Feature 1080)."""
         content = read_ohlc_js()
 
-        pan_mode_pattern = r"pan:\s*\{[^}]*mode:\s*['\"]x['\"]"
+        # Feature 1080: Changed from 'x' to 'xy' to enable vertical panning after zoom
+        pan_mode_pattern = r"pan:\s*\{[^}]*mode:\s*['\"]xy['\"]"
         assert re.search(pan_mode_pattern, content), (
-            "Pan mode not set to 'x'. " "Use mode: 'x' for horizontal-only panning."
+            "Pan mode not set to 'xy'. "
+            "Use mode: 'xy' for bi-directional panning (Feature 1080)."
+        )
+
+    def test_x_axis_limits_exist(self) -> None:
+        """Verify X-axis limits are configured for pan boundaries (Feature 1080)."""
+        content = read_ohlc_js()
+
+        # Feature 1080: X-axis limits are required for pan to work
+        x_limits_pattern = r"limits:\s*\{[^}]*x:\s*\{"
+        assert re.search(x_limits_pattern, content), (
+            "X-axis limits not configured. "
+            "Add limits.x config for pan boundaries (Feature 1080)."
         )

--- a/tests/unit/dashboard/test_price_chart_pan.py
+++ b/tests/unit/dashboard/test_price_chart_pan.py
@@ -52,15 +52,16 @@ class TestPanConfiguration:
             "Pan not enabled. " "Add enabled: true to pan configuration."
         )
 
-    def test_pan_mode_x_axis(self) -> None:
-        """Verify pan is configured for X-axis only (horizontal pan)."""
+    def test_pan_mode_xy_axis(self) -> None:
+        """Verify pan is configured for XY-axis (bi-directional pan, Feature 1080)."""
         content = read_ohlc_js()
 
-        # Look for mode: 'x' in pan configuration
-        # We need to find mode: 'x' within the pan block
-        pan_mode_pattern = r"pan:\s*\{[^}]*mode:\s*['\"]x['\"]"
+        # Feature 1080: Look for mode: 'xy' in pan configuration
+        # Changed from 'x' to 'xy' to enable vertical panning after zoom
+        pan_mode_pattern = r"pan:\s*\{[^}]*mode:\s*['\"]xy['\"]"
         assert re.search(pan_mode_pattern, content, re.DOTALL), (
-            "Pan mode not set to 'x'. " "Use mode: 'x' for horizontal-only panning."
+            "Pan mode not set to 'xy'. "
+            "Use mode: 'xy' for bi-directional panning (Feature 1080)."
         )
 
     def test_pan_has_threshold(self) -> None:
@@ -117,22 +118,26 @@ class TestPanAndZoomCoexistence:
         )
         assert has_mode_y, (
             "Zoom mode should be 'y' for vertical zoom. "
-            "Pan is 'x' for horizontal, zoom is 'y' for vertical."
+            "Pan is 'xy' for bi-directional, zoom is 'y' for vertical."
         )
 
-    def test_pan_x_zoom_y_separation(self) -> None:
-        """Verify pan is X-axis and zoom is Y-axis (orthogonal controls)."""
+    def test_pan_xy_zoom_y_configuration(self) -> None:
+        """Verify pan is XY-axis and zoom is Y-axis (Feature 1080)."""
         content = read_ohlc_js()
 
         # Check that we have both modes configured correctly
-        # Pan is in its own block: pan: { mode: 'x' }
-        has_pan_x = re.search(r"pan:\s*\{[^}]*mode:\s*['\"]x['\"]", content, re.DOTALL)
+        # Pan is in its own block: pan: { mode: 'xy' } for bi-directional
+        has_pan_xy = re.search(
+            r"pan:\s*\{[^}]*mode:\s*['\"]xy['\"]", content, re.DOTALL
+        )
 
         # For zoom mode, just check that mode: 'y' appears in the file
         # along with scaleMode: 'y' which confirms it's for Y-axis zoom
         has_zoom_y = "mode: 'y'" in content and "scaleMode: 'y'" in content
 
-        assert has_pan_x, "Pan should be configured for X-axis (mode: 'x')"
+        assert (
+            has_pan_xy
+        ), "Pan should be configured for XY-axis (mode: 'xy', Feature 1080)"
         assert (
             has_zoom_y
         ), "Zoom should be configured for Y-axis (mode: 'y' and scaleMode: 'y')"


### PR DESCRIPTION
## Summary
- Add `limits.x` configuration to zoom plugin with min/max: 'original' for time axis boundaries
- Change pan mode from 'x' to 'xy' to enable vertical panning after zoom
- Update test files to expect new 'xy' pan mode

## Root Cause
Pan functionality was not working because:
1. Missing `limits.x` config meant chartjs-plugin-zoom had no X-axis boundaries
2. `mode: 'x'` restricted pan to horizontal only, blocking vertical pan after zoom

## Test plan
- [x] All 26 pan-related unit tests pass
- [x] All 2461 unit tests pass
- [ ] Verify horizontal pan works (left-right time navigation)
- [ ] Verify vertical pan works after zoom (up-down price navigation)
- [ ] Verify sentiment axis remains fixed at -1 to 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)