### PR TITLE
docs(1099): Update Lambda URL after container migration

### DIFF
--- a/.github/WORKFLOW_DOCUMENTATION.md
+++ b/.github/WORKFLOW_DOCUMENTATION.md
@@ -427,8 +427,8 @@ terraform workspace select dev
 terraform output -raw dashboard_url
 ```
 
-### Current URLs (as of 2025-11-24)
-- **Preprod**: https://ee2a3fxtkxmpwp2bhul3uylmb40hfknf.lambda-url.us-east-1.on.aws/
+### Current URLs (as of 2025-12-29)
+- **Preprod**: https://cjx6qw4a7xqw6cuifvkbi6ae2e0evviw.lambda-url.us-east-1.on.aws/
 - **Prod**: (Not yet deployed)
 - **Dev**: (Not yet deployed)
 

--- a/DEMO_URLS.local.md
+++ b/DEMO_URLS.local.md
@@ -3,20 +3,20 @@
 ## Quick Access
 
 **Main Dashboard (Browser):**
-https://ee2a3fxtkxmpwp2bhul3uylmb40hfknf.lambda-url.us-east-1.on.aws/
+https://cjx6qw4a7xqw6cuifvkbi6ae2e0evviw.lambda-url.us-east-1.on.aws/
 
 **API Docs:**
-https://ee2a3fxtkxmpwp2bhul3uylmb40hfknf.lambda-url.us-east-1.on.aws/docs
+https://cjx6qw4a7xqw6cuifvkbi6ae2e0evviw.lambda-url.us-east-1.on.aws/docs
 
 **OAuth URLs (GET - no auth):**
-https://ee2a3fxtkxmpwp2bhul3uylmb40hfknf.lambda-url.us-east-1.on.aws/api/v2/auth/oauth/urls
+https://cjx6qw4a7xqw6cuifvkbi6ae2e0evviw.lambda-url.us-east-1.on.aws/api/v2/auth/oauth/urls
 
 ---
 
 ## API Base URL
 
 ```
-API=https://ee2a3fxtkxmpwp2bhul3uylmb40hfknf.lambda-url.us-east-1.on.aws
+API=https://cjx6qw4a7xqw6cuifvkbi6ae2e0evviw.lambda-url.us-east-1.on.aws
 ```
 
 ---
@@ -24,7 +24,7 @@ API=https://ee2a3fxtkxmpwp2bhul3uylmb40hfknf.lambda-url.us-east-1.on.aws
 ## Terminal Demo Script
 
 ```bash
-API="https://ee2a3fxtkxmpwp2bhul3uylmb40hfknf.lambda-url.us-east-1.on.aws"
+API="https://cjx6qw4a7xqw6cuifvkbi6ae2e0evviw.lambda-url.us-east-1.on.aws"
 
 # 1. Get anonymous token (POST required)
 TOKEN=$(curl -s -X POST "$API/api/v2/auth/anonymous" \

--- a/interview/traffic_generator.py
+++ b/interview/traffic_generator.py
@@ -32,7 +32,7 @@ import httpx
 
 # Environment configurations
 ENVIRONMENTS = {
-    "preprod": "https://ee2a3fxtkxmpwp2bhul3uylmb40hfknf.lambda-url.us-east-1.on.aws",
+    "preprod": "https://cjx6qw4a7xqw6cuifvkbi6ae2e0evviw.lambda-url.us-east-1.on.aws",
     "prod": "https://prod-sentiment-dashboard.lambda-url.us-east-1.on.aws",
 }
 


### PR DESCRIPTION
## Summary

This PR updates orphaned Lambda Function URLs in documentation that were left behind after the container migration.

## Problem

After migrating Lambda functions to container images, the Function URLs changed but the documentation still referenced the old URLs, causing 403 Forbidden errors.

## Solution

Updated all documentation references to use the correct post-migration Lambda Function URLs.

## Test Plan

- Verified URLs in documentation match current Lambda Function URLs
- Confirmed documentation is consistent across all files

## Related

- Fixes orphaned URLs from container migration
- Prevents 403 errors from outdated documentation references

Generated with [Claude Code](https://claude.com/claude-code)