### PR TITLE
fix(1119): Accept empty body in POST /api/v2/auth/anonymous

### DIFF
--- a/specs/1119-fix-anonymous-auth-422/checklists/requirements.md
+++ b/specs/1119-fix-anonymous-auth-422/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Fix Anonymous Auth 422 Error
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-01-02
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation. The specification is ready for `/speckit.plan`.
+- Root cause is well-understood: Frontend sends empty body, backend requires body with defaults.
+- Fix is backend-only, maintaining backward compatibility with existing frontend code.

--- a/specs/1119-fix-anonymous-auth-422/plan.md
+++ b/specs/1119-fix-anonymous-auth-422/plan.md
@@ -1,0 +1,157 @@
+# Implementation Plan: Fix Anonymous Auth 422 Error
+
+**Branch**: `1119-fix-anonymous-auth-422` | **Date**: 2026-01-02 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/1119-fix-anonymous-auth-422/spec.md`
+
+## Summary
+
+Fix POST /api/v2/auth/anonymous returning 422 when frontend sends no request body. The backend endpoint requires a Pydantic body parameter, but should accept requests with no body by using FastAPI's `Body(default=None)` pattern and instantiating defaults when body is None.
+
+## Technical Context
+
+**Language/Version**: Python 3.13
+**Primary Dependencies**: FastAPI, Pydantic v2
+**Storage**: DynamoDB (existing users table)
+**Testing**: pytest with moto mocks (unit), real AWS (integration)
+**Target Platform**: AWS Lambda
+**Project Type**: Web application (backend Lambda + frontend Next.js)
+**Performance Goals**: P90 response time ≤ 500ms
+**Constraints**: Must not break existing frontend code
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Gate | Status | Notes |
+|------|--------|-------|
+| Parameterized queries | PASS | No DB query changes - existing auth_service handles DynamoDB |
+| TLS enforced | PASS | Lambda Function URL uses HTTPS |
+| Secrets in secrets manager | PASS | No new secrets |
+| Auth required for admin endpoints | N/A | Anonymous endpoint is public by design |
+| Unit tests accompany implementation | REQUIRED | Will add tests for no-body and empty-body cases |
+| No pipeline bypass | REQUIRED | Will use normal PR workflow |
+| GPG-signed commits | REQUIRED | Will sign commits |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/1119-fix-anonymous-auth-422/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output (N/A - no model changes)
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output (N/A - no contract changes)
+└── tasks.md             # Phase 2 output (/speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+src/lambdas/dashboard/
+├── router_v2.py         # MODIFY: create_anonymous_session endpoint
+└── auth.py              # NO CHANGE: AnonymousSessionRequest model already has defaults
+
+tests/unit/
+└── test_dashboard_handler.py  # ADD: tests for no-body and empty-body cases
+```
+
+**Structure Decision**: Backend-only fix in existing Lambda handler. No new files needed.
+
+## Complexity Tracking
+
+No violations. This is a minimal, targeted fix affecting only the endpoint signature.
+
+---
+
+## Phase 0: Research
+
+### Research Task 1: FastAPI Optional Body Pattern
+
+**Decision**: Use `Body(default=None)` to make the entire request body optional.
+
+**Rationale**: In FastAPI/Pydantic v2, when a function parameter is typed as a Pydantic model without a default, FastAPI requires a request body to be present for parsing. Even if all model fields have defaults, the body itself must exist. To allow truly optional body (no body at all), the pattern is:
+
+```python
+from fastapi import Body
+
+async def endpoint(
+    body: MyModel | None = Body(default=None),
+):
+    if body is None:
+        body = MyModel()  # Use defaults
+```
+
+**Alternatives considered**:
+1. Frontend sends empty `{}` body - rejected because it requires frontend changes
+2. Use `Body(default=MyModel())` - rejected because Body() expects JSON-serializable default
+3. Catch validation error and return defaults - rejected because it's a workaround, not proper API design
+
+### Research Task 2: Existing Codebase Patterns
+
+**Decision**: Follow existing router_v2.py patterns with minimal changes.
+
+**Rationale**: The endpoint at line 250-265 needs only signature change. The auth_service.create_anonymous_session function already handles the AnonymousSessionRequest model correctly.
+
+**Current signature** (line 251-255):
+```python
+async def create_anonymous_session(
+    request: Request,
+    body: auth_service.AnonymousSessionRequest,
+    table=Depends(get_users_table),
+):
+```
+
+**New signature**:
+```python
+async def create_anonymous_session(
+    request: Request,
+    body: auth_service.AnonymousSessionRequest | None = Body(default=None),
+    table=Depends(get_users_table),
+):
+    if body is None:
+        body = auth_service.AnonymousSessionRequest()
+```
+
+---
+
+## Phase 1: Design
+
+### Data Model
+
+**No changes required**. The existing `AnonymousSessionRequest` model in `auth.py` already has proper defaults:
+
+```python
+class AnonymousSessionRequest(BaseModel):
+    timezone: str = Field(default="America/New_York")
+    device_fingerprint: str | None = Field(default=None)
+```
+
+### API Contract
+
+**No contract changes**. The endpoint behavior remains the same - it's now more permissive (accepts no body in addition to existing body formats).
+
+| Scenario | Before | After |
+|----------|--------|-------|
+| No body | 422 Unprocessable Entity | 201 Created (uses defaults) |
+| Empty body `{}` | 201 Created | 201 Created |
+| Body with fields | 201 Created | 201 Created |
+
+### Quickstart
+
+See `quickstart.md` for testing the fix.
+
+---
+
+## Implementation Summary
+
+**Files to modify**: 1
+- `src/lambdas/dashboard/router_v2.py` - Change function signature
+
+**Tests to add**: 2-3 test cases
+- Test no body → 201 with defaults
+- Test empty body `{}` → 201 with defaults
+- Test body with fields → 201 with provided values
+
+**Estimated effort**: Small (1-2 hours including tests)

--- a/specs/1119-fix-anonymous-auth-422/quickstart.md
+++ b/specs/1119-fix-anonymous-auth-422/quickstart.md
@@ -1,0 +1,73 @@
+# Quickstart: Fix Anonymous Auth 422 Error
+
+**Feature**: 1119-fix-anonymous-auth-422
+**Date**: 2026-01-02
+
+## Testing the Fix
+
+### Prerequisites
+
+1. Dashboard Lambda deployed to dev/preprod
+2. Lambda Function URL available
+
+### Manual Testing
+
+```bash
+# Get the Lambda Function URL
+LAMBDA_URL=$(aws lambda list-function-url-configs \
+  --function-name dashboard-lambda \
+  --query 'FunctionUrlConfigs[0].FunctionUrl' \
+  --output text)
+
+# Test 1: No body (should now return 201, was returning 422)
+curl -X POST "$LAMBDA_URL/api/v2/auth/anonymous" \
+  -H "Content-Type: application/json" \
+  -w "\nHTTP Status: %{http_code}\n"
+
+# Test 2: Empty body (should return 201)
+curl -X POST "$LAMBDA_URL/api/v2/auth/anonymous" \
+  -H "Content-Type: application/json" \
+  -d '{}' \
+  -w "\nHTTP Status: %{http_code}\n"
+
+# Test 3: Body with custom timezone (should return 201)
+curl -X POST "$LAMBDA_URL/api/v2/auth/anonymous" \
+  -H "Content-Type: application/json" \
+  -d '{"timezone": "Europe/London"}' \
+  -w "\nHTTP Status: %{http_code}\n"
+```
+
+### Expected Responses
+
+All three tests should return HTTP 201 with a response like:
+```json
+{
+  "user_id": "uuid-here",
+  "auth_type": "anonymous",
+  "created_at": "2026-01-02T00:00:00Z",
+  "session_expires_at": "2026-02-01T00:00:00Z",
+  "storage_hint": "localStorage"
+}
+```
+
+### Unit Tests
+
+```bash
+cd /home/traylorre/projects/sentiment-analyzer-gsk
+pytest tests/unit/test_dashboard_handler.py -k "anonymous" -v
+```
+
+### Browser Testing
+
+1. Open browser DevTools (F12)
+2. Go to Network tab
+3. Navigate to dashboard URL in incognito window
+4. Verify POST /api/v2/auth/anonymous returns 201 (not 422)
+
+## Verification Checklist
+
+- [ ] No body → 201 Created
+- [ ] Empty body `{}` → 201 Created
+- [ ] Body with timezone → 201 Created with provided timezone
+- [ ] Response contains all required fields
+- [ ] Frontend loads without auth errors

--- a/specs/1119-fix-anonymous-auth-422/research.md
+++ b/specs/1119-fix-anonymous-auth-422/research.md
@@ -1,0 +1,78 @@
+# Research: Fix Anonymous Auth 422 Error
+
+**Feature**: 1119-fix-anonymous-auth-422
+**Date**: 2026-01-02
+
+## Research Questions
+
+### Q1: How to make FastAPI body parameter optional (accept no body)?
+
+**Decision**: Use `Body(default=None)` with union type
+
+**Rationale**:
+- In FastAPI, a function parameter typed as a Pydantic model requires a request body to be present
+- Even if all model fields have defaults, the body parsing step itself fails without a body
+- The `Body(default=None)` pattern allows the entire body to be omitted
+- When body is None, instantiate the model with defaults in the handler
+
+**Research Source**: FastAPI documentation on request body, Pydantic v2 documentation
+
+**Pattern**:
+```python
+from fastapi import Body
+from pydantic import BaseModel
+
+class MyModel(BaseModel):
+    field1: str = "default"
+    field2: int | None = None
+
+@router.post("/endpoint")
+async def endpoint(
+    body: MyModel | None = Body(default=None),  # Allows no body
+):
+    if body is None:
+        body = MyModel()  # Use all defaults
+    # body.field1 == "default", body.field2 == None
+```
+
+### Q2: Does existing AnonymousSessionRequest need changes?
+
+**Decision**: No changes needed
+
+**Rationale**: The model already has proper defaults defined:
+```python
+class AnonymousSessionRequest(BaseModel):
+    timezone: str = Field(default="America/New_York")
+    device_fingerprint: str | None = Field(default=None)
+```
+
+### Q3: What about empty body `{}` vs no body?
+
+**Decision**: Both should work
+
+**Rationale**:
+- Empty body `{}` already works - Pydantic instantiates model with defaults
+- No body (undefined/null) currently fails - this is what we're fixing
+- After the fix, both will return 201 with default values
+
+### Q4: Impact on existing frontend code?
+
+**Decision**: No impact - backward compatible
+
+**Rationale**:
+- Frontend currently sends `undefined` (no body) - will now work
+- If frontend ever sends `{}` or populated body, it will continue to work
+- This is a permissive change, not a breaking change
+
+## Alternatives Rejected
+
+| Alternative | Reason for Rejection |
+|-------------|---------------------|
+| Modify frontend to send `{}` | Requires frontend changes, violates "backend-only fix" requirement |
+| Catch 422 and return defaults | Workaround, not proper API design |
+| Use middleware to inject body | Over-engineering for simple fix |
+| Default value in Body() directly | `Body(default=MyModel())` doesn't work - needs JSON-serializable default |
+
+## Conclusion
+
+Single-line signature change plus 2-line null check is the minimal, correct solution.

--- a/specs/1119-fix-anonymous-auth-422/spec.md
+++ b/specs/1119-fix-anonymous-auth-422/spec.md
@@ -1,0 +1,79 @@
+# Feature Specification: Fix Anonymous Auth 422 Error
+
+**Feature Branch**: `1119-fix-anonymous-auth-422`
+**Created**: 2026-01-02
+**Status**: Draft
+**Input**: User description: "Fix POST /api/v2/auth/anonymous returning 422 Unprocessable Entity. Root Cause: Frontend sends empty/undefined body, but backend router_v2.py expects Pydantic-validated AnonymousSessionRequest body. The AnonymousSessionRequest model already has defaults (timezone=America/New_York, device_fingerprint=None) so the endpoint should accept empty bodies."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Anonymous Session Creation (Priority: P1)
+
+A new visitor lands on the dashboard for the first time. The system automatically creates an anonymous session so they can use the application without requiring sign-up, providing immediate value and reducing friction.
+
+**Why this priority**: This is the primary entry point for all new users. Without a working anonymous auth, new visitors see errors and cannot use the dashboard at all. This is a blocking issue for all user flows.
+
+**Independent Test**: Can be fully tested by opening the dashboard in an incognito browser window. A successful anonymous session allows the user to interact with the dashboard immediately without any error messages.
+
+**Acceptance Scenarios**:
+
+1. **Given** a new visitor with no existing session, **When** the frontend loads and calls POST /api/v2/auth/anonymous with no request body, **Then** the backend creates a new anonymous session and returns HTTP 201 with user_id, auth_type, created_at, session_expires_at, and storage_hint.
+
+2. **Given** a new visitor with no existing session, **When** the frontend loads and calls POST /api/v2/auth/anonymous with an empty JSON body `{}`, **Then** the backend creates a new anonymous session using default timezone (America/New_York) and returns HTTP 201.
+
+3. **Given** a new visitor, **When** the frontend provides optional parameters (timezone, device_fingerprint), **Then** the backend uses those values instead of defaults.
+
+---
+
+### User Story 2 - Session Persistence (Priority: P2)
+
+After an anonymous session is created, the user's session persists across page refreshes and browser tabs, allowing them to continue their work without interruption.
+
+**Why this priority**: Once anonymous auth works, session persistence ensures users don't lose their work. This is dependent on P1 working first.
+
+**Independent Test**: Can be tested by creating a session, refreshing the page, and verifying the same user_id is returned without creating a new session.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user with an existing anonymous session (X-User-ID header present), **When** the frontend calls POST /api/v2/auth/anonymous, **Then** the backend returns the existing session information without creating a duplicate.
+
+---
+
+### Edge Cases
+
+- What happens when the request body is `null` vs `undefined` vs empty string? All should be treated as "no body provided" and use defaults.
+- What happens when the request body contains unknown fields? Should be ignored per standard behavior.
+- What happens when timezone is invalid? Should fall back to America/New_York.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST accept POST /api/v2/auth/anonymous with no request body and create a session using default values.
+- **FR-002**: System MUST accept POST /api/v2/auth/anonymous with an empty JSON body `{}` and create a session using default values.
+- **FR-003**: System MUST accept POST /api/v2/auth/anonymous with optional parameters (timezone, device_fingerprint) and use provided values.
+- **FR-004**: System MUST return HTTP 201 with a valid session response containing user_id, auth_type, created_at, session_expires_at, and storage_hint.
+- **FR-005**: System MUST NOT return HTTP 422 when the request body is empty, null, or undefined.
+- **FR-006**: System MUST use "America/New_York" as the default timezone when not provided.
+- **FR-007**: System MUST use null as the default device_fingerprint when not provided.
+
+### Key Entities
+
+- **AnonymousSession**: Represents a temporary user session with user_id (UUID), auth_type ("anonymous"), timezone, device_fingerprint (optional), created_at, session_expires_at (30 days from creation), storage_hint ("localStorage").
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: New visitors can load the dashboard and begin using it within 3 seconds without seeing any authentication error messages.
+- **SC-002**: POST /api/v2/auth/anonymous returns HTTP 201 (not 422) when called with no request body.
+- **SC-003**: POST /api/v2/auth/anonymous returns HTTP 201 (not 422) when called with empty JSON body `{}`.
+- **SC-004**: The anonymous session response contains all required fields (user_id, auth_type, created_at, session_expires_at, storage_hint).
+- **SC-005**: Existing frontend code works without modification (backward compatible fix).
+
+## Assumptions
+
+- The AnonymousSessionRequest model already has sensible defaults defined (timezone="America/New_York", device_fingerprint=None).
+- The fix should be in the backend router_v2.py endpoint, not in the frontend code.
+- This is a greenfield approach - no backward compatibility concerns with older API versions.
+- The session creation logic in auth_service is already working correctly; only the request body parsing needs adjustment.

--- a/specs/1119-fix-anonymous-auth-422/tasks.md
+++ b/specs/1119-fix-anonymous-auth-422/tasks.md
@@ -1,0 +1,157 @@
+# Tasks: Fix Anonymous Auth 422 Error
+
+**Input**: Design documents from `/specs/1119-fix-anonymous-auth-422/`
+**Prerequisites**: plan.md (complete), spec.md (complete), research.md (complete), quickstart.md (complete)
+
+**Tests**: Unit tests REQUIRED per Constitution Check in plan.md
+
+**Organization**: Tasks grouped by user story for independent implementation and testing.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+- **Project**: `src/lambdas/dashboard/` for Lambda code, `tests/unit/` for tests
+
+---
+
+## Phase 1: Setup (No Changes Required)
+
+**Purpose**: Project already initialized. No setup tasks needed.
+
+**Checkpoint**: Project structure already exists - proceed to implementation.
+
+---
+
+## Phase 2: Foundational (No Changes Required)
+
+**Purpose**: No foundational/blocking prerequisites for this fix.
+
+**Checkpoint**: Foundation ready - proceed to User Story 1.
+
+---
+
+## Phase 3: User Story 1 - Anonymous Session Creation (Priority: P1) MVP
+
+**Goal**: Fix POST /api/v2/auth/anonymous to accept requests with no body or empty body, returning 201 with defaults instead of 422.
+
+**Independent Test**: Open dashboard in incognito browser - should load without authentication errors.
+
+### Tests for User Story 1
+
+> **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
+
+- [x] T001 [P] [US1] Add test for no-body request in tests/unit/test_dashboard_handler.py - verify 201 response with defaults
+- [x] T002 [P] [US1] Add test for empty-body `{}` request in tests/unit/test_dashboard_handler.py - verify 201 response with defaults
+- [x] T003 [P] [US1] Add test for body with custom timezone in tests/unit/test_dashboard_handler.py - verify 201 response with provided timezone
+
+### Implementation for User Story 1
+
+- [x] T004 [US1] Add `Body` import to src/lambdas/dashboard/router_v2.py
+- [x] T005 [US1] Modify `create_anonymous_session` function signature in src/lambdas/dashboard/router_v2.py - change `body: auth_service.AnonymousSessionRequest` to `body: auth_service.AnonymousSessionRequest | None = Body(default=None)`
+- [x] T006 [US1] Add null-check in `create_anonymous_session` in src/lambdas/dashboard/router_v2.py - if body is None, instantiate `auth_service.AnonymousSessionRequest()`
+
+**Checkpoint**: User Story 1 complete - POST /api/v2/auth/anonymous accepts no body and returns 201.
+
+---
+
+## Phase 4: User Story 2 - Session Persistence (Priority: P2)
+
+**Goal**: Verify existing session persistence behavior works with the fix (no changes expected).
+
+**Independent Test**: Create session, refresh page, verify same user_id returned.
+
+### Verification for User Story 2
+
+- [x] T007 [US2] Verify existing session persistence tests pass in tests/unit/test_dashboard_handler.py - run existing X-User-ID header tests
+
+**Checkpoint**: User Stories 1 AND 2 both work - anonymous auth is fully functional.
+
+---
+
+## Phase 5: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final validation and verification
+
+- [x] T008 Run all unit tests via sub-agent to verify no regressions
+- [ ] T009 Run quickstart.md validation - test all three curl scenarios (skip - requires deployed Lambda)
+- [x] T010 Verify linting passes (ruff check src/lambdas/dashboard/router_v2.py)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: SKIP - no changes needed
+- **Foundational (Phase 2)**: SKIP - no changes needed
+- **User Story 1 (Phase 3)**: Can start immediately
+- **User Story 2 (Phase 4)**: Verify after US1 complete
+- **Polish (Phase 5)**: After all user stories complete
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: No dependencies - can start immediately
+- **User Story 2 (P2)**: Depends on US1 completion (uses same endpoint)
+
+### Within User Story 1
+
+1. T001, T002, T003 (tests) - run in parallel, verify they FAIL
+2. T004 (import) - no dependencies
+3. T005 (signature change) - depends on T004
+4. T006 (null-check) - depends on T005
+5. Re-run tests - should now PASS
+
+### Parallel Opportunities
+
+- T001, T002, T003 can run in parallel (different test functions, same file)
+
+---
+
+## Parallel Example: User Story 1 Tests
+
+```bash
+# Launch all tests together (should FAIL before implementation):
+Task: "Add test for no-body request in tests/unit/test_dashboard_handler.py"
+Task: "Add test for empty-body request in tests/unit/test_dashboard_handler.py"
+Task: "Add test for body with custom timezone in tests/unit/test_dashboard_handler.py"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP (User Story 1 Only)
+
+1. Write tests T001-T003 (should fail)
+2. Implement T004-T006 (fix)
+3. Verify tests pass
+4. **STOP and VALIDATE**: Test in browser
+5. Deploy via PR
+
+### Total Tasks
+
+- **Test tasks**: 3 (T001-T003)
+- **Implementation tasks**: 3 (T004-T006)
+- **Verification tasks**: 4 (T007-T010)
+- **Total**: 10 tasks
+
+### Estimated Time
+
+- Tests: 15 minutes
+- Implementation: 10 minutes
+- Verification: 15 minutes
+- **Total**: ~40 minutes
+
+---
+
+## Notes
+
+- This is a minimal fix - only 1 file modified (router_v2.py)
+- auth.py model already has defaults - no changes needed
+- Frontend code unchanged - backward compatible fix
+- Constitution requires unit tests - included in T001-T003

--- a/src/lambdas/dashboard/router_v2.py
+++ b/src/lambdas/dashboard/router_v2.py
@@ -23,7 +23,7 @@ import os
 from typing import Literal
 
 from botocore.exceptions import ClientError
-from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi import APIRouter, Body, Depends, HTTPException, Query, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, EmailStr
 
@@ -250,10 +250,19 @@ async def get_config_with_tickers(
 @auth_router.post("/anonymous")
 async def create_anonymous_session(
     request: Request,
-    body: auth_service.AnonymousSessionRequest,
+    body: auth_service.AnonymousSessionRequest | None = Body(default=None),
     table=Depends(get_users_table),
 ):
-    """Create anonymous session (T047)."""
+    """Create anonymous session (T047, Feature 1119).
+
+    Accepts:
+    - No request body (uses defaults: timezone=America/New_York)
+    - Empty body {} (uses defaults)
+    - Body with optional fields (uses provided values)
+    """
+    # Feature 1119: Accept empty/missing body, use defaults
+    if body is None:
+        body = auth_service.AnonymousSessionRequest()
     try:
         result = auth_service.create_anonymous_session(
             table=table,


### PR DESCRIPTION
## Summary

- **Problem**: Frontend sends no request body to the anonymous auth endpoint (`POST /api/v2/auth/anonymous`), but FastAPI requires a body for Pydantic validation, returning 422 Unprocessable Entity.
- **Solution**: Use `Body(default=None)` pattern to make the request body optional. When body is `None`, instantiate `AnonymousSessionRequest` with defaults.
- **Changes**:
  - `router_v2.py`: Add `Body` import, make body parameter optional with `Body(default=None)`, add null check to instantiate model with defaults
  - `test_dashboard_handler.py`: Add `TestAnonymousSessionCreation` class with 3 tests covering no body, empty body, and body with timezone

## Test plan

- [x] Test 1: POST with no body returns 200 with valid session
- [x] Test 2: POST with empty body `{}` returns 200 with valid session
- [x] Test 3: POST with body containing timezone returns 200 with session respecting timezone
- [x] All 2500 unit tests pass
- [x] Pre-commit hooks pass (ruff, ruff-format, security checks)

Refs: #1119