### PR TITLE
fix(1111): Simplify Amplify service role trust policy

### DIFF
--- a/infrastructure/terraform/modules/amplify/iam.tf
+++ b/infrastructure/terraform/modules/amplify/iam.tf
@@ -8,20 +8,17 @@
 resource "aws_iam_role" "amplify_service" {
   name = "${var.environment}-amplify-service-role"
 
-  # Trust policy for SSR (WEB_COMPUTE) requires additional service principals
+  # Trust policy for Amplify service role (used during builds)
   # See: https://docs.aws.amazon.com/amplify/latest/userguide/amplify-SSR-compute-role.html
+  # Note: This is the SERVICE role for builds, not the SSR Compute role for runtime
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
       {
-        Sid    = "AmplifySSRTrust"
+        Sid    = "AmplifyServiceTrust"
         Effect = "Allow"
         Principal = {
-          Service = [
-            "amplify.amazonaws.com",
-            "amplify.us-east-1.amazonaws.com",
-            "lambda.amazonaws.com"
-          ]
+          Service = "amplify.amazonaws.com"
         }
         Action = "sts:AssumeRole"
       }


### PR DESCRIPTION
## Summary
- Simplify trust policy to only amplify.amazonaws.com (per AWS docs)
- Remove extra lambda and regional principals that were causing issues

## Root Cause
Service role trust policy should only have amplify.amazonaws.com. Extra principals may cause assumption issues.

## Test Plan
- [ ] Terraform apply updates trust policy
- [ ] Amplify build succeeds

Refs: #1105

🤖 Generated with [Claude Code](https://claude.com/claude-code)