### PR TITLE
fix(1109): Add SSR service principals to Amplify IAM trust policy

### DIFF
--- a/infrastructure/terraform/modules/amplify/iam.tf
+++ b/infrastructure/terraform/modules/amplify/iam.tf
@@ -8,13 +8,20 @@
 resource "aws_iam_role" "amplify_service" {
   name = "${var.environment}-amplify-service-role"
 
+  # Trust policy for SSR (WEB_COMPUTE) requires additional service principals
+  # See: https://docs.aws.amazon.com/amplify/latest/userguide/amplify-SSR-compute-role.html
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
       {
+        Sid    = "AmplifySSRTrust"
         Effect = "Allow"
         Principal = {
-          Service = "amplify.amazonaws.com"
+          Service = [
+            "amplify.amazonaws.com",
+            "amplify.us-east-1.amazonaws.com",
+            "lambda.amazonaws.com"
+          ]
         }
         Action = "sts:AssumeRole"
       }


### PR DESCRIPTION
## Summary
- Add regional amplify.us-east-1.amazonaws.com principal
- Add lambda.amazonaws.com for SSR execution
- Fixes 'Unable to assume IAM Role' error in Amplify builds

## Root Cause
Amplify SSR (WEB_COMPUTE) uses Lambda under the hood and needs trust for both Amplify and Lambda services.

## Test Plan
- [ ] Terraform apply updates IAM role trust policy
- [ ] Amplify build succeeds
- [ ] Dashboard loads at Amplify URL

Refs: #1105

🤖 Generated with [Claude Code](https://claude.com/claude-code)