### PR TITLE
fix(1107): Add Name tag to Cognito User Pool for IAM policy

### DIFF
--- a/infrastructure/terraform/modules/cognito/main.tf
+++ b/infrastructure/terraform/modules/cognito/main.tf
@@ -88,6 +88,7 @@ resource "aws_cognito_user_pool" "main" {
   deletion_protection = var.environment == "prod" ? "ACTIVE" : "INACTIVE"
 
   tags = {
+    Name        = "${var.environment}-sentiment-users" # Required for CI IAM policy condition
     Environment = var.environment
     Feature     = "006-user-config-dashboard"
     Component   = "authentication"


### PR DESCRIPTION
## Summary
- Add Name tag to Cognito User Pool matching CI IAM policy condition
- Fixes AccessDeniedException on cognito-idp:UpdateUserPoolClient

## Root Cause
The CI IAM policy has a tag condition requiring `Name` tag matching `*-sentiment-*`. The Cognito User Pool had no tags, causing the Amplify callback URL provisioner to fail.

## Test Plan
- [ ] Terraform apply updates Cognito tags
- [ ] Cognito callback patch succeeds
- [ ] Full deploy completes

Refs: #1105

🤖 Generated with [Claude Code](https://claude.com/claude-code)