### PR TITLE
fix(1146): Remove X-User-ID header fallback (CVSS 9.1 Critical)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1249,9 +1249,10 @@ jobs:
           echo "This ensures observability tests have real metrics to validate."
           echo ""
 
-          # Feature 1047: Use X-User-ID for session auth (consistent with all endpoints)
+          # Feature 1047: Use Bearer token for session auth (consistent with all endpoints)
           # API key auth was removed in Feature 1039 - all endpoints now use session auth
-          # Feature 1049: X-User-ID must be a valid UUID format
+          # Feature 1049: User ID must be a valid UUID format
+          # Feature 1146: X-User-ID header fallback removed - use Bearer only
           WARMUP_USER_ID="00000000-0000-0000-0000-000000000001"
 
           # Invoke dashboard Lambda multiple times to generate metrics
@@ -1262,10 +1263,10 @@ jobs:
             echo "  ⚠️ Health endpoint returned $HTTP_CODE (continuing, may be cold start)"
           fi
 
-          # Feature 1047: Use X-User-ID header for session auth
+          # Feature 1146: Use Bearer token for session auth (X-User-ID removed)
           echo "2. Invoking /api/v2/metrics endpoint (session auth)..."
           HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
-            -H "X-User-ID: ${WARMUP_USER_ID}" \
+            -H "Authorization: Bearer ${WARMUP_USER_ID}" \
             "${DASHBOARD_URL}/api/v2/metrics" || echo "000")
           echo "  HTTP $HTTP_CODE"
           if [ "$HTTP_CODE" != "200" ]; then
@@ -1274,10 +1275,10 @@ jobs:
             exit 1
           fi
 
-          # All endpoints now use X-User-ID header for session auth
+          # Feature 1146: All endpoints now use Bearer token for session auth
           echo "3. Invoking /api/v2/tickers/AAPL/sentiment/history endpoint (warmup only)..."
           HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
-            -H "X-User-ID: ${WARMUP_USER_ID}" \
+            -H "Authorization: Bearer ${WARMUP_USER_ID}" \
             "${DASHBOARD_URL}/api/v2/tickers/AAPL/sentiment/history" || echo "000")
           echo "  HTTP $HTTP_CODE (non-critical warmup, any response is acceptable)"
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,12 @@ Auto-generated from all feature plans. Last updated: 2025-11-26
 - N/A (configuration change) (1114-cors-api-gateway-fix)
 - TypeScript 5.x, React 18.x, Next.js 14.x (App Router) + zustand 5.x, @tanstack/react-query, next-auth (not used - custom auth), tailwindcss (1122-zustand-hydration-fix)
 - localStorage (zustand persist), React Query cache (1122-zustand-hydration-fix)
+- Python 3.13 + FastAPI, functools (stdlib), typing (stdlib) (1130-require-role-decorator)
+- N/A (roles read from JWT, no database access) (1130-require-role-decorator)
+- TypeScript 5.x (Next.js frontend) + Next.js, Zustand (state management) (1145-delete-cookies-ts)
+- N/A (removing storage mechanism) (1145-delete-cookies-ts)
+- Python 3.13 + FastAPI, PyJWT, boto3 (DynamoDB) (1146-remove-xuserid-fallback)
+- DynamoDB (users table, sessions) (1146-remove-xuserid-fallback)
 
 - **Python 3.13** with FastAPI, boto3, pydantic, aws-lambda-powertools, httpx
 - **AWS Services**: DynamoDB (single-table design), S3, Lambda, SNS, EventBridge, Cognito, CloudFront
@@ -828,9 +834,9 @@ aws cloudwatch get-metric-data --metric-data-queries '[...]' --start-time ... --
 ```
 
 ## Recent Changes
-- 1122-zustand-hydration-fix: Added TypeScript 5.x, React 18.x, Next.js 14.x (App Router) + zustand 5.x, @tanstack/react-query, next-auth (not used - custom auth), tailwindcss
-- 1114-cors-api-gateway-fix: Added Terraform 1.5+ (infrastructure change only) + AWS Amplify, Lambda Function URL
-- 1113-ohlc-intraday-backend: Added Python 3.13 + AWS Lambda, pydantic, httpx (Tiingo API client)
+- 1146-remove-xuserid-fallback: Added Python 3.13 + FastAPI, PyJWT, boto3 (DynamoDB)
+- 1145-delete-cookies-ts: Added TypeScript 5.x (Next.js frontend) + Next.js, Zustand (state management)
+- 1130-require-role-decorator: Added Python 3.13 + FastAPI, functools (stdlib), typing (stdlib)
 
 <!-- MANUAL ADDITIONS START -->
 

--- a/frontend/src/stores/auth-store.ts
+++ b/frontend/src/stores/auth-store.ts
@@ -67,7 +67,8 @@ export const useAuthStore = create<AuthStore>()(
           isAuthenticated: !!user,
           isAnonymous,
         });
-        // Feature 014: Sync userId with API client for X-User-ID header
+        // Feature 1146: setUserId now also sets accessToken for Bearer auth
+        // This ensures anonymous sessions use Bearer token, not X-User-ID header
         setUserId(user?.userId ?? null);
       },
 

--- a/specs/1126-auth-httponly-migration/archive/spec-v1-archived.md
+++ b/specs/1126-auth-httponly-migration/archive/spec-v1-archived.md
@@ -1,0 +1,615 @@
+# Feature Specification: Auth Architecture Rewrite
+
+**Feature Branch**: `1126-auth-rewrite`
+**Created**: 2026-01-03
+**Status**: Draft
+**Priority**: P0 - Security + Architecture Foundation
+
+## Problem Statement
+
+Current auth implementation has fundamental flaws:
+1. Tokens stored in localStorage (XSS vulnerable)
+2. Refresh token sent in request body (should be httpOnly cookie)
+3. No role system (only auth_type enum)
+4. No decorator-based authorization
+5. Admin endpoints unprotected
+
+## Target Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                         AUTH FLOW                               │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│  LOGIN (any method: anonymous, magic link, OAuth)               │
+│  ─────────────────────────────────────────────────────────────  │
+│  Client                           Server                        │
+│    │                                │                           │
+│    │  POST /api/auth/login          │                           │
+│    │  { credentials }  ───────────► │                           │
+│    │                                │  Validate                 │
+│    │                                │  Generate JWT:            │
+│    │                                │    sub: user_id           │
+│    │                                │    roles: ["authenticated"]│
+│    │                                │    exp: +15min            │
+│    │                                │  Generate refresh token   │
+│    │                                │                           │
+│    │  ◄─────────────────────────────│                           │
+│    │  Body: { access_token, user }  │                           │
+│    │  Set-Cookie: refresh_token=xyz;│                           │
+│    │    HttpOnly; Secure; SameSite=Lax; Path=/api/auth          │
+│    │                                │                           │
+│    │  Store access_token IN MEMORY  │                           │
+│    │  (not localStorage)            │                           │
+│                                                                 │
+│  ─────────────────────────────────────────────────────────────  │
+│  API REQUESTS                                                   │
+│  ─────────────────────────────────────────────────────────────  │
+│  Client                           Server                        │
+│    │                                │                           │
+│    │  GET /api/settings             │                           │
+│    │  Authorization: Bearer {token} │                           │
+│    │  ─────────────────────────────►│                           │
+│    │                                │  @require_role("authenticated")
+│    │                                │  1. Extract Bearer token  │
+│    │                                │  2. Validate JWT sig+exp  │
+│    │                                │  3. Check roles in claims │
+│    │                                │  4. Pass or 401/403       │
+│    │  ◄─────────────────────────────│                           │
+│    │  200 OK or 401/403             │                           │
+│                                                                 │
+│  ─────────────────────────────────────────────────────────────  │
+│  TOKEN REFRESH                                                  │
+│  ─────────────────────────────────────────────────────────────  │
+│  Client                           Server                        │
+│    │                                │                           │
+│    │  POST /api/auth/refresh        │                           │
+│    │  (no body needed)              │                           │
+│    │  Cookie: refresh_token=xyz ────►  (browser sends auto)     │
+│    │                                │  Validate refresh token   │
+│    │                                │  Issue new access_token   │
+│    │                                │  Rotate refresh token     │
+│    │  ◄─────────────────────────────│                           │
+│    │  Body: { access_token }        │                           │
+│    │  Set-Cookie: refresh_token=new │                           │
+│                                                                 │
+│  ─────────────────────────────────────────────────────────────  │
+│  PAGE LOAD (session restore)                                    │
+│  ─────────────────────────────────────────────────────────────  │
+│  Client                           Server                        │
+│    │                                │                           │
+│    │  POST /api/auth/refresh ───────►  (try to restore session) │
+│    │  Cookie sent automatically     │                           │
+│    │                                │                           │
+│    │  ◄─────────────────────────────│                           │
+│    │  200 + new token = logged in   │                           │
+│    │  401 = not logged in           │                           │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Role System
+
+### Role Definition
+
+```python
+# src/lambdas/shared/models/roles.py
+from enum import Enum
+
+class Role(str, Enum):
+    """User roles. Users can have multiple roles."""
+    ANONYMOUS = "anonymous"           # Temporary session, no email
+    AUTHENTICATED = "authenticated"   # Logged in with email verified
+    PAID = "paid"                     # Active subscription
+    OPERATOR = "operator"             # On-call/admin access
+```
+
+### JWT Claims Structure
+
+```json
+{
+  "sub": "user-123",
+  "email": "user@example.com",
+  "roles": ["authenticated", "paid"],
+  "iat": 1704307200,
+  "exp": 1704308100
+}
+```
+
+### Role Decorator
+
+```python
+# src/lambdas/shared/middleware/require_role.py
+from functools import wraps
+from fastapi import HTTPException, Request
+
+def require_role(*required_roles: str):
+    """
+    Decorator to enforce role-based access control.
+
+    Usage:
+        @require_role("authenticated")
+        async def get_settings(request: Request): ...
+
+        @require_role("operator")
+        async def admin_endpoint(request: Request): ...
+
+        @require_role("authenticated", "paid")
+        async def premium_feature(request: Request): ...
+    """
+    def decorator(func):
+        @wraps(func)
+        async def wrapper(request: Request, *args, **kwargs):
+            # Extract token from Authorization header
+            auth_header = request.headers.get("Authorization", "")
+            if not auth_header.startswith("Bearer "):
+                raise HTTPException(
+                    status_code=401,
+                    detail="Missing or invalid Authorization header"
+                )
+
+            token = auth_header[7:]
+
+            # Validate JWT (signature, expiration)
+            try:
+                claims = validate_jwt(token)
+            except JWTError as e:
+                raise HTTPException(status_code=401, detail=str(e))
+
+            # Check roles
+            user_roles = set(claims.get("roles", []))
+            required = set(required_roles)
+
+            if not required.issubset(user_roles):
+                raise HTTPException(
+                    status_code=403,
+                    detail=f"Insufficient permissions. Required: {required_roles}"
+                )
+
+            # Inject user context for downstream use
+            request.state.user_id = claims["sub"]
+            request.state.email = claims.get("email")
+            request.state.roles = user_roles
+
+            return await func(request, *args, **kwargs)
+        return wrapper
+    return decorator
+```
+
+## API Endpoints
+
+### Auth Endpoints
+
+| Endpoint | Method | Auth Required | Description |
+|----------|--------|---------------|-------------|
+| `/api/auth/anonymous` | POST | No | Create anonymous session |
+| `/api/auth/magic-link` | POST | No | Request magic link email |
+| `/api/auth/magic-link/verify` | GET | No | Verify magic link, issue tokens |
+| `/api/auth/oauth/urls` | GET | No | Get OAuth provider URLs |
+| `/api/auth/oauth/callback` | POST | No | Exchange OAuth code for tokens |
+| `/api/auth/refresh` | POST | Refresh cookie | Get new access token |
+| `/api/auth/logout` | POST | Refresh cookie | Clear session |
+| `/api/auth/me` | GET | Bearer token | Get current user info |
+
+### Token Response Format
+
+All auth endpoints that issue tokens return:
+
+```json
+{
+  "access_token": "eyJhbG...",
+  "user": {
+    "id": "user-123",
+    "email": "user@example.com",
+    "roles": ["authenticated"]
+  }
+}
+```
+
+Plus `Set-Cookie` header for refresh token.
+
+### Refresh Token Cookie Attributes
+
+```
+Set-Cookie: refresh_token=<token>;
+  HttpOnly;           # JavaScript cannot read
+  Secure;             # HTTPS only
+  SameSite=Lax;       # Sent on top-level navigations
+  Path=/api/auth;     # Only sent to auth endpoints
+  Max-Age=604800      # 7 days
+```
+
+**Why SameSite=Lax instead of Strict:**
+- `Strict` breaks OAuth redirects (cookie not sent on redirect from OAuth provider)
+- `Lax` is secure enough (not sent on cross-origin POST)
+- Path restriction limits exposure
+
+## Frontend Implementation
+
+### Auth Store (No Persistence)
+
+```typescript
+// frontend/src/stores/auth-store.ts
+import { create } from 'zustand';
+// NO persist middleware - tokens live in memory only
+
+interface User {
+  id: string;
+  email?: string;
+  roles: string[];
+}
+
+interface AuthStore {
+  // State
+  accessToken: string | null;
+  user: User | null;
+  isLoading: boolean;
+  isInitialized: boolean;
+  error: string | null;
+
+  // Computed
+  isAuthenticated: boolean;
+  isAnonymous: boolean;
+  hasRole: (role: string) => boolean;
+
+  // Actions
+  setAuth: (token: string, user: User) => void;
+  clearAuth: () => void;
+  setLoading: (loading: boolean) => void;
+  setInitialized: () => void;
+  setError: (error: string | null) => void;
+}
+
+export const useAuthStore = create<AuthStore>((set, get) => ({
+  accessToken: null,
+  user: null,
+  isLoading: false,
+  isInitialized: false,
+  error: null,
+
+  get isAuthenticated() {
+    return get().accessToken !== null;
+  },
+
+  get isAnonymous() {
+    return get().user?.roles.includes('anonymous') ?? false;
+  },
+
+  hasRole: (role: string) => {
+    return get().user?.roles.includes(role) ?? false;
+  },
+
+  setAuth: (token, user) => set({
+    accessToken: token,
+    user,
+    error: null
+  }),
+
+  clearAuth: () => set({
+    accessToken: null,
+    user: null
+  }),
+
+  setLoading: (loading) => set({ isLoading: loading }),
+  setInitialized: () => set({ isInitialized: true }),
+  setError: (error) => set({ error }),
+}));
+```
+
+### API Client
+
+```typescript
+// frontend/src/lib/api/client.ts
+import { useAuthStore } from '@/stores/auth-store';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || '';
+
+class ApiClient {
+  private getAuthHeader(): HeadersInit {
+    const token = useAuthStore.getState().accessToken;
+    return token ? { 'Authorization': `Bearer ${token}` } : {};
+  }
+
+  async request<T>(
+    path: string,
+    options: RequestInit = {}
+  ): Promise<T> {
+    const url = `${API_BASE}${path}`;
+
+    const response = await fetch(url, {
+      ...options,
+      headers: {
+        'Content-Type': 'application/json',
+        ...this.getAuthHeader(),
+        ...options.headers,
+      },
+      credentials: 'include', // Always send cookies
+    });
+
+    // If 401, try refresh once
+    if (response.status === 401) {
+      const refreshed = await this.tryRefresh();
+      if (refreshed) {
+        // Retry with new token
+        return this.request(path, options);
+      }
+      // Refresh failed - clear auth state
+      useAuthStore.getState().clearAuth();
+      throw new ApiError(401, 'Session expired');
+    }
+
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({}));
+      throw new ApiError(response.status, error.detail || 'Request failed');
+    }
+
+    if (response.status === 204) {
+      return undefined as T;
+    }
+
+    return response.json();
+  }
+
+  private async tryRefresh(): Promise<boolean> {
+    try {
+      const response = await fetch(`${API_BASE}/api/auth/refresh`, {
+        method: 'POST',
+        credentials: 'include',
+      });
+
+      if (!response.ok) return false;
+
+      const { access_token, user } = await response.json();
+      useAuthStore.getState().setAuth(access_token, user);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  // Convenience methods
+  get<T>(path: string) {
+    return this.request<T>(path, { method: 'GET' });
+  }
+
+  post<T>(path: string, body?: unknown) {
+    return this.request<T>(path, {
+      method: 'POST',
+      body: body ? JSON.stringify(body) : undefined,
+    });
+  }
+
+  put<T>(path: string, body: unknown) {
+    return this.request<T>(path, {
+      method: 'PUT',
+      body: JSON.stringify(body),
+    });
+  }
+
+  delete<T>(path: string) {
+    return this.request<T>(path, { method: 'DELETE' });
+  }
+}
+
+export const apiClient = new ApiClient();
+
+class ApiError extends Error {
+  constructor(public status: number, message: string) {
+    super(message);
+    this.name = 'ApiError';
+  }
+}
+```
+
+### Session Initialization
+
+```typescript
+// frontend/src/hooks/use-session-init.ts
+import { useEffect } from 'react';
+import { useAuthStore } from '@/stores/auth-store';
+
+export function useSessionInit() {
+  const { isInitialized, setAuth, clearAuth, setLoading, setInitialized, setError } = useAuthStore();
+
+  useEffect(() => {
+    if (isInitialized) return;
+
+    const init = async () => {
+      setLoading(true);
+
+      try {
+        // Try to refresh - if we have valid refresh cookie, we get tokens
+        const response = await fetch('/api/auth/refresh', {
+          method: 'POST',
+          credentials: 'include',
+        });
+
+        if (response.ok) {
+          const { access_token, user } = await response.json();
+          setAuth(access_token, user);
+        } else {
+          // No valid session - that's fine, user is not logged in
+          clearAuth();
+        }
+      } catch (error) {
+        // Network error during init
+        setError('Failed to initialize session');
+        clearAuth();
+      } finally {
+        setLoading(false);
+        setInitialized();
+      }
+    };
+
+    init();
+  }, [isInitialized, setAuth, clearAuth, setLoading, setInitialized, setError]);
+
+  return {
+    isLoading: useAuthStore((s) => s.isLoading),
+    isInitialized: useAuthStore((s) => s.isInitialized),
+    error: useAuthStore((s) => s.error),
+  };
+}
+```
+
+## Migration Path
+
+### Phase 1: Backend (No Breaking Changes)
+
+1. Add `Role` enum and JWT generation with roles
+2. Add `@require_role` decorator
+3. Add `/api/auth/refresh` endpoint that reads httpOnly cookie
+4. Update existing auth endpoints to:
+   - Return `access_token` in body
+   - Set `refresh_token` as httpOnly cookie
+   - Include `roles` in JWT claims
+5. **Keep existing header auth working** during transition
+
+### Phase 2: Frontend
+
+1. Rewrite `auth-store.ts` (no persist)
+2. Rewrite `client.ts` (header-based auth, auto-refresh)
+3. Rewrite `use-session-init.ts` (cookie-based restore)
+4. Update `protected-route.tsx` to use new store
+5. Delete: `cookies.ts`, token-related code in `api/auth.ts`
+
+### Phase 3: Cleanup
+
+1. Remove localStorage migration code
+2. Remove old token handling from backend
+3. Add `@require_role` to all protected endpoints
+
+## Files to Modify
+
+### Backend
+
+| File | Action | Description |
+|------|--------|-------------|
+| `src/lambdas/shared/models/roles.py` | Create | Role enum |
+| `src/lambdas/shared/middleware/require_role.py` | Create | Role decorator |
+| `src/lambdas/shared/middleware/jwt.py` | Create | JWT validation |
+| `src/lambdas/dashboard/auth.py` | Modify | Add httpOnly cookie handling |
+| `src/lambdas/dashboard/router_v2.py` | Modify | Add @require_role to endpoints |
+
+### Frontend
+
+| File | Action | Description |
+|------|--------|-------------|
+| `frontend/src/stores/auth-store.ts` | Rewrite | No persist, roles support |
+| `frontend/src/lib/api/client.ts` | Rewrite | Header auth, auto-refresh |
+| `frontend/src/hooks/use-session-init.ts` | Rewrite | Cookie-based restore |
+| `frontend/src/components/auth/protected-route.tsx` | Modify | Use new store |
+| `frontend/src/components/providers/session-provider.tsx` | Modify | Simpler logic |
+| `frontend/src/lib/cookies.ts` | Delete | No longer needed |
+| `frontend/src/lib/api/auth.ts` | Simplify | Remove token handling |
+
+## Success Criteria
+
+1. No tokens in localStorage or sessionStorage
+2. No tokens accessible via JavaScript
+3. All API requests use `Authorization: Bearer` header
+4. Token refresh works via httpOnly cookie
+5. Session restored on page reload via cookie
+6. All protected endpoints use `@require_role` decorator
+7. 401 returned for missing/invalid token
+8. 403 returned for insufficient roles
+
+## Edge Cases and Clarifications
+
+### Anonymous Users
+
+Anonymous users follow the same pattern:
+1. POST `/api/auth/anonymous` (no credentials needed)
+2. Server creates anonymous user, issues tokens
+3. Response: `{ access_token, user: { id, roles: ["anonymous"] } }`
+4. Set-Cookie: refresh_token (httpOnly)
+
+Anonymous users get refresh cookies. Session persists across page loads.
+
+### Anonymous → Authenticated Upgrade
+
+When anonymous user authenticates (magic link or OAuth):
+1. Frontend sends `anonymous_user_id` with auth request (extracted from current user state)
+2. Backend:
+   - Creates/finds authenticated user
+   - Merges anonymous user's data (configs, alerts) if `anonymous_user_id` provided
+   - Invalidates old anonymous refresh token
+   - Issues new refresh token with `roles: ["authenticated"]`
+3. Frontend receives new access_token, replaces user state
+
+### OAuth Callback Flow
+
+```
+1. User clicks "Sign in with Google"
+2. Frontend redirects to Cognito authorize URL
+3. User authenticates with Google
+4. Cognito redirects to /auth/verify?code=xyz
+5. Frontend POSTs code to /api/auth/oauth/callback
+6. Backend:
+   - Exchanges code for Cognito tokens
+   - Extracts email from ID token
+   - Creates/finds user, assigns roles
+   - Returns access_token in body
+   - Sets refresh_token as httpOnly cookie
+7. Frontend stores access_token in memory
+```
+
+### Token Expiry During Form Submission
+
+The API client retry logic preserves the request:
+
+```typescript
+// client.ts - already handles this
+if (response.status === 401) {
+  const refreshed = await this.tryRefresh();
+  if (refreshed) {
+    return this.request(path, options); // options includes body
+  }
+}
+```
+
+The original `options` (including `body`) is reused on retry.
+
+### Multi-Tab Behavior
+
+- Logout in one tab does NOT immediately affect other tabs
+- Other tabs continue with their in-memory access token until it expires (15 min max)
+- On next API call after expiry, refresh fails (cookie cleared), user sees login prompt
+- This is acceptable. Cross-tab sync via BroadcastChannel is out of scope.
+
+### CSRF Protection
+
+Not required for this architecture because:
+1. Access token is in memory, not cookie - attacker cannot include it
+2. Refresh cookie has `SameSite=Lax` - not sent on cross-origin POST
+3. Bearer token authentication is inherently CSRF-resistant
+
+If paranoid, add `Origin` header validation on backend (defense in depth).
+
+### Session Init Error Handling
+
+When `/api/auth/refresh` fails:
+
+| Status | Meaning | Action |
+|--------|---------|--------|
+| 401 | No valid session | `clearAuth()`, user is logged out (expected for new users) |
+| 500 | Server error | `setError("Server error")`, show retry button |
+| Network error | Offline/unreachable | `setError("Network error")`, show offline banner |
+
+SessionProvider MUST show error UI, not silently render broken app.
+
+### Refresh Rate Limiting
+
+If refresh endpoint returns 429:
+1. Parse `Retry-After` header
+2. Show "Please wait X seconds" message
+3. Auto-retry after delay
+4. If still failing, show "Session expired, please log in again"
+
+## Out of Scope
+
+- Subscription/payment integration (Paid role assignment)
+- Operator role assignment UI
+- Multi-device session management
+- Token revocation list
+- Cross-tab session sync (BroadcastChannel)

--- a/specs/1127-random-magic-tokens/checklists/requirements.md
+++ b/specs/1127-random-magic-tokens/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Random Magic Link Tokens
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-01-04
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items passed validation on first iteration.
+- Spec is ready for `/speckit.plan` phase.
+- This is a Phase 0 CRITICAL security fix (CVSS 9.1).
+- Clear separation from related fixes (C3 atomic consumption, Phase 3 rate limiting).

--- a/specs/1127-random-magic-tokens/spec.md
+++ b/specs/1127-random-magic-tokens/spec.md
@@ -1,0 +1,104 @@
+# Feature Specification: Random Magic Link Tokens
+
+**Feature Branch**: `1127-random-magic-tokens`
+**Created**: 2026-01-04
+**Status**: Draft
+**Input**: Phase 0 C1/D2: Replace HMAC-based magic link secret with cryptographically secure random tokens. Delete hardcoded fallback secret. CVSS 9.1 - BLOCKING PRODUCTION.
+**Security Priority**: CRITICAL (Phase 0 - Must complete before any other feature work)
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Secure Magic Link Request (Priority: P1)
+
+A user requests a magic link for passwordless authentication. The system generates a cryptographically secure random token that cannot be predicted or forged, even if an attacker knows the system's internal logic.
+
+**Why this priority**: This is the core security fix. The current HMAC-based approach allows token prediction if the secret is compromised (or uses the hardcoded fallback). Random tokens are cryptographically unpredictable by design.
+
+**Independent Test**: Can be fully tested by requesting a magic link and verifying the token meets randomness requirements (256-bit entropy, unpredictable across requests).
+
+**Acceptance Scenarios**:
+
+1. **Given** a user requests a magic link, **When** the system generates a token, **Then** the token MUST be 256 bits of cryptographic randomness (43 URL-safe characters).
+2. **Given** multiple magic link requests, **When** tokens are generated, **Then** each token MUST be statistically independent (no predictable pattern).
+3. **Given** a magic link token, **When** an attacker attempts to forge a valid token, **Then** the probability of success MUST be less than 1 in 2^256.
+
+---
+
+### User Story 2 - Hardcoded Secret Elimination (Priority: P1)
+
+The system MUST NOT contain any hardcoded fallback secrets for magic link generation. If configuration is missing, the system must fail securely rather than using an insecure default.
+
+**Why this priority**: Equal priority to P1 because hardcoded secrets (CVSS 9.1) are the root cause of the vulnerability. The current fallback `'default-dev-secret-change-in-prod'` allows complete token forgery.
+
+**Independent Test**: Can be tested by searching the codebase for hardcoded secrets and verifying the system fails when proper configuration is absent.
+
+**Acceptance Scenarios**:
+
+1. **Given** the magic link secret configuration is missing, **When** the system attempts to generate a token, **Then** the system MUST fail with a clear error (not silently use a fallback).
+2. **Given** the codebase, **When** security scanning tools analyze the code, **Then** no hardcoded secrets related to magic link generation MUST be found.
+3. **Given** a deployment without proper secret configuration, **When** a user requests a magic link, **Then** the request MUST fail with a 500 error and log the misconfiguration (no token generated).
+
+---
+
+### User Story 3 - Magic Link Verification Unchanged (Priority: P2)
+
+Users clicking valid magic links continue to authenticate successfully. The verification process remains functionally identical from the user's perspective.
+
+**Why this priority**: Lower priority because this is about maintaining existing functionality, not the core security fix. However, breaking verification would block users entirely.
+
+**Independent Test**: Can be tested by requesting a magic link, clicking it within the validity window, and verifying successful authentication.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user receives a valid magic link, **When** they click it within 1 hour, **Then** they MUST be authenticated successfully.
+2. **Given** a user receives a valid magic link, **When** they click it after 1 hour, **Then** authentication MUST fail with "link expired" message.
+3. **Given** a user clicks a magic link, **When** the link has already been used, **Then** authentication MUST fail with "link already used" message.
+
+---
+
+### Edge Cases
+
+- What happens when the random number generator fails? System MUST fail securely (500 error, no token generated).
+- What happens when token storage fails after generation? System MUST NOT send the magic link email if storage failed.
+- What happens during migration (old HMAC tokens still in database)? Existing tokens MUST continue to work until they expire naturally (backward compatibility).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST generate magic link tokens using a cryptographically secure random number generator producing 256 bits of entropy.
+- **FR-002**: System MUST NOT contain any hardcoded secret values for magic link token generation or verification.
+- **FR-003**: System MUST fail with a clear, logged error if cryptographic operations fail (fail-secure, not fail-open).
+- **FR-004**: System MUST maintain backward compatibility with existing unexpired magic link tokens during migration.
+- **FR-005**: System MUST store tokens in a way that allows verification without reconstructing them from secrets.
+- **FR-006**: System MUST log security-relevant events (token generation, verification attempts, failures) without logging the tokens themselves.
+- **FR-007**: System MUST reject any attempt to use a token more than once (one-time use enforcement).
+
+### Key Entities
+
+- **Magic Link Token**: A cryptographically random string (256-bit, URL-safe encoded) used for passwordless authentication. Stored with: user association, creation timestamp, expiration timestamp, used flag.
+- **Token Request**: Records of magic link generation attempts. Includes: requesting email, IP address, timestamp, success/failure status.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Zero hardcoded secrets in the codebase related to magic link generation (verified by automated security scanning).
+- **SC-002**: Token entropy MUST be 256 bits or greater (verified by statistical randomness tests on sample tokens).
+- **SC-003**: System continues to successfully authenticate users via magic links (no regression in success rate).
+- **SC-004**: Security scanners (secret detection tools) report zero findings for magic link-related code paths.
+- **SC-005**: Failed cryptographic operations result in 500 errors with appropriate logging (verified by fault injection testing).
+
+## Assumptions
+
+- The existing token storage mechanism (database) does not require changes - only the token generation method changes.
+- Magic link expiration (1 hour) and one-time-use behavior remain unchanged.
+- The system has access to a cryptographically secure random number generator (standard in all supported deployment environments).
+- Existing unexpired tokens using the old method will naturally expire within 1 hour, so no explicit migration is needed.
+
+## Out of Scope
+
+- Atomic token consumption (covered in separate Phase 0 fix C3)
+- Rate limiting for magic link requests (covered in Phase 3)
+- Changes to magic link email templates or delivery mechanism
+- Changes to user-facing error messages beyond what's needed for security

--- a/specs/1128-guard-mock-tokens/checklists/requirements.md
+++ b/specs/1128-guard-mock-tokens/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Guard Mock Token Generation
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-01-05
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All 16 checklist items passed
+- Spec is ready for `/speckit.plan`
+- This is a security-critical feature with clear scope (single function guard)

--- a/specs/1128-guard-mock-tokens/plan.md
+++ b/specs/1128-guard-mock-tokens/plan.md
@@ -1,0 +1,134 @@
+# Implementation Plan: Guard Mock Token Generation
+
+**Branch**: `1128-guard-mock-tokens` | **Date**: 2026-01-05 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/1128-guard-mock-tokens/spec.md`
+
+## Summary
+
+Add environment guard to `_generate_tokens()` function in auth.py to prevent mock token generation in AWS Lambda environment. This is a critical security fix that blocks fake/predictable tokens from being issued in production while maintaining local development workflow.
+
+## Technical Context
+
+**Language/Version**: Python 3.13 (existing project standard)
+**Primary Dependencies**: None new - uses stdlib `os` module (already imported)
+**Storage**: N/A
+**Testing**: pytest with moto mocks (unit), LocalStack (integration)
+**Target Platform**: AWS Lambda (serverless)
+**Project Type**: Web application (Lambda backend)
+**Performance Goals**: Negligible latency impact (single env var lookup)
+**Constraints**: Must not break local development workflow
+**Scale/Scope**: Single function modification (~5 lines of code)
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Gate | Status | Notes |
+|------|--------|-------|
+| Security & Access Control (3) | PASS | Prevents authentication bypass in production |
+| Preventing SQL injection | N/A | No DB changes |
+| Testing & Validation (7) | PASS | Unit tests required per Implementation Accompaniment Rule |
+| Git Workflow (8) | PASS | Feature branch, GPG-signed commits |
+| Local SAST (10) | PASS | Will run `make validate` before push |
+
+**No violations requiring justification.**
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/1128-guard-mock-tokens/
+├── plan.md              # This file
+├── research.md          # Phase 0 output (minimal - well-understood pattern)
+├── checklists/
+│   └── requirements.md  # Quality checklist
+└── tasks.md             # Phase 2 output
+```
+
+### Source Code (repository root)
+
+```text
+src/lambdas/dashboard/
+└── auth.py              # _generate_tokens() function at lines 1510-1529
+
+tests/unit/lambdas/dashboard/
+└── test_auth_guard.py   # New unit tests for environment guard
+```
+
+**Structure Decision**: Single file modification in existing backend Lambda module. No new directories or architectural changes needed.
+
+## Complexity Tracking
+
+> No violations requiring justification. This is a minimal, targeted security fix.
+
+---
+
+## Phase 0: Research
+
+**Status**: Complete (pattern is well-understood)
+
+The environment detection pattern using `AWS_LAMBDA_FUNCTION_NAME` is a canonical AWS best practice:
+- AWS sets this variable automatically in all Lambda environments
+- It contains the function name (e.g., `sentiment-analyzer-dashboard`)
+- Absent in local development, present in Lambda (including LocalStack)
+
+No additional research needed - this is a standard pattern documented in AWS Lambda environment variables documentation.
+
+---
+
+## Phase 1: Design
+
+### Implementation Approach
+
+1. Add guard check at the start of `_generate_tokens()` function
+2. Check if `AWS_LAMBDA_FUNCTION_NAME` is set and non-empty
+3. If true, raise `RuntimeError` with descriptive message
+4. Log the blocked attempt at ERROR level
+5. Existing mock token generation logic remains unchanged for local development
+
+### Code Change (Pseudo-code)
+
+```python
+def _generate_tokens(user: User) -> tuple[dict, str]:
+    """Generate mock tokens for testing.
+
+    In production, tokens come from Cognito.
+    SECURITY: Blocked in Lambda environment.
+    """
+    # SECURITY GUARD: Block mock tokens in Lambda environment
+    if os.environ.get("AWS_LAMBDA_FUNCTION_NAME"):
+        logger.error(
+            "SECURITY: Mock token generation blocked in Lambda environment. "
+            "Production must use Cognito tokens."
+        )
+        raise RuntimeError(
+            "Mock token generation is disabled in Lambda environment. "
+            "Use real Cognito tokens in production."
+        )
+
+    # Existing mock token generation (unchanged)
+    refresh_token = f"mock_refresh_token_{user.user_id[:8]}"
+    body_tokens = {
+        "id_token": f"mock_id_token_{user.user_id[:8]}",
+        "access_token": f"mock_access_token_{user.user_id[:8]}",
+        "expires_in": 3600,
+    }
+    return body_tokens, refresh_token
+```
+
+### Test Strategy
+
+Unit tests will cover:
+1. **Lambda environment (blocked)**: Set `AWS_LAMBDA_FUNCTION_NAME`, verify RuntimeError
+2. **Local environment (allowed)**: Unset variable, verify tokens generated
+3. **Empty string (allowed)**: Set to empty string, verify tokens generated
+4. **Error message content**: Verify message contains actionable guidance
+
+### No API Contracts Needed
+
+This feature does not introduce new APIs or change existing contracts. It only adds an internal guard to an existing function.
+
+### No Data Model Changes
+
+No new entities or data model modifications required.

--- a/specs/1128-guard-mock-tokens/research.md
+++ b/specs/1128-guard-mock-tokens/research.md
@@ -1,0 +1,51 @@
+# Research: Guard Mock Token Generation
+
+**Feature**: 1128-guard-mock-tokens
+**Date**: 2026-01-05
+
+## Summary
+
+Minimal research required - this feature uses a well-established AWS pattern for Lambda environment detection.
+
+## AWS Lambda Environment Detection
+
+### Decision: Use `AWS_LAMBDA_FUNCTION_NAME`
+
+**Rationale**: This is the canonical AWS-recommended way to detect Lambda runtime environment.
+
+**Alternatives Considered**:
+1. `AWS_EXECUTION_ENV` - Also set by AWS, but format varies (e.g., `AWS_Lambda_python3.13`)
+2. `LAMBDA_TASK_ROOT` - Set to `/var/task`, but less semantically clear
+3. `_HANDLER` - Contains handler path, but not as universally reliable
+
+**Why `AWS_LAMBDA_FUNCTION_NAME` is best**:
+- Always set in Lambda, never set locally
+- Contains clear, readable value (the function name)
+- Documented in official AWS Lambda environment variables docs
+- LocalStack also sets this variable for realistic testing
+- Used by AWS SDK and other AWS tooling for detection
+
+## Implementation Pattern
+
+```python
+import os
+
+# Standard Lambda detection pattern
+if os.environ.get("AWS_LAMBDA_FUNCTION_NAME"):
+    # Running in Lambda
+    pass
+else:
+    # Running locally or in non-Lambda environment
+    pass
+```
+
+## Security Considerations
+
+- **Defense in depth**: This guard is one layer; production should also have real Cognito integration
+- **Fail-closed**: If detection fails somehow, better to block mock tokens than allow them
+- **Logging**: ERROR-level log enables security monitoring and alerting
+
+## References
+
+- AWS Lambda Environment Variables: https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html
+- LocalStack Lambda Support: https://docs.localstack.cloud/user-guide/aws/lambda/

--- a/specs/1128-guard-mock-tokens/spec.md
+++ b/specs/1128-guard-mock-tokens/spec.md
@@ -1,0 +1,108 @@
+# Feature Specification: Guard Mock Token Generation
+
+**Feature Branch**: `1128-guard-mock-tokens`
+**Created**: 2026-01-05
+**Status**: Implemented
+**Input**: User description: "Phase 0 C2: Guard mock token generation with Lambda environment check. Prevents production Lambda from generating fake tokens."
+**Context**: Part of Phase 0 Security Blocking for HTTPOnly cookie migration. Related spec: specs/1126-auth-httponly-migration/spec-v2.md
+
+## Problem Statement
+
+The `_generate_tokens()` function in `auth.py` (lines 1510-1529) generates mock tokens with predictable format (`mock_<type>_<user_id[:8]>`) without any environment validation. This function is called during:
+- Magic link verification (`verify_magic_link()` at line 1465)
+- OAuth callbacks (`handle_oauth_callback()` at line 1662)
+
+**Security Risk**: If this code reaches production Lambda, authentication will succeed with fake tokens that:
+1. Are predictable based on user ID
+2. Bypass real Cognito token validation
+3. Enable unauthorized access
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 - Production Lambda Rejects Mock Token Generation (Priority: P1)
+
+When the application runs in AWS Lambda production environment, any attempt to generate mock tokens must immediately fail with a clear error, preventing fake credentials from being issued.
+
+**Why this priority**: This is a critical security control. Mock tokens in production would allow authentication bypass.
+
+**Independent Test**: Deploy to Lambda, trigger mock token generation path, verify RuntimeError is raised and no tokens are returned.
+
+**Acceptance Scenarios**:
+
+1. **Given** the application is running in AWS Lambda (AWS_LAMBDA_FUNCTION_NAME is set), **When** `_generate_tokens()` is called, **Then** a RuntimeError is raised with message indicating mock tokens are disabled in Lambda
+2. **Given** the application is running in AWS Lambda, **When** authentication flow would normally generate mock tokens, **Then** the request fails before any token is returned to the client
+3. **Given** the application is running in AWS Lambda, **When** RuntimeError is raised, **Then** the error is logged for security monitoring
+
+---
+
+### User Story 2 - Local Development Continues to Work (Priority: P1)
+
+Developers running the application locally (outside Lambda) must continue to receive mock tokens for testing and development purposes.
+
+**Why this priority**: Development velocity must not be impacted. Local testing is essential.
+
+**Independent Test**: Run application locally without AWS_LAMBDA_FUNCTION_NAME, verify mock tokens are generated normally.
+
+**Acceptance Scenarios**:
+
+1. **Given** the application is running locally (AWS_LAMBDA_FUNCTION_NAME is not set), **When** `_generate_tokens()` is called, **Then** mock tokens are generated as before
+2. **Given** the application is running in test environment without Lambda, **When** authentication flow runs, **Then** mock tokens work normally
+
+---
+
+### User Story 3 - Clear Error Messages for Debugging (Priority: P2)
+
+When mock token generation is blocked in Lambda, the error message must clearly indicate why and suggest the proper solution (use real Cognito tokens).
+
+**Why this priority**: Operators debugging production issues need clear guidance.
+
+**Independent Test**: Trigger the error in Lambda, verify error message contains actionable information.
+
+**Acceptance Scenarios**:
+
+1. **Given** mock token generation is blocked in Lambda, **When** the error is logged, **Then** the message explains that production must use Cognito tokens
+2. **Given** mock token generation fails, **When** operator reviews logs, **Then** they understand the root cause without additional investigation
+
+---
+
+### Edge Cases
+
+- What happens when AWS_LAMBDA_FUNCTION_NAME is set to empty string? System treats as local development (empty string is falsy in Python)
+- What happens when running in LocalStack Lambda emulation? LocalStack sets AWS_LAMBDA_FUNCTION_NAME, so mock tokens are blocked - this is correct behavior as it validates production paths
+- How does system handle if error occurs mid-authentication? Authentication fails cleanly, no partial state is left
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+- **FR-001**: System MUST check for `AWS_LAMBDA_FUNCTION_NAME` environment variable at the start of `_generate_tokens()` function
+- **FR-002**: System MUST raise `RuntimeError` with descriptive message when mock token generation is attempted in Lambda environment
+- **FR-003**: System MUST allow mock token generation when `AWS_LAMBDA_FUNCTION_NAME` is not set or is empty
+- **FR-004**: System MUST NOT modify the mock token format or structure (maintain backward compatibility for local development)
+- **FR-005**: System MUST log the blocked attempt at ERROR level for security monitoring
+
+### Non-Functional Requirements
+
+- **NFR-001**: Guard check adds negligible latency (single environment variable lookup)
+- **NFR-002**: No new dependencies required
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of mock token generation attempts in Lambda environment are blocked
+- **SC-002**: 100% of mock token generation attempts in local environment succeed unchanged
+- **SC-003**: All blocked attempts are logged with sufficient detail for security audit
+- **SC-004**: Zero breaking changes to local development workflow
+
+## Assumptions
+
+1. `AWS_LAMBDA_FUNCTION_NAME` is the canonical way to detect Lambda environment (AWS documentation confirms this)
+2. LocalStack sets this variable when emulating Lambda, so tests using LocalStack will exercise the production path
+3. Production will eventually use real Cognito tokens - this guard is a safety net during transition
+
+## Out of Scope
+
+- Implementing real Cognito token generation (separate feature)
+- Removing the mock token function entirely (Phase 3 cleanup)
+- Modifying other authentication code paths

--- a/specs/1128-guard-mock-tokens/tasks.md
+++ b/specs/1128-guard-mock-tokens/tasks.md
@@ -1,0 +1,114 @@
+# Tasks: Guard Mock Token Generation
+
+**Feature Branch**: `1128-guard-mock-tokens`
+**Generated**: 2026-01-05
+**Spec**: [spec.md](./spec.md) | **Plan**: [plan.md](./plan.md)
+
+## Summary
+
+| Metric | Value |
+|--------|-------|
+| Total Tasks | 6 |
+| User Story 1 Tasks | 2 |
+| User Story 2 Tasks | 1 |
+| User Story 3 Tasks | 1 |
+| Parallel Opportunities | 0 (sequential due to dependencies) |
+| MVP Scope | US1 + US2 (security + dev workflow) |
+
+## User Stories (from spec.md)
+
+| Story | Priority | Description | Independent Test |
+|-------|----------|-------------|------------------|
+| US1 | P1 | Production Lambda Rejects Mock Tokens | Set AWS_LAMBDA_FUNCTION_NAME, verify RuntimeError |
+| US2 | P1 | Local Development Continues to Work | Unset env var, verify tokens generated |
+| US3 | P2 | Clear Error Messages for Debugging | Verify error message contains actionable info |
+
+## Dependencies
+
+```
+Phase 1: Setup
+    ↓
+Phase 2: US1 (Production Guard) + US2 (Local Dev) + US3 (Error Messages)
+    ↓
+Phase 3: Polish (Validation)
+```
+
+Note: US1, US2, and US3 are implemented together in a single function change. They cannot be parallelized as they modify the same code block.
+
+---
+
+## Phase 1: Setup
+
+> No setup tasks needed - this feature modifies existing code with no new dependencies.
+
+---
+
+## Phase 2: Implementation (US1 + US2 + US3)
+
+**Goal**: Add environment guard to `_generate_tokens()` that blocks mock tokens in Lambda while preserving local development workflow.
+
+**Independent Test**:
+- US1: With `AWS_LAMBDA_FUNCTION_NAME` set, call `_generate_tokens()` → expect RuntimeError
+- US2: Without env var, call `_generate_tokens()` → expect mock tokens returned
+- US3: Check RuntimeError message contains "Cognito" guidance
+
+### Tasks
+
+- [x] T001 [US1] [US2] [US3] Add Lambda environment guard to `_generate_tokens()` function in `src/lambdas/dashboard/auth.py`
+  - Add guard check at function start: `if os.environ.get("AWS_LAMBDA_FUNCTION_NAME"):`
+  - Log error at ERROR level with security message
+  - Raise RuntimeError with descriptive message mentioning Cognito
+  - Keep existing mock token generation unchanged (for local dev)
+
+- [x] T002 [US1] [US2] [US3] Create unit tests for environment guard in `tests/unit/lambdas/dashboard/test_auth_guard.py`
+  - Test: Lambda environment (AWS_LAMBDA_FUNCTION_NAME set) → RuntimeError raised
+  - Test: Local environment (no env var) → mock tokens generated correctly
+  - Test: Empty string env var → mock tokens generated (empty is falsy)
+  - Test: Error message contains "Cognito" and "production"
+  - Test: Verify tokens format unchanged for local dev
+
+---
+
+## Phase 3: Polish & Validation
+
+- [x] T003 Run `make validate` to ensure code passes linting, formatting, and SAST checks
+- [x] T004 Run `pytest tests/unit/lambdas/dashboard/test_auth_guard.py -v` to verify all tests pass
+- [ ] T005 Verify no existing tests are broken by running `pytest tests/unit/ -v --tb=short`
+- [x] T006 Update spec.md status from "Draft" to "Implemented" in `specs/1128-guard-mock-tokens/spec.md`
+
+---
+
+## Implementation Strategy
+
+### MVP (Minimum Viable Product)
+
+US1 + US2 together (T001 + T002) - cannot be separated as they're the same code change tested from different perspectives.
+
+### Incremental Delivery
+
+1. **First commit**: T001 (implementation) + T002 (tests)
+2. **Second commit**: T003-T006 (validation and cleanup)
+
+### File Changes Summary
+
+| File | Change Type | Tasks |
+|------|-------------|-------|
+| `src/lambdas/dashboard/auth.py` | Modify | T001 |
+| `tests/unit/lambdas/dashboard/test_auth_guard.py` | Create | T002 |
+| `specs/1128-guard-mock-tokens/spec.md` | Modify | T006 |
+
+---
+
+## Acceptance Criteria Traceability
+
+| Requirement | Task | Verification |
+|-------------|------|--------------|
+| FR-001: Check AWS_LAMBDA_FUNCTION_NAME | T001 | T002 test case |
+| FR-002: Raise RuntimeError | T001 | T002 test case |
+| FR-003: Allow mock tokens locally | T001 | T002 test case |
+| FR-004: Maintain token format | T001 | T002 test case |
+| FR-005: Log at ERROR level | T001 | T002 test case |
+| SC-001: 100% blocked in Lambda | T002 | Unit test |
+| SC-002: 100% success locally | T002 | Unit test |
+| SC-003: Logged for audit | T001, T002 | Unit test |
+| SC-004: No dev workflow impact | T002 | Unit test |

--- a/specs/1146-remove-xuserid-fallback/checklists/requirements.md
+++ b/specs/1146-remove-xuserid-fallback/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Remove X-User-ID Header Fallback
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-01-05
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Requirements are testable and unambiguous
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] User scenarios cover primary flows
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- All checklist items pass
+- Ready for `/speckit.plan`
+- This is a security-critical deletion task (CVSS 9.1)
+- No clarifications needed - scope is clear (remove header fallback)

--- a/specs/1146-remove-xuserid-fallback/plan.md
+++ b/specs/1146-remove-xuserid-fallback/plan.md
@@ -1,0 +1,228 @@
+# Implementation Plan: Remove X-User-ID Header Fallback
+
+**Branch**: `1146-remove-xuserid-fallback` | **Date**: 2026-01-05 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/1146-remove-xuserid-fallback/spec.md`
+
+## Summary
+
+Remove the X-User-ID header fallback mechanism from auth_middleware.py that allows user impersonation attacks. The middleware currently accepts X-User-ID header as a fallback when Bearer token is missing, enabling CVSS 9.1 Critical vulnerability. Fix requires removing fallback code and updating tests to use proper session-based authentication.
+
+## Technical Context
+
+**Language/Version**: Python 3.13
+**Primary Dependencies**: FastAPI, PyJWT, boto3 (DynamoDB)
+**Storage**: DynamoDB (users table, sessions)
+**Testing**: pytest, moto (AWS mocks)
+**Target Platform**: AWS Lambda
+**Project Type**: Web application (backend + frontend)
+**Performance Goals**: No latency impact (removing code)
+**Constraints**: Must not break legitimate auth flows (magic link, OAuth, anonymous)
+**Scale/Scope**: Security fix - minimal code change, significant test updates
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Gate | Status | Notes |
+|------|--------|-------|
+| Security & Access Control (§3) | PASS | Removing insecure fallback improves security |
+| NoSQL/Expression safety (§100) | N/A | No DynamoDB changes |
+| Functional Integrity Principle (§240-252) | PASS | Tests will be updated to use proper auth |
+| Implementation Accompaniment Rule (§232-239) | PASS | All changes accompanied by test updates |
+| Pipeline Check Bypass (§446-470) | N/A | Will not bypass |
+| Environment Testing Matrix (§181-206) | PASS | Unit tests with mocks, E2E with real AWS |
+
+**Pre-Phase 0 Result**: PASS - No violations
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/1146-remove-xuserid-fallback/
+├── spec.md              # Feature specification
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # N/A (no data model changes)
+├── quickstart.md        # N/A (security fix, no new features)
+├── contracts/           # N/A (no API contract changes)
+└── tasks.md             # Phase 2 output
+```
+
+### Source Code (affected files)
+
+```text
+# Backend - Core Changes
+src/lambdas/shared/middleware/
+└── auth_middleware.py          # Lines 204-212, 314-325: Remove X-User-ID fallback
+
+src/lambdas/dashboard/
+└── router_v2.py                # Lines 283, 321, 420: Remove X-User-ID reads
+
+# Frontend - Changes Required
+frontend/src/lib/api/
+└── client.ts                   # Lines 54-63, 115-121: Remove X-User-ID header
+
+frontend/src/stores/
+└── auth-store.ts               # Lines 70-71, 262-264: Remove setUserId sync
+
+# CI/CD - Changes Required
+.github/workflows/
+└── deploy.yml                  # Lines 1252-1280: Update warmup requests
+
+# Tests - Major Updates Required
+tests/unit/dashboard/
+├── test_auth.py                # Update: 5 tests use X-User-ID
+├── test_ohlc.py                # Update: 17+ tests use X-User-ID headers
+├── test_sentiment_history.py   # Update: AUTH_HEADERS uses X-User-ID
+└── test_sse.py                 # Update: 1 test uses X-User-ID
+
+tests/unit/lambdas/shared/auth/
+└── test_session_consistency.py # Update: 6 tests use X-User-ID
+
+tests/e2e/
+├── test_metrics_auth.py        # Review/update
+└── test_anonymous_restrictions.py # Review/update
+```
+
+**Structure Decision**: Web application with backend/ and frontend/ directories. Changes span both, plus CI/CD workflows.
+
+## Complexity Tracking
+
+No violations requiring justification. This is a removal/simplification, not an addition of complexity.
+
+## Phase 0: Research Summary
+
+### R1: X-User-ID Fallback Locations
+
+**Primary Fallback (MUST REMOVE)**:
+- `auth_middleware.py:204-212` in `extract_user_id()`:
+  ```python
+  # Lines to remove:
+  user_id = normalized_headers.get("x-user-id")
+  if user_id:
+      return user_id
+  ```
+
+- `auth_middleware.py:314-325` in `extract_auth_context_typed()`:
+  ```python
+  # Lines to remove:
+  user_id = normalized_headers.get("x-user-id")
+  if user_id and _is_valid_uuid(user_id):
+      return AuthContext(
+          user_id=user_id,
+          auth_type=AuthType.ANONYMOUS,
+          auth_method="x-user-id",
+          ...
+      )
+  ```
+
+**Secondary Reads (EVALUATE)**:
+- `router_v2.py:283` - GET /validate reads X-User-ID (optional linking)
+- `router_v2.py:321` - POST /magic-link reads X-User-ID (optional linking)
+- `router_v2.py:420` - Similar optional read
+
+### R2: Authentication Flow Preservation
+
+**Flows that MUST continue working**:
+1. **Anonymous**: POST /auth/anonymous → returns UUID token → Bearer {uuid}
+2. **Magic Link**: Request → email → verify → JWT tokens → Bearer {jwt}
+3. **OAuth**: Redirect → provider → callback → JWT tokens → Bearer {jwt}
+
+**Key insight**: All legitimate flows already use Bearer tokens. X-User-ID is ONLY used by:
+- Legacy test code (must update)
+- Frontend fallback (must remove)
+- Warmup requests in CI (must update to use Bearer)
+
+### R3: Test Migration Strategy
+
+**Tests requiring update** (total ~30 tests):
+- Replace `headers={"X-User-ID": uuid}` with `headers={"Authorization": f"Bearer {uuid}"}`
+- For authenticated tests, use proper JWT fixture
+- No behavior change expected - just header format
+
+### R4: Frontend Impact
+
+**client.ts:115-121** sets X-User-ID when no Bearer token:
+```typescript
+// Must remove this fallback:
+if (!accessToken && state.userId) {
+  headers['X-User-ID'] = state.userId;
+}
+```
+After removal, frontend MUST use Bearer token always. Anonymous sessions already get a token from POST /auth/anonymous, so this is safe.
+
+## Phase 1: Design
+
+### D1: Backend Changes
+
+**auth_middleware.py**:
+1. Remove X-User-ID fallback from `extract_user_id()` (lines 204-212)
+2. Remove X-User-ID fallback from `extract_auth_context_typed()` (lines 314-325)
+3. Update function docstrings to clarify Bearer-only authentication
+
+**router_v2.py**:
+1. Evaluate each X-User-ID read - if for optional linking, remove
+2. If any endpoint REQUIRES X-User-ID, refactor to use Bearer token
+
+### D2: Frontend Changes
+
+**client.ts**:
+1. Remove X-User-ID header fallback (lines 115-121)
+2. Ensure all requests use Authorization: Bearer header
+
+**auth-store.ts**:
+1. Remove setUserId sync to API client (lines 70-71, 262-264)
+2. Keep userId in store for display purposes only
+
+### D3: CI/CD Changes
+
+**deploy.yml**:
+1. Update warmup requests to use Bearer token format
+2. Use a valid anonymous UUID as Bearer token
+
+### D4: Test Updates
+
+**Strategy**: Global find/replace where safe, manual review for edge cases
+
+Pattern transformation:
+```python
+# Before:
+headers={"X-User-ID": TEST_USER_ID}
+
+# After:
+headers={"Authorization": f"Bearer {TEST_USER_ID}"}
+```
+
+**Files to update**:
+- tests/unit/dashboard/test_auth.py (5 tests)
+- tests/unit/dashboard/test_ohlc.py (17+ tests)
+- tests/unit/dashboard/test_sentiment_history.py (AUTH_HEADERS constant)
+- tests/unit/dashboard/test_sse.py (1 test)
+- tests/unit/lambdas/shared/auth/test_session_consistency.py (6 tests)
+
+### D5: Test Cases to ADD
+
+New tests to verify security fix:
+1. `test_x_user_id_header_ignored()` - X-User-ID in request should be completely ignored
+2. `test_x_user_id_without_bearer_returns_401()` - No Bearer + X-User-ID = 401
+3. `test_bearer_only_authentication()` - Verify only Bearer is accepted
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Tests fail after header change | Automated find/replace with manual review |
+| Frontend breaks for anonymous users | Verify /auth/anonymous returns token before deployment |
+| Warmup requests fail | Test warmup with Bearer format in staging |
+| Hidden X-User-ID dependencies | Comprehensive grep search before merge |
+
+## Success Criteria Verification
+
+| Criterion | How to Verify |
+|-----------|---------------|
+| SC-001: X-User-ID rejected without session | New test: send X-User-ID only, expect 401 |
+| SC-002: Valid sessions work | All existing auth tests pass with Bearer |
+| SC-003: Auth flows unchanged | E2E tests pass in preprod |
+| SC-004: No regressions | Full test suite green |
+| SC-005: Attack blocked | New test: X-User-ID spoofing returns 401 |

--- a/specs/1146-remove-xuserid-fallback/research.md
+++ b/specs/1146-remove-xuserid-fallback/research.md
@@ -1,0 +1,78 @@
+# Research: Remove X-User-ID Header Fallback
+
+**Feature**: 1146-remove-xuserid-fallback
+**Date**: 2026-01-05
+
+## Research Questions
+
+### RQ1: Where is X-User-ID fallback implemented?
+
+**Decision**: Remove fallback from two locations in auth_middleware.py
+
+**Findings**:
+- `extract_user_id()` at lines 204-212: Falls back to X-User-ID after Bearer token check
+- `extract_auth_context_typed()` at lines 314-325: Returns AuthContext with auth_method="x-user-id"
+- Both functions normalize headers to lowercase and check for `x-user-id` key
+
+**Rationale**: These are the ONLY locations where X-User-ID is accepted as identity source. Other router_v2.py reads are for optional account linking, not primary identity.
+
+**Alternatives Considered**:
+- Deprecation warning first: Rejected - this is a CVSS 9.1 Critical vulnerability
+- Feature flag: Rejected - security fixes must be immediate, not gradual
+
+### RQ2: What legitimate code uses X-User-ID?
+
+**Decision**: Update all legitimate uses to Bearer token format
+
+**Findings**:
+1. **Frontend client.ts:115-121**: Sets X-User-ID when no Bearer token (fallback)
+2. **Frontend auth-store.ts:70-71**: Syncs userId to API client for X-User-ID
+3. **CI deploy.yml:1252-1280**: Warmup requests use X-User-ID header
+4. **Tests**: ~30 test functions use X-User-ID for test authentication
+
+**Rationale**: All legitimate authentication already supports Bearer tokens. The /auth/anonymous endpoint returns a UUID that can be used as Bearer token. X-User-ID is redundant.
+
+**Alternatives Considered**:
+- Keep X-User-ID for backwards compatibility: Rejected - security vulnerability
+- Add migration period: Rejected - no external clients depend on this header
+
+### RQ3: How should tests be updated?
+
+**Decision**: Replace X-User-ID headers with Bearer authorization headers
+
+**Findings**:
+- Anonymous auth uses UUID as both user_id and token
+- Pattern: `headers={"X-User-ID": uuid}` → `headers={"Authorization": f"Bearer {uuid}"}`
+- Tests for X-User-ID rejection should be ADDED (not existing behavior)
+
+**Rationale**: This is the minimal change that preserves test coverage while using the correct authentication method.
+
+**Alternatives Considered**:
+- Create new auth fixture with JWT mocking: Overkill for anonymous tests
+- Use actual session creation in tests: Adds complexity without benefit
+
+### RQ4: What is the frontend impact?
+
+**Decision**: Remove X-User-ID fallback from client.ts, rely on Bearer token only
+
+**Findings**:
+- Frontend stores accessToken from /auth/anonymous response
+- accessToken IS the user_id for anonymous sessions
+- X-User-ID is only set when accessToken is missing (edge case that shouldn't occur)
+
+**Rationale**: If accessToken is missing, the user should re-authenticate via /auth/anonymous rather than fall back to insecure header.
+
+**Alternatives Considered**:
+- Keep X-User-ID as backup: Rejected - defeats the security fix
+- Auto-redirect to /auth/anonymous if no token: Could add, but out of scope for this fix
+
+## Summary
+
+| Question | Decision | Confidence |
+|----------|----------|------------|
+| RQ1: Fallback location | Remove from auth_middleware.py (2 functions) | High |
+| RQ2: Legitimate uses | Update frontend, CI, tests to use Bearer | High |
+| RQ3: Test strategy | Find/replace header format | High |
+| RQ4: Frontend impact | Remove fallback, require Bearer token | High |
+
+All research questions resolved. No NEEDS CLARIFICATION items remaining.

--- a/specs/1146-remove-xuserid-fallback/spec.md
+++ b/specs/1146-remove-xuserid-fallback/spec.md
@@ -1,0 +1,135 @@
+# Feature Specification: Remove X-User-ID Header Fallback
+
+**Feature Branch**: `1146-remove-xuserid-fallback`
+**Created**: 2026-01-05
+**Status**: Draft
+**Priority**: P0 - Critical Security Fix
+**CVSS**: 9.1 (Critical)
+**Input**: User description: "Phase 0 D5: Remove X-User-ID header fallback from auth middleware. Backend currently accepts X-User-ID header as fallback identity source, enabling impersonation attacks. Must remove fallback and require authenticated session only. CVSS 9.1 (Critical). Security fix - no new features."
+
+---
+
+## Problem Statement
+
+The authentication middleware currently accepts an `X-User-ID` header as a fallback mechanism for user identification. This creates a critical security vulnerability where any client can impersonate any user by simply setting this header. This bypasses all authentication controls and allows unauthorized access to user accounts and data.
+
+**Attack Vector**: Attacker sends request with `X-User-ID: <victim-user-id>` header → System accepts this as the authenticated user → Attacker gains full access to victim's data.
+
+---
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Security Fix (Priority: P1)
+
+As a **security engineer**, I need the X-User-ID header fallback removed so that users can only be identified through properly authenticated sessions, preventing impersonation attacks.
+
+**Why this priority**: This is a CVSS 9.1 Critical vulnerability that allows complete account takeover. No feature work can proceed until this is fixed.
+
+**Independent Test**: Can be fully tested by sending requests with fake X-User-ID headers and verifying they are rejected. Delivers security by closing the impersonation attack vector.
+
+**Acceptance Scenarios**:
+
+1. **Given** a valid authenticated session, **When** a request is made without X-User-ID header, **Then** the system identifies the user from the authenticated session
+2. **Given** a valid authenticated session, **When** a request includes a malicious X-User-ID header, **Then** the system ignores the header and uses only the session identity
+3. **Given** no authenticated session, **When** a request includes an X-User-ID header, **Then** the system returns 401 Unauthorized (not accepting the header as identity)
+4. **Given** no authenticated session and no X-User-ID header, **When** a request is made to a protected endpoint, **Then** the system returns 401 Unauthorized
+
+---
+
+### User Story 2 - Application Stability (Priority: P2)
+
+As a **user**, I need the system to continue functioning correctly after the security fix so that my normal usage is unaffected.
+
+**Why this priority**: After closing the security hole, the application must still work for legitimate users.
+
+**Independent Test**: Can be fully tested by performing all authentication flows (anonymous, magic link, OAuth) and verifying protected endpoints still work with valid sessions.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user authenticates via magic link, **When** they access protected endpoints, **Then** their requests succeed with proper authorization
+2. **Given** a user authenticates via OAuth, **When** they access protected endpoints, **Then** their requests succeed with proper authorization
+3. **Given** an anonymous user creates a session, **When** they access anonymous-allowed endpoints, **Then** their requests succeed
+
+---
+
+### Edge Cases
+
+- What happens when legacy clients still send X-User-ID header? System must ignore it silently (no error, just ignored)
+- What happens when session cookie is present but expired? System returns 401, does not fall back to X-User-ID
+- What happens when both session and X-User-ID header are present with different user IDs? System uses only session identity, completely ignores header
+- What happens to anonymous sessions that previously used X-User-ID? Anonymous sessions must use proper session tracking, not header-based identification
+
+---
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST NOT accept X-User-ID header as an identity source under any circumstances
+- **FR-002**: System MUST derive user identity exclusively from authenticated session tokens
+- **FR-003**: System MUST return 401 Unauthorized for requests to protected endpoints without valid session
+- **FR-004**: System MUST ignore any X-User-ID header silently (no error response for including it, just not used)
+- **FR-005**: System MUST maintain backward compatibility for all legitimate authentication flows (magic link, OAuth, anonymous)
+- **FR-006**: System MUST NOT break any existing functionality that relies on proper session-based authentication
+
+### Non-Functional Requirements
+
+- **NFR-001**: Change must not increase request latency by more than 1ms
+- **NFR-002**: All existing tests must pass after the change (no regression)
+- **NFR-003**: Security fix must be atomic - no partial states where header is sometimes accepted
+
+---
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of requests with fake X-User-ID headers (and no valid session) receive 401 Unauthorized
+- **SC-002**: 100% of requests with valid sessions continue to work regardless of X-User-ID header presence
+- **SC-003**: All existing authentication flows (magic link, OAuth, anonymous) continue to function with no change in success rate
+- **SC-004**: Zero regressions in existing test suite
+- **SC-005**: Attack simulation: Requests with `X-User-ID: <other-user>` header cannot access other user's data
+
+---
+
+## Scope
+
+### In Scope
+
+- Remove X-User-ID header fallback from authentication middleware
+- Update any code that reads X-User-ID header for identity
+- Update tests that relied on X-User-ID header (convert to proper session auth)
+
+### Out of Scope
+
+- New authentication methods
+- Changes to session token format
+- Changes to OAuth or magic link flows
+- Frontend changes (backend-only fix)
+- Adding new security features
+
+---
+
+## Assumptions
+
+- The codebase uses middleware-based authentication
+- User identity should come exclusively from JWT/session tokens
+- The X-User-ID header was a development convenience that should never have been in production
+- Anonymous sessions have their own session token mechanism (not X-User-ID based)
+
+---
+
+## Dependencies
+
+- Must be completed after D4 (cookies.ts deletion) - completed
+- Blocks C4 and C5 (endpoint protection) which need clean identity model
+
+---
+
+## Risk Assessment
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Breaking legitimate functionality | Low | High | Comprehensive test coverage before and after |
+| Missing some code paths that use X-User-ID | Medium | High | Full codebase search for all references |
+| Tests that relied on X-User-ID fail | High | Low | Update tests to use proper auth |

--- a/specs/1146-remove-xuserid-fallback/tasks.md
+++ b/specs/1146-remove-xuserid-fallback/tasks.md
@@ -1,0 +1,192 @@
+# Tasks: Remove X-User-ID Header Fallback
+
+**Input**: Design documents from `/specs/1146-remove-xuserid-fallback/`
+**Prerequisites**: plan.md (complete), spec.md (complete), research.md (complete)
+
+**Tests**: This feature REQUIRES new security tests to verify the vulnerability is closed. Existing tests must be updated to use Bearer tokens.
+
+**Organization**: Tasks grouped by user story for independent implementation and testing.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1=Security Fix, US2=Application Stability)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+- **Backend**: `src/lambdas/shared/middleware/`, `src/lambdas/dashboard/`
+- **Frontend**: `frontend/src/lib/api/`, `frontend/src/stores/`
+- **Tests**: `tests/unit/`, `tests/e2e/`
+- **CI/CD**: `.github/workflows/`
+
+---
+
+## Phase 1: Setup (No Setup Required)
+
+**Purpose**: This is a security fix removing existing code - no new project setup needed.
+
+**Checkpoint**: Proceed directly to Foundational phase.
+
+---
+
+## Phase 2: Foundational (Test Infrastructure Update)
+
+**Purpose**: Update test infrastructure to use Bearer tokens instead of X-User-ID headers. MUST complete before user story implementation to prevent test failures.
+
+**⚠️ CRITICAL**: These test updates are blocking - the security fix will cause all X-User-ID tests to fail.
+
+- [X] T001 [P] Update AUTH_HEADERS constant from X-User-ID to Bearer in tests/unit/dashboard/test_sentiment_history.py
+- [X] T002 [P] Update all X-User-ID headers to Bearer format in tests/unit/dashboard/test_ohlc.py (~17 occurrences)
+- [X] T003 [P] Update X-User-ID headers to Bearer format in tests/unit/dashboard/test_sse.py
+- [X] T004 [P] Update 6 X-User-ID test cases in tests/unit/lambdas/shared/auth/test_session_consistency.py to use Bearer
+- [X] T005 [P] Review and update tests/e2e/test_metrics_auth.py for Bearer authentication (uses API client abstraction - no changes needed)
+- [X] T006 [P] Review and update tests/e2e/test_anonymous_restrictions.py for Bearer authentication (uses API client abstraction - no changes needed)
+- [X] T007 Update warmup requests in .github/workflows/deploy.yml from X-User-ID to Bearer format (lines 1252-1280)
+
+**Checkpoint**: All tests should still pass with existing code (X-User-ID fallback still exists). Tests are now ready for the security fix.
+
+---
+
+## Phase 3: User Story 1 - Security Fix (Priority: P1) 🎯 MVP
+
+**Goal**: Close CVSS 9.1 Critical vulnerability by removing X-User-ID header fallback from auth middleware.
+
+**Independent Test**: Send request with X-User-ID header only (no Bearer token) → expect 401 Unauthorized.
+
+### New Security Tests for User Story 1
+
+> **NOTE: Write these tests FIRST, ensure they FAIL before removing the fallback**
+
+- [X] T008 [P] [US1] Add test_x_user_id_header_ignored() in tests/unit/dashboard/test_auth.py - verify X-User-ID with valid Bearer still uses Bearer identity
+- [X] T009 [P] [US1] Add test_x_user_id_without_bearer_returns_401() in tests/unit/dashboard/test_auth.py - verify X-User-ID alone gets 401
+- [X] T010 [P] [US1] Add test_bearer_only_authentication() in tests/unit/dashboard/test_auth.py - verify only Bearer accepted
+
+### Implementation for User Story 1
+
+- [X] T011 [US1] Remove X-User-ID fallback from extract_user_id() in src/lambdas/shared/middleware/auth_middleware.py (lines 204-212)
+- [X] T012 [US1] Remove X-User-ID fallback from extract_auth_context_typed() in src/lambdas/shared/middleware/auth_middleware.py (lines 314-325)
+- [X] T013 [US1] Update docstrings in auth_middleware.py to document Bearer-only authentication
+- [X] T014 [P] [US1] Review and remove X-User-ID reads from router_v2.py (lines 283, 321, 420) - refactored to use get_user_id_from_request()
+- [X] T015 [US1] Run unit tests to verify security tests now pass (T008-T010) - All 39 tests passed
+
+**Checkpoint**: Security vulnerability closed. Requests with only X-User-ID header return 401. All unit tests pass.
+
+---
+
+## Phase 4: User Story 2 - Application Stability (Priority: P2)
+
+**Goal**: Ensure all legitimate authentication flows continue working after the security fix.
+
+**Independent Test**: Perform magic link, OAuth, and anonymous authentication flows → all should succeed with proper Bearer tokens.
+
+### Tests for User Story 2
+
+> **NOTE: Existing tests should pass - these verify no regression**
+
+- [X] T016 [US2] Run existing auth flow tests to verify magic link still works (covered by auth tests)
+- [X] T017 [US2] Run existing auth flow tests to verify OAuth still works (covered by auth tests)
+- [X] T018 [US2] Run existing auth flow tests to verify anonymous session still works (covered by auth tests)
+
+### Implementation for User Story 2 (Frontend Updates)
+
+- [X] T019 [P] [US2] Remove X-User-ID header fallback from frontend/src/lib/api/client.ts (lines 115-121)
+- [X] T020 [P] [US2] Update setUserId in auth-store.ts to ensure Bearer token is set (lines 70-71)
+- [X] T021 [US2] Verify frontend builds without errors after X-User-ID removal - TypeScript + lint pass
+- [X] T022 [US2] Run frontend unit tests to verify no regressions - 414/414 tests pass
+
+**Checkpoint**: Frontend uses Bearer-only authentication. All auth flows work correctly.
+
+---
+
+## Phase 5: Polish & Verification
+
+**Purpose**: Final verification and documentation
+
+- [X] T023 Run full test suite (make test-local) to verify zero regressions - 2588/2588 unit tests pass
+- [X] T024 Grep codebase for any remaining X-User-ID references that might be missed - 417 refs found, most are comments/docs or tests verifying rejection
+- [X] T025 [P] Update integration/E2E test helpers to use Bearer tokens (api_client.py, auth_headers fixtures)
+- [ ] T026 Run E2E tests in preprod to verify all auth flows work end-to-end (requires deployment)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: Skipped - no setup required
+- **Foundational (Phase 2)**: Must complete first - updates tests to prevent failures
+- **User Story 1 (Phase 3)**: Depends on Phase 2 - security fix
+- **User Story 2 (Phase 4)**: Depends on Phase 3 - frontend alignment
+- **Polish (Phase 5)**: Depends on Phase 3 and 4 - final verification
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Can start after Foundational (Phase 2)
+- **User Story 2 (P2)**: Can start after US1 complete (frontend needs backend fix deployed/tested first)
+
+### Within Each Phase
+
+- Security tests (T008-T010) MUST be written and FAIL before T011-T012
+- Backend fix (T011-T012) before frontend update (T019-T020)
+- Each task commits independently
+
+### Parallel Opportunities
+
+- **Phase 2**: All T001-T007 can run in parallel (different files)
+- **Phase 3 Tests**: T008, T009, T010 can run in parallel
+- **Phase 4 Frontend**: T019, T020 can run in parallel (different files)
+
+---
+
+## Parallel Example: Phase 2 (Foundational)
+
+```bash
+# Launch all test updates in parallel (different files):
+Task: "Update AUTH_HEADERS in tests/unit/dashboard/test_sentiment_history.py"
+Task: "Update X-User-ID headers in tests/unit/dashboard/test_ohlc.py"
+Task: "Update X-User-ID headers in tests/unit/dashboard/test_sse.py"
+Task: "Update tests in tests/unit/lambdas/shared/auth/test_session_consistency.py"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 2: Foundational (test updates)
+2. Complete Phase 3: User Story 1 (security fix)
+3. **STOP and VALIDATE**: Run unit tests, verify 401 for X-User-ID only
+4. Can deploy backend independently if frontend update is delayed
+
+### Incremental Delivery
+
+1. Phase 2 → Test infrastructure ready
+2. Phase 3 (US1) → Security vulnerability closed (MVP!)
+3. Phase 4 (US2) → Frontend aligned with new auth model
+4. Phase 5 → Final polish and E2E verification
+
+### Sequential Execution (Recommended)
+
+This feature should be executed sequentially (not parallel teams) because:
+- Security fix is atomic
+- Frontend depends on backend fix
+- All changes must land together for consistency
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [US1] = Security Fix (CVSS 9.1 Critical)
+- [US2] = Application Stability (non-breaking)
+- T011-T012 are the CRITICAL security fix tasks
+- All existing tests must pass after T001-T007
+- Security tests (T008-T010) must fail before T011-T012, pass after
+- Commit after each task or logical group
+- Total tasks: 26
+- US1 tasks: 8 (security focus)
+- US2 tasks: 7 (stability focus)
+- Foundational: 7 (test prep)
+- Polish: 4 (verification)

--- a/tests/integration/ohlc/test_error_resilience.py
+++ b/tests/integration/ohlc/test_error_resilience.py
@@ -64,8 +64,8 @@ def clear_ohlc_cache():
 
 @pytest.fixture
 def auth_headers():
-    """Headers with valid authentication (Feature 1049: valid UUID required)."""
-    return {"X-User-ID": "550e8400-e29b-41d4-a716-446655440000"}
+    """Headers with valid authentication (Feature 1146: Bearer-only auth)."""
+    return {"Authorization": "Bearer 550e8400-e29b-41d4-a716-446655440000"}
 
 
 def create_test_client_with_injectors(

--- a/tests/integration/ohlc/test_happy_path.py
+++ b/tests/integration/ohlc/test_happy_path.py
@@ -61,8 +61,8 @@ def test_client(mock_tiingo, mock_finnhub):
 
 @pytest.fixture
 def auth_headers():
-    """Headers with valid authentication (Feature 1049: valid UUID required)."""
-    return {"X-User-ID": "550e8400-e29b-41d4-a716-446655440000"}
+    """Headers with valid authentication (Feature 1146: Bearer-only auth)."""
+    return {"Authorization": "Bearer 550e8400-e29b-41d4-a716-446655440000"}
 
 
 class TestOHLCHappyPath:

--- a/tests/integration/sentiment_history/test_happy_path.py
+++ b/tests/integration/sentiment_history/test_happy_path.py
@@ -37,8 +37,8 @@ def test_client():
 
 @pytest.fixture
 def auth_headers():
-    """Headers with valid authentication (Feature 1049: valid UUID required)."""
-    return {"X-User-ID": "550e8400-e29b-41d4-a716-446655440000"}
+    """Headers with valid authentication (Feature 1146: Bearer-only auth)."""
+    return {"Authorization": "Bearer 550e8400-e29b-41d4-a716-446655440000"}
 
 
 class TestSentimentHistoryHappyPath:

--- a/tests/integration/test_dashboard_dev.py
+++ b/tests/integration/test_dashboard_dev.py
@@ -52,10 +52,10 @@ def client():
 def auth_headers():
     """Return valid authorization headers.
 
-    Feature 1039: Uses X-User-ID with anonymous UUID for session auth.
-    Anonymous sessions are accepted for public endpoints.
+    Feature 1146: Bearer-only authentication (X-User-ID fallback removed).
+    Anonymous sessions use Bearer token with UUID.
     """
-    return {"X-User-ID": "550e8400-e29b-41d4-a716-446655440000"}
+    return {"Authorization": "Bearer 550e8400-e29b-41d4-a716-446655440000"}
 
 
 class TestDashboardDevE2E:

--- a/tests/unit/dashboard/test_ohlc.py
+++ b/tests/unit/dashboard/test_ohlc.py
@@ -73,7 +73,7 @@ class TestOHLCEndpoint:
 
         response = client.get(
             "/api/v2/tickers/AAPL/ohlc",
-            headers={"X-User-ID": TEST_USER_ID},
+            headers={"Authorization": f"Bearer {TEST_USER_ID}"},
         )
 
         assert response.status_code == 200
@@ -98,7 +98,7 @@ class TestOHLCEndpoint:
         """Should reject invalid ticker symbols."""
         response = client.get(
             "/api/v2/tickers/INVALID123/ohlc",
-            headers={"X-User-ID": TEST_USER_ID},
+            headers={"Authorization": f"Bearer {TEST_USER_ID}"},
         )
 
         assert response.status_code == 400
@@ -121,7 +121,7 @@ class TestOHLCEndpoint:
 
         response = client.get(
             "/api/v2/tickers/AAPL/ohlc",
-            headers={"X-User-ID": TEST_USER_ID},
+            headers={"Authorization": f"Bearer {TEST_USER_ID}"},
         )
 
         assert response.status_code == 404
@@ -141,7 +141,7 @@ class TestOHLCEndpoint:
 
         response = client.get(
             "/api/v2/tickers/AAPL/ohlc",
-            headers={"X-User-ID": TEST_USER_ID},
+            headers={"Authorization": f"Bearer {TEST_USER_ID}"},
         )
 
         assert response.status_code == 404
@@ -157,7 +157,7 @@ class TestOHLCEndpoint:
 
         response = client.get(
             "/api/v2/tickers/AAPL/ohlc?range=3M",
-            headers={"X-User-ID": TEST_USER_ID},
+            headers={"Authorization": f"Bearer {TEST_USER_ID}"},
         )
 
         assert response.status_code == 200
@@ -173,7 +173,7 @@ class TestOHLCEndpoint:
 
         response = client.get(
             "/api/v2/tickers/AAPL/ohlc?start_date=2024-01-01&end_date=2024-01-31",
-            headers={"X-User-ID": TEST_USER_ID},
+            headers={"Authorization": f"Bearer {TEST_USER_ID}"},
         )
 
         assert response.status_code == 200
@@ -185,7 +185,7 @@ class TestOHLCEndpoint:
         """Should reject when start_date is after end_date."""
         response = client.get(
             "/api/v2/tickers/AAPL/ohlc?start_date=2024-12-31&end_date=2024-01-01",
-            headers={"X-User-ID": TEST_USER_ID},
+            headers={"Authorization": f"Bearer {TEST_USER_ID}"},
         )
 
         assert response.status_code == 400
@@ -201,7 +201,7 @@ class TestOHLCEndpoint:
 
         response = client.get(
             "/api/v2/tickers/AAPL/ohlc",
-            headers={"X-User-ID": TEST_USER_ID},
+            headers={"Authorization": f"Bearer {TEST_USER_ID}"},
         )
 
         assert response.status_code == 200
@@ -217,7 +217,7 @@ class TestOHLCEndpoint:
 
         response = client.get(
             "/api/v2/tickers/aapl/ohlc",
-            headers={"X-User-ID": TEST_USER_ID},
+            headers={"Authorization": f"Bearer {TEST_USER_ID}"},
         )
 
         assert response.status_code == 200
@@ -283,7 +283,7 @@ class TestOHLCResolutionEndpoint:
 
         response = client.get(
             "/api/v2/tickers/AAPL/ohlc?resolution=5",
-            headers={"X-User-ID": TEST_USER_ID},
+            headers={"Authorization": f"Bearer {TEST_USER_ID}"},
         )
 
         assert response.status_code == 200
@@ -300,7 +300,7 @@ class TestOHLCResolutionEndpoint:
 
         response = client.get(
             "/api/v2/tickers/AAPL/ohlc",
-            headers={"X-User-ID": TEST_USER_ID},
+            headers={"Authorization": f"Bearer {TEST_USER_ID}"},
         )
 
         assert response.status_code == 200
@@ -324,7 +324,7 @@ class TestOHLCResolutionEndpoint:
 
         response = client.get(
             "/api/v2/tickers/AAPL/ohlc?resolution=5",
-            headers={"X-User-ID": TEST_USER_ID},
+            headers={"Authorization": f"Bearer {TEST_USER_ID}"},
         )
 
         assert response.status_code == 200
@@ -347,7 +347,7 @@ class TestOHLCResolutionEndpoint:
 
         response = client.get(
             "/api/v2/tickers/AAPL/ohlc",
-            headers={"X-User-ID": TEST_USER_ID},
+            headers={"Authorization": f"Bearer {TEST_USER_ID}"},
         )
 
         assert response.status_code == 200
@@ -377,7 +377,7 @@ class TestOHLCResolutionEndpoint:
 
         response = client.get(
             "/api/v2/tickers/AAPL/ohlc?resolution=5",
-            headers={"X-User-ID": TEST_USER_ID},
+            headers={"Authorization": f"Bearer {TEST_USER_ID}"},
         )
 
         assert response.status_code == 200
@@ -409,7 +409,7 @@ class TestOHLCResolutionEndpoint:
 
         response = client.get(
             f"/api/v2/tickers/AAPL/ohlc?resolution={resolution}",
-            headers={"X-User-ID": TEST_USER_ID},
+            headers={"Authorization": f"Bearer {TEST_USER_ID}"},
         )
 
         assert response.status_code == 200
@@ -420,7 +420,7 @@ class TestOHLCResolutionEndpoint:
         """Should reject invalid resolution values."""
         response = client.get(
             "/api/v2/tickers/AAPL/ohlc?resolution=invalid",
-            headers={"X-User-ID": TEST_USER_ID},
+            headers={"Authorization": f"Bearer {TEST_USER_ID}"},
         )
 
         assert response.status_code == 422  # Validation error

--- a/tests/unit/dashboard/test_sentiment_history.py
+++ b/tests/unit/dashboard/test_sentiment_history.py
@@ -17,7 +17,8 @@ client = TestClient(app)
 
 
 # Feature 1049: Valid UUID required for auth
-AUTH_HEADERS = {"X-User-ID": "12345678-1234-5678-1234-567812345678"}
+# Feature 1146: Bearer-only authentication (X-User-ID header fallback removed)
+AUTH_HEADERS = {"Authorization": "Bearer 12345678-1234-5678-1234-567812345678"}
 
 
 class TestSentimentHistoryEndpoint:

--- a/tests/unit/dashboard/test_sse.py
+++ b/tests/unit/dashboard/test_sse.py
@@ -375,7 +375,7 @@ class TestConfigStreamEndpoint:
                         client = TestClient(app)
                         response = client.get(
                             "/api/v2/configurations/invalid-config/stream",
-                            headers={"X-User-ID": "user-123"},
+                            headers={"Authorization": "Bearer user-123"},
                         )
                         assert response.status_code == 404
 

--- a/tests/unit/lambdas/shared/auth/test_session_consistency.py
+++ b/tests/unit/lambdas/shared/auth/test_session_consistency.py
@@ -1,10 +1,13 @@
 """Unit tests for session consistency (Feature 014, User Story 1).
 
-Tests for FR-001, FR-002, FR-003: Hybrid auth header support and session validation.
+Tests for FR-001, FR-002, FR-003: Bearer-only authentication and session validation.
+
+Feature 1146: X-User-ID header fallback REMOVED for security (CVSS 9.1).
 
 These tests verify:
-- Backend accepts both X-User-ID and Authorization: Bearer headers
-- User ID is extracted consistently from either format
+- Backend ONLY accepts Authorization: Bearer headers
+- X-User-ID header is IGNORED (no longer accepted for identity)
+- User ID is extracted exclusively from Bearer tokens
 - Invalid headers are rejected appropriately
 """
 
@@ -22,8 +25,8 @@ from src.lambdas.shared.middleware.auth_middleware import (
 @pytest.mark.unit
 @pytest.mark.session_consistency
 @pytest.mark.session_us1
-class TestHybridHeaderExtraction:
-    """Tests for hybrid authentication header extraction (FR-001, FR-002)."""
+class TestBearerOnlyAuthentication:
+    """Tests for Bearer-only authentication (Feature 1146 security fix)."""
 
     def test_extract_user_id_from_bearer_token(self):
         """FR-001: Backend accepts Authorization: Bearer token."""
@@ -34,17 +37,18 @@ class TestHybridHeaderExtraction:
 
         assert result == user_id
 
-    def test_extract_user_id_from_x_user_id_header(self):
-        """FR-001: Backend accepts X-User-ID header (legacy)."""
+    def test_x_user_id_header_ignored(self):
+        """Feature 1146: X-User-ID header is IGNORED (security fix)."""
         user_id = str(uuid.uuid4())
         event = {"headers": {"X-User-ID": user_id}}
 
         result = extract_user_id(event)
 
-        assert result == user_id
+        # X-User-ID should be ignored - returns None
+        assert result is None
 
-    def test_bearer_token_takes_precedence_over_x_user_id(self):
-        """FR-001: Bearer token is preferred when both headers present."""
+    def test_bearer_token_used_even_with_x_user_id_present(self):
+        """Feature 1146: Only Bearer token used, X-User-ID completely ignored."""
         bearer_user_id = str(uuid.uuid4())
         header_user_id = str(uuid.uuid4())
         event = {
@@ -56,19 +60,17 @@ class TestHybridHeaderExtraction:
 
         result = extract_user_id(event)
 
+        # Only Bearer token should be used
         assert result == bearer_user_id
+        assert result != header_user_id
 
-    def test_extract_user_id_case_insensitive_headers(self):
-        """FR-002: Header keys are case-insensitive."""
+    def test_extract_user_id_case_insensitive_authorization_header(self):
+        """FR-002: Authorization header keys are case-insensitive."""
         user_id = str(uuid.uuid4())
 
-        # Test lowercase
-        event1 = {"headers": {"authorization": f"Bearer {user_id}"}}
-        assert extract_user_id(event1) == user_id
-
-        # Test mixed case
-        event2 = {"headers": {"x-user-id": user_id}}
-        assert extract_user_id(event2) == user_id
+        # Test lowercase authorization
+        event = {"headers": {"authorization": f"Bearer {user_id}"}}
+        assert extract_user_id(event) == user_id
 
     def test_extract_user_id_returns_none_for_missing_headers(self):
         """No user ID when headers are missing."""
@@ -81,14 +83,6 @@ class TestHybridHeaderExtraction:
     def test_extract_user_id_returns_none_for_invalid_bearer(self):
         """Invalid Bearer token (non-UUID) returns None."""
         event = {"headers": {"Authorization": "Bearer invalid-not-uuid"}}
-
-        result = extract_user_id(event)
-
-        assert result is None
-
-    def test_extract_user_id_returns_none_for_invalid_x_user_id(self):
-        """Invalid X-User-ID (non-UUID) returns None."""
-        event = {"headers": {"X-User-ID": "invalid-not-uuid"}}
 
         result = extract_user_id(event)
 
@@ -120,16 +114,17 @@ class TestAuthContext:
         assert context["auth_method"] == "bearer"
         assert context["is_authenticated"] is True
 
-    def test_extract_auth_context_x_user_id(self):
-        """Auth context includes method when using X-User-ID."""
+    def test_extract_auth_context_x_user_id_returns_unauthenticated(self):
+        """Feature 1146: X-User-ID header returns unauthenticated context."""
         user_id = str(uuid.uuid4())
         event = {"headers": {"X-User-ID": user_id}}
 
         context = extract_auth_context(event)
 
-        assert context["user_id"] == user_id
-        assert context["auth_method"] == "x-user-id"
-        assert context["is_authenticated"] is True
+        # X-User-ID is ignored, so no authentication
+        assert context["user_id"] is None
+        assert context["auth_method"] is None
+        assert context["is_authenticated"] is False
 
     def test_extract_auth_context_unauthenticated(self):
         """Auth context for unauthenticated request."""
@@ -148,14 +143,23 @@ class TestAuthContext:
 class TestRequireAuth:
     """Tests for require_auth helper (FR-002)."""
 
-    def test_require_auth_returns_user_id_when_valid(self):
-        """require_auth returns user_id for valid request."""
+    def test_require_auth_returns_user_id_when_valid_bearer(self):
+        """require_auth returns user_id for valid Bearer token."""
         user_id = str(uuid.uuid4())
-        event = {"headers": {"X-User-ID": user_id}}
+        event = {"headers": {"Authorization": f"Bearer {user_id}"}}
 
         result = require_auth(event)
 
         assert result == user_id
+
+    def test_require_auth_raises_for_x_user_id_only(self):
+        """Feature 1146: require_auth raises when only X-User-ID present."""
+        user_id = str(uuid.uuid4())
+        event = {"headers": {"X-User-ID": user_id}}
+
+        # X-User-ID alone should NOT authenticate
+        with pytest.raises(ValueError, match="Authentication required"):
+            require_auth(event)
 
     def test_require_auth_raises_for_missing_auth(self):
         """require_auth raises ValueError when no auth present."""
@@ -165,8 +169,8 @@ class TestRequireAuth:
             require_auth(event)
 
     def test_require_auth_raises_for_invalid_uuid(self):
-        """require_auth raises ValueError for invalid UUID."""
-        event = {"headers": {"X-User-ID": "not-a-uuid"}}
+        """require_auth raises ValueError for invalid UUID in Bearer."""
+        event = {"headers": {"Authorization": "Bearer not-a-uuid"}}
 
         with pytest.raises(ValueError, match="Authentication required"):
             require_auth(event)

--- a/tests/unit/middleware/test_jwt_validation.py
+++ b/tests/unit/middleware/test_jwt_validation.py
@@ -256,13 +256,18 @@ class TestExtractUserId:
         user_id = extract_user_id(event)
         assert user_id == uuid_token
 
-    def test_x_user_id_header_fallback(self):
-        """Should fall back to X-User-ID header."""
+    def test_x_user_id_header_ignored(self):
+        """Feature 1146: X-User-ID header is IGNORED (security fix).
+
+        X-User-ID header fallback was removed to prevent impersonation attacks.
+        Users MUST use Bearer token for authentication.
+        """
         user_id_value = "550e8400-e29b-41d4-a716-446655440000"
         event = {"headers": {"X-User-ID": user_id_value}}
 
         user_id = extract_user_id(event)
-        assert user_id == user_id_value
+        # X-User-ID is ignored - returns None
+        assert user_id is None
 
     def test_no_auth_returns_none(self):
         """Should return None if no authentication present."""


### PR DESCRIPTION
## Summary

- **Security fix (CVSS 9.1 Critical)**: Remove X-User-ID header fallback that enabled user impersonation attacks
- **Backend**: Remove X-User-ID fallback from auth middleware and refactor router endpoints to use Bearer-only authentication  
- **Frontend**: Update client and auth-store to use Bearer token exclusively
- **Tests**: Update ~30 test files to use Bearer token format, add security regression tests

## Test plan

- [ ] Verify all unit tests pass with Bearer token authentication
- [ ] Confirm security tests reject X-User-ID header attempts
- [ ] Validate integration tests work with Bearer format
- [ ] Check E2E tests pass with updated api_client helper
- [ ] Verify CI warmup requests use Bearer format

Refs: #1146

🤖 Generated with [Claude Code](https://claude.com/claude-code)