### PR TITLE
fix(1110): Add UpdateAssumeRolePolicy to CI IAM policy

### DIFF
--- a/infrastructure/terraform/ci-user-policy.tf
+++ b/infrastructure/terraform/ci-user-policy.tf
@@ -583,6 +583,7 @@ data "aws_iam_policy_document" "ci_deploy_iam" {
       "iam:DeleteRole",
       "iam:GetRole",
       "iam:UpdateRole",
+      "iam:UpdateAssumeRolePolicy", # Feature 1109: Update trust policy for SSR
       "iam:AttachRolePolicy",
       "iam:DetachRolePolicy",
       "iam:PutRolePolicy",


### PR DESCRIPTION
## Summary
- Add iam:UpdateAssumeRolePolicy permission for Amplify role management
- Enables CI to update trust policies for SSR configuration

## Root Cause
PR #574 updated Amplify trust policy for SSR but CI deployer lacked permission to update assume role policies.

## Test Plan
- [ ] Terraform apply updates Amplify trust policy
- [ ] Amplify build succeeds

Refs: #1105, #1109

🤖 Generated with [Claude Code](https://claude.com/claude-code)