### PR TITLE
fix(1104): Add textColor to enable x-axis label refresh on pan

### DIFF
--- a/frontend/src/components/charts/price-sentiment-chart.tsx
+++ b/frontend/src/components/charts/price-sentiment-chart.tsx
@@ -217,6 +217,7 @@ export function PriceSentimentChart({
         borderColor: 'rgba(0, 255, 255, 0.1)',
         timeVisible: true,
         secondsVisible: false,
+        textColor: '#a3a3a3',  // Enable label refresh on pan
       },
     });
 

--- a/specs/1104-ohlc-xaxis-label-refresh/plan.md
+++ b/specs/1104-ohlc-xaxis-label-refresh/plan.md
@@ -1,0 +1,35 @@
+# Implementation Plan: OHLC Chart X-Axis Label Refresh
+
+**Feature**: 1104-ohlc-xaxis-label-refresh
+**Created**: 2025-12-29
+**Complexity**: Low (single property addition)
+
+## Overview
+
+Add `textColor` property to timeScale configuration to enable x-axis label refresh during pan.
+
+## Implementation Steps
+
+### Step 1: Add textColor to timeScale
+
+**File**: `frontend/src/components/charts/price-sentiment-chart.tsx`
+**Location**: timeScale configuration block (~line 216)
+
+Add `textColor: '#a3a3a3'` to match other charts in the codebase.
+
+### Step 2: Verify Behavior
+
+1. Load chart with 1h resolution
+2. Pan left/right
+3. Verify x-axis labels update to show new time range
+
+## Risk Assessment
+
+- **Risk**: Very low - uses existing lightweight-charts feature
+- **Rollback**: Remove textColor property
+- **Dependencies**: None
+
+## Testing
+
+- Manual: Verify x-axis labels update during pan on all resolutions
+- Visual: Compare with sentiment-chart.tsx styling

--- a/specs/1104-ohlc-xaxis-label-refresh/spec.md
+++ b/specs/1104-ohlc-xaxis-label-refresh/spec.md
@@ -1,0 +1,69 @@
+# Feature Specification: OHLC Chart X-Axis Label Refresh on Pan
+
+**Feature Branch**: `1104-ohlc-xaxis-label-refresh`
+**Created**: 2025-12-29
+**Status**: Draft
+**Input**: User description: "1h view pans but x-axis labels don't update during pan"
+
+## Problem Statement
+
+The OHLC price chart (price-sentiment-chart.tsx) allows panning on intraday resolutions like 1h, but the x-axis labels don't update to show the new visible time range. Other charts in the codebase (sentiment-chart.tsx, atr-chart.tsx) have proper label refresh because they include explicit `textColor` in their timeScale configuration.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - X-Axis Labels Update on Pan (Priority: P1)
+
+As a user panning the 1h OHLC chart, I want the x-axis labels to update to reflect the visible time range so I can see which hours I'm viewing.
+
+**Why this priority**: Core UX expectation - axis labels should always reflect visible data.
+
+**Independent Test**: Load 1h chart, pan left, verify x-axis labels change to show earlier times.
+
+**Acceptance Scenarios**:
+
+1. **Given** I am viewing 1h OHLC chart, **When** I pan left, **Then** x-axis labels update to show earlier hours
+2. **Given** I pan right after viewing history, **When** chart moves, **Then** x-axis labels reflect current visible range
+3. **Given** any resolution (1m, 5m, 15m, 30m, 1h, D), **When** I pan, **Then** x-axis labels update accordingly
+
+---
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: X-axis labels MUST update during pan operations
+- **FR-002**: timeScale configuration MUST include textColor property
+- **FR-003**: Labels should use consistent styling with other charts (#a3a3a3)
+
+### Key Entities
+
+- **timeScale**: lightweight-charts time axis configuration
+- **textColor**: CSS color for axis label text
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: X-axis labels visibly update when panning on all resolutions
+- **SC-002**: No regression in chart rendering or pan behavior
+- **SC-003**: Visual consistency with sentiment-chart and atr-chart
+
+## Implementation
+
+### Change Required
+
+In `frontend/src/components/charts/price-sentiment-chart.tsx`, add `textColor` to timeScale config:
+
+```typescript
+timeScale: {
+  borderColor: 'rgba(0, 255, 255, 0.1)',
+  timeVisible: true,
+  secondsVisible: false,
+  textColor: '#a3a3a3',  // ADD: Enable label refresh on pan
+},
+```
+
+## Assumptions
+
+- Adding textColor is sufficient to enable label refresh (matches other working charts)
+- No changes to time formatting logic needed

--- a/specs/1104-ohlc-xaxis-label-refresh/tasks.md
+++ b/specs/1104-ohlc-xaxis-label-refresh/tasks.md
@@ -1,0 +1,10 @@
+# Tasks: OHLC Chart X-Axis Label Refresh
+
+**Feature**: 1104-ohlc-xaxis-label-refresh
+**Created**: 2025-12-29
+
+## Tasks
+
+- [ ] T001: Add textColor: '#a3a3a3' to timeScale config in price-sentiment-chart.tsx
+- [ ] T002: Verify x-axis labels update during pan on 1h resolution
+- [ ] T003: Verify no regression on other resolutions


### PR DESCRIPTION
## Summary
- Add `textColor: '#a3a3a3'` to timeScale configuration
- Enables x-axis labels to update during pan operations
- Matches styling of sentiment-chart and atr-chart

## Problem
The price-sentiment-chart timeScale was missing textColor property, causing x-axis labels to not refresh during pan operations on intraday resolutions (1h, etc.).

## Test Plan
- [ ] Load 1h OHLC chart
- [ ] Pan left/right and verify x-axis labels update
- [ ] Verify no regression on other resolutions

🤖 Generated with [Claude Code](https://claude.com/claude-code)