### PR TITLE
feat(1102): Implement OHLC market gap visualization

### DIFF
--- a/frontend/src/components/charts/index.ts
+++ b/frontend/src/components/charts/index.ts
@@ -23,3 +23,4 @@ export {
   AnimatedProgress,
   AnimatedGauge,
 } from './animated-value';
+export { GapShaderPrimitive } from './primitives';

--- a/frontend/src/components/charts/primitives/gap-shader-primitive.ts
+++ b/frontend/src/components/charts/primitives/gap-shader-primitive.ts
@@ -1,0 +1,216 @@
+/**
+ * Gap Shader Primitive for lightweight-charts.
+ *
+ * Renders red-shaded rectangles for market closure periods (weekends, holidays).
+ * Uses the Series Primitives API for custom canvas drawing.
+ */
+
+import type {
+  ISeriesPrimitive,
+  IPrimitivePaneView,
+  IPrimitivePaneRenderer,
+  SeriesAttachedParameter,
+  PrimitiveHoveredItem,
+  Time,
+} from 'lightweight-charts';
+
+import type { GapMarker } from '@/types/chart';
+
+/**
+ * Gap information with logical index for rendering.
+ */
+interface GapInfo {
+  /** Logical index in the data array */
+  index: number;
+  /** Gap marker data */
+  marker: GapMarker;
+}
+
+/**
+ * Rendering context passed to the renderer.
+ */
+interface GapRenderContext {
+  gaps: GapInfo[];
+  getTimeToCoordinate: (time: Time) => number | null;
+  getBarSpacing: () => number;
+}
+
+/**
+ * Renderer for drawing red rectangles on the chart canvas.
+ */
+class GapShaderRenderer implements IPrimitivePaneRenderer {
+  private context: GapRenderContext;
+  private chartHeight: number;
+
+  constructor(context: GapRenderContext, chartHeight: number) {
+    this.context = context;
+    this.chartHeight = chartHeight;
+  }
+
+  // The draw method receives a target with useBitmapCoordinateSpace
+  draw(target: {
+    useBitmapCoordinateSpace: (callback: (scope: {
+      context: CanvasRenderingContext2D;
+      horizontalPixelRatio: number;
+      verticalPixelRatio: number;
+      bitmapSize: { width: number; height: number };
+    }) => void) => void;
+  }): void {
+    const { gaps, getTimeToCoordinate, getBarSpacing } = this.context;
+
+    if (gaps.length === 0) return;
+
+    target.useBitmapCoordinateSpace(({ context: ctx, horizontalPixelRatio, bitmapSize }) => {
+      const barSpacing = getBarSpacing();
+      const halfBar = barSpacing / 2;
+
+      // Save context state
+      ctx.save();
+
+      // Light red with transparency for gap shading
+      ctx.fillStyle = 'rgba(255, 100, 100, 0.12)';
+
+      for (const gap of gaps) {
+        const x = getTimeToCoordinate(gap.marker.time as Time);
+        if (x === null) continue;
+
+        // Draw rectangle spanning full height at the gap position
+        // Convert from media coordinates to bitmap coordinates
+        const rectX = Math.round((x - halfBar) * horizontalPixelRatio);
+        const rectWidth = Math.round(barSpacing * horizontalPixelRatio);
+
+        ctx.fillRect(rectX, 0, rectWidth, bitmapSize.height);
+      }
+
+      // Restore context state
+      ctx.restore();
+    });
+  }
+}
+
+/**
+ * Pane view that provides the renderer for the gap shading.
+ */
+class GapShaderPaneView implements IPrimitivePaneView {
+  private primitive: GapShaderPrimitive;
+
+  constructor(primitive: GapShaderPrimitive) {
+    this.primitive = primitive;
+  }
+
+  zOrder(): 'bottom' | 'normal' | 'top' {
+    // Draw behind the candlesticks
+    return 'bottom';
+  }
+
+  renderer(): IPrimitivePaneRenderer {
+    const context: GapRenderContext = {
+      gaps: this.primitive.getGaps(),
+      getTimeToCoordinate: this.primitive.getTimeToCoordinate.bind(this.primitive),
+      getBarSpacing: this.primitive.getBarSpacing.bind(this.primitive),
+    };
+    return new GapShaderRenderer(context, this.primitive.getChartHeight());
+  }
+}
+
+/**
+ * Series Primitive that renders red-shaded rectangles for market gaps.
+ *
+ * Usage:
+ * ```typescript
+ * const gapShader = new GapShaderPrimitive();
+ * candleSeries.attachPrimitive(gapShader);
+ *
+ * // When data changes:
+ * gapShader.updateGaps(gapMarkers);
+ * ```
+ */
+export class GapShaderPrimitive implements ISeriesPrimitive<Time> {
+  private gaps: GapInfo[] = [];
+  private attachedParams: SeriesAttachedParameter<Time> | null = null;
+  private paneView: GapShaderPaneView;
+  private chartHeight: number = 400;
+
+  constructor() {
+    this.paneView = new GapShaderPaneView(this);
+  }
+
+  /**
+   * Update the gap markers to render.
+   *
+   * @param markers - Array of gap markers with their logical indices
+   */
+  updateGaps(markers: Array<{ index: number; marker: GapMarker }>): void {
+    this.gaps = markers;
+    this.requestUpdate();
+  }
+
+  /**
+   * Set the chart height for rendering.
+   */
+  setChartHeight(height: number): void {
+    this.chartHeight = height;
+    this.requestUpdate();
+  }
+
+  /**
+   * Get the current gaps.
+   */
+  getGaps(): GapInfo[] {
+    return this.gaps;
+  }
+
+  /**
+   * Get the chart height.
+   */
+  getChartHeight(): number {
+    return this.chartHeight;
+  }
+
+  /**
+   * Convert a time value to x-coordinate.
+   */
+  getTimeToCoordinate(time: Time): number | null {
+    if (!this.attachedParams?.chart) return null;
+    return this.attachedParams.chart.timeScale().timeToCoordinate(time);
+  }
+
+  /**
+   * Get the current bar spacing.
+   */
+  getBarSpacing(): number {
+    if (!this.attachedParams?.chart) return 10;
+    // Use the time scale's bar spacing directly
+    const barSpacing = this.attachedParams.chart.timeScale().options().barSpacing;
+    return barSpacing;
+  }
+
+  // --- ISeriesPrimitive interface ---
+
+  attached(params: SeriesAttachedParameter<Time>): void {
+    this.attachedParams = params;
+  }
+
+  detached(): void {
+    this.attachedParams = null;
+  }
+
+  paneViews(): readonly IPrimitivePaneView[] {
+    return [this.paneView];
+  }
+
+  updateAllViews(): void {
+    // Views update automatically via renderer
+  }
+
+  hitTest(): PrimitiveHoveredItem | null {
+    // No hit testing for gap shading
+    return null;
+  }
+
+  private requestUpdate(): void {
+    if (this.attachedParams?.requestUpdate) {
+      this.attachedParams.requestUpdate();
+    }
+  }
+}

--- a/frontend/src/components/charts/primitives/index.ts
+++ b/frontend/src/components/charts/primitives/index.ts
@@ -1,0 +1,1 @@
+export { GapShaderPrimitive } from './gap-shader-primitive';

--- a/frontend/src/lib/utils/index.ts
+++ b/frontend/src/lib/utils/index.ts
@@ -18,4 +18,14 @@ export {
   formatDateTime,
   formatRelativeTime,
   formatCountdown,
+  formatChartDate,
 } from './format';
+export {
+  isHoliday,
+  isWeekend,
+  isMarketOpen,
+  fillGaps,
+  extractGapMarkers,
+  getGapIndices,
+  isGapMarker,
+} from './market-calendar';

--- a/frontend/src/lib/utils/market-calendar.ts
+++ b/frontend/src/lib/utils/market-calendar.ts
@@ -1,0 +1,328 @@
+/**
+ * Market calendar utilities for detecting trading gaps.
+ *
+ * Used to identify and fill non-trading periods (weekends, holidays)
+ * for proper chart visualization with gap markers.
+ */
+
+import type { GapMarker, OHLCResolution, PriceCandle } from '@/types/chart';
+
+/**
+ * US Stock Market holidays (NYSE/NASDAQ).
+ * Dates are in MM-DD format for fixed holidays, or computed for floating holidays.
+ */
+interface Holiday {
+  name: string;
+  /** For fixed-date holidays like Independence Day */
+  fixedDate?: string; // MM-DD format
+  /** For floating holidays like Thanksgiving */
+  compute?: (year: number) => string; // Returns YYYY-MM-DD
+}
+
+const US_MARKET_HOLIDAYS: Holiday[] = [
+  { name: "New Year's Day", fixedDate: '01-01' },
+  {
+    name: 'Martin Luther King Jr. Day',
+    compute: (year) => getNthWeekdayOfMonth(year, 1, 1, 3), // 3rd Monday of January
+  },
+  {
+    name: "Presidents' Day",
+    compute: (year) => getNthWeekdayOfMonth(year, 2, 1, 3), // 3rd Monday of February
+  },
+  {
+    name: 'Good Friday',
+    compute: (year) => getGoodFriday(year),
+  },
+  {
+    name: 'Memorial Day',
+    compute: (year) => getLastWeekdayOfMonth(year, 5, 1), // Last Monday of May
+  },
+  { name: 'Juneteenth', fixedDate: '06-19' },
+  { name: 'Independence Day', fixedDate: '07-04' },
+  {
+    name: 'Labor Day',
+    compute: (year) => getNthWeekdayOfMonth(year, 9, 1, 1), // 1st Monday of September
+  },
+  {
+    name: 'Thanksgiving Day',
+    compute: (year) => getNthWeekdayOfMonth(year, 11, 4, 4), // 4th Thursday of November
+  },
+  { name: 'Christmas Day', fixedDate: '12-25' },
+];
+
+/**
+ * Get the Nth weekday of a month (e.g., 3rd Monday of January).
+ */
+function getNthWeekdayOfMonth(
+  year: number,
+  month: number,
+  weekday: number,
+  n: number
+): string {
+  const firstDay = new Date(year, month - 1, 1);
+  let count = 0;
+  for (let day = 1; day <= 31; day++) {
+    const date = new Date(year, month - 1, day);
+    if (date.getMonth() !== month - 1) break;
+    if (date.getDay() === weekday) {
+      count++;
+      if (count === n) {
+        return formatDateYYYYMMDD(date);
+      }
+    }
+  }
+  throw new Error(`Could not find ${n}th weekday ${weekday} in ${month}/${year}`);
+}
+
+/**
+ * Get the last weekday of a month (e.g., last Monday of May).
+ */
+function getLastWeekdayOfMonth(year: number, month: number, weekday: number): string {
+  const lastDay = new Date(year, month, 0); // Last day of month
+  for (let day = lastDay.getDate(); day >= 1; day--) {
+    const date = new Date(year, month - 1, day);
+    if (date.getDay() === weekday) {
+      return formatDateYYYYMMDD(date);
+    }
+  }
+  throw new Error(`Could not find last weekday ${weekday} in ${month}/${year}`);
+}
+
+/**
+ * Calculate Good Friday (2 days before Easter Sunday).
+ * Uses the Anonymous Gregorian algorithm.
+ */
+function getGoodFriday(year: number): string {
+  // Calculate Easter Sunday using Anonymous Gregorian algorithm
+  const a = year % 19;
+  const b = Math.floor(year / 100);
+  const c = year % 100;
+  const d = Math.floor(b / 4);
+  const e = b % 4;
+  const f = Math.floor((b + 8) / 25);
+  const g = Math.floor((b - f + 1) / 3);
+  const h = (19 * a + b - d - g + 15) % 30;
+  const i = Math.floor(c / 4);
+  const k = c % 4;
+  const l = (32 + 2 * e + 2 * i - h - k) % 7;
+  const m = Math.floor((a + 11 * h + 22 * l) / 451);
+  const month = Math.floor((h + l - 7 * m + 114) / 31);
+  const day = ((h + l - 7 * m + 114) % 31) + 1;
+
+  // Good Friday is 2 days before Easter
+  const easter = new Date(year, month - 1, day);
+  easter.setDate(easter.getDate() - 2);
+  return formatDateYYYYMMDD(easter);
+}
+
+function formatDateYYYYMMDD(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+/**
+ * Cache for holiday dates by year.
+ */
+const holidayCache: Map<number, Map<string, string>> = new Map();
+
+/**
+ * Get all holidays for a given year as a Map<date, holidayName>.
+ */
+function getHolidaysForYear(year: number): Map<string, string> {
+  if (holidayCache.has(year)) {
+    return holidayCache.get(year)!;
+  }
+
+  const holidays = new Map<string, string>();
+  for (const holiday of US_MARKET_HOLIDAYS) {
+    let dateStr: string;
+    if (holiday.fixedDate) {
+      dateStr = `${year}-${holiday.fixedDate}`;
+    } else if (holiday.compute) {
+      dateStr = holiday.compute(year);
+    } else {
+      continue;
+    }
+
+    // Handle observed holidays (if falls on weekend, observed on adjacent weekday)
+    const date = new Date(dateStr);
+    const dayOfWeek = date.getDay();
+
+    if (dayOfWeek === 0) {
+      // Sunday: observed on Monday
+      date.setDate(date.getDate() + 1);
+      dateStr = formatDateYYYYMMDD(date);
+    } else if (dayOfWeek === 6) {
+      // Saturday: observed on Friday
+      date.setDate(date.getDate() - 1);
+      dateStr = formatDateYYYYMMDD(date);
+    }
+
+    holidays.set(dateStr, holiday.name);
+  }
+
+  holidayCache.set(year, holidays);
+  return holidays;
+}
+
+/**
+ * Check if a given date is a US market holiday.
+ */
+export function isHoliday(date: Date): { isHoliday: boolean; name?: string } {
+  const dateStr = formatDateYYYYMMDD(date);
+  const holidays = getHolidaysForYear(date.getFullYear());
+  const holidayName = holidays.get(dateStr);
+  return holidayName ? { isHoliday: true, name: holidayName } : { isHoliday: false };
+}
+
+/**
+ * Check if a date is a weekend (Saturday or Sunday).
+ */
+export function isWeekend(date: Date): boolean {
+  const day = date.getDay();
+  return day === 0 || day === 6;
+}
+
+/**
+ * Check if the US stock market is open for a given date/time.
+ *
+ * @param date - Date to check
+ * @param resolution - OHLC resolution for time-based checks
+ * @returns Object with isOpen boolean and reason if closed
+ */
+export function isMarketOpen(
+  date: Date,
+  resolution: OHLCResolution
+): { isOpen: boolean; reason?: 'weekend' | 'holiday' | 'after_hours'; holidayName?: string } {
+  // Check weekend
+  if (isWeekend(date)) {
+    return { isOpen: false, reason: 'weekend' };
+  }
+
+  // Check holiday
+  const holiday = isHoliday(date);
+  if (holiday.isHoliday) {
+    return { isOpen: false, reason: 'holiday', holidayName: holiday.name };
+  }
+
+  // For intraday resolutions, check market hours (9:30 AM - 4:00 PM ET)
+  if (resolution !== 'D') {
+    const hours = date.getHours();
+    const minutes = date.getMinutes();
+    const timeInMinutes = hours * 60 + minutes;
+
+    // Market hours: 9:30 AM (570 min) to 4:00 PM (960 min) Eastern Time
+    // Note: This assumes the date is already in Eastern Time or UTC
+    const marketOpen = 9 * 60 + 30; // 9:30 AM
+    const marketClose = 16 * 60; // 4:00 PM
+
+    if (timeInMinutes < marketOpen || timeInMinutes >= marketClose) {
+      return { isOpen: false, reason: 'after_hours' };
+    }
+  }
+
+  return { isOpen: true };
+}
+
+/**
+ * Get all dates between two dates (exclusive of start and end).
+ */
+function getDatesBetween(startDate: Date, endDate: Date): Date[] {
+  const dates: Date[] = [];
+  const current = new Date(startDate);
+  current.setDate(current.getDate() + 1);
+
+  while (current < endDate) {
+    dates.push(new Date(current));
+    current.setDate(current.getDate() + 1);
+  }
+
+  return dates;
+}
+
+/**
+ * Fill gaps in candle data with GapMarker entries.
+ *
+ * Inserts markers for weekends and holidays between trading days.
+ * This enables the chart to display red-shaded rectangles for market closures.
+ *
+ * @param candles - Array of OHLC candles from the API
+ * @param resolution - OHLC resolution
+ * @returns Array of candles and gap markers, maintaining chronological order
+ */
+export function fillGaps(
+  candles: PriceCandle[],
+  resolution: OHLCResolution
+): (PriceCandle | GapMarker)[] {
+  if (candles.length < 2) {
+    return candles;
+  }
+
+  const result: (PriceCandle | GapMarker)[] = [];
+
+  for (let i = 0; i < candles.length; i++) {
+    // Add the current candle
+    result.push(candles[i]);
+
+    // Check for gaps before the next candle
+    if (i < candles.length - 1) {
+      const currentDate = new Date(candles[i].date);
+      const nextDate = new Date(candles[i + 1].date);
+
+      // Get dates between current and next candle
+      const betweenDates = getDatesBetween(currentDate, nextDate);
+
+      for (const date of betweenDates) {
+        const marketStatus = isMarketOpen(date, resolution);
+
+        if (!marketStatus.isOpen && marketStatus.reason) {
+          // Only add gap markers for closed market days
+          const gapMarker: GapMarker = {
+            time: formatDateYYYYMMDD(date),
+            isGap: true,
+            reason: marketStatus.reason,
+          };
+
+          if (marketStatus.holidayName) {
+            gapMarker.holidayName = marketStatus.holidayName;
+          }
+
+          result.push(gapMarker);
+        }
+      }
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Extract gap markers from a mixed array of candles and gap markers.
+ */
+export function extractGapMarkers(data: (PriceCandle | GapMarker)[]): GapMarker[] {
+  return data.filter((item): item is GapMarker => 'isGap' in item && item.isGap);
+}
+
+/**
+ * Get the index positions of gaps in the data array.
+ * Used by the GapShaderPrimitive to know where to draw rectangles.
+ */
+export function getGapIndices(data: (PriceCandle | GapMarker)[]): number[] {
+  const indices: number[] = [];
+  for (let i = 0; i < data.length; i++) {
+    const item = data[i];
+    if ('isGap' in item && item.isGap) {
+      indices.push(i);
+    }
+  }
+  return indices;
+}
+
+/**
+ * Check if a data point is a GapMarker.
+ */
+export function isGapMarker(item: PriceCandle | GapMarker): item is GapMarker {
+  return 'isGap' in item && item.isGap === true;
+}

--- a/frontend/src/types/chart.ts
+++ b/frontend/src/types/chart.ts
@@ -100,3 +100,18 @@ export interface ChartDataBundle {
 
 /** Chart loading states */
 export type ChartLoadingState = 'idle' | 'loading' | 'success' | 'error';
+
+/**
+ * Marker for dates with no trading data (weekends, holidays).
+ * Used to render red-shaded gap rectangles in the chart.
+ */
+export interface GapMarker {
+  /** Date in YYYY-MM-DD format (daily) or Unix timestamp (intraday) */
+  time: string | number;
+  /** Always true for gap markers */
+  isGap: true;
+  /** Human-readable reason for the gap */
+  reason: 'weekend' | 'holiday' | 'after_hours';
+  /** Holiday name if applicable */
+  holidayName?: string;
+}


### PR DESCRIPTION
## Summary
- Shows market closures (weekends, holidays) as red-shaded rectangles
- Maintains equal-width candlesticks using gap markers
- Uses lightweight-charts Series Primitives API for custom drawing
- Includes US market calendar with holiday detection
- Tooltip shows "Market Closed" for gap areas

## Changes
- `frontend/src/types/chart.ts` - Added GapMarker type
- `frontend/src/lib/utils/market-calendar.ts` - NEW: Gap detection with US holidays
- `frontend/src/components/charts/primitives/gap-shader-primitive.ts` - NEW: Red rectangle renderer
- `frontend/src/components/charts/price-sentiment-chart.tsx` - Integrated gap visualization

## Test plan
- [ ] View daily chart spanning a weekend, verify red shading
- [ ] View chart around Christmas 2025, verify holiday shading
- [ ] Hover over gap area, verify tooltip shows "Market Closed"
- [ ] Verify candlesticks remain equal width

🤖 Generated with [Claude Code](https://claude.com/claude-code)