### PR TITLE
fix(1105): Add GetSecretValue and amplify/* to CI IAM policy

### DIFF
--- a/infrastructure/terraform/ci-user-policy.tf
+++ b/infrastructure/terraform/ci-user-policy.tf
@@ -243,7 +243,7 @@ data "aws_iam_policy_document" "ci_deploy_core" {
   }
 
   # Secrets Manager
-  # SECURITY: Scoped to {env}/sentiment-analyzer/* naming pattern (FR-006)
+  # SECURITY: Scoped to {env}/sentiment-analyzer/* and {env}/amplify/* patterns (FR-006)
   statement {
     sid    = "SecretsManager"
     effect = "Allow"
@@ -252,6 +252,7 @@ data "aws_iam_policy_document" "ci_deploy_core" {
       "secretsmanager:DeleteSecret",
       "secretsmanager:DescribeSecret",
       "secretsmanager:GetResourcePolicy",
+      "secretsmanager:GetSecretValue", # Required for Terraform data sources (Feature 1105)
       "secretsmanager:UpdateSecret",
       "secretsmanager:PutSecretValue",
       "secretsmanager:TagResource",
@@ -259,7 +260,9 @@ data "aws_iam_policy_document" "ci_deploy_core" {
     ]
     resources = [
       # Pattern: {env}/sentiment-analyzer/* (preprod/sentiment-analyzer/tiingo, etc.)
-      "arn:aws:secretsmanager:*:*:secret:*/sentiment-analyzer/*"
+      "arn:aws:secretsmanager:*:*:secret:*/sentiment-analyzer/*",
+      # Pattern: {env}/amplify/* (preprod/amplify/github-token for Amplify SSR - Feature 1105)
+      "arn:aws:secretsmanager:*:*:secret:*/amplify/*"
     ]
   }
 


### PR DESCRIPTION
## Summary

Fixes Deploy Pipeline failure - CI deployer couldn't read Amplify GitHub token.

## Changes

- **Add** `secretsmanager:GetSecretValue` action (required for TF data sources)
- **Add** `*/amplify/*` resource pattern for Amplify secrets

## Root Cause

The `data.aws_secretsmanager_secret_version.amplify_github_token` in main.tf requires `GetSecretValue` permission, which was missing from the CI IAM policy.

## Test Plan

- [ ] Terraform validate passes
- [ ] Deploy pipeline succeeds
- [ ] Amplify app is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)