### PR TITLE
fix(1105): Break Amplify circular dependency with terraform_data pattern

### DIFF
--- a/infrastructure/terraform/modules/amplify/variables.tf
+++ b/infrastructure/terraform/modules/amplify/variables.tf
@@ -12,9 +12,10 @@ variable "github_repository" {
 }
 
 variable "github_access_token" {
-  description = "GitHub Personal Access Token with repo scope for Amplify"
+  description = "GitHub Personal Access Token - initially empty, patched via terraform_data after IAM exists"
   type        = string
   sensitive   = true
+  default     = ""
 }
 
 variable "api_gateway_url" {


### PR DESCRIPTION
## Summary
- Remove data source that reads GitHub token at plan time (causes deadlock)
- Create Amplify app WITHOUT access_token initially
- Add `lifecycle { ignore_changes = [access_token] }` to prevent drift
- Patch token via `terraform_data.amplify_github_token_patch` AFTER module.iam exists

## Root Cause
Deploy pipeline fails at Terraform Refresh because `data.aws_secretsmanager_secret_version.amplify_github_token` reads the secret at plan time, but CI IAM permission for `secretsmanager:GetSecretValue` is only applied at apply time. This creates a deadlock.

## Solution
Gap 4 pattern (same as Cognito Gap 3): Defer secret retrieval until after IAM permissions exist using a provisioner.

## Test Plan
- [ ] PR checks pass (Terraform validate, unit tests)
- [ ] Deploy pipeline succeeds on main
- [ ] Amplify app has GitHub token after terraform_data provisioner runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)