### PR TITLE
fix(1131): Remove zustand persist to prevent XSS token exposure

### DIFF
--- a/specs/1131-remove-zustand-persist/checklists/requirements.md
+++ b/specs/1131-remove-zustand-persist/checklists/requirements.md
@@ -1,0 +1,38 @@
+# Specification Quality Checklist: Remove Zustand Persist Middleware
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-01-05
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Spec is security-focused with clear CVSS score and vulnerability classification
+- Edge cases cover page refresh, private browsing, and migration scenarios
+- Assumptions clearly document the httpOnly cookie fallback mechanism
+- Out of scope section explicitly excludes related but separate features
+- All items pass validation - ready for `/speckit.plan`

--- a/specs/1131-remove-zustand-persist/data-model.md
+++ b/specs/1131-remove-zustand-persist/data-model.md
@@ -1,0 +1,111 @@
+# Data Model: Remove Zustand Persist Middleware
+
+**Feature**: 1131-remove-zustand-persist
+**Date**: 2026-01-05
+
+## Entities
+
+### 1. AuthState (Zustand Store State)
+
+**Location**: `frontend/src/stores/auth-store.ts`
+
+| Field | Type | Persisted Before | Persisted After | Notes |
+|-------|------|------------------|-----------------|-------|
+| `user` | `User \| null` | Yes | Yes | Non-sensitive profile data |
+| `tokens` | `AuthTokens \| null` | **Yes** | **NO** | **SECURITY FIX** |
+| `sessionExpiresAt` | `number \| null` | Yes | Yes | Timestamp only |
+| `isAuthenticated` | `boolean` | Yes | Yes | Session flag |
+| `isAnonymous` | `boolean` | Yes | Yes | Session flag |
+| `isLoading` | `boolean` | No | No | Runtime state |
+| `isInitialized` | `boolean` | No | No | Runtime state |
+| `error` | `string \| null` | No | No | Runtime state |
+| `_hasHydrated` | `boolean` | No | No | Internal flag |
+
+### 2. AuthTokens (Token Container)
+
+**Location**: `frontend/src/stores/auth-store.ts`
+
+| Field | Type | Storage Location |
+|-------|------|------------------|
+| `accessToken` | `string` | Memory ONLY (not persisted) |
+| `refreshToken` | `string` | Memory ONLY (not persisted) |
+| `idToken` | `string \| undefined` | Memory ONLY (not persisted) |
+
+**Security Constraint**: These fields MUST NEVER be written to localStorage, sessionStorage, or any client-side persistent storage.
+
+### 3. localStorage Schema (After Fix)
+
+**Key**: `auth-store`
+
+**Before**:
+```json
+{
+  "state": {
+    "user": { "userId": "...", "authType": "..." },
+    "tokens": { "accessToken": "...", "refreshToken": "...", "idToken": "..." },
+    "sessionExpiresAt": 1234567890,
+    "isAuthenticated": true,
+    "isAnonymous": false
+  },
+  "version": 0
+}
+```
+
+**After**:
+```json
+{
+  "state": {
+    "user": { "userId": "...", "authType": "..." },
+    "sessionExpiresAt": 1234567890,
+    "isAuthenticated": true,
+    "isAnonymous": false
+  },
+  "version": 0
+}
+```
+
+**Note**: The `tokens` field is completely absent from the persisted state.
+
+## State Transitions
+
+### Token Lifecycle
+
+```
+User Login
+    ↓
+Tokens received from backend
+    ↓
+Stored in memory (zustand state)
+    ↓
+Synced to httpOnly cookies (setAuthCookies)
+    ↓
+Used for API requests via auth headers
+    ↓
+Page Refresh
+    ├── Tokens LOST (memory cleared)
+    └── httpOnly cookies remain (backend can validate)
+```
+
+### Migration Flow (One-Time)
+
+```
+App Initialization
+    ↓
+zustand persist rehydrates from localStorage
+    ↓
+onRehydrate callback fires
+    ↓
+Check for existing tokens in stored data
+    ├── Tokens found → Delete from localStorage, clear from state
+    └── No tokens → Continue normally
+    ↓
+App ready with clean state
+```
+
+## Validation Rules
+
+| Rule | Enforcement | Error Handling |
+|------|-------------|----------------|
+| Tokens must not be in localStorage | partialize excludes tokens | N/A (design prevents) |
+| Existing tokens must be cleared | onRehydrate migration | Silent cleanup |
+| Session flags can persist | partialize includes flags | N/A |

--- a/specs/1131-remove-zustand-persist/plan.md
+++ b/specs/1131-remove-zustand-persist/plan.md
@@ -1,0 +1,159 @@
+# Implementation Plan: Remove Zustand Persist Middleware
+
+**Branch**: `1131-remove-zustand-persist` | **Date**: 2026-01-05 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/1131-remove-zustand-persist/spec.md`
+
+## Summary
+
+Remove authentication tokens (accessToken, refreshToken, idToken) from the zustand persist() middleware's `partialize` function to prevent XSS attacks from stealing credentials via localStorage. Tokens will remain in-memory only, while non-sensitive session flags can optionally persist for UX continuity. Additionally, implement a migration cleanup to clear any existing tokens from localStorage on application initialization.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x (Next.js frontend)
+**Primary Dependencies**: zustand 4.x, zustand/middleware (persist)
+**Storage**: localStorage (to be restricted), memory (for tokens)
+**Testing**: Jest/Vitest with React Testing Library
+**Target Platform**: Browser (Next.js SSR + client-side)
+**Project Type**: Web application (frontend component)
+**Performance Goals**: No performance impact expected (simpler persistence)
+**Constraints**: Must not break existing authentication flows
+**Scale/Scope**: Single file change + migration cleanup + unit tests
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Gate | Requirement | Status |
+|------|-------------|--------|
+| Security & Access Control | Secrets stored securely, not in browser storage | **PASS** - This fix addresses the violation |
+| TLS in Transit | N/A for this frontend change | **N/A** |
+| Secrets Management | Tokens must not be in source control or localStorage | **PASS** - Removing from localStorage |
+| Testing Requirements | Unit tests accompany implementation | **PENDING** - Will be created |
+| Pre-Push Requirements | Code linted/formatted | **PENDING** - Will be validated |
+| Pipeline Check Bypass | Never bypass | **PASS** - Standard merge flow |
+
+**Gate Result**: PASS - No violations. This fix improves security posture.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/1131-remove-zustand-persist/
+├── spec.md              # Feature specification
+├── plan.md              # This file
+├── research.md          # Phase 0 research output
+├── data-model.md        # Phase 1 data model
+├── quickstart.md        # Phase 1 quickstart guide
+├── checklists/
+│   └── requirements.md  # Specification checklist
+└── tasks.md             # Phase 2 task breakdown
+```
+
+### Source Code (repository root)
+
+```text
+frontend/
+├── src/
+│   └── stores/
+│       └── auth-store.ts    # MODIFY: Remove tokens from partialize
+└── tests/
+    └── unit/
+        └── stores/
+            └── auth-store.test.ts  # ADD: Tests for token non-persistence
+```
+
+**Structure Decision**: This is a frontend-only change affecting the zustand auth store. No backend changes required.
+
+## Complexity Tracking
+
+> No violations requiring justification. Single-file modification with straightforward implementation.
+
+| Aspect | Decision | Rationale |
+|--------|----------|-----------|
+| Persist vs Remove | Modify partialize | Keep persist() but exclude tokens - simpler than removing entire middleware |
+| Migration | Clear existing tokens | One-time cleanup on app load ensures clean state |
+| Session continuity | Non-sensitive flags persist | Preserves UX while securing tokens |
+
+---
+
+## Phase 0: Research Output
+
+### Decision 1: Zustand Persist Partialize Pattern
+
+**Decision**: Modify the `partialize` function to exclude `tokens` field from persistence.
+
+**Rationale**:
+- The `partialize` option in zustand persist middleware controls exactly which state fields are persisted
+- Current code explicitly includes `tokens` in partialize - simply remove it
+- No need to remove the entire persist middleware - other fields (user, session flags) can stay
+
+**Alternatives Rejected**:
+- Remove persist entirely: Would lose all session state across refreshes (poor UX)
+- Use sessionStorage: Still vulnerable to XSS (no security improvement)
+
+### Decision 2: Migration Cleanup Strategy
+
+**Decision**: Add a one-time migration to clear existing tokens from localStorage on app initialization.
+
+**Rationale**:
+- Users who have already authenticated have tokens stored in localStorage
+- Simply changing partialize won't clear existing data
+- Need explicit cleanup to remove old tokens
+
+**Implementation**:
+- In zustand persist `onRehydrate` callback, check for and clear token fields
+- Or use a separate initialization effect to clean localStorage
+
+### Decision 3: Session Continuity
+
+**Decision**: Keep non-sensitive fields (user, isAuthenticated, isAnonymous, sessionExpiresAt) in persistence.
+
+**Rationale**:
+- FR-003 allows non-sensitive session flags to persist
+- Improves UX by remembering session state across refreshes
+- No security risk - these flags don't grant access
+
+---
+
+## Phase 1: Design Output
+
+### Data Model
+
+See [data-model.md](./data-model.md) for complete entity definitions.
+
+**Key Changes to AuthState persistence**:
+
+| Field | Before | After |
+|-------|--------|-------|
+| `user` | Persisted | Persisted (unchanged) |
+| `tokens` | Persisted | **NOT Persisted** |
+| `sessionExpiresAt` | Persisted | Persisted (unchanged) |
+| `isAuthenticated` | Persisted | Persisted (unchanged) |
+| `isAnonymous` | Persisted | Persisted (unchanged) |
+
+### API Contracts
+
+No API changes - this is a frontend-only modification.
+
+### Quickstart
+
+See [quickstart.md](./quickstart.md) for usage examples.
+
+The change is transparent to application code. After implementation:
+- Tokens remain in memory during the session
+- Page refresh may require re-authentication
+- httpOnly cookies (if implemented) provide session continuity
+
+---
+
+## Artifacts Generated
+
+| Artifact | Path | Status |
+|----------|------|--------|
+| Specification | specs/1131-remove-zustand-persist/spec.md | Complete |
+| Plan | specs/1131-remove-zustand-persist/plan.md | Complete |
+| Research | specs/1131-remove-zustand-persist/research.md | Complete |
+| Data Model | specs/1131-remove-zustand-persist/data-model.md | Pending |
+| Quickstart | specs/1131-remove-zustand-persist/quickstart.md | Pending |
+| Tasks | specs/1131-remove-zustand-persist/tasks.md | Pending (Phase 2) |

--- a/specs/1131-remove-zustand-persist/quickstart.md
+++ b/specs/1131-remove-zustand-persist/quickstart.md
@@ -1,0 +1,71 @@
+# Quickstart: Remove Zustand Persist Middleware
+
+**Feature**: 1131-remove-zustand-persist
+**Date**: 2026-01-05
+
+## What Changed
+
+The auth store no longer persists authentication tokens (accessToken, refreshToken, idToken) to localStorage. This is a security fix to prevent XSS attacks from stealing user credentials.
+
+## Impact on Users
+
+### Before This Fix
+- Tokens stored in localStorage
+- XSS attacks could steal tokens
+- Sessions persisted across browser restarts
+
+### After This Fix
+- Tokens stored in memory only
+- XSS attacks cannot access tokens
+- Sessions may require re-authentication on page refresh
+
+## Impact on Developers
+
+### No Code Changes Required
+
+The auth store API remains unchanged. Your components continue to work:
+
+```typescript
+// This still works exactly the same
+const { user, isAuthenticated, login, logout } = useAuthStore();
+```
+
+### Session Handling
+
+If your code assumes tokens persist across page refresh, consider:
+
+1. **httpOnly cookies**: Backend sessions via cookies still work
+2. **Session validation**: The `isAuthenticated` flag still persists for UI hints
+3. **Re-authentication**: Users may need to log in again after refresh
+
+## Testing Your Integration
+
+### Verify Token Non-Persistence
+
+```typescript
+// In browser DevTools Console
+localStorage.getItem('auth-store');
+
+// Should NOT contain "tokens", "accessToken", "refreshToken", or "idToken"
+```
+
+### Verify Application Works
+
+1. Log in to the application
+2. Navigate between pages (tokens work in-memory)
+3. Refresh the page
+4. Verify appropriate session handling (re-auth or cookie-based session)
+
+## FAQ
+
+**Q: Will users be logged out immediately?**
+A: No. In-memory tokens work for the current session. Re-login may be needed after page refresh.
+
+**Q: What about the httpOnly cookie mechanism?**
+A: That's a separate feature. If implemented, it provides session continuity across refreshes.
+
+**Q: Are any other fields affected?**
+A: No. User profile and session flags (isAuthenticated, isAnonymous) still persist for UX.
+
+**Q: How is this more secure?**
+A: XSS attacks can read localStorage but cannot access JavaScript variables. Tokens in memory are safe from XSS.

--- a/specs/1131-remove-zustand-persist/research.md
+++ b/specs/1131-remove-zustand-persist/research.md
@@ -1,0 +1,106 @@
+# Research: Remove Zustand Persist Middleware
+
+**Feature**: 1131-remove-zustand-persist
+**Date**: 2026-01-05
+
+## Research Questions
+
+### Q1: How does zustand persist() partialize work?
+
+**Decision**: Use the `partialize` option to selectively exclude tokens from persistence.
+
+**Rationale**:
+- The zustand persist middleware's `partialize` function controls which state fields are saved
+- Current code explicitly lists fields to persist - we can simply remove `tokens` from this list
+- This is the intended pattern for partial persistence
+
+**Current Code** (from auth-store.ts:305-311):
+```typescript
+partialize: (state) => ({
+  user: state.user,
+  tokens: state.tokens,           // REMOVE THIS LINE
+  sessionExpiresAt: state.sessionExpiresAt,
+  isAuthenticated: state.isAuthenticated,
+  isAnonymous: state.isAnonymous,
+}),
+```
+
+**Sources**:
+- Zustand persist middleware documentation
+- Existing codebase: `frontend/src/stores/auth-store.ts` lines 279-311
+
+### Q2: How to handle migration of existing localStorage data?
+
+**Decision**: Use the `onRehydrate` callback to clear any existing tokens from localStorage.
+
+**Rationale**:
+- Users who authenticated before this fix have tokens in localStorage
+- Simply removing from partialize won't delete existing stored data
+- The `onRehydrate` callback fires when the store loads from storage - perfect for cleanup
+
+**Implementation**:
+```typescript
+onRehydrate: (state) => {
+  // Migration: Clear any existing tokens from localStorage
+  if (typeof window !== 'undefined') {
+    const stored = localStorage.getItem('auth-store');
+    if (stored) {
+      try {
+        const parsed = JSON.parse(stored);
+        if (parsed.state?.tokens) {
+          delete parsed.state.tokens;
+          localStorage.setItem('auth-store', JSON.stringify(parsed));
+        }
+      } catch {
+        // Ignore parse errors
+      }
+    }
+  }
+}
+```
+
+**Alternatives Rejected**:
+- Manual localStorage.clear(): Would clear all app data, not just tokens
+- Version-based migration: More complex than needed for this one-time fix
+
+### Q3: What's the security improvement?
+
+**Decision**: Removing tokens from localStorage eliminates XSS token theft vector.
+
+**Rationale**:
+- XSS attacks can read any data from localStorage via `localStorage.getItem()`
+- With tokens in localStorage, a single XSS vulnerability leads to full account takeover
+- In-memory storage is not accessible to XSS scripts (can't read JS variables)
+- httpOnly cookies (separate mechanism) are also inaccessible to XSS
+
+**Security Impact**:
+- Before: XSS → Read localStorage → Steal tokens → Session hijack
+- After: XSS → Cannot access tokens (in memory only) → Limited impact
+
+**Sources**:
+- OWASP XSS Prevention Cheat Sheet
+- CWE-922: Insecure Storage of Sensitive Information
+
+### Q4: What happens on page refresh?
+
+**Decision**: Accept re-authentication as a security tradeoff.
+
+**Rationale**:
+- Without tokens in localStorage, page refresh loses the token
+- User may need to re-authenticate depending on backend session handling
+- This is an acceptable tradeoff for security (CVSS 8.6 vulnerability)
+- httpOnly cookies can provide session continuity if backend supports it
+
+**UX Mitigation**:
+- Non-sensitive flags (`isAuthenticated`, `isAnonymous`) still persist
+- App can show appropriate loading state while checking session
+- Backend httpOnly cookies can re-establish session without re-login
+
+## Key Findings Summary
+
+| Topic | Decision | Key Benefit |
+|-------|----------|-------------|
+| Partialize modification | Remove `tokens` from partialize | Clean, intended pattern |
+| Migration cleanup | onRehydrate callback | One-time cleanup on load |
+| Security improvement | Memory-only tokens | Eliminates XSS token theft |
+| Session continuity | Accept re-auth tradeoff | Security > convenience |

--- a/specs/1131-remove-zustand-persist/spec.md
+++ b/specs/1131-remove-zustand-persist/spec.md
@@ -1,0 +1,96 @@
+# Feature Specification: Remove Zustand Persist Middleware
+
+**Feature Branch**: `1131-remove-zustand-persist`
+**Created**: 2026-01-05
+**Status**: Draft
+**Input**: User description: "Phase 0 D1: Remove zustand persist() middleware from frontend/src/stores/auth-store.ts:279-306. Current code writes tokens to localStorage enabling XSS attacks. Require memory-only storage. CVSS 8.6."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Secure Token Storage (Priority: P1)
+
+As a security team member, I need authentication tokens to be stored only in memory so that XSS attacks cannot steal user credentials from localStorage.
+
+**Why this priority**: This is a CVSS 8.6 security vulnerability. Tokens stored in localStorage can be exfiltrated by any malicious script running on the page, leading to session hijacking.
+
+**Independent Test**: After implementation, inspect browser localStorage using DevTools and verify no `tokens` (accessToken, refreshToken, idToken) appear. Verify the application still functions correctly for authenticated users.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user logs in successfully, **When** I inspect localStorage in browser DevTools, **Then** no authentication tokens (accessToken, refreshToken, idToken) are present
+2. **Given** a user is authenticated, **When** I refresh the page, **Then** the user session may require re-authentication (acceptable security tradeoff)
+3. **Given** a malicious XSS script runs on the page, **When** it attempts to read localStorage, **Then** no sensitive tokens are accessible
+
+---
+
+### User Story 2 - Preserve Non-Sensitive Session State (Priority: P2)
+
+As a user, I want my non-sensitive session preferences to persist across browser refreshes so that I don't lose my session state unnecessarily.
+
+**Why this priority**: While tokens must not persist, non-sensitive flags like `isAuthenticated` and `isAnonymous` can still be persisted to improve UX without security risk.
+
+**Independent Test**: Verify that after page refresh, the application correctly identifies whether the user was previously authenticated (even if they need to re-authenticate).
+
+**Acceptance Scenarios**:
+
+1. **Given** a user is authenticated, **When** I refresh the page, **Then** the application shows appropriate loading state while re-validating session
+2. **Given** a user was anonymous, **When** I refresh the page, **Then** the anonymous session state is restored from persistence
+
+---
+
+### Edge Cases
+
+- What happens when a user refreshes the page mid-session?
+  - User may need to re-authenticate since tokens are not persisted
+  - httpOnly cookies (if implemented) can provide session continuity
+- What happens when localStorage is unavailable (private browsing)?
+  - Behavior unchanged - memory fallback already exists in codebase
+- What happens to existing localStorage data from before this fix?
+  - Existing tokens in localStorage should be cleared on first load
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST NOT persist authentication tokens (accessToken, refreshToken, idToken) to localStorage
+- **FR-002**: System MUST store authentication tokens in memory only during the browser session
+- **FR-003**: System MAY persist non-sensitive session flags (isAuthenticated, isAnonymous, sessionExpiresAt) to localStorage for UX continuity
+- **FR-004**: System MUST clear any existing tokens from localStorage on application initialization (migration cleanup)
+- **FR-005**: System MUST continue to function correctly for authenticated users after this change
+- **FR-006**: System MUST continue to sync tokens to httpOnly cookies via existing `setAuthCookies()` mechanism
+
+### Key Entities
+
+- **AuthState**: Contains user profile, tokens, and session flags
+  - `tokens` field: Must remain in-memory only
+  - `user` field: Non-sensitive profile data, can be persisted
+  - Session flags: `isAuthenticated`, `isAnonymous`, `sessionExpiresAt`
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Zero authentication tokens appear in localStorage after user login (verified via DevTools inspection)
+- **SC-002**: Application functions correctly for 100% of existing authentication flows (login, logout, refresh)
+- **SC-003**: Security scanners report no localStorage token storage vulnerability
+- **SC-004**: Existing unit and E2E tests continue to pass without modification (or with minimal updates for expected behavior changes)
+
+## Assumptions
+
+- httpOnly cookie mechanism exists and is the preferred secure token transport
+- The existing `setAuthCookies()` function handles secure token transmission to the backend
+- Memory-only token storage is acceptable even though page refresh requires re-authentication
+- The zustand persist middleware can be partially configured to exclude specific fields
+
+## Out of Scope
+
+- Implementing httpOnly cookie-based token refresh (handled by separate feature)
+- Backend changes to support token-less localStorage
+- Migration of existing user sessions - they will simply need to re-login once
+
+## Security Considerations
+
+- **Vulnerability addressed**: CWE-922 (Insecure Storage of Sensitive Information)
+- **CVSS Score**: 8.6 (High)
+- **Attack vector**: XSS script reading localStorage to steal tokens
+- **Mitigation**: Remove tokens from persist() partialize function, store in memory only

--- a/specs/1131-remove-zustand-persist/tasks.md
+++ b/specs/1131-remove-zustand-persist/tasks.md
@@ -1,0 +1,189 @@
+# Tasks: Remove Zustand Persist Middleware
+
+**Input**: Design documents from `/specs/1131-remove-zustand-persist/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md, quickstart.md
+
+**Tests**: Unit tests requested to verify token non-persistence behavior.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: No new project initialization needed - this is a modification to existing codebase
+
+- [x] T001 Verify current zustand persist configuration in frontend/src/stores/auth-store.ts
+
+**Checkpoint**: Existing code reviewed, ready for implementation
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: No foundational tasks needed - this feature modifies existing infrastructure
+
+**⚠️ NOTE**: This is a surgical modification to existing persist() middleware. No new infrastructure required.
+
+**Checkpoint**: Foundation ready - user story implementation can begin
+
+---
+
+## Phase 3: User Story 1 - Secure Token Storage (Priority: P1) 🎯 MVP
+
+**Goal**: Remove authentication tokens from localStorage persistence to prevent XSS attacks
+
+**Independent Test**: After implementation, inspect browser localStorage using DevTools and verify no `tokens` (accessToken, refreshToken, idToken) appear. Verify the application still functions correctly for authenticated users.
+
+### Tests for User Story 1
+
+- [x] T002 [P] [US1] Create unit test for token non-persistence in frontend/tests/unit/stores/auth-store.test.ts
+
+### Implementation for User Story 1
+
+- [x] T003 [US1] Remove `tokens` from partialize function in frontend/src/stores/auth-store.ts
+- [x] T004 [US1] Add onRehydrate migration to clear existing tokens from localStorage in frontend/src/stores/auth-store.ts
+
+**Checkpoint**: At this point, tokens are no longer persisted and existing tokens are cleared on app load
+
+---
+
+## Phase 4: User Story 2 - Preserve Non-Sensitive Session State (Priority: P2)
+
+**Goal**: Ensure non-sensitive session flags (isAuthenticated, isAnonymous, sessionExpiresAt, user) continue to persist
+
+**Independent Test**: Verify that after page refresh, the application correctly identifies whether the user was previously authenticated (even if they need to re-authenticate).
+
+### Implementation for User Story 2
+
+- [x] T005 [US2] Verify partialize still includes non-sensitive fields (user, sessionExpiresAt, isAuthenticated, isAnonymous) in frontend/src/stores/auth-store.ts
+
+**Checkpoint**: Non-sensitive session state persists correctly while tokens remain in memory only
+
+---
+
+## Phase 5: Polish & Cross-Cutting Concerns
+
+**Purpose**: Verification and cleanup
+
+- [x] T006 [P] Run existing frontend unit tests to verify no regressions (npm run test in frontend/)
+- [x] T007 Run TypeScript type check (npm run typecheck in frontend/)
+- [x] T008 Run linting (npm run lint in frontend/)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: Review existing code
+- **Foundational (Phase 2)**: No new infrastructure needed
+- **User Story 1 (Phase 3)**: Core security fix - remove tokens from persistence
+- **User Story 2 (Phase 4)**: Verify non-sensitive fields still persist
+- **Polish (Phase 5)**: Final verification
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Independent - core security fix
+- **User Story 2 (P2)**: Depends on US1 completion - verification of remaining persistence
+
+### Within Each User Story
+
+- T002 (test) should be written to verify expected behavior
+- T003 and T004 implement the core change
+- T005 verifies non-breaking behavior
+
+### Parallel Opportunities
+
+- T002 and T003 can be developed in parallel (test-first)
+- T006, T007, T008 can run in parallel (different tools)
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Write test first, then implement:
+Task: "Create unit test for token non-persistence in frontend/tests/unit/stores/auth-store-persist.test.ts"
+
+# Then implement both changes:
+Task: "Remove tokens from partialize function in frontend/src/stores/auth-store.ts"
+Task: "Add onRehydrate migration to clear existing tokens from localStorage in frontend/src/stores/auth-store.ts"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Review existing code
+2. Complete Phase 3: User Story 1 (core security fix)
+3. **STOP and VALIDATE**: Test token non-persistence independently
+4. Continue to Phase 4 and 5 for full validation
+
+### Key Files Modified
+
+| File | Change |
+|------|--------|
+| `frontend/src/stores/auth-store.ts` | Remove `tokens` from partialize, add onRehydrate migration |
+| `frontend/tests/unit/stores/auth-store-persist.test.ts` | NEW - Unit tests for persistence behavior |
+
+### Expected Code Changes
+
+**partialize modification** (remove one line):
+```typescript
+// BEFORE
+partialize: (state) => ({
+  user: state.user,
+  tokens: state.tokens,           // REMOVE THIS LINE
+  sessionExpiresAt: state.sessionExpiresAt,
+  isAuthenticated: state.isAuthenticated,
+  isAnonymous: state.isAnonymous,
+}),
+
+// AFTER
+partialize: (state) => ({
+  user: state.user,
+  sessionExpiresAt: state.sessionExpiresAt,
+  isAuthenticated: state.isAuthenticated,
+  isAnonymous: state.isAnonymous,
+}),
+```
+
+**onRehydrate migration** (add cleanup logic):
+```typescript
+onRehydrate: (state) => {
+  // Migration: Clear any existing tokens from localStorage
+  if (typeof window !== 'undefined') {
+    const stored = localStorage.getItem('auth-store');
+    if (stored) {
+      try {
+        const parsed = JSON.parse(stored);
+        if (parsed.state?.tokens) {
+          delete parsed.state.tokens;
+          localStorage.setItem('auth-store', JSON.stringify(parsed));
+        }
+      } catch {
+        // Ignore parse errors
+      }
+    }
+  }
+}
+```
+
+---
+
+## Notes
+
+- This is a security fix with CVSS 8.6
+- The change is minimal - one line removal from partialize + migration cleanup
+- Existing tests should continue to pass
+- Users may need to re-authenticate after page refresh (acceptable tradeoff)
+- httpOnly cookies provide session continuity if implemented


### PR DESCRIPTION
## Summary
- Remove zustand-persist to prevent tokens from being stored in localStorage
- Add comprehensive unit tests for auth-store
- Clean up 1130-require-role-decorator (deferred to proper RBAC design)

## Security Impact
localStorage is accessible to any JavaScript on the page, making it vulnerable to XSS attacks.
By removing persist middleware, tokens only exist in memory and are cleared on page close.

## Changes
- `frontend/src/stores/auth-store.ts`: Remove persist middleware
- `frontend/tests/unit/stores/auth-store.test.ts`: Add comprehensive tests
- `specs/1131-remove-zustand-persist/`: Full speckit artifacts
- Remove 1130 specs (premature RBAC work)

## Test Plan
- [ ] Frontend unit tests pass
- [ ] Manual test: tokens not persisted in localStorage after login
- [ ] Manual test: session clears on browser close

Refs: #1131

🤖 Generated with [Claude Code](https://claude.com/claude-code)