### PR TITLE
feat(ohlc): Add date context to multi-day intraday time labels (Feature 1081)

### DIFF
--- a/specs/1081-time-axis-formatting/checklists/requirements.md
+++ b/specs/1081-time-axis-formatting/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: OHLC Time Axis Formatting Fix
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2025-12-28
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Requirements are testable and unambiguous
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] User scenarios cover primary flows
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- Simple formatting fix with clear before/after behavior
+- Static analysis testing approach matches existing patterns

--- a/specs/1081-time-axis-formatting/plan.md
+++ b/specs/1081-time-axis-formatting/plan.md
@@ -1,0 +1,82 @@
+# Implementation Plan: OHLC Time Axis Formatting Fix
+
+**Branch**: `1081-time-axis-formatting` | **Date**: 2025-12-28 | **Spec**: [spec.md](spec.md)
+
+## Summary
+
+Fix time axis formatting to include date context for multi-day intraday data by detecting day boundaries and showing abbreviated dates for first candle of each day.
+
+## Technical Context
+
+**Language/Version**: JavaScript (ES6+)
+**Primary Dependencies**: Chart.js v4.x
+**Storage**: N/A (frontend-only fix)
+**Testing**: Static analysis unit tests + browser manual testing
+**Target Platform**: Web browser
+**Project Type**: Web application (frontend fix only)
+**Scale/Scope**: Single file change (ohlc.js)
+
+## Implementation Details
+
+### Change 1: Track Day Boundaries in Labels
+
+Modify `formatTimestamp()` to accept candle index and detect day transitions:
+
+```javascript
+/**
+ * Format timestamp for chart label with day context
+ * @param {string} timestamp - ISO timestamp
+ * @param {number} index - Candle index in data array
+ * @param {Array} candles - All candles for day boundary detection
+ */
+formatTimestamp(timestamp, index, candles) {
+    const date = new Date(timestamp);
+    const resolution = this.currentResolution;
+
+    if (resolution === 'D') {
+        // Day resolution: "Dec 23" format
+        return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+    }
+
+    // Check if this is first candle of a new day
+    const isFirstOfDay = index === 0 || this.isDifferentDay(candles[index - 1].date, timestamp);
+
+    if (isFirstOfDay) {
+        // Show abbreviated date: "Mon 12/23"
+        const weekday = date.toLocaleDateString('en-US', { weekday: 'short' });
+        const monthDay = `${date.getMonth() + 1}/${date.getDate()}`;
+        return `${weekday} ${monthDay}`;
+    }
+
+    // Same day: show time only
+    return date.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: false });
+}
+
+/**
+ * Check if two timestamps are on different calendar days
+ */
+isDifferentDay(timestamp1, timestamp2) {
+    const d1 = new Date(timestamp1);
+    const d2 = new Date(timestamp2);
+    return d1.toDateString() !== d2.toDateString();
+}
+```
+
+### Change 2: Pass Candle Context to Formatter
+
+Update `updateChart()` to pass index and candles array:
+
+```javascript
+const labels = candles.map((c, index) => this.formatTimestamp(c.date, index, candles));
+```
+
+## File Changes
+
+- `src/dashboard/ohlc.js`: Lines ~597 (labels generation), ~743 (formatTimestamp method)
+
+## Testing
+
+Add static analysis tests in `tests/unit/dashboard/test_time_axis_formatting.py`:
+- Test `isDifferentDay` method exists
+- Test `formatTimestamp` handles day boundaries
+- Test Feature 1081 comment exists for traceability

--- a/specs/1081-time-axis-formatting/spec.md
+++ b/specs/1081-time-axis-formatting/spec.md
@@ -1,0 +1,70 @@
+# Feature Specification: OHLC Time Axis Formatting Fix
+
+**Feature Branch**: `1081-time-axis-formatting`
+**Created**: 2025-12-28
+**Status**: Draft
+**Input**: Fix OHLC time axis formatting to include date context for multi-day intraday data
+
+## User Scenarios & Testing
+
+### User Story 1 - Date Context in Multi-Day Time Labels (Priority: P1)
+
+When viewing multi-day intraday OHLC data, time labels should include date context so traders can distinguish which candles belong to which trading day. Currently, times like "09:30" repeat across multiple days with no visual distinction.
+
+**Why this priority**: Core usability issue - users cannot interpret chart correctly without knowing which day each candle represents.
+
+**Independent Test**: Load 7-day intraday chart (1h resolution). First candle of each day should show "Mon 12/23" format, subsequent candles show "10:00" format.
+
+**Acceptance Scenarios**:
+
+1. **Given** 7-day intraday data at 1h resolution, **When** chart renders, **Then** each day's first candle label shows abbreviated weekday and date (e.g., "Mon 12/23")
+2. **Given** 7-day intraday data, **When** user hovers over time axis, **Then** can clearly identify which candles belong to which day
+3. **Given** single-day intraday data, **When** chart renders, **Then** labels show time only ("09:30", "10:00") with no date prefix
+
+---
+
+### User Story 2 - Day Resolution Labels (Priority: P2)
+
+Day resolution charts should continue showing month-day format for consistency with existing behavior.
+
+**Why this priority**: Maintains backward compatibility with existing correct behavior.
+
+**Independent Test**: Load chart at Day resolution. Labels show "Dec 23", "Dec 24" format.
+
+**Acceptance Scenarios**:
+
+1. **Given** Day resolution selected, **When** chart renders, **Then** labels show "Dec 23" format (unchanged from current)
+
+---
+
+### Edge Cases
+
+- What happens when market is closed (weekend/holiday)? Skip those days in formatting
+- What happens at year boundary (Dec 31 to Jan 1)? Show appropriate dates
+- What happens with pre-market/after-hours candles? Include in same day as regular session
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: System MUST detect if candle data spans multiple calendar days
+- **FR-002**: System MUST show abbreviated date (e.g., "Mon 12/23") for first candle of each new trading day when data spans multiple days
+- **FR-003**: System MUST show time only (e.g., "09:30") for subsequent candles on the same day
+- **FR-004**: System MUST preserve existing Day resolution format ("Dec 23")
+- **FR-005**: System MUST use Chart.js autoSkip to prevent label overlap
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: Multi-day intraday charts clearly show day boundaries with date labels
+- **SC-002**: No label overlap or truncation at any resolution
+- **SC-003**: Single-day view remains clean with time-only labels
+- **SC-004**: All existing price chart unit tests pass (26+ tests)
+- **SC-005**: Day resolution behavior unchanged
+
+## Out of Scope
+
+- Resolution mapping changes (handled by UNIFIED_RESOLUTIONS design)
+- Backend API changes
+- Sentiment chart time axis formatting

--- a/specs/1081-time-axis-formatting/tasks.md
+++ b/specs/1081-time-axis-formatting/tasks.md
@@ -1,0 +1,31 @@
+# Implementation Tasks: OHLC Time Axis Formatting Fix
+
+**Branch**: `1081-time-axis-formatting` | **Created**: 2025-12-28
+
+## Phase 1: Implementation
+
+- [X] T001 [US1] Add isDifferentDay helper method in src/dashboard/ohlc.js
+- [X] T002 [US1] Update formatTimestamp to accept index and candles array in src/dashboard/ohlc.js
+- [X] T003 [US1] Add day boundary detection logic with abbreviated date format in src/dashboard/ohlc.js
+- [X] T004 [US1] Update updateChart label generation to pass candle context in src/dashboard/ohlc.js
+
+## Phase 2: Testing
+
+- [X] T005 Create static analysis tests in tests/unit/dashboard/test_time_axis_formatting.py
+
+## Phase 3: Verification
+
+- [ ] T006 Deploy and verify multi-day intraday shows date context
+- [ ] T007 Verify single-day data shows time-only labels
+- [ ] T008 Verify Day resolution unchanged
+
+## Dependencies
+
+```text
+T001 → T002 → T003 → T004 → T005 → T006 → T007 → T008
+```
+
+## Notes
+
+- All changes in single file (ohlc.js)
+- Backward compatible - Day resolution unchanged

--- a/tests/unit/dashboard/test_time_axis_formatting.py
+++ b/tests/unit/dashboard/test_time_axis_formatting.py
@@ -1,0 +1,164 @@
+"""
+Time Axis Formatting Tests for Dashboard JavaScript.
+
+Feature 1081: Tests that verify the time axis includes date context
+for multi-day intraday data.
+
+These tests use static analysis of JavaScript source code to verify:
+1. isDifferentDay helper method exists
+2. formatTimestamp accepts index and candles parameters
+3. Day boundary detection logic exists with abbreviated date format
+4. Feature 1081 comment exists for traceability
+
+Run: pytest tests/unit/dashboard/test_time_axis_formatting.py -v
+"""
+
+import re
+from pathlib import Path
+
+
+def get_repo_root() -> Path:
+    """Get the repository root directory."""
+    return Path(__file__).parents[3]
+
+
+def read_ohlc_js() -> str:
+    """Read the ohlc.js file content."""
+    repo_root = get_repo_root()
+    ohlc_path = repo_root / "src" / "dashboard" / "ohlc.js"
+    assert ohlc_path.exists(), f"ohlc.js not found at {ohlc_path}"
+    return ohlc_path.read_text()
+
+
+class TestDayBoundaryDetection:
+    """Test that day boundary detection is implemented."""
+
+    def test_is_different_day_method_exists(self) -> None:
+        """Verify isDifferentDay helper method exists."""
+        content = read_ohlc_js()
+
+        assert "isDifferentDay" in content, (
+            "isDifferentDay method not found. "
+            "Add helper to detect day boundaries (Feature 1081)."
+        )
+
+    def test_is_different_day_compares_dates(self) -> None:
+        """Verify isDifferentDay uses toDateString for comparison."""
+        content = read_ohlc_js()
+
+        assert "toDateString()" in content, (
+            "toDateString not found. "
+            "Use toDateString() for reliable day comparison (Feature 1081)."
+        )
+
+    def test_has_feature_1081_comment(self) -> None:
+        """Verify Feature 1081 comment exists in ohlc.js for traceability."""
+        content = read_ohlc_js()
+
+        assert "Feature 1081" in content or "1081" in content, (
+            "Missing Feature 1081 reference in ohlc.js. "
+            "Add a comment for traceability."
+        )
+
+
+class TestFormatTimestampSignature:
+    """Test that formatTimestamp accepts context parameters."""
+
+    def test_format_timestamp_accepts_index(self) -> None:
+        """Verify formatTimestamp has index parameter."""
+        content = read_ohlc_js()
+
+        # Look for formatTimestamp with index parameter
+        pattern = r"formatTimestamp\s*\([^)]*index"
+        assert re.search(pattern, content), (
+            "formatTimestamp missing index parameter. "
+            "Add index for day boundary detection (Feature 1081)."
+        )
+
+    def test_format_timestamp_accepts_candles(self) -> None:
+        """Verify formatTimestamp has candles parameter."""
+        content = read_ohlc_js()
+
+        # Look for formatTimestamp with candles parameter
+        pattern = r"formatTimestamp\s*\([^)]*candles"
+        assert re.search(pattern, content), (
+            "formatTimestamp missing candles parameter. "
+            "Add candles array for day boundary context (Feature 1081)."
+        )
+
+
+class TestDayBoundaryFormatting:
+    """Test that day boundaries show abbreviated date format."""
+
+    def test_weekday_format_exists(self) -> None:
+        """Verify weekday abbreviation is used for day boundaries."""
+        content = read_ohlc_js()
+
+        # Look for weekday format option
+        pattern = r"weekday:\s*['\"]short['\"]"
+        assert re.search(pattern, content), (
+            "Weekday abbreviation not found. "
+            "Use { weekday: 'short' } for day labels (Feature 1081)."
+        )
+
+    def test_month_day_format_exists(self) -> None:
+        """Verify month/day format is used for day boundaries."""
+        content = read_ohlc_js()
+
+        # Look for month/day construction
+        pattern = r"getMonth\(\)|getDate\(\)"
+        assert re.search(pattern, content), (
+            "Month/day extraction not found. "
+            "Use getMonth()/getDate() for 'Mon 12/23' format (Feature 1081)."
+        )
+
+
+class TestLabelGeneration:
+    """Test that label generation passes context to formatTimestamp."""
+
+    def test_labels_map_passes_index(self) -> None:
+        """Verify labels.map passes index to formatTimestamp."""
+        content = read_ohlc_js()
+
+        # Look for map with index parameter
+        pattern = r"candles\.map\s*\(\s*\(\s*c\s*,\s*i\s*\)"
+        assert re.search(pattern, content), (
+            "Labels map not passing index. "
+            "Use candles.map((c, i) => ...) for index access (Feature 1081)."
+        )
+
+    def test_labels_map_passes_candles(self) -> None:
+        """Verify formatTimestamp is called with candles array."""
+        content = read_ohlc_js()
+
+        # Look for formatTimestamp call with candles
+        pattern = r"formatTimestamp\s*\([^)]+,\s*i\s*,\s*candles\s*\)"
+        assert re.search(pattern, content), (
+            "formatTimestamp not receiving candles. "
+            "Pass candles array for day boundary detection (Feature 1081)."
+        )
+
+
+class TestDayResolutionUnchanged:
+    """Test that Day resolution formatting is preserved."""
+
+    def test_day_resolution_uses_month_short(self) -> None:
+        """Verify Day resolution still uses 'Dec 23' format."""
+        content = read_ohlc_js()
+
+        # Look for month: 'short' in the Day resolution branch
+        pattern = r"month:\s*['\"]short['\"]"
+        assert re.search(pattern, content), (
+            "Day resolution format missing month: 'short'. "
+            "Preserve 'Dec 23' format for Day resolution."
+        )
+
+    def test_day_resolution_check_exists(self) -> None:
+        """Verify resolution === 'D' check exists."""
+        content = read_ohlc_js()
+
+        pattern = r"resolution\s*===\s*['\"]D['\"]"
+        assert re.search(pattern, content), (
+            "Day resolution check not found. "
+            "Use resolution === 'D' to detect daily data."
+        )


### PR DESCRIPTION
## Summary
- Add date context to time axis labels for multi-day intraday data
- First candle of each day shows "Mon 12/23" format
- Subsequent candles show time-only "10:00" format
- Day resolution unchanged ("Dec 23")

## Root Cause
When viewing multi-day intraday data, time labels repeated (e.g., "09:30") 
without date context, making it impossible to distinguish which candles 
belonged to which trading day.

## Changes
- `src/dashboard/ohlc.js`: Add `isDifferentDay()` helper and update 
  `formatTimestamp()` to detect day boundaries
- `tests/unit/dashboard/test_time_axis_formatting.py`: 11 static analysis tests

## Test plan
- [x] All 11 new time axis formatting tests pass
- [x] All 47 price chart unit tests pass
- [x] All 2461 unit tests pass
- [ ] Verify multi-day intraday shows date context
- [ ] Verify single-day data shows time-only labels
- [ ] Verify Day resolution unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)