### PR TITLE
feat(1097): Add SSE Lambda URL runtime config for streaming

### DIFF
--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -427,6 +427,9 @@ module "dashboard_lambda" {
     FINNHUB_SECRET_ARN = module.secrets.finnhub_secret_arn
     # Feature 1087: OHLC persistent cache table for write-through caching
     OHLC_CACHE_TABLE = module.dynamodb.ohlc_cache_table_name
+    # Feature 1097: SSE Lambda URL for frontend to connect to streaming endpoint
+    # Two-Lambda architecture: Dashboard Lambda (BUFFERED) + SSE Lambda (RESPONSE_STREAM)
+    SSE_LAMBDA_URL = module.sse_streaming_lambda.function_url
   }
 
   # Function URL with CORS

--- a/src/lambdas/dashboard/handler.py
+++ b/src/lambdas/dashboard/handler.py
@@ -85,6 +85,8 @@ SENTIMENTS_TABLE = os.environ[
 ]  # news items, sentiment analysis (has GSIs)
 CHAOS_EXPERIMENTS_TABLE = os.environ.get("CHAOS_EXPERIMENTS_TABLE", "")
 ENVIRONMENT = os.environ["ENVIRONMENT"]
+# Feature 1097: SSE Lambda URL for two-Lambda architecture
+SSE_LAMBDA_URL = os.environ.get("SSE_LAMBDA_URL", "")
 
 
 # Feature 1039: get_api_key() removed - using session auth only
@@ -430,6 +432,25 @@ async def health_check():
 # ===================================================================
 # API v2 Endpoints (POWERPLAN Mobile Dashboard)
 # ===================================================================
+
+
+@app.get("/api/v2/runtime")
+async def get_runtime_config():
+    """
+    Get runtime configuration for the frontend (Feature 1097).
+
+    Returns URLs and settings that may vary by environment.
+    Used by frontend to discover the SSE Lambda URL for streaming.
+
+    Returns:
+        JSON with runtime configuration including SSE Lambda URL
+    """
+    return JSONResponse(
+        {
+            "sse_url": SSE_LAMBDA_URL or None,  # Empty string -> null for frontend
+            "environment": ENVIRONMENT,
+        }
+    )
 
 
 @app.get("/api/v2/metrics")


### PR DESCRIPTION
## Summary
- Fixes /api/v2/stream timeout by providing SSE Lambda URL to frontend
- Adds /api/v2/runtime endpoint to expose environment-specific config
- Frontend fetches SSE URL at startup and connects to correct Lambda

## Root Cause
Dashboard Lambda uses BUFFERED mode (for REST API) while SSE requires RESPONSE_STREAM mode. The SSE Lambda exists but frontend didn't know its URL.

## Technical Changes
- Terraform: Add SSE_LAMBDA_URL env var to dashboard Lambda
- Backend: Add /api/v2/runtime endpoint returning SSE URL
- Frontend: Fetch runtime config before connecting to SSE stream

## Test plan
- [x] TestRuntimeConfig tests pass (3/3)
- [ ] SSE stream connects to correct Lambda
- [ ] Heartbeat events received in browser console

🤖 Generated with [Claude Code](https://claude.com/claude-code)