### PR TITLE
fix(terraform): Use enable_ohlc_cache bool to avoid computed count dependency

### DIFF
--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -881,6 +881,7 @@ module "iam" {
   enable_timeseries    = true
   timeseries_table_arn = module.dynamodb.timeseries_table_arn
   # Feature 1087: OHLC persistent cache table
+  enable_ohlc_cache    = true
   ohlc_cache_table_arn = module.dynamodb.ohlc_cache_table_arn
 }
 

--- a/infrastructure/terraform/modules/iam/main.tf
+++ b/infrastructure/terraform/modules/iam/main.tf
@@ -565,8 +565,9 @@ resource "aws_iam_role_policy" "dashboard_timeseries" {
 
 # Feature 1087: Dashboard Lambda - OHLC persistent cache read/write access
 # Read for cache lookup, write for write-through caching from external APIs
+# Note: Using enable_ohlc_cache bool to avoid count depending on computed ARN
 resource "aws_iam_role_policy" "dashboard_ohlc_cache" {
-  count = var.ohlc_cache_table_arn != "" ? 1 : 0
+  count = var.enable_ohlc_cache ? 1 : 0
   name  = "${var.environment}-dashboard-ohlc-cache-policy"
   role  = aws_iam_role.dashboard_lambda.id
 

--- a/infrastructure/terraform/modules/iam/variables.tf
+++ b/infrastructure/terraform/modules/iam/variables.tf
@@ -95,3 +95,9 @@ variable "ohlc_cache_table_arn" {
   type        = string
   default     = ""
 }
+
+variable "enable_ohlc_cache" {
+  description = "Whether to enable OHLC cache IAM policy (avoids count depends on computed ARN)"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
## Summary
- Fixes deploy pipeline failure caused by Terraform count depending on computed ARN
- Adds `enable_ohlc_cache` boolean variable to IAM module
- Uses static boolean instead of checking ARN != ""

## Test plan
- [ ] Terraform validate passes
- [ ] Deploy pipeline completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)