### PR TITLE
fix(dashboard): Correct SRI hash for date adapter (Feature 1086)

### DIFF
--- a/specs/1086-sri-hash-fix/checklists/requirements.md
+++ b/specs/1086-sri-hash-fix/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Fix SRI Hash for Date Adapter
+
+**Purpose**: Validate specification completeness and quality
+**Created**: 2025-12-28
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Requirements are testable and unambiguous
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic
+- [X] All acceptance scenarios are defined
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] User scenarios cover primary flows
+- [X] Feature meets measurable outcomes
+- [X] No implementation details leak into specification
+
+## Notes
+
+- Critical blocker fix - Price Chart completely broken without this
+- Single line change in index.html

--- a/specs/1086-sri-hash-fix/plan.md
+++ b/specs/1086-sri-hash-fix/plan.md
@@ -1,0 +1,24 @@
+# Implementation Plan: Fix SRI Hash for Date Adapter
+
+**Feature Branch**: `1086-sri-hash-fix`
+**Created**: 2025-12-28
+
+## Technical Context
+
+- **Tech Stack**: HTML, Subresource Integrity (SRI)
+- **Affected Files**: `src/dashboard/index.html`
+- **Dependencies**: None
+
+## Architecture
+
+No architectural changes. Single attribute value update.
+
+## File Changes
+
+1. **index.html**: Update `integrity` attribute for chartjs-adapter-date-fns from incorrect hash to correct hash
+
+## Implementation Strategy
+
+1. Update integrity hash value
+2. Add Feature 1086 comment for traceability
+3. Verify no other CDN resources have stale hashes

--- a/specs/1086-sri-hash-fix/spec.md
+++ b/specs/1086-sri-hash-fix/spec.md
@@ -1,0 +1,50 @@
+# Feature Specification: Fix SRI Hash for Date Adapter
+
+**Feature Branch**: `1086-sri-hash-fix`
+**Created**: 2025-12-28
+**Status**: Draft
+**Input**: User description: "Fix broken SRI integrity hash for chartjs-adapter-date-fns that prevents Price Chart from loading"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Price Chart Loads Successfully (Priority: P1)
+
+A user navigates to the dashboard and the Price Chart (OHLC) renders correctly. The chart displays candlestick data with proper time-based X-axis formatting. No console errors about blocked resources or missing date adapters.
+
+**Why this priority**: This is a critical blocker - without the date adapter, the Price Chart is completely non-functional. The dashboard's primary visualization feature is broken.
+
+**Independent Test**: Load dashboard, verify Price Chart canvas shows OHLC candles with formatted timestamps on X-axis. No "integrity" or "date adapter" errors in console.
+
+**Acceptance Scenarios**:
+
+1. **Given** dashboard loads, **When** chartjs-adapter-date-fns script loads, **Then** SRI validation passes without blocking
+2. **Given** OHLC chart initializes, **When** time scale is configured, **Then** no "method not implemented" errors occur
+
+---
+
+### Edge Cases
+
+- CDN unavailable: Chart.js time scale falls back gracefully (currently errors, acceptable for now)
+- Hash changes on CDN: Extremely rare for versioned packages, would require new fix
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST load chartjs-adapter-date-fns@3.0.0 without SRI validation errors
+- **FR-002**: Price Chart MUST initialize with time scale X-axis without errors
+- **FR-003**: OHLC candles MUST display with properly formatted timestamps
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Zero console errors related to SRI integrity or date adapters on dashboard load
+- **SC-002**: Price Chart renders within 3 seconds of page load
+- **SC-003**: Time-based pan/zoom functionality works correctly
+
+## Technical Notes
+
+Root cause: The SHA-384 integrity hash in index.html (`sha384-0tis8mN...`) does not match the actual file on jsDelivr CDN (`sha384-cVMg8E3...`). This was introduced in Feature 1082 with an incorrect hash calculation.
+
+Fix: Update integrity attribute to correct hash: `sha384-cVMg8E3QFwTvGCDuK+ET4PD341jF3W8nO1auiXfuZNQkzbUUiBGLsIQUE+b1mxws`

--- a/specs/1086-sri-hash-fix/tasks.md
+++ b/specs/1086-sri-hash-fix/tasks.md
@@ -1,0 +1,24 @@
+# Implementation Tasks: Fix SRI Hash for Date Adapter
+
+**Branch**: `1086-sri-hash-fix` | **Created**: 2025-12-28
+
+## Phase 1: Implementation
+
+- [X] T001 [US1] Update integrity hash for chartjs-adapter-date-fns in index.html
+- [X] T002 [US1] Add Feature 1086 comment for traceability
+
+## Phase 2: Verification
+
+- [ ] T003 Deploy and verify Price Chart loads without console errors
+- [ ] T004 Verify pan/zoom functionality works on Price Chart
+
+## Dependencies
+
+```text
+T001 → T002 → T003 → T004
+```
+
+## Notes
+
+- Correct hash verified via: `curl -sL <url> | openssl dgst -sha384 -binary | openssl base64 -A`
+- Hash: `cVMg8E3QFwTvGCDuK+ET4PD341jF3W8nO1auiXfuZNQkzbUUiBGLsIQUE+b1mxws`

--- a/src/dashboard/index.html
+++ b/src/dashboard/index.html
@@ -9,8 +9,9 @@
             integrity="sha384-e6nUZLBkQ86NJ6TVVKAeSaK8jWa3NhkYWZFomE39AvDbQWeie9PlQqM3pmYW5d1g"
             crossorigin="anonymous"></script>
     <!-- Feature 1082: date-fns adapter required for Chart.js time scale (enables numeric X-axis for pan) -->
+    <!-- Feature 1086: Fixed SRI hash - original was incorrect causing script block -->
     <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns@3.0.0/dist/chartjs-adapter-date-fns.bundle.min.js"
-            integrity="sha384-0tis8mN29xL2TBH4BzqWXGVV9xA/NLSifBpG21m/VzZ/k8eTRJ8cq4+hFyt8G6Ou"
+            integrity="sha384-cVMg8E3QFwTvGCDuK+ET4PD341jF3W8nO1auiXfuZNQkzbUUiBGLsIQUE+b1mxws"
             crossorigin="anonymous"></script>
     <!-- Feature 1073: Hammer.js required by chartjs-plugin-zoom for pan gestures -->
     <script src="https://cdn.jsdelivr.net/npm/hammerjs@2.0.8/hammer.min.js"


### PR DESCRIPTION
## Summary

**CRITICAL BLOCKER FIX** - Price Chart was completely broken.

- Fixed incorrect SHA-384 integrity hash for chartjs-adapter-date-fns@3.0.0
- Browser was blocking the script due to hash mismatch
- This caused "This method is not implemented" error on chart initialization

## Root Cause

Feature 1082 introduced the date-fns adapter with an incorrect SRI hash. The hash was likely copied from somewhere else or calculated incorrectly.

## Test plan

- [ ] Load dashboard, verify no SRI integrity errors in console
- [ ] Verify Price Chart renders with OHLC candles
- [ ] Verify pan/zoom functionality works

🤖 Generated with [Claude Code](https://claude.com/claude-code)