### PR TITLE
fix(dashboard): Prevent panning beyond loaded OHLC data range (Feature 1098)

### DIFF
--- a/src/dashboard/ohlc.js
+++ b/src/dashboard/ohlc.js
@@ -696,13 +696,13 @@ class OHLCChart {
         this.chart.options.plugins.zoom.limits.price.min = priceLimits.min;
         this.chart.options.plugins.zoom.limits.price.max = priceLimits.max;
 
-        // Feature 1094: Set X-axis limits for pan boundaries (category scale uses indices)
-        // Allow small buffer for edge panning
+        // Feature 1098: Set X-axis limits to data range (no buffer)
+        // Prevents panning into empty space where no data exists
+        // User can pan freely within the loaded data but not beyond
         const xMin = 0;
         const xMax = data.length - 1;
-        const xBuffer = Math.max(1, Math.floor(data.length * 0.05));  // 5% buffer
-        this.chart.options.plugins.zoom.limits.x.min = xMin - xBuffer;
-        this.chart.options.plugins.zoom.limits.x.max = xMax + xBuffer;
+        this.chart.options.plugins.zoom.limits.x.min = xMin;
+        this.chart.options.plugins.zoom.limits.x.max = xMax;
 
         // Feature 1092: Set scale min/max directly (not via options) to avoid resetZoom issues
         // Chart.js zoom plugin stores "original" values when chart initializes with no data,


### PR DESCRIPTION
## Summary
- Remove 5% buffer from pan limits that allowed panning into empty space
- Set x-axis pan limits exactly to data range (0 to data.length-1)
- Users can pan freely within loaded data but not beyond

## Root Cause
The pan limits had a 5% buffer (`Math.round(len * 0.05)`) which allowed users to pan past the last data point into empty space where no candles exist.

## Test plan
- [x] All 14 time axis formatting tests pass
- [x] All 2494 unit tests pass
- [ ] Manual test: Pan chart to edges, verify cannot pan beyond data

🤖 Generated with [Claude Code](https://claude.com/claude-code)