### PR TITLE
feat(1105): Enable AWS Amplify SSR frontend for preprod

### DIFF
--- a/infrastructure/terraform/preprod.tfvars
+++ b/infrastructure/terraform/preprod.tfvars
@@ -32,3 +32,9 @@ cors_allowed_origins = [
 # This must match PREPROD_TEST_JWT_SECRET used by E2E tests (Feature 1053)
 # The value is passed via TF_VAR_jwt_secret in CI to avoid committing secrets
 # Default for local dev: "test-jwt-secret-for-e2e-only-not-production"
+
+# Feature 1105: AWS Amplify SSR Frontend
+# Deploys Next.js frontend via Amplify Hosting (replaces vanilla JS dashboard)
+# GitHub PAT stored in Secrets Manager: preprod/amplify/github-token
+enable_amplify            = true
+amplify_github_repository = "https://github.com/traylorre/sentiment-analyzer-gsk"


### PR DESCRIPTION
## Summary

Enables the Amplify module (created in PR #565) by:
- **Secrets Manager integration**: GitHub PAT read via data source (secure)
- **preprod.tfvars**: `enable_amplify = true`
- **Repository config**: Points to sentiment-analyzer-gsk

## Security

- GitHub PAT stored in Secrets Manager: `preprod/amplify/github-token`
- Never in tfvars or Terraform state
- Read at apply time via `aws_secretsmanager_secret_version` data source

## Prerequisite

Secret must exist before Terraform apply:
```bash
aws secretsmanager create-secret \
  --name "preprod/amplify/github-token" \
  --secret-string '{"token": "github_pat_..."}' \
  --region us-east-1
```

## Test Plan

- [ ] Terraform validate passes
- [ ] Deploy pipeline creates Amplify app
- [ ] Amplify builds Next.js frontend
- [ ] Amplify URL serves dashboard

## Spec

`specs/1105-nextjs-migration/spec.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)