### PR TITLE
feat(dashboard): Hide hybrid resolution buckets (Feature 1084)

### DIFF
--- a/specs/1084-hide-hybrid-resolutions/checklists/requirements.md
+++ b/specs/1084-hide-hybrid-resolutions/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Hide Hybrid Resolution Buckets
+
+**Purpose**: Validate specification completeness and quality
+**Created**: 2025-12-28
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Requirements are testable and unambiguous
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic
+- [X] All acceptance scenarios are defined
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] User scenarios cover primary flows
+- [X] Feature meets measurable outcomes
+- [X] No implementation details leak into specification
+
+## Notes
+
+- Simple UI filtering feature - minimal complexity
+- Uses existing `exact` property in UNIFIED_RESOLUTIONS config

--- a/specs/1084-hide-hybrid-resolutions/plan.md
+++ b/specs/1084-hide-hybrid-resolutions/plan.md
@@ -1,0 +1,25 @@
+# Implementation Plan: Hide Hybrid Resolution Buckets
+
+**Feature Branch**: `1084-hide-hybrid-resolutions`
+**Created**: 2025-12-28
+
+## Technical Context
+
+- **Tech Stack**: Vanilla JavaScript (browser), Chart.js
+- **Affected Files**: `src/dashboard/unified-resolution.js`, `src/dashboard/config.js`
+- **Dependencies**: None (uses existing `exact` property)
+
+## Architecture
+
+No architectural changes required. This is a simple filter on the existing UNIFIED_RESOLUTIONS array.
+
+## File Changes
+
+1. **unified-resolution.js**: Filter buttons to only show `exact: true` resolutions
+2. **config.js**: Ensure DEFAULT_UNIFIED_RESOLUTION is an exact resolution (currently '1h' which is exact)
+
+## Implementation Strategy
+
+1. Modify `renderSelector()` to filter UNIFIED_RESOLUTIONS by `exact === true`
+2. Modify `loadSavedResolution()` to validate saved preference is still visible
+3. Add static analysis test to verify only exact resolutions render

--- a/specs/1084-hide-hybrid-resolutions/spec.md
+++ b/specs/1084-hide-hybrid-resolutions/spec.md
@@ -1,0 +1,56 @@
+# Feature Specification: Hide Hybrid Resolution Buckets
+
+**Feature Branch**: `1084-hide-hybrid-resolutions`
+**Created**: 2025-12-28
+**Status**: Draft
+**Input**: User description: "Hide hybrid resolution buckets from unified resolution selector. The resolution selector shows non-exact mappings like 30min->1h that confuse users. Only show resolutions where OHLC and sentiment resolutions have exact 1:1 correspondence (e.g., 1min, 5min, 1h, Day)."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Clean Resolution Selector (Priority: P1)
+
+A user viewing the dashboard sees only resolution options that display consistent data across both the price chart and sentiment overlay. The selector shows 1m, 5m, 1h, and Day buttons - resolutions where OHLC candle size matches the sentiment aggregation bucket exactly. Hybrid mappings like "30m" (which maps to 30-minute OHLC but 1-hour sentiment) are hidden.
+
+**Why this priority**: Users reported the hybrid buckets as "trashy-looking" because the OHLC candle timeframe doesn't match the sentiment bucket, leading to visual misalignment and confusion about what the data represents.
+
+**Independent Test**: Load dashboard, verify only 4 resolution buttons appear (1m, 5m, 1h, Day). Click each button and verify both charts update with matching time granularity.
+
+**Acceptance Scenarios**:
+
+1. **Given** the dashboard loads, **When** the resolution selector renders, **Then** only resolutions with `exact: true` are shown (1m, 5m, 1h, Day)
+2. **Given** the user clicks a resolution button, **When** the charts update, **Then** both OHLC and sentiment show data at the same time granularity
+
+---
+
+### Edge Cases
+
+- If all resolutions are hidden (configuration error), show at least "Day" as fallback
+- Default resolution should be updated if current default is a hybrid resolution
+- Saved user preference for a hybrid resolution should fallback to nearest exact resolution
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST filter UNIFIED_RESOLUTIONS to only display items with `exact: true`
+- **FR-002**: Resolution selector buttons MUST only render for exact-match resolutions
+- **FR-003**: System MUST preserve existing resolution switching behavior for shown resolutions
+- **FR-004**: System MUST update default resolution if current default is hybrid (fallback to '1h')
+- **FR-005**: System MUST handle saved preferences for hidden resolutions by falling back to default
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Resolution selector displays exactly 4 buttons: 1m, 5m, 1h, Day
+- **SC-002**: No visual misalignment between OHLC candles and sentiment overlay
+- **SC-003**: All existing resolution functionality continues to work for shown resolutions
+- **SC-004**: No console errors or warnings related to hidden resolutions
+
+## Technical Notes
+
+The UNIFIED_RESOLUTIONS array in config.js already has the `exact` property:
+- `exact: true`: 1m, 5m, 1h, Day - OHLC and sentiment resolutions match
+- `exact: false`: 10m, 15m, 30m, 3h, 6h, 12h - hybrid mappings that should be hidden
+
+Implementation involves filtering in unified-resolution.js where buttons are rendered.

--- a/specs/1084-hide-hybrid-resolutions/tasks.md
+++ b/specs/1084-hide-hybrid-resolutions/tasks.md
@@ -1,0 +1,30 @@
+# Implementation Tasks: Hide Hybrid Resolution Buckets
+
+**Branch**: `1084-hide-hybrid-resolutions` | **Created**: 2025-12-28
+
+## Phase 1: Implementation
+
+- [X] T001 [US1] Filter UNIFIED_RESOLUTIONS by exact:true in renderSelector()
+- [X] T002 [US1] Validate saved resolution is exact in loadSavedResolution()
+- [X] T003 [US1] Add Feature 1084 comment for traceability
+
+## Phase 2: Testing
+
+- [X] T004 Create static analysis test for exact-only resolutions
+
+## Phase 3: Verification
+
+- [ ] T005 Deploy and verify only 4 buttons appear (1m, 5m, 1h, Day)
+- [ ] T006 Verify clicking each button updates both charts correctly
+
+## Dependencies
+
+```text
+T001 → T002 → T003 → T004 → T005 → T006
+```
+
+## Notes
+
+- Existing `exact` property already defined in config.js
+- Default resolution '1h' is already exact - no change needed
+- Minimal code change: add `.filter(r => r.exact !== false)` to button render

--- a/tests/unit/dashboard/test_hide_hybrid_resolutions.py
+++ b/tests/unit/dashboard/test_hide_hybrid_resolutions.py
@@ -1,0 +1,97 @@
+"""
+Hide Hybrid Resolutions Tests for Dashboard JavaScript.
+
+Feature 1084: Tests that verify only exact-match resolutions are rendered
+in the unified resolution selector (hides hybrid buckets).
+
+These tests use static analysis of JavaScript source code to verify:
+1. Resolution filter uses exact property
+2. Saved resolution validation checks exact property
+3. Feature 1084 comment exists for traceability
+
+Run: pytest tests/unit/dashboard/test_hide_hybrid_resolutions.py -v
+"""
+
+import re
+from pathlib import Path
+
+
+def get_repo_root() -> Path:
+    """Get the repository root directory."""
+    return Path(__file__).parents[3]
+
+
+def read_unified_resolution_js() -> str:
+    """Read the unified-resolution.js file content."""
+    repo_root = get_repo_root()
+    file_path = repo_root / "src" / "dashboard" / "unified-resolution.js"
+    assert file_path.exists(), f"unified-resolution.js not found at {file_path}"
+    return file_path.read_text()
+
+
+class TestHideHybridResolutions:
+    """Test that hybrid resolutions are hidden from the selector."""
+
+    def test_has_feature_1084_comment(self) -> None:
+        """Verify Feature 1084 comment exists for traceability."""
+        content = read_unified_resolution_js()
+
+        assert "Feature 1084" in content, (
+            "Missing Feature 1084 reference in unified-resolution.js. "
+            "Add a comment for traceability."
+        )
+
+    def test_render_filters_by_exact_property(self) -> None:
+        """Verify render() filters UNIFIED_RESOLUTIONS by exact property."""
+        content = read_unified_resolution_js()
+
+        # Look for filter with exact property
+        pattern = r"filter\s*\(\s*r\s*=>\s*r\.exact\s*!==\s*false\s*\)"
+        assert re.search(pattern, content), (
+            "render() not filtering by exact property. "
+            "Use .filter(r => r.exact !== false) to hide hybrid buckets (Feature 1084)."
+        )
+
+    def test_load_resolution_validates_exact(self) -> None:
+        """Verify loadResolution() validates saved resolution is exact."""
+        content = read_unified_resolution_js()
+
+        # Look for exact check in loadResolution
+        pattern = r"r\.key\s*===\s*saved\s*&&\s*r\.exact\s*!==\s*false"
+        assert re.search(pattern, content), (
+            "loadResolution() not validating exact property. "
+            "Add r.exact !== false check to fallback hybrid saved preferences (Feature 1084)."
+        )
+
+
+class TestExactResolutionsConfig:
+    """Test that config.js has correct exact property values."""
+
+    def test_config_has_exact_resolutions(self) -> None:
+        """Verify config.js defines exact:true for 1m, 5m, 1h, Day."""
+        repo_root = get_repo_root()
+        config_path = repo_root / "src" / "dashboard" / "config.js"
+        assert config_path.exists(), f"config.js not found at {config_path}"
+        content = config_path.read_text()
+
+        # Verify exact:true resolutions
+        exact_resolutions = ["'1m'", "'5m'", "'1h'", "'D'"]
+        for res in exact_resolutions:
+            pattern = rf"key:\s*{res}.*?exact:\s*true"
+            assert re.search(
+                pattern, content, re.DOTALL
+            ), f"Resolution {res} should have exact: true in config.js"
+
+    def test_config_has_hybrid_resolutions_marked(self) -> None:
+        """Verify config.js has exact:false for hybrid resolutions."""
+        repo_root = get_repo_root()
+        config_path = repo_root / "src" / "dashboard" / "config.js"
+        content = config_path.read_text()
+
+        # Verify at least some exact:false resolutions exist
+        pattern = r"exact:\s*false"
+        matches = re.findall(pattern, content)
+        assert len(matches) >= 4, (
+            "Expected at least 4 hybrid resolutions with exact: false. "
+            "Found: {len(matches)}"
+        )


### PR DESCRIPTION
## Summary

- Filters unified resolution selector to show only exact-match resolutions (1m, 5m, 1h, Day)
- Hides hybrid buckets (10m, 15m, 30m, 3h, 6h, 12h) where OHLC/sentiment resolutions don't match
- Validates saved user preferences - falls back to default if saved preference is hybrid

## Test plan

- [x] Static analysis tests verify exact-only filter pattern
- [x] 316/316 dashboard unit tests pass
- [ ] Manual verification: Load dashboard, verify only 4 resolution buttons appear
- [ ] Manual verification: Click each button, verify charts update correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)