### PR TITLE
feat(1130): Add @require_role decorator for RBAC

### DIFF
--- a/specs/1130-require-role-decorator/checklists/requirements.md
+++ b/specs/1130-require-role-decorator/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Require Role Decorator
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-01-05
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Spec mentions FastAPI and JWT as context (existing codebase patterns) but requirements are technology-agnostic
+- Dependencies on Phase 1.5 are documented; decorator will function correctly once roles claim exists
+- Role enumeration prevention is explicitly called out as security requirement (FR-004)
+- All items pass validation - ready for `/speckit.plan`

--- a/specs/1130-require-role-decorator/contracts/role-decorator.yaml
+++ b/specs/1130-require-role-decorator/contracts/role-decorator.yaml
@@ -1,0 +1,139 @@
+# Role Decorator Contract
+# Feature: 1130-require-role-decorator
+# Date: 2026-01-05
+
+# This contract defines the behavior of the @require_role decorator
+# Not an API contract per se, but documents decorator behavior
+
+decorator:
+  name: require_role
+  module: src.lambdas.shared.middleware.require_role
+  signature: "require_role(required_role: str) -> Callable"
+
+# Valid role values (canonical)
+roles:
+  valid_values:
+    - anonymous
+    - free
+    - paid
+    - operator
+
+  validation:
+    timing: decoration_time  # Not runtime
+    error_type: ValueError
+    error_message: "Invalid role '{role}'. Valid roles: {sorted_valid_roles}"
+
+# Decorator behavior
+behavior:
+  # Order of checks
+  checks:
+    - name: authentication_check
+      condition: "user_id is None"
+      response:
+        status_code: 401
+        body:
+          detail: "Authentication required"
+
+    - name: roles_claim_check
+      condition: "roles claim missing from JWT"
+      response:
+        status_code: 401
+        body:
+          detail: "Invalid token structure"
+
+    - name: role_authorization_check
+      condition: "required_role not in user roles"
+      response:
+        status_code: 403
+        body:
+          detail: "Access denied"  # Generic - prevents enumeration
+
+    - name: success
+      condition: "all checks pass"
+      action: "proceed to decorated handler"
+
+# Error response schemas
+error_responses:
+  unauthorized:
+    status_code: 401
+    content_type: application/json
+    schema:
+      type: object
+      properties:
+        detail:
+          type: string
+          example: "Authentication required"
+      required:
+        - detail
+
+  forbidden:
+    status_code: 403
+    content_type: application/json
+    schema:
+      type: object
+      properties:
+        detail:
+          type: string
+          example: "Access denied"
+      required:
+        - detail
+
+# Security considerations
+security:
+  enumeration_prevention:
+    description: "Error messages MUST NOT reveal required role"
+    examples:
+      good:
+        - "Access denied"
+        - "Forbidden"
+      bad:
+        - "Requires operator role"
+        - "Missing role: operator"
+        - "Insufficient permissions for admin"
+
+  timing_attack_prevention:
+    description: "All authorization failures should take similar time"
+    implementation: "Use constant-time role check (set membership)"
+
+# Usage examples
+examples:
+  basic:
+    code: |
+      from src.lambdas.shared.middleware import require_role
+
+      @router.post("/admin/sessions/revoke")
+      @require_role("operator")
+      async def revoke_sessions(request: Request):
+          # Only operators reach this point
+          pass
+
+  with_dependencies:
+    code: |
+      @router.post("/admin/users/lookup")
+      @require_role("operator")
+      async def lookup_user(
+          request: Request,
+          table=Depends(get_users_table),
+      ):
+          # Operator role verified, table injected
+          pass
+
+  paid_feature:
+    code: |
+      @router.get("/premium/analytics")
+      @require_role("paid")
+      async def premium_analytics(request: Request):
+          # Only paid users can access
+          pass
+
+# Integration points
+integration:
+  auth_context:
+    function: extract_auth_context_typed
+    module: src.lambdas.shared.middleware.auth_middleware
+    role_extraction: "auth_context.roles from JWT 'roles' claim"
+
+  jwt_claim:
+    claim_name: "roles"
+    claim_type: "array of strings"
+    example: '["free", "paid"]'

--- a/specs/1130-require-role-decorator/data-model.md
+++ b/specs/1130-require-role-decorator/data-model.md
@@ -1,0 +1,172 @@
+# Data Model: Require Role Decorator
+
+**Feature**: 1130-require-role-decorator
+**Date**: 2026-01-05
+
+## Entities
+
+### 1. Role (Canonical Values)
+
+**Location**: `src/lambdas/shared/auth/constants.py`
+
+| Value | Description | Typical Assignment |
+|-------|-------------|-------------------|
+| `anonymous` | Unauthenticated user with UUID token | Auto-assigned to anonymous sessions |
+| `free` | Authenticated user, no subscription | Default for email/OAuth sign-up |
+| `paid` | Active subscription holder | When `subscription_active=True` |
+| `operator` | Administrative access | Manual assignment by existing operator |
+
+**Constraints**:
+- Roles are additive: a `paid` user has `['free', 'paid']`
+- An `operator` user has `['free', 'paid', 'operator']` or `['free', 'operator']` depending on subscription
+- `anonymous` users have `['anonymous']` only
+- Empty roles list `[]` is treated as unauthorized for any role check
+
+**Implementation**:
+```python
+from enum import StrEnum
+
+class Role(StrEnum):
+    ANONYMOUS = "anonymous"
+    FREE = "free"
+    PAID = "paid"
+    OPERATOR = "operator"
+
+VALID_ROLES: frozenset[str] = frozenset(role.value for role in Role)
+```
+
+### 2. AuthContext (Extended)
+
+**Location**: `src/lambdas/shared/middleware/auth_middleware.py`
+
+**Current Fields**:
+| Field | Type | Description |
+|-------|------|-------------|
+| `user_id` | `str \| None` | User UUID or None if no auth |
+| `auth_type` | `AuthType` | `ANONYMOUS` or `AUTHENTICATED` |
+| `auth_method` | `str \| None` | `"bearer"`, `"x-user-id"`, or None |
+
+**New Field**:
+| Field | Type | Description |
+|-------|------|-------------|
+| `roles` | `list[str] \| None` | List of role strings from JWT `roles` claim |
+
+**Extended Definition**:
+```python
+@dataclass(frozen=True)
+class AuthContext:
+    """Authentication context from validated token (Feature 1048)."""
+    user_id: str | None
+    auth_type: AuthType
+    auth_method: str | None = None
+    roles: list[str] | None = None  # Feature 1130: Role-based access control
+```
+
+**Invariants**:
+- If `user_id is None`, then `roles` should be `None` (no auth = no roles)
+- If `auth_type == ANONYMOUS`, then `roles` should be `["anonymous"]`
+- If `auth_type == AUTHENTICATED`, then `roles` should be non-empty list
+
+### 3. RoleValidationError (Internal Exception)
+
+**Location**: `src/lambdas/shared/errors/auth_errors.py`
+
+| Exception | Description | HTTP Mapping |
+|-----------|-------------|--------------|
+| `InvalidRoleError` | Role parameter not in VALID_ROLES | N/A (startup error) |
+| `MissingRolesClaimError` | JWT has no `roles` claim | 401 Unauthorized |
+| `InsufficientRoleError` | User lacks required role | 403 Forbidden |
+
+**Implementation**:
+```python
+class InvalidRoleError(ValueError):
+    """Raised at decoration time for invalid role parameters."""
+    def __init__(self, role: str, valid_roles: frozenset[str]):
+        self.role = role
+        self.valid_roles = valid_roles
+        super().__init__(f"Invalid role '{role}'. Valid roles: {sorted(valid_roles)}")
+
+class MissingRolesClaimError(Exception):
+    """Raised when JWT is missing the roles claim."""
+    pass
+
+class InsufficientRoleError(Exception):
+    """Raised when user lacks the required role."""
+    pass
+```
+
+## State Transitions
+
+### Role Assignment Flow
+
+```
+User Creation → Anonymous Session
+    roles: ["anonymous"]
+        ↓
+Email/OAuth Sign-up → Free User
+    roles: ["free"]
+        ↓
+Subscription Purchase → Paid User
+    roles: ["free", "paid"]
+        ↓
+Operator Assignment → Operator
+    roles: ["free", "paid", "operator"] or ["free", "operator"]
+```
+
+### Role Check Flow
+
+```
+Request Received
+    ↓
+Extract Auth Context (extract_auth_context_typed)
+    ↓
+Check user_id present?
+    ├── No → 401 "Authentication required"
+    └── Yes ↓
+Check roles claim present?
+    ├── No → 401 "Invalid token structure"
+    └── Yes ↓
+Check required_role in roles?
+    ├── No → 403 "Access denied"
+    └── Yes → Proceed to handler
+```
+
+## Relationships
+
+```
+┌─────────────────┐
+│   JWT Token     │
+│  ┌───────────┐  │
+│  │  roles    │──┼──→ AuthContext.roles
+│  │  claim    │  │
+│  └───────────┘  │
+└─────────────────┘
+        ↓
+┌─────────────────┐
+│  AuthContext    │
+│  ┌───────────┐  │
+│  │ user_id   │  │
+│  │ auth_type │  │
+│  │ auth_meth │  │
+│  │ roles     │──┼──→ @require_role validation
+│  └───────────┘  │
+└─────────────────┘
+        ↓
+┌─────────────────┐
+│ @require_role   │
+│  ┌───────────┐  │
+│  │ required  │──┼──→ Check: required_role in roles
+│  │ role      │  │
+│  └───────────┘  │
+└─────────────────┘
+```
+
+## Validation Rules
+
+| Rule | Enforcement | Error |
+|------|-------------|-------|
+| Role parameter must be valid | Decoration time | `InvalidRoleError` |
+| User must be authenticated | Request time | HTTP 401 |
+| JWT must have roles claim | Request time | HTTP 401 |
+| User must have required role | Request time | HTTP 403 |
+| Error messages must be generic | Code review | N/A |

--- a/specs/1130-require-role-decorator/plan.md
+++ b/specs/1130-require-role-decorator/plan.md
@@ -1,0 +1,205 @@
+# Implementation Plan: Require Role Decorator
+
+**Branch**: `1130-require-role-decorator` | **Date**: 2026-01-05 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/1130-require-role-decorator/spec.md`
+
+## Summary
+
+Create a `@require_role(role: str)` decorator for FastAPI endpoints that validates user roles from JWT claims before allowing access. The decorator integrates with existing `extract_auth_context_typed()` and prevents role enumeration attacks by using generic 403 error messages. This is a Phase 0 security-critical component that enables protection of admin endpoints (`/admin/sessions/revoke`, `/users/lookup`).
+
+## Technical Context
+
+**Language/Version**: Python 3.13
+**Primary Dependencies**: FastAPI, functools (stdlib), typing (stdlib)
+**Storage**: N/A (roles read from JWT, no database access)
+**Testing**: pytest 7.4.3+ with pytest-asyncio 0.23.0+
+**Target Platform**: AWS Lambda via Mangum adapter
+**Project Type**: Serverless Lambda (existing web application)
+**Performance Goals**: <50ms overhead per decorated endpoint
+**Constraints**: Must not leak role information in error responses
+**Scale/Scope**: Applied to 2 admin endpoints initially, extensible to all role-protected endpoints
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Gate | Requirement | Status |
+|------|-------------|--------|
+| Security & Access Control | All admin endpoints must require authentication | **PASS** - Decorator enforces auth before role check |
+| No Unauthenticated Management Access | Admin endpoints protected | **PASS** - 401 for no auth, 403 for wrong role |
+| TLS in Transit | N/A for decorator | **N/A** |
+| Secrets Management | No secrets in decorator | **PASS** - Roles from JWT, not hardcoded |
+| Testing Requirements | Unit tests accompany implementation | **PENDING** - Will be created |
+| Pre-Push Requirements | Code linted/formatted | **PENDING** - Will be validated |
+| Pipeline Check Bypass | Never bypass | **PASS** - Standard merge flow |
+
+**Gate Result**: PASS - No violations. Ready for Phase 0.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/1130-require-role-decorator/
+├── spec.md              # Feature specification
+├── plan.md              # This file
+├── research.md          # Phase 0 research output
+├── data-model.md        # Phase 1 data model
+├── quickstart.md        # Phase 1 quickstart guide
+├── contracts/           # Phase 1 API contracts
+│   └── role-decorator.yaml
+├── checklists/
+│   └── requirements.md  # Specification checklist
+└── tasks.md             # Phase 2 task breakdown
+```
+
+### Source Code (repository root)
+
+```text
+src/lambdas/shared/
+├── middleware/
+│   ├── __init__.py           # Export require_role
+│   ├── auth_middleware.py    # Existing auth context extraction
+│   └── require_role.py       # NEW: @require_role decorator
+├── auth/
+│   └── constants.py          # NEW: Canonical role definitions
+└── errors/
+    └── auth_errors.py        # NEW: Role-specific error types
+
+tests/unit/lambdas/shared/middleware/
+└── test_require_role.py      # NEW: Unit tests for decorator
+
+tests/unit/lambdas/shared/auth/
+└── test_constants.py         # NEW: Role enum tests
+```
+
+**Structure Decision**: Extends existing `src/lambdas/shared/middleware/` structure. New module `require_role.py` follows established pattern of separate concerns per file (auth_middleware.py, rate_limit.py, security_headers.py).
+
+## Complexity Tracking
+
+> No violations requiring justification. Implementation follows existing patterns.
+
+| Aspect | Decision | Rationale |
+|--------|----------|-----------|
+| Decorator vs Depends | Decorator wrapping Depends | Cleaner syntax `@require_role('operator')` vs `role=Depends(require_role('operator'))` |
+| Role storage | JWT claims | No database lookup required, roles included in token per Phase 1.5 |
+| Error messages | Generic "Access denied" | Prevents role enumeration attacks per FR-004 |
+
+---
+
+## Phase 0: Research Output
+
+### Decision 1: Decorator Implementation Pattern
+
+**Decision**: Use a decorator factory that returns a FastAPI dependency wrapper.
+
+**Rationale**:
+- FastAPI's `Depends()` is the standard pattern in this codebase
+- A decorator factory `@require_role(role)` provides clean syntax
+- The decorator internally creates a dependency that extracts auth context and validates role
+
+**Alternatives Rejected**:
+- Pure dependency function: Requires verbose `Depends(lambda: check_role('operator'))` syntax
+- Middleware-based: Too broad, applies to all routes instead of selective protection
+
+### Decision 2: Role Enumeration Prevention
+
+**Decision**: Use identical generic error message for all role failures: "Access denied"
+
+**Rationale**:
+- FR-004 requires preventing role leakage
+- Attacker cannot distinguish "role not found" from "wrong role" from "role disabled"
+- Same 403 status code and message regardless of failure reason
+
+**Alternatives Rejected**:
+- Role-specific messages: Enables enumeration ("requires operator" reveals operator role exists)
+- Different status codes: Could fingerprint different failure modes
+
+### Decision 3: Role Validation Location
+
+**Decision**: Validate role parameter at decoration time (module import), not runtime
+
+**Rationale**:
+- FR-005 requires startup-time validation
+- Invalid roles like `@require_role('admn')` fail immediately on app startup
+- Prevents runtime surprises and silent failures
+
+**Implementation**: Check against `VALID_ROLES` set during decorator factory execution
+
+### Decision 4: Integration with Existing Auth
+
+**Decision**: Reuse `extract_auth_context_typed()` for token parsing, extend `AuthContext` with optional `roles` field
+
+**Rationale**:
+- FR-010 requires integration with existing auth
+- `AuthContext` already has `user_id`, `auth_type`, `auth_method`
+- Adding `roles: list[str] | None` follows existing pattern
+- Feature 1048 guarantees auth_type from token validation, not headers
+
+**Alternatives Rejected**:
+- Separate role extraction function: Duplicates token parsing logic
+- Database lookup: Adds latency, violates JWT-based role assumption
+
+---
+
+## Phase 1: Design Output
+
+### Data Model
+
+See [data-model.md](./data-model.md) for complete entity definitions.
+
+**Key Entities**:
+
+1. **Role** (Enum/Constants)
+   - `ANONYMOUS = "anonymous"`
+   - `FREE = "free"`
+   - `PAID = "paid"`
+   - `OPERATOR = "operator"`
+
+2. **AuthContext** (Extended)
+   - Existing: `user_id`, `auth_type`, `auth_method`
+   - New: `roles: list[str] | None`
+
+3. **RoleError** (Exception)
+   - `InsufficientRoleError` - For internal use, caught and converted to HTTPException
+
+### API Contracts
+
+See [contracts/role-decorator.yaml](./contracts/role-decorator.yaml) for OpenAPI spec.
+
+**Error Responses**:
+
+| Condition | Status | Body |
+|-----------|--------|------|
+| No authentication | 401 | `{"detail": "Authentication required"}` |
+| Missing roles claim | 401 | `{"detail": "Invalid token structure"}` |
+| Insufficient role | 403 | `{"detail": "Access denied"}` |
+
+### Quickstart
+
+See [quickstart.md](./quickstart.md) for usage examples.
+
+**Basic Usage**:
+```python
+from src.lambdas.shared.middleware import require_role
+
+@auth_router.post("/admin/sessions/revoke")
+@require_role("operator")
+async def revoke_sessions(request: Request):
+    # Only operators reach here
+    ...
+```
+
+---
+
+## Artifacts Generated
+
+| Artifact | Path | Status |
+|----------|------|--------|
+| Specification | specs/1130-require-role-decorator/spec.md | Complete |
+| Plan | specs/1130-require-role-decorator/plan.md | Complete |
+| Research | specs/1130-require-role-decorator/research.md | Pending |
+| Data Model | specs/1130-require-role-decorator/data-model.md | Pending |
+| Contracts | specs/1130-require-role-decorator/contracts/ | Pending |
+| Quickstart | specs/1130-require-role-decorator/quickstart.md | Pending |
+| Tasks | specs/1130-require-role-decorator/tasks.md | Pending (Phase 2) |

--- a/specs/1130-require-role-decorator/quickstart.md
+++ b/specs/1130-require-role-decorator/quickstart.md
@@ -1,0 +1,196 @@
+# Quickstart: @require_role Decorator
+
+**Feature**: 1130-require-role-decorator
+**Date**: 2026-01-05
+
+## Installation
+
+The decorator is available after implementing this feature. No additional packages required.
+
+## Basic Usage
+
+```python
+from src.lambdas.shared.middleware import require_role
+
+@router.post("/admin/sessions/revoke")
+@require_role("operator")
+async def revoke_all_sessions(request: Request):
+    """Revoke all active sessions. Requires operator role."""
+    # Only operators can execute this code
+    ...
+```
+
+## Available Roles
+
+| Role | Description | Use Case |
+|------|-------------|----------|
+| `anonymous` | Unauthenticated user | Public content with session tracking |
+| `free` | Authenticated, no subscription | Basic features |
+| `paid` | Active subscription | Premium features |
+| `operator` | Administrative access | Admin endpoints |
+
+## Common Patterns
+
+### Protecting Admin Endpoints
+
+```python
+from src.lambdas.shared.middleware import require_role
+from fastapi import APIRouter, Request, Depends
+
+admin_router = APIRouter(prefix="/admin")
+
+@admin_router.post("/sessions/revoke")
+@require_role("operator")
+async def revoke_sessions(request: Request):
+    """Requires operator role."""
+    ...
+
+@admin_router.get("/users/lookup")
+@require_role("operator")
+async def lookup_user(request: Request, email: str):
+    """Requires operator role."""
+    ...
+```
+
+### Protecting Paid Features
+
+```python
+@router.get("/premium/analytics")
+@require_role("paid")
+async def get_premium_analytics(request: Request):
+    """Requires paid subscription."""
+    ...
+
+@router.get("/premium/export")
+@require_role("paid")
+async def export_data(request: Request):
+    """Requires paid subscription."""
+    ...
+```
+
+### Combining with Dependencies
+
+```python
+from fastapi import Depends
+
+@router.post("/admin/config")
+@require_role("operator")
+async def update_config(
+    request: Request,
+    table=Depends(get_users_table),
+    body: ConfigUpdate = Body(...),
+):
+    """Decorator works with other dependencies."""
+    # table is injected, role is verified
+    ...
+```
+
+## Error Responses
+
+### 401 Unauthorized (No Authentication)
+
+```json
+{
+  "detail": "Authentication required"
+}
+```
+
+### 401 Unauthorized (Invalid Token)
+
+```json
+{
+  "detail": "Invalid token structure"
+}
+```
+
+### 403 Forbidden (Insufficient Role)
+
+```json
+{
+  "detail": "Access denied"
+}
+```
+
+**Note**: The 403 response is intentionally generic to prevent role enumeration attacks.
+
+## Decorator Order
+
+The decorator should be applied **after** the route decorator:
+
+```python
+# CORRECT
+@router.post("/admin/endpoint")
+@require_role("operator")
+async def admin_endpoint(request: Request):
+    ...
+
+# INCORRECT (will not work)
+@require_role("operator")
+@router.post("/admin/endpoint")
+async def admin_endpoint(request: Request):
+    ...
+```
+
+## Testing Protected Endpoints
+
+```python
+import pytest
+from fastapi.testclient import TestClient
+from unittest.mock import patch
+
+def test_operator_can_access_admin_endpoint(client: TestClient):
+    """Test that operators can access protected endpoints."""
+    # Mock auth context to return operator role
+    mock_context = AuthContext(
+        user_id="test-user",
+        auth_type=AuthType.AUTHENTICATED,
+        auth_method="bearer",
+        roles=["free", "operator"],
+    )
+
+    with patch("src.lambdas.shared.middleware.auth_middleware.extract_auth_context_typed", return_value=mock_context):
+        response = client.post("/admin/sessions/revoke")
+        assert response.status_code == 200
+
+def test_non_operator_gets_403(client: TestClient):
+    """Test that non-operators get 403."""
+    mock_context = AuthContext(
+        user_id="test-user",
+        auth_type=AuthType.AUTHENTICATED,
+        auth_method="bearer",
+        roles=["free"],  # No operator role
+    )
+
+    with patch("src.lambdas.shared.middleware.auth_middleware.extract_auth_context_typed", return_value=mock_context):
+        response = client.post("/admin/sessions/revoke")
+        assert response.status_code == 403
+        assert response.json()["detail"] == "Access denied"
+```
+
+## Invalid Role Detection
+
+Using an invalid role will raise an error at **startup**, not runtime:
+
+```python
+@router.get("/endpoint")
+@require_role("admn")  # Typo!
+async def endpoint(request: Request):
+    ...
+
+# On app startup:
+# ValueError: Invalid role 'admn'. Valid roles: ['anonymous', 'free', 'operator', 'paid']
+```
+
+## FAQ
+
+**Q: What happens if I use a role that doesn't exist?**
+A: The application will fail to start with a clear error message.
+
+**Q: Can I require multiple roles?**
+A: This feature supports single role checks. For multiple roles, chain decorators or use a custom dependency.
+
+**Q: Why is the error message generic?**
+A: To prevent role enumeration attacks. An attacker cannot determine which roles exist by probing endpoints.
+
+**Q: How do roles get into the JWT?**
+A: That's handled by Phase 1.5 (jwt-roles-claim). This decorator only reads the `roles` claim.

--- a/specs/1130-require-role-decorator/research.md
+++ b/specs/1130-require-role-decorator/research.md
@@ -1,0 +1,177 @@
+# Research: Require Role Decorator
+
+**Feature**: 1130-require-role-decorator
+**Date**: 2026-01-05
+
+## Research Questions
+
+### Q1: Best pattern for FastAPI decorator-based authorization?
+
+**Decision**: Decorator factory wrapping FastAPI dependency injection
+
+**Rationale**:
+- FastAPI's `Depends()` is the established pattern in this codebase (see `router_v2.py`)
+- A decorator factory provides cleaner syntax: `@require_role('operator')`
+- The decorator internally creates a dependency that validates roles
+- Compatible with async handlers (all endpoints in codebase are `async def`)
+
+**Pattern**:
+```python
+def require_role(required_role: str):
+    """Decorator factory for role-based access control."""
+    if required_role not in VALID_ROLES:
+        raise ValueError(f"Invalid role: {required_role}")
+
+    def decorator(func):
+        @functools.wraps(func)
+        async def wrapper(*args, request: Request, **kwargs):
+            # Validate role from auth context
+            auth_context = extract_auth_context_typed({"headers": dict(request.headers)})
+            if auth_context.user_id is None:
+                raise HTTPException(status_code=401, detail="Authentication required")
+            if auth_context.roles is None:
+                raise HTTPException(status_code=401, detail="Invalid token structure")
+            if required_role not in auth_context.roles:
+                raise HTTPException(status_code=403, detail="Access denied")
+            return await func(*args, request=request, **kwargs)
+        return wrapper
+    return decorator
+```
+
+**Sources**:
+- Codebase: `src/lambdas/dashboard/router_v2.py` lines 191-218 (`get_authenticated_user_id`)
+- FastAPI docs: Dependency injection pattern
+
+### Q2: How to prevent role enumeration attacks?
+
+**Decision**: Generic error message "Access denied" for all authorization failures
+
+**Rationale**:
+- FR-004 explicitly requires preventing role leakage
+- Attacker cannot distinguish between:
+  - "User has no roles"
+  - "User has wrong role"
+  - "Role doesn't exist"
+  - "Role is disabled"
+- Same HTTP 403 status code and identical message body
+
+**Implementation**:
+```python
+# GOOD: Generic message
+raise HTTPException(status_code=403, detail="Access denied")
+
+# BAD: Reveals role information
+raise HTTPException(status_code=403, detail="Requires operator role")
+raise HTTPException(status_code=403, detail="Missing role: operator")
+```
+
+**Sources**:
+- OWASP: Authorization Testing Cheat Sheet
+- Spec FR-004: "System MUST use a generic 403 error message that does NOT reveal the required role"
+
+### Q3: Where to validate role parameter (startup vs runtime)?
+
+**Decision**: Validate at decoration time (module import/startup)
+
+**Rationale**:
+- FR-005 requires startup-time validation
+- Typos like `@require_role('admn')` caught immediately on app start
+- Prevents silent failures in production
+- Uses `VALID_ROLES` constant for validation
+
+**Implementation**:
+```python
+VALID_ROLES = frozenset({"anonymous", "free", "paid", "operator"})
+
+def require_role(required_role: str):
+    if required_role not in VALID_ROLES:
+        raise ValueError(f"Invalid role '{required_role}'. Valid roles: {sorted(VALID_ROLES)}")
+    # ... rest of decorator
+```
+
+**Sources**:
+- Python best practices: Fail fast principle
+- Spec FR-005: "System MUST validate the role parameter against known canonical roles at decoration time"
+
+### Q4: How to integrate with existing auth context?
+
+**Decision**: Extend `AuthContext` dataclass with `roles: list[str] | None` field
+
+**Rationale**:
+- FR-010 requires integration with `extract_auth_context_typed()`
+- `AuthContext` already exists with `user_id`, `auth_type`, `auth_method`
+- Adding optional `roles` field is backward-compatible
+- Roles extracted from JWT `roles` claim during token validation
+
+**Current AuthContext** (from `auth_middleware.py:40-56`):
+```python
+@dataclass(frozen=True)
+class AuthContext:
+    user_id: str | None
+    auth_type: AuthType
+    auth_method: str | None = None
+```
+
+**Extended AuthContext**:
+```python
+@dataclass(frozen=True)
+class AuthContext:
+    user_id: str | None
+    auth_type: AuthType
+    auth_method: str | None = None
+    roles: list[str] | None = None  # NEW: from JWT 'roles' claim
+```
+
+**Sources**:
+- Codebase: `src/lambdas/shared/middleware/auth_middleware.py` lines 40-56
+- Spec FR-006: "System MUST read user roles from the JWT `roles` claim"
+
+## Alternatives Considered
+
+### Alternative 1: Pure Dependency Function (Rejected)
+
+```python
+def check_role(role: str):
+    def dependency(request: Request):
+        # validation logic
+    return dependency
+
+# Usage (verbose)
+@router.post("/admin")
+async def admin_endpoint(user=Depends(check_role("operator"))):
+    ...
+```
+
+**Why Rejected**: More verbose syntax, less readable than decorator pattern.
+
+### Alternative 2: Middleware-Based (Rejected)
+
+```python
+@app.middleware("http")
+async def role_middleware(request: Request, call_next):
+    # check role for all requests
+```
+
+**Why Rejected**: Too broad - applies to all routes instead of selective protection.
+
+### Alternative 3: Database Role Lookup (Rejected)
+
+```python
+async def get_user_roles(user_id: str) -> list[str]:
+    # Query DynamoDB for user roles
+```
+
+**Why Rejected**:
+- Adds latency (DynamoDB call per request)
+- Violates assumption that roles are in JWT
+- Not consistent with Phase 1.5 JWT-based role design
+
+## Key Findings Summary
+
+| Topic | Decision | Key Benefit |
+|-------|----------|-------------|
+| Pattern | Decorator factory + dependency injection | Clean syntax, FastAPI-native |
+| Error messages | Generic "Access denied" | Prevents enumeration |
+| Validation timing | Decoration time (startup) | Fail fast, no runtime surprises |
+| Auth integration | Extend AuthContext | Backward compatible, reuses existing parsing |
+| Role storage | JWT claims | No database lookup, consistent with Phase 1.5 |

--- a/specs/1130-require-role-decorator/spec.md
+++ b/specs/1130-require-role-decorator/spec.md
@@ -1,0 +1,114 @@
+# Feature Specification: Require Role Decorator
+
+**Feature Branch**: `1130-require-role-decorator`
+**Created**: 2026-01-05
+**Status**: Draft
+**Input**: User description: "Phase 0 D6: Create @require_role decorator at src/lambdas/shared/middleware/require_role.py. Syntax: @require_role('operator'). Must prevent role leakage in 403 error responses. REQUIRED by C4/C5 - must be implemented before those fixes."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Protect Admin Endpoints (Priority: P1)
+
+An operator (administrative user) needs to access sensitive endpoints like session revocation and user lookup. The system must verify the user has the `operator` role before allowing access. Non-operator users attempting these endpoints receive a generic access denied response that does not reveal what role is required.
+
+**Why this priority**: Security-critical. Without role protection, any authenticated user can perform admin actions like revoking all sessions or enumerating users. This is the core functionality that enables C4/C5 endpoint protection.
+
+**Independent Test**: Can be fully tested by decorating a test endpoint with `@require_role('operator')` and verifying that users without the role receive 403 while operators can access it.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user with `operator` role, **When** they access an endpoint decorated with `@require_role('operator')`, **Then** the request proceeds to the handler and returns the expected response.
+
+2. **Given** a user with `free` role (no operator role), **When** they access an endpoint decorated with `@require_role('operator')`, **Then** they receive a 403 Forbidden response with a generic message that does NOT mention "operator" or any specific role.
+
+3. **Given** an anonymous (unauthenticated) user, **When** they access an endpoint decorated with `@require_role('operator')`, **Then** they receive a 401 Unauthorized response (authentication required before authorization check).
+
+---
+
+### User Story 2 - Support Multiple Role Levels (Priority: P2)
+
+The system supports a hierarchy of roles (anonymous, free, paid, operator) where decorators can require any specific role. This enables tiered feature access where paid features require `paid` role and admin features require `operator` role.
+
+**Why this priority**: Enables future feature gating for subscription tiers. Foundation for monetization but not blocking for initial security fixes.
+
+**Independent Test**: Can be tested by creating endpoints with different role requirements (`@require_role('paid')`, `@require_role('free')`) and verifying correct access control per role.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user with `paid` role, **When** they access an endpoint requiring `paid`, **Then** access is granted.
+
+2. **Given** a user with `free` role (no paid subscription), **When** they access an endpoint requiring `paid`, **Then** they receive 403 Forbidden with generic message.
+
+3. **Given** a user with `operator` role, **When** they access an endpoint requiring `paid`, **Then** access is granted (operators implicitly have all lower roles via role accumulation).
+
+---
+
+### User Story 3 - Composable with Existing Auth (Priority: P3)
+
+The decorator integrates seamlessly with the existing FastAPI dependency injection pattern for authentication. It can be combined with other dependencies and does not conflict with the current `get_authenticated_user_id` or `extract_auth_context_typed` functions.
+
+**Why this priority**: Ensures the decorator fits into the existing architecture without breaking current patterns. Important for maintainability but not blocking for initial implementation.
+
+**Independent Test**: Can be tested by applying decorator to an endpoint that also uses `Depends(get_users_table)` and verifying both work correctly.
+
+**Acceptance Scenarios**:
+
+1. **Given** an endpoint with `@require_role('operator')` and `Depends(get_users_table)`, **When** an operator accesses it, **Then** both the role check passes and the table dependency is injected.
+
+---
+
+### Edge Cases
+
+- What happens when a user's token is valid but missing the `roles` claim? The decorator should reject with 401 (invalid token structure, not authorization failure).
+- What happens when the roles claim contains an empty list? Treat as having no roles; 403 if role required.
+- What happens when role parameter is invalid (typo like `@require_role('admn')`)? Fail at decoration time (startup) with clear error, not runtime.
+- What happens with concurrent role changes (user demoted mid-session)? Role is read from JWT at request time; demotion takes effect on next token refresh.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST provide a `@require_role(role: str)` decorator that can be applied to FastAPI route handlers.
+- **FR-002**: System MUST return 401 Unauthorized if the request lacks valid authentication (no token or invalid token).
+- **FR-003**: System MUST return 403 Forbidden if the authenticated user lacks the required role.
+- **FR-004**: System MUST use a generic 403 error message that does NOT reveal the required role (prevent role enumeration).
+- **FR-005**: System MUST validate the role parameter against known canonical roles at decoration time (startup), raising an error for unknown roles.
+- **FR-006**: System MUST read user roles from the JWT `roles` claim (list of strings).
+- **FR-007**: System MUST support the canonical role values: `anonymous`, `free`, `paid`, `operator`.
+- **FR-008**: System MUST reject tokens missing the `roles` claim with 401 (malformed token, not authorization failure).
+- **FR-009**: Decorator MUST be composable with FastAPI's `Depends()` system without conflicts.
+- **FR-010**: Decorator MUST integrate with existing `extract_auth_context_typed()` function for token parsing.
+
+### Key Entities
+
+- **Role**: A string identifier representing a permission level. Canonical values: `anonymous`, `free`, `paid`, `operator`. Roles are additive (a paid user has `['free', 'paid']`).
+- **AuthContext**: Existing dataclass containing `user_id`, `auth_type`, `auth_method`. Extended to include `roles: list[str]`.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Decorated endpoints return 403 for unauthorized users within 50ms overhead (negligible latency impact).
+- **SC-002**: 100% of admin endpoints (revoke, lookup) are protected before Phase 0 completion.
+- **SC-003**: Security audit shows zero role information leakage in error responses.
+- **SC-004**: Decorator can be applied to existing endpoints with single-line change (no handler refactoring required).
+- **SC-005**: Invalid role parameters detected at application startup, preventing runtime failures.
+
+## Assumptions
+
+- JWT tokens will include a `roles` claim (list of strings) as per Phase 1.5 planning. Until Phase 1.5, this decorator will reject all tokens as malformed (acceptable for Phase 0 since admin endpoints shouldn't be accessible yet).
+- The canonical role enum (`anonymous`, `free`, `paid`, `operator`) is stable and will not change frequently.
+- Role checking is based on exact string matching against the roles list (e.g., `'operator' in roles`).
+- The decorator pattern is acceptable even though the codebase currently uses dependency injection; this provides cleaner syntax for role requirements.
+
+## Dependencies
+
+- **Phase 1.5 (role-enum-canonical)**: Defines the canonical role values this decorator validates against.
+- **Phase 1.5 (jwt-roles-claim)**: Ensures JWTs contain the `roles` claim this decorator reads.
+- **Existing**: `extract_auth_context_typed()` from auth_middleware.py for token parsing.
+
+## Out of Scope
+
+- Role hierarchy/inheritance (operator > paid > free) - this decorator checks for exact role presence; the role assignment logic (handled in Phase 1.5) is responsible for role accumulation.
+- Role management UI or API endpoints.
+- Database storage for roles (roles are in JWT, not fetched from database per request).

--- a/specs/1130-require-role-decorator/tasks.md
+++ b/specs/1130-require-role-decorator/tasks.md
@@ -1,0 +1,175 @@
+# Tasks: Require Role Decorator
+
+**Feature**: 1130-require-role-decorator
+**Branch**: `1130-require-role-decorator`
+**Generated**: 2026-01-05
+**Spec**: [spec.md](./spec.md) | **Plan**: [plan.md](./plan.md)
+
+## Summary
+
+| Metric | Value |
+|--------|-------|
+| Total Tasks | 14 |
+| User Story 1 (P1) Tasks | 5 |
+| User Story 2 (P2) Tasks | 2 |
+| User Story 3 (P3) Tasks | 2 |
+| Parallel Opportunities | 4 |
+| MVP Scope | Phase 1-3 (Setup + Foundational + US1) |
+
+## Dependencies
+
+```
+Phase 1 (Setup)
+    ↓
+Phase 2 (Foundational) ──┬── T003 Role constants
+    │                    └── T004 Auth errors
+    ↓
+Phase 3 (US1: Protect Admin) ──┬── T005 Extend AuthContext
+    │                          ├── T006 require_role decorator
+    │                          └── T007-T009 Tests
+    ↓
+Phase 4 (US2: Multiple Roles) ── T010-T011 (builds on US1)
+    ↓
+Phase 5 (US3: Composable Auth) ── T012-T013 (builds on US1)
+    ↓
+Phase 6 (Polish) ── T014 Final validation
+```
+
+---
+
+## Phase 1: Setup
+
+**Goal**: Ensure project structure and directories exist for new modules.
+
+- [x] T001 Create auth constants directory at `src/lambdas/shared/auth/` if not exists
+- [x] T002 [P] Create auth errors module at `src/lambdas/shared/errors/auth_errors.py` with empty file
+
+---
+
+## Phase 2: Foundational
+
+**Goal**: Implement shared components required by all user stories (blocking prerequisites).
+
+- [x] T003 [P] Implement Role enum with canonical values (ANONYMOUS, FREE, PAID, OPERATOR) and VALID_ROLES frozenset in `src/lambdas/shared/auth/constants.py`
+- [x] T004 [P] Implement role exception classes (InvalidRoleError, MissingRolesClaimError, InsufficientRoleError) in `src/lambdas/shared/errors/auth_errors.py`
+
+---
+
+## Phase 3: User Story 1 - Protect Admin Endpoints (P1)
+
+**Goal**: Operators can access admin endpoints; non-operators receive generic 403.
+
+**Independent Test**: Decorate test endpoint with `@require_role('operator')`, verify operators pass and non-operators get 403 without role leakage.
+
+**Acceptance Criteria**:
+- Operator role grants access to decorated endpoints
+- Non-operator authenticated users receive 403 "Access denied"
+- Unauthenticated users receive 401 "Authentication required"
+- Error messages do NOT reveal required role
+
+### Implementation
+
+- [x] T005 [US1] Extend AuthContext dataclass with `roles: list[str] | None = None` field in `src/lambdas/shared/middleware/auth_middleware.py`
+- [x] T006 [US1] Implement `require_role(role: str)` decorator factory with startup validation, auth context extraction, and generic error messages in `src/lambdas/shared/middleware/require_role.py`
+- [x] T007 [US1] Export `require_role` from middleware `__init__.py` at `src/lambdas/shared/middleware/__init__.py`
+
+### Tests
+
+- [x] T008 [P] [US1] Create unit tests for require_role decorator covering operator access, non-operator 403, unauthenticated 401, and generic error messages in `tests/unit/lambdas/shared/middleware/test_require_role.py`
+- [x] T009 [P] [US1] Create unit tests for Role enum and VALID_ROLES validation in `tests/unit/lambdas/shared/auth/test_constants.py`
+
+---
+
+## Phase 4: User Story 2 - Support Multiple Role Levels (P2)
+
+**Goal**: Decorator supports all canonical roles (anonymous, free, paid, operator).
+
+**Independent Test**: Create endpoints with different role requirements and verify correct access control per role.
+
+**Acceptance Criteria**:
+- `@require_role('paid')` grants access to paid users
+- `@require_role('free')` grants access to free users
+- Role accumulation works (operator has all lower roles)
+
+### Implementation
+
+- [x] T010 [US2] Add test cases for paid role requirement in `tests/unit/lambdas/shared/middleware/test_require_role.py`
+- [x] T011 [US2] Add test cases for free role requirement and role accumulation (operator accessing paid endpoints) in `tests/unit/lambdas/shared/middleware/test_require_role.py`
+
+---
+
+## Phase 5: User Story 3 - Composable with Existing Auth (P3)
+
+**Goal**: Decorator works alongside FastAPI Depends() without conflicts.
+
+**Independent Test**: Apply decorator to endpoint with `Depends(get_users_table)` and verify both work.
+
+**Acceptance Criteria**:
+- Decorator does not break existing dependency injection
+- Multiple decorators can be combined
+- Works with async handlers
+
+### Implementation
+
+- [x] T012 [US3] Add integration test for decorator combined with Depends() in `tests/unit/lambdas/shared/middleware/test_require_role.py`
+- [x] T013 [US3] Add test for decorator on async handler with multiple dependencies in `tests/unit/lambdas/shared/middleware/test_require_role.py`
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Goal**: Final validation and code quality checks.
+
+- [x] T014 Run linting (ruff check) and formatting (ruff format) on all new files, verify tests pass with `pytest tests/unit/lambdas/shared/middleware/test_require_role.py tests/unit/lambdas/shared/auth/test_constants.py -v`
+
+---
+
+## Parallel Execution Examples
+
+### Setup Phase (T001-T002)
+```bash
+# Can run in parallel - independent directories/files
+T001 & T002
+```
+
+### Foundational Phase (T003-T004)
+```bash
+# Can run in parallel - different files
+T003 & T004
+```
+
+### US1 Tests (T008-T009)
+```bash
+# Can run in parallel - different test files
+T008 & T009
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (Phases 1-3)
+Complete Setup, Foundational, and User Story 1 to deliver:
+- Working `@require_role('operator')` decorator
+- Protection for admin endpoints
+- Generic error messages preventing enumeration
+
+### Incremental Delivery
+- **After Phase 3**: Deploy and protect `/admin/sessions/revoke` and `/users/lookup` endpoints
+- **After Phase 4**: Enable `@require_role('paid')` for premium features
+- **After Phase 5**: Full integration confidence with existing auth patterns
+
+---
+
+## File Manifest
+
+| File | Action | Phase |
+|------|--------|-------|
+| `src/lambdas/shared/auth/__init__.py` | Create | 1 |
+| `src/lambdas/shared/auth/constants.py` | Create | 2 |
+| `src/lambdas/shared/errors/auth_errors.py` | Create | 2 |
+| `src/lambdas/shared/middleware/auth_middleware.py` | Modify | 3 |
+| `src/lambdas/shared/middleware/require_role.py` | Create | 3 |
+| `src/lambdas/shared/middleware/__init__.py` | Modify | 3 |
+| `tests/unit/lambdas/shared/auth/test_constants.py` | Create | 3 |
+| `tests/unit/lambdas/shared/middleware/test_require_role.py` | Create | 3-5 |

--- a/src/lambdas/shared/auth/__init__.py
+++ b/src/lambdas/shared/auth/__init__.py
@@ -9,6 +9,10 @@ from src.lambdas.shared.auth.cognito import (
     revoke_token,
     validate_access_token,
 )
+from src.lambdas.shared.auth.constants import (
+    VALID_ROLES,
+    Role,
+)
 from src.lambdas.shared.auth.merge import (
     MergeResult,
     merge_anonymous_data,
@@ -24,4 +28,7 @@ __all__ = [
     "validate_access_token",
     "MergeResult",
     "merge_anonymous_data",
+    # Feature 1130: RBAC constants
+    "Role",
+    "VALID_ROLES",
 ]

--- a/src/lambdas/shared/auth/constants.py
+++ b/src/lambdas/shared/auth/constants.py
@@ -1,0 +1,29 @@
+"""Canonical role definitions for RBAC (Feature 1130).
+
+This module defines the valid roles used throughout the application.
+Roles are validated at decoration time to catch typos early.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class Role(StrEnum):
+    """Canonical user roles for role-based access control.
+
+    Roles are additive:
+    - anonymous: UUID token holders only
+    - free: Authenticated users (includes anonymous upgrade)
+    - paid: Active subscription holders (has free + paid)
+    - operator: Administrative access (has free + paid + operator)
+    """
+
+    ANONYMOUS = "anonymous"
+    FREE = "free"
+    PAID = "paid"
+    OPERATOR = "operator"
+
+
+# Immutable set for O(1) validation at decoration time
+VALID_ROLES: frozenset[str] = frozenset(role.value for role in Role)

--- a/src/lambdas/shared/errors/__init__.py
+++ b/src/lambdas/shared/errors/__init__.py
@@ -6,6 +6,11 @@ while adding Feature 014 session-specific error types.
 
 # Re-export original error utilities (backward compatibility)
 # Feature 014: Session-specific error types
+from src.lambdas.shared.errors.auth_errors import (
+    InsufficientRoleError,
+    InvalidRoleError,
+    MissingRolesClaimError,
+)
 from src.lambdas.shared.errors.session_errors import (
     EmailAlreadyExistsError,
     InvalidMergeTargetError,
@@ -50,4 +55,8 @@ __all__ = [
     "SessionRevokedException",
     "TokenAlreadyUsedError",
     "TokenExpiredError",
+    # Feature 1130: RBAC errors
+    "InsufficientRoleError",
+    "InvalidRoleError",
+    "MissingRolesClaimError",
 ]

--- a/src/lambdas/shared/errors/auth_errors.py
+++ b/src/lambdas/shared/errors/auth_errors.py
@@ -1,0 +1,41 @@
+"""Role-based access control error types (Feature 1130).
+
+These exceptions are used internally by the require_role decorator.
+They are caught and converted to HTTPExceptions with generic messages
+to prevent role enumeration attacks.
+"""
+
+from __future__ import annotations
+
+
+class InvalidRoleError(ValueError):
+    """Raised at decoration time for invalid role parameters.
+
+    This error indicates a programming mistake (typo in role name)
+    and should cause the application to fail to start.
+    """
+
+    def __init__(self, role: str, valid_roles: frozenset[str]) -> None:
+        self.role = role
+        self.valid_roles = valid_roles
+        super().__init__(f"Invalid role '{role}'. Valid roles: {sorted(valid_roles)}")
+
+
+class MissingRolesClaimError(Exception):
+    """Raised when JWT is missing the roles claim.
+
+    Indicates a token structure issue - the user authenticated but
+    the token doesn't contain role information.
+    """
+
+    pass
+
+
+class InsufficientRoleError(Exception):
+    """Raised when user lacks the required role.
+
+    This is an internal exception caught by the decorator and
+    converted to a generic 403 response to prevent enumeration.
+    """
+
+    pass

--- a/src/lambdas/shared/middleware/__init__.py
+++ b/src/lambdas/shared/middleware/__init__.py
@@ -1,7 +1,10 @@
 """Shared middleware for Lambda handlers."""
 
 from src.lambdas.shared.middleware.auth_middleware import (
+    AuthContext,
+    AuthType,
     extract_auth_context,
+    extract_auth_context_typed,
     extract_user_id,
     require_auth,
 )
@@ -14,20 +17,32 @@ from src.lambdas.shared.middleware.rate_limit import (
     check_rate_limit,
     get_client_ip,
 )
+from src.lambdas.shared.middleware.require_role import (
+    require_role,
+)
 from src.lambdas.shared.middleware.security_headers import (
     add_security_headers,
     get_cors_headers,
 )
 
 __all__ = [
-    "CaptchaRequired",
-    "RateLimitExceeded",
-    "add_security_headers",
-    "check_rate_limit",
+    # Auth middleware
+    "AuthContext",
+    "AuthType",
     "extract_auth_context",
+    "extract_auth_context_typed",
     "extract_user_id",
-    "get_client_ip",
-    "get_cors_headers",
     "require_auth",
+    # Feature 1130: Role-based access control
+    "require_role",
+    # hCaptcha
+    "CaptchaRequired",
     "verify_captcha",
+    # Rate limiting
+    "RateLimitExceeded",
+    "check_rate_limit",
+    "get_client_ip",
+    # Security headers
+    "add_security_headers",
+    "get_cors_headers",
 ]

--- a/src/lambdas/shared/middleware/require_role.py
+++ b/src/lambdas/shared/middleware/require_role.py
@@ -1,0 +1,138 @@
+"""Role-based access control decorator for FastAPI endpoints (Feature 1130).
+
+This module provides the @require_role decorator for protecting endpoints
+based on user roles from JWT claims.
+
+Usage:
+    from src.lambdas.shared.middleware import require_role
+
+    @router.post("/admin/sessions/revoke")
+    @require_role("operator")
+    async def revoke_sessions(request: Request):
+        ...
+
+Security:
+    - Generic error messages prevent role enumeration attacks
+    - Role validation at decoration time catches typos early
+    - Integrates with existing auth context extraction
+"""
+
+from __future__ import annotations
+
+import functools
+import logging
+from collections.abc import Callable
+from typing import Any, TypeVar
+
+from fastapi import HTTPException, Request
+
+from src.lambdas.shared.auth.constants import VALID_ROLES
+from src.lambdas.shared.errors.auth_errors import InvalidRoleError
+from src.lambdas.shared.middleware.auth_middleware import extract_auth_context_typed
+
+logger = logging.getLogger(__name__)
+
+# Type variable for preserving function signatures
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+def require_role(required_role: str) -> Callable[[F], F]:
+    """Decorator factory for role-based access control.
+
+    Creates a decorator that validates the user has the specified role
+    before allowing access to the endpoint.
+
+    Args:
+        required_role: The role required to access the endpoint.
+            Must be one of: 'anonymous', 'free', 'paid', 'operator'
+
+    Returns:
+        A decorator function that wraps the endpoint handler.
+
+    Raises:
+        InvalidRoleError: At decoration time if role is not valid.
+            This causes app startup to fail, catching typos early.
+
+    Example:
+        @router.post("/admin/endpoint")
+        @require_role("operator")
+        async def admin_endpoint(request: Request):
+            ...
+    """
+    # Validate role at decoration time (startup)
+    if required_role not in VALID_ROLES:
+        raise InvalidRoleError(required_role, VALID_ROLES)
+
+    def decorator(func: F) -> F:
+        @functools.wraps(func)
+        async def wrapper(*args: Any, **kwargs: Any) -> Any:
+            # Extract request from args or kwargs
+            request: Request | None = None
+
+            # Check kwargs first
+            if "request" in kwargs:
+                request = kwargs["request"]
+            else:
+                # Check positional args for Request object
+                for arg in args:
+                    if isinstance(arg, Request):
+                        request = arg
+                        break
+
+            if request is None:
+                # This shouldn't happen in normal FastAPI usage
+                logger.error("require_role: No Request object found in handler args")
+                raise HTTPException(
+                    status_code=500,
+                    detail="Internal server error",
+                )
+
+            # Build event dict from request for auth context extraction
+            headers_dict = dict(request.headers)
+            event = {"headers": headers_dict}
+
+            # Extract auth context
+            auth_context = extract_auth_context_typed(event)
+
+            # Check authentication
+            if auth_context.user_id is None:
+                logger.debug(
+                    f"require_role({required_role}): No user_id, returning 401"
+                )
+                raise HTTPException(
+                    status_code=401,
+                    detail="Authentication required",
+                )
+
+            # Check roles claim exists
+            if auth_context.roles is None:
+                logger.debug(
+                    f"require_role({required_role}): No roles claim, returning 401"
+                )
+                raise HTTPException(
+                    status_code=401,
+                    detail="Invalid token structure",
+                )
+
+            # Check required role
+            if required_role not in auth_context.roles:
+                # SECURITY: Generic message prevents role enumeration
+                logger.debug(
+                    f"require_role({required_role}): User {auth_context.user_id[:8]}... "
+                    f"has roles {auth_context.roles}, returning 403"
+                )
+                raise HTTPException(
+                    status_code=403,
+                    detail="Access denied",
+                )
+
+            # Role check passed
+            logger.debug(
+                f"require_role({required_role}): User {auth_context.user_id[:8]}... "
+                f"authorized with roles {auth_context.roles}"
+            )
+            return await func(*args, **kwargs)
+
+        return wrapper  # type: ignore[return-value]
+
+    return decorator

--- a/tests/unit/lambdas/shared/auth/test_constants.py
+++ b/tests/unit/lambdas/shared/auth/test_constants.py
@@ -1,0 +1,93 @@
+"""Unit tests for RBAC constants (Feature 1130).
+
+Tests:
+- Role enum values
+- VALID_ROLES frozenset
+- Role validation behavior
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.lambdas.shared.auth.constants import VALID_ROLES, Role
+
+
+class TestRoleEnum:
+    """Tests for the Role enum."""
+
+    def test_role_has_four_values(self) -> None:
+        """Role enum should have exactly 4 canonical roles."""
+        assert len(Role) == 4
+
+    def test_anonymous_value(self) -> None:
+        """Role.ANONYMOUS should have value 'anonymous'."""
+        assert Role.ANONYMOUS == "anonymous"
+        assert Role.ANONYMOUS.value == "anonymous"
+
+    def test_free_value(self) -> None:
+        """Role.FREE should have value 'free'."""
+        assert Role.FREE == "free"
+        assert Role.FREE.value == "free"
+
+    def test_paid_value(self) -> None:
+        """Role.PAID should have value 'paid'."""
+        assert Role.PAID == "paid"
+        assert Role.PAID.value == "paid"
+
+    def test_operator_value(self) -> None:
+        """Role.OPERATOR should have value 'operator'."""
+        assert Role.OPERATOR == "operator"
+        assert Role.OPERATOR.value == "operator"
+
+    def test_role_is_str_enum(self) -> None:
+        """Role should be a StrEnum for string comparisons."""
+        # Can compare directly with strings
+        assert Role.OPERATOR == "operator"
+        assert "operator" == Role.OPERATOR
+
+    def test_role_can_be_used_in_string_operations(self) -> None:
+        """Role values should work in string operations."""
+        role = Role.OPERATOR
+        assert f"User has {role} role" == "User has operator role"
+
+
+class TestValidRoles:
+    """Tests for the VALID_ROLES constant."""
+
+    def test_valid_roles_is_frozenset(self) -> None:
+        """VALID_ROLES should be immutable (frozenset)."""
+        assert isinstance(VALID_ROLES, frozenset)
+
+    def test_valid_roles_contains_all_role_values(self) -> None:
+        """VALID_ROLES should contain all Role enum values."""
+        expected = {"anonymous", "free", "paid", "operator"}
+        assert VALID_ROLES == expected
+
+    def test_valid_roles_membership_check_is_o1(self) -> None:
+        """VALID_ROLES should support O(1) membership check."""
+        # This test documents the performance expectation
+        # frozenset provides O(1) average case for 'in' operator
+        assert "operator" in VALID_ROLES
+        assert "admin" not in VALID_ROLES
+
+    def test_valid_roles_cannot_be_modified(self) -> None:
+        """VALID_ROLES should be immutable."""
+        with pytest.raises(AttributeError):
+            VALID_ROLES.add("admin")  # type: ignore[attr-defined]
+
+    @pytest.mark.parametrize(
+        "role",
+        ["anonymous", "free", "paid", "operator"],
+    )
+    def test_all_canonical_roles_are_valid(self, role: str) -> None:
+        """All canonical role strings should be in VALID_ROLES."""
+        assert role in VALID_ROLES
+
+    @pytest.mark.parametrize(
+        "invalid_role",
+        ["admin", "superuser", "root", "OPERATOR", "Operator", "", "admn"],
+    )
+    def test_invalid_roles_not_in_valid_roles(self, invalid_role: str) -> None:
+        """Non-canonical role strings should not be in VALID_ROLES."""
+        assert invalid_role not in VALID_ROLES

--- a/tests/unit/lambdas/shared/middleware/__init__.py
+++ b/tests/unit/lambdas/shared/middleware/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for shared middleware."""

--- a/tests/unit/lambdas/shared/middleware/test_require_role.py
+++ b/tests/unit/lambdas/shared/middleware/test_require_role.py
@@ -1,0 +1,513 @@
+"""Unit tests for @require_role decorator (Feature 1130).
+
+Tests cover:
+- US1: Operator access to admin endpoints (P1)
+- US2: Multiple role levels (P2)
+- US3: Composability with FastAPI Depends (P3)
+- Error message security (no role enumeration)
+- Startup validation of role parameters
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import Depends, FastAPI, Request
+from fastapi.testclient import TestClient
+
+from src.lambdas.shared.auth.constants import VALID_ROLES
+from src.lambdas.shared.errors.auth_errors import InvalidRoleError
+from src.lambdas.shared.middleware import AuthContext, AuthType
+from src.lambdas.shared.middleware.require_role import require_role
+
+# ============================================================================
+# Test Fixtures
+# ============================================================================
+
+
+@pytest.fixture
+def app() -> FastAPI:
+    """Create a FastAPI app for testing."""
+    return FastAPI()
+
+
+@pytest.fixture
+def client(app: FastAPI) -> TestClient:
+    """Create a test client for the app."""
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def mock_auth_context(
+    user_id: str | None = "test-user-id",
+    auth_type: AuthType = AuthType.AUTHENTICATED,
+    roles: list[str] | None = None,
+) -> AuthContext:
+    """Create a mock AuthContext for testing."""
+    return AuthContext(
+        user_id=user_id,
+        auth_type=auth_type,
+        auth_method="bearer" if user_id else None,
+        roles=roles,
+    )
+
+
+# ============================================================================
+# US1: Protect Admin Endpoints (P1)
+# ============================================================================
+
+
+class TestOperatorAccess:
+    """Tests for operator role access control (US1)."""
+
+    def test_operator_can_access_protected_endpoint(
+        self, app: FastAPI, client: TestClient
+    ) -> None:
+        """Operators should be able to access @require_role('operator') endpoints."""
+
+        @app.post("/admin/sessions/revoke")
+        @require_role("operator")
+        async def revoke_sessions(request: Request) -> dict[str, str]:
+            return {"status": "revoked"}
+
+        mock_ctx = mock_auth_context(roles=["free", "operator"])
+
+        with patch(
+            "src.lambdas.shared.middleware.require_role.extract_auth_context_typed",
+            return_value=mock_ctx,
+        ):
+            response = client.post("/admin/sessions/revoke")
+            assert response.status_code == 200
+            assert response.json() == {"status": "revoked"}
+
+    def test_non_operator_gets_403(self, app: FastAPI, client: TestClient) -> None:
+        """Non-operators should receive 403 Access denied."""
+
+        @app.post("/admin/sessions/revoke")
+        @require_role("operator")
+        async def revoke_sessions(request: Request) -> dict[str, str]:
+            return {"status": "revoked"}
+
+        mock_ctx = mock_auth_context(roles=["free"])
+
+        with patch(
+            "src.lambdas.shared.middleware.require_role.extract_auth_context_typed",
+            return_value=mock_ctx,
+        ):
+            response = client.post("/admin/sessions/revoke")
+            assert response.status_code == 403
+            assert response.json()["detail"] == "Access denied"
+
+    def test_unauthenticated_user_gets_401(
+        self, app: FastAPI, client: TestClient
+    ) -> None:
+        """Unauthenticated users should receive 401 Authentication required."""
+
+        @app.post("/admin/sessions/revoke")
+        @require_role("operator")
+        async def revoke_sessions(request: Request) -> dict[str, str]:
+            return {"status": "revoked"}
+
+        mock_ctx = mock_auth_context(user_id=None, roles=None)
+
+        with patch(
+            "src.lambdas.shared.middleware.require_role.extract_auth_context_typed",
+            return_value=mock_ctx,
+        ):
+            response = client.post("/admin/sessions/revoke")
+            assert response.status_code == 401
+            assert response.json()["detail"] == "Authentication required"
+
+    def test_missing_roles_claim_gets_401(
+        self, app: FastAPI, client: TestClient
+    ) -> None:
+        """User with no roles claim should receive 401 Invalid token structure."""
+
+        @app.post("/admin/sessions/revoke")
+        @require_role("operator")
+        async def revoke_sessions(request: Request) -> dict[str, str]:
+            return {"status": "revoked"}
+
+        mock_ctx = mock_auth_context(user_id="test-user", roles=None)
+
+        with patch(
+            "src.lambdas.shared.middleware.require_role.extract_auth_context_typed",
+            return_value=mock_ctx,
+        ):
+            response = client.post("/admin/sessions/revoke")
+            assert response.status_code == 401
+            assert response.json()["detail"] == "Invalid token structure"
+
+
+class TestGenericErrorMessages:
+    """Tests for role enumeration prevention (FR-004)."""
+
+    def test_error_does_not_reveal_required_role(
+        self, app: FastAPI, client: TestClient
+    ) -> None:
+        """403 error should NOT reveal what role is required."""
+
+        @app.post("/admin/endpoint")
+        @require_role("operator")
+        async def admin_endpoint(request: Request) -> dict[str, str]:
+            return {"status": "ok"}
+
+        mock_ctx = mock_auth_context(roles=["free"])
+
+        with patch(
+            "src.lambdas.shared.middleware.require_role.extract_auth_context_typed",
+            return_value=mock_ctx,
+        ):
+            response = client.post("/admin/endpoint")
+            detail = response.json()["detail"]
+            # Must NOT contain the required role name
+            assert "operator" not in detail.lower()
+            assert detail == "Access denied"
+
+    def test_all_role_failures_use_same_message(
+        self, app: FastAPI, client: TestClient
+    ) -> None:
+        """All role check failures should return the same generic message."""
+
+        @app.post("/endpoint-operator")
+        @require_role("operator")
+        async def operator_endpoint(request: Request) -> dict[str, str]:
+            return {"status": "ok"}
+
+        @app.post("/endpoint-paid")
+        @require_role("paid")
+        async def paid_endpoint(request: Request) -> dict[str, str]:
+            return {"status": "ok"}
+
+        mock_ctx = mock_auth_context(roles=["anonymous"])
+
+        with patch(
+            "src.lambdas.shared.middleware.require_role.extract_auth_context_typed",
+            return_value=mock_ctx,
+        ):
+            response1 = client.post("/endpoint-operator")
+            response2 = client.post("/endpoint-paid")
+
+            # Both should have identical error responses
+            assert response1.status_code == response2.status_code == 403
+            assert response1.json()["detail"] == response2.json()["detail"]
+            assert response1.json()["detail"] == "Access denied"
+
+
+class TestStartupValidation:
+    """Tests for decoration-time role validation (FR-005)."""
+
+    def test_invalid_role_raises_at_decoration_time(self) -> None:
+        """Invalid role parameter should raise InvalidRoleError immediately."""
+        with pytest.raises(InvalidRoleError) as exc_info:
+
+            @require_role("admn")  # Typo!
+            async def endpoint(request: Request) -> dict[str, str]:
+                return {"status": "ok"}
+
+        assert exc_info.value.role == "admn"
+        assert exc_info.value.valid_roles == VALID_ROLES
+
+    def test_invalid_role_error_message_lists_valid_roles(self) -> None:
+        """InvalidRoleError message should list valid roles for debugging."""
+        with pytest.raises(InvalidRoleError) as exc_info:
+
+            @require_role("superuser")
+            async def endpoint(request: Request) -> dict[str, str]:
+                return {"status": "ok"}
+
+        error_message = str(exc_info.value)
+        assert "superuser" in error_message
+        assert "Valid roles:" in error_message
+        # Valid roles should be listed
+        for role in ["anonymous", "free", "paid", "operator"]:
+            assert role in error_message
+
+    @pytest.mark.parametrize("valid_role", ["anonymous", "free", "paid", "operator"])
+    def test_valid_roles_do_not_raise(self, valid_role: str) -> None:
+        """Valid role parameters should not raise at decoration time."""
+
+        # Should not raise
+        @require_role(valid_role)
+        async def endpoint(request: Request) -> dict[str, str]:
+            return {"status": "ok"}
+
+
+# ============================================================================
+# US2: Support Multiple Role Levels (P2)
+# ============================================================================
+
+
+class TestPaidRoleRequirement:
+    """Tests for paid role access control (US2)."""
+
+    def test_paid_user_can_access_paid_endpoint(
+        self, app: FastAPI, client: TestClient
+    ) -> None:
+        """Paid users should access @require_role('paid') endpoints."""
+
+        @app.get("/premium/analytics")
+        @require_role("paid")
+        async def premium_analytics(request: Request) -> dict[str, str]:
+            return {"data": "premium"}
+
+        mock_ctx = mock_auth_context(roles=["free", "paid"])
+
+        with patch(
+            "src.lambdas.shared.middleware.require_role.extract_auth_context_typed",
+            return_value=mock_ctx,
+        ):
+            response = client.get("/premium/analytics")
+            assert response.status_code == 200
+
+    def test_free_user_cannot_access_paid_endpoint(
+        self, app: FastAPI, client: TestClient
+    ) -> None:
+        """Free users should not access @require_role('paid') endpoints."""
+
+        @app.get("/premium/analytics")
+        @require_role("paid")
+        async def premium_analytics(request: Request) -> dict[str, str]:
+            return {"data": "premium"}
+
+        mock_ctx = mock_auth_context(roles=["free"])
+
+        with patch(
+            "src.lambdas.shared.middleware.require_role.extract_auth_context_typed",
+            return_value=mock_ctx,
+        ):
+            response = client.get("/premium/analytics")
+            assert response.status_code == 403
+
+
+class TestFreeRoleRequirement:
+    """Tests for free role access control (US2)."""
+
+    def test_free_user_can_access_free_endpoint(
+        self, app: FastAPI, client: TestClient
+    ) -> None:
+        """Free users should access @require_role('free') endpoints."""
+
+        @app.get("/basic/feature")
+        @require_role("free")
+        async def basic_feature(request: Request) -> dict[str, str]:
+            return {"data": "basic"}
+
+        mock_ctx = mock_auth_context(roles=["free"])
+
+        with patch(
+            "src.lambdas.shared.middleware.require_role.extract_auth_context_typed",
+            return_value=mock_ctx,
+        ):
+            response = client.get("/basic/feature")
+            assert response.status_code == 200
+
+
+class TestRoleAccumulation:
+    """Tests for role accumulation behavior (US2)."""
+
+    def test_operator_can_access_paid_endpoint(
+        self, app: FastAPI, client: TestClient
+    ) -> None:
+        """Operators with paid role should access @require_role('paid') endpoints."""
+
+        @app.get("/premium/analytics")
+        @require_role("paid")
+        async def premium_analytics(request: Request) -> dict[str, str]:
+            return {"data": "premium"}
+
+        # Operator has accumulated roles
+        mock_ctx = mock_auth_context(roles=["free", "paid", "operator"])
+
+        with patch(
+            "src.lambdas.shared.middleware.require_role.extract_auth_context_typed",
+            return_value=mock_ctx,
+        ):
+            response = client.get("/premium/analytics")
+            assert response.status_code == 200
+
+    def test_operator_can_access_free_endpoint(
+        self, app: FastAPI, client: TestClient
+    ) -> None:
+        """Operators with free role should access @require_role('free') endpoints."""
+
+        @app.get("/basic/feature")
+        @require_role("free")
+        async def basic_feature(request: Request) -> dict[str, str]:
+            return {"data": "basic"}
+
+        mock_ctx = mock_auth_context(roles=["free", "operator"])
+
+        with patch(
+            "src.lambdas.shared.middleware.require_role.extract_auth_context_typed",
+            return_value=mock_ctx,
+        ):
+            response = client.get("/basic/feature")
+            assert response.status_code == 200
+
+
+# ============================================================================
+# US3: Composable with Existing Auth (P3)
+# ============================================================================
+
+
+class TestDependencyInjectionCompatibility:
+    """Tests for compatibility with FastAPI Depends() (US3)."""
+
+    def test_decorator_works_with_depends(
+        self, app: FastAPI, client: TestClient
+    ) -> None:
+        """Decorator should work alongside Depends() injected parameters."""
+
+        def get_config() -> dict[str, str]:
+            return {"setting": "value"}
+
+        @app.post("/admin/config")
+        @require_role("operator")
+        async def update_config(
+            request: Request,
+            config: dict[str, str] = Depends(get_config),  # noqa: B008
+        ) -> dict[str, Any]:
+            return {"config": config}
+
+        mock_ctx = mock_auth_context(roles=["free", "operator"])
+
+        with patch(
+            "src.lambdas.shared.middleware.require_role.extract_auth_context_typed",
+            return_value=mock_ctx,
+        ):
+            response = client.post("/admin/config")
+            assert response.status_code == 200
+            assert response.json()["config"] == {"setting": "value"}
+
+    def test_decorator_preserves_function_signature(self) -> None:
+        """Decorator should preserve the wrapped function's metadata."""
+
+        @require_role("operator")
+        async def my_endpoint(request: Request) -> dict[str, str]:
+            """My endpoint docstring."""
+            return {"status": "ok"}
+
+        assert my_endpoint.__name__ == "my_endpoint"
+        assert my_endpoint.__doc__ == "My endpoint docstring."
+
+
+class TestAsyncHandlerCompatibility:
+    """Tests for async handler compatibility (US3)."""
+
+    def test_decorator_works_with_async_handlers(
+        self, app: FastAPI, client: TestClient
+    ) -> None:
+        """Decorator should work with async def handlers."""
+
+        @app.get("/async/endpoint")
+        @require_role("free")
+        async def async_endpoint(request: Request) -> dict[str, str]:
+            return {"async": "true"}
+
+        mock_ctx = mock_auth_context(roles=["free"])
+
+        with patch(
+            "src.lambdas.shared.middleware.require_role.extract_auth_context_typed",
+            return_value=mock_ctx,
+        ):
+            response = client.get("/async/endpoint")
+            assert response.status_code == 200
+            assert response.json() == {"async": "true"}
+
+    def test_decorator_with_multiple_dependencies(
+        self, app: FastAPI, client: TestClient
+    ) -> None:
+        """Decorator should work with multiple Depends() parameters."""
+
+        def get_db() -> MagicMock:
+            return MagicMock(name="db")
+
+        def get_cache() -> MagicMock:
+            return MagicMock(name="cache")
+
+        @app.post("/admin/operation")
+        @require_role("operator")
+        async def admin_operation(
+            request: Request,
+            db: MagicMock = Depends(get_db),  # noqa: B008
+            cache: MagicMock = Depends(get_cache),  # noqa: B008
+        ) -> dict[str, str]:
+            return {"db": str(db), "cache": str(cache)}
+
+        mock_ctx = mock_auth_context(roles=["free", "operator"])
+
+        with patch(
+            "src.lambdas.shared.middleware.require_role.extract_auth_context_typed",
+            return_value=mock_ctx,
+        ):
+            response = client.post("/admin/operation")
+            assert response.status_code == 200
+
+
+# ============================================================================
+# Edge Cases
+# ============================================================================
+
+
+class TestEdgeCases:
+    """Tests for edge cases and boundary conditions."""
+
+    def test_empty_roles_list_returns_403(
+        self, app: FastAPI, client: TestClient
+    ) -> None:
+        """Empty roles list should result in 403 for any role requirement."""
+
+        @app.get("/endpoint")
+        @require_role("free")
+        async def endpoint(request: Request) -> dict[str, str]:
+            return {"status": "ok"}
+
+        mock_ctx = mock_auth_context(roles=[])
+
+        with patch(
+            "src.lambdas.shared.middleware.require_role.extract_auth_context_typed",
+            return_value=mock_ctx,
+        ):
+            response = client.get("/endpoint")
+            assert response.status_code == 403
+
+    def test_case_sensitive_role_matching(
+        self, app: FastAPI, client: TestClient
+    ) -> None:
+        """Role matching should be case-sensitive."""
+
+        @app.get("/endpoint")
+        @require_role("operator")
+        async def endpoint(request: Request) -> dict[str, str]:
+            return {"status": "ok"}
+
+        # Roles with wrong case
+        mock_ctx = mock_auth_context(roles=["OPERATOR", "Operator"])
+
+        with patch(
+            "src.lambdas.shared.middleware.require_role.extract_auth_context_typed",
+            return_value=mock_ctx,
+        ):
+            response = client.get("/endpoint")
+            assert response.status_code == 403  # Case mismatch should fail
+
+    def test_anonymous_role_for_public_with_tracking(
+        self, app: FastAPI, client: TestClient
+    ) -> None:
+        """Anonymous role should work for public content with session tracking."""
+
+        @app.get("/public/content")
+        @require_role("anonymous")
+        async def public_content(request: Request) -> dict[str, str]:
+            return {"content": "public"}
+
+        mock_ctx = mock_auth_context(roles=["anonymous"])
+
+        with patch(
+            "src.lambdas.shared.middleware.require_role.extract_auth_context_typed",
+            return_value=mock_ctx,
+        ):
+            response = client.get("/public/content")
+            assert response.status_code == 200

--- a/tests/unit/test_secrets.py
+++ b/tests/unit/test_secrets.py
@@ -184,8 +184,11 @@ class TestGetSecret:
 
     def test_cache_expiry(self, secrets_manager, monkeypatch):
         """Test that cache expires after TTL."""
-        # Set short TTL for test
-        os.environ["SECRETS_CACHE_TTL_SECONDS"] = "1"
+        # Clear any stale cache entries from previous tests
+        clear_cache()
+
+        # Set short TTL for test (use monkeypatch for proper cleanup)
+        monkeypatch.setenv("SECRETS_CACHE_TTL_SECONDS", "1")
 
         # First call - caches the secret
         get_secret("dev/sentiment-analyzer/tiingo")


### PR DESCRIPTION
## Summary
- Add `@require_role(role)` decorator for role-based access control
- Implement Role enum with canonical values (anonymous, free, paid, operator)
- Extend AuthContext with `roles` field from JWT claims
- Add error types: InvalidRoleError, MissingRolesClaimError, InsufficientRoleError

## Security
- Generic "Access denied" message prevents role enumeration attacks (FR-004)
- Startup validation catches invalid role parameters (FR-005)
- Integrates with existing `extract_auth_context_typed()` (FR-010)

## Files Changed
- `src/lambdas/shared/auth/constants.py` - Role enum and VALID_ROLES
- `src/lambdas/shared/errors/auth_errors.py` - Role exception classes
- `src/lambdas/shared/middleware/require_role.py` - Decorator implementation
- `src/lambdas/shared/middleware/auth_middleware.py` - AuthContext roles field

## Test Plan
- [x] 46 unit tests covering US1-US3 scenarios
- [x] Operator access control tests
- [x] Generic error message verification
- [x] Startup validation tests
- [x] Depends() compatibility tests

Refs: #1130

🤖 Generated with [Claude Code](https://claude.com/claude-code)