### PR TITLE
fix(1148): Protect /admin/sessions/revoke with @require_role("operator")

### DIFF
--- a/specs/1148-protect-admin-sessions-revoke/plan.md
+++ b/specs/1148-protect-admin-sessions-revoke/plan.md
@@ -1,0 +1,63 @@
+# Implementation Plan: Feature 1148
+
+## Overview
+
+Apply `@require_role("operator")` decorator to `/admin/sessions/revoke` endpoint.
+
+## Phase Analysis
+
+This feature is part of **Phase 1.5 (RBAC Infrastructure)** - adding authorization to admin endpoints.
+
+## Implementation Steps
+
+### Step 1: Add require_role Import
+
+- **File**: `src/lambdas/dashboard/router_v2.py`
+- **Action**: Add import for `require_role` decorator
+- **Risk**: Low (import only)
+
+### Step 2: Apply Decorator to Endpoint
+
+- **File**: `src/lambdas/dashboard/router_v2.py`
+- **Action**: Add `@require_role("operator")` below `@admin_router.post("/sessions/revoke")`
+- **Note**: Decorator order matters - `@require_role` must be AFTER route decorator
+- **Risk**: Low (pattern already proven in codebase)
+
+### Step 3: Add Request Parameter
+
+- **File**: `src/lambdas/dashboard/router_v2.py`
+- **Action**: Add `request: Request` parameter to handler function
+- **Note**: Required for `require_role` to extract auth context
+- **Risk**: Low
+
+### Step 4: Add Unit Tests
+
+- **File**: `tests/unit/lambdas/dashboard/test_admin_sessions_revoke_auth.py`
+- **Tests**:
+  - `test_revoke_without_jwt_returns_401`
+  - `test_revoke_without_operator_role_returns_403`
+  - `test_revoke_with_operator_role_succeeds`
+  - `test_revoke_error_message_does_not_enumerate_roles`
+- **Risk**: Low
+
+### Step 5: Run Existing Tests
+
+- **Command**: `pytest tests/unit/lambdas/dashboard/ -v`
+- **Verify**: No regression in existing revocation tests
+- **Risk**: Low
+
+## Dependency Check
+
+| Dependency | Status | Verified |
+|------------|--------|----------|
+| `@require_role` decorator | COMPLETE | Feature 1130 |
+| JWT `roles` claim | COMPLETE | Phase 1.5 |
+| Role constants | COMPLETE | `shared/auth/constants.py` |
+
+## Rollback Plan
+
+Remove decorator and `request` parameter - single commit revert.
+
+## Estimated Complexity
+
+**Low** - Pattern is established, implementation is ~5 lines of code change + tests.

--- a/specs/1148-protect-admin-sessions-revoke/spec.md
+++ b/specs/1148-protect-admin-sessions-revoke/spec.md
@@ -1,0 +1,110 @@
+# Feature 1148: Protect /admin/sessions/revoke Endpoint
+
+## Problem Statement
+
+The `POST /api/v2/admin/sessions/revoke` endpoint allows bulk session revocation (andon cord pattern for security incidents) but is **currently unprotected**. Any authenticated user can revoke any other user's sessions, which is a critical authorization bypass vulnerability (CVSS ~8.0).
+
+## Security Context
+
+- **Phase**: 1.5 (RBAC Infrastructure)
+- **Severity**: High - Authorization bypass enabling session hijacking attacks
+- **Attack Vector**: Authenticated attacker can:
+  1. Revoke legitimate admin sessions
+  2. Cause denial-of-service by mass revoking user sessions
+  3. Disrupt security incident response by revoking responder sessions
+
+## Requirements
+
+### Functional Requirements
+
+| ID | Requirement |
+|----|-------------|
+| FR-001 | Endpoint MUST require `operator` role for access |
+| FR-002 | Requests without valid JWT MUST return 401 Unauthorized |
+| FR-003 | Requests with valid JWT but missing `operator` role MUST return 403 Forbidden |
+| FR-004 | Error messages MUST NOT enumerate valid roles (generic messages only) |
+| FR-005 | Existing bulk revocation logic MUST remain unchanged |
+
+### Non-Functional Requirements
+
+| ID | Requirement |
+|----|-------------|
+| NFR-001 | Authorization check MUST use existing `@require_role` decorator |
+| NFR-002 | No new dependencies may be introduced |
+| NFR-003 | Must maintain backward compatibility for authorized callers |
+
+## Technical Design
+
+### Solution: Apply @require_role Decorator
+
+The fix applies the existing `@require_role("operator")` decorator to the endpoint. This decorator:
+
+1. Extracts JWT from Authorization header via `extract_auth_context_typed()`
+2. Validates `roles` claim contains required role
+3. Returns appropriate error codes (401/403) with generic messages
+
+### Code Change
+
+**File**: `src/lambdas/dashboard/router_v2.py` (lines 548-563)
+
+```python
+# Before
+@admin_router.post("/sessions/revoke")
+async def revoke_sessions_bulk(...):
+
+# After
+from src.lambdas.shared.middleware.require_role import require_role
+
+@admin_router.post("/sessions/revoke")
+@require_role("operator")
+async def revoke_sessions_bulk(request: Request, ...):
+```
+
+### Authorization Flow
+
+```
+Request → JWT Extraction → Role Validation → Handler
+                ↓               ↓
+           401 if missing   403 if role missing
+```
+
+## Test Plan
+
+### Unit Tests
+
+| Test Case | Expected Outcome |
+|-----------|------------------|
+| No JWT provided | 401 Unauthorized |
+| JWT without roles claim | 403 Forbidden |
+| JWT with `free` role only | 403 Forbidden |
+| JWT with `paid` role only | 403 Forbidden |
+| JWT with `operator` role | 200 OK (handler executes) |
+| JWT with expired token | 401 Unauthorized |
+
+### Integration Tests
+
+| Test Case | Expected Outcome |
+|-----------|------------------|
+| Operator can bulk revoke sessions | Revocation succeeds |
+| Non-operator gets 403 on revoke attempt | Access denied |
+| Audit trail includes revocation metadata | reason, timestamp logged |
+
+## Dependencies
+
+- Feature 1130: `@require_role` decorator (COMPLETE)
+- JWT `roles` claim support (COMPLETE)
+- Role constants in `shared/auth/constants.py` (COMPLETE)
+
+## Acceptance Criteria
+
+1. Endpoint protected with `@require_role("operator")`
+2. All unit tests pass
+3. No regression in authorized bulk revocation functionality
+4. Generic error messages (no role enumeration)
+
+## References
+
+- Spec 1130: require_role decorator specification
+- SESSION-SUMMARY-2.md: Phase 1.5 RBAC architecture
+- Router: `src/lambdas/dashboard/router_v2.py:548-563`
+- Decorator: `src/lambdas/shared/middleware/require_role.py`

--- a/specs/1148-protect-admin-sessions-revoke/tasks.md
+++ b/specs/1148-protect-admin-sessions-revoke/tasks.md
@@ -1,0 +1,48 @@
+# Tasks: Feature 1148
+
+## Task Execution Order
+
+### T001: Add require_role Import
+- [ ] Add import statement to router_v2.py
+- **File**: `src/lambdas/dashboard/router_v2.py`
+- **Change**: `from src.lambdas.shared.middleware.require_role import require_role`
+
+### T002: Apply Decorator to Endpoint
+- [ ] Add `@require_role("operator")` decorator
+- **File**: `src/lambdas/dashboard/router_v2.py`
+- **Location**: After `@admin_router.post("/sessions/revoke")`, before function def
+- **Important**: Decorator order: route decorator first, then require_role
+
+### T003: Add Request Parameter
+- [ ] Add `request: Request` as first parameter to handler
+- **File**: `src/lambdas/dashboard/router_v2.py`
+- **Function**: `revoke_sessions_bulk()`
+- **Change**: `async def revoke_sessions_bulk(request: Request, body: BulkRevocationRequest, ...)`
+
+### T004: Create Unit Tests
+- [ ] Create test file `tests/unit/lambdas/dashboard/test_admin_sessions_revoke_auth.py`
+- **Tests to implement**:
+  - `test_revoke_without_jwt_returns_401`
+  - `test_revoke_without_operator_role_returns_403`
+  - `test_revoke_with_operator_role_succeeds`
+  - `test_error_message_generic`
+
+### T005: Run Unit Tests
+- [ ] Execute `pytest tests/unit/lambdas/dashboard/ -v --tb=short`
+- [ ] Verify all tests pass
+- [ ] Verify no regression in existing tests
+
+### T006: Commit and Push
+- [ ] Stage changes
+- [ ] Commit with conventional format
+- [ ] Push and create PR
+- [ ] Enable auto-merge
+
+## Acceptance Verification
+
+- [ ] Endpoint returns 401 without JWT
+- [ ] Endpoint returns 403 without operator role
+- [ ] Endpoint allows operator role access
+- [ ] Error messages are generic (no role enumeration)
+- [ ] All unit tests pass
+- [ ] No regression in existing functionality

--- a/src/lambdas/dashboard/router_v2.py
+++ b/src/lambdas/dashboard/router_v2.py
@@ -54,6 +54,7 @@ from src.lambdas.shared.middleware.auth_middleware import (
     AuthType,
     extract_auth_context_typed,
 )
+from src.lambdas.shared.middleware.require_role import require_role
 from src.lambdas.shared.response_models import (
     UserMeResponse,
     mask_email,
@@ -546,14 +547,16 @@ admin_router = APIRouter(prefix="/api/v2/admin", tags=["admin"])
 
 
 @admin_router.post("/sessions/revoke")
+@require_role("operator")
 async def revoke_sessions_bulk(
+    request: Request,
     body: BulkRevocationRequest,
     table=Depends(get_users_table),
 ):
     """Bulk session revocation - andon cord pattern (T057).
 
     Feature 014: Revoke multiple sessions at once for security incidents.
-    Requires admin authentication in production.
+    Protected by @require_role("operator") - Feature 1148.
     """
     result = auth_service.revoke_sessions_bulk(
         table=table,

--- a/tests/unit/lambdas/dashboard/test_admin_sessions_revoke_auth.py
+++ b/tests/unit/lambdas/dashboard/test_admin_sessions_revoke_auth.py
@@ -1,0 +1,248 @@
+"""Tests for /admin/sessions/revoke endpoint authorization (Feature 1148).
+
+Verifies that the bulk session revocation endpoint is properly protected
+by @require_role("operator") decorator.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.lambdas.shared.middleware import AuthContext, AuthType
+
+
+def mock_auth_context(
+    user_id: str | None = "test-user-id",
+    auth_type: AuthType = AuthType.AUTHENTICATED,
+    roles: list[str] | None = None,
+) -> AuthContext:
+    """Create a mock AuthContext for testing."""
+    return AuthContext(
+        user_id=user_id,
+        auth_type=auth_type,
+        auth_method="bearer" if user_id else None,
+        roles=roles,
+    )
+
+
+@pytest.fixture
+def mock_users_table() -> MagicMock:
+    """Mock DynamoDB users table."""
+    return MagicMock()
+
+
+@pytest.fixture
+def app(mock_users_table: MagicMock) -> FastAPI:
+    """Create a FastAPI app with the admin router for testing."""
+    from src.lambdas.dashboard.router_v2 import admin_router, get_users_table
+
+    test_app = FastAPI()
+    test_app.include_router(admin_router)
+
+    # Override the users table dependency
+    test_app.dependency_overrides[get_users_table] = lambda: mock_users_table
+
+    return test_app
+
+
+@pytest.fixture
+def client(app: FastAPI) -> TestClient:
+    """Create a test client for the app."""
+    return TestClient(app, raise_server_exceptions=False)
+
+
+class TestAdminSessionsRevokeAuth:
+    """Tests for /admin/sessions/revoke authorization (Feature 1148)."""
+
+    def test_revoke_without_jwt_returns_401(self, client: TestClient) -> None:
+        """Unauthenticated requests should return 401 Authentication required."""
+        mock_ctx = mock_auth_context(user_id=None, roles=None)
+
+        with patch(
+            "src.lambdas.shared.middleware.require_role.extract_auth_context_typed",
+            return_value=mock_ctx,
+        ):
+            response = client.post(
+                "/api/v2/admin/sessions/revoke",
+                json={"user_ids": ["user-1"], "reason": "test"},
+            )
+            assert response.status_code == 401
+            assert response.json()["detail"] == "Authentication required"
+
+    def test_revoke_without_operator_role_returns_403(self, client: TestClient) -> None:
+        """Authenticated users without operator role should get 403."""
+        mock_ctx = mock_auth_context(roles=["free"])
+
+        with patch(
+            "src.lambdas.shared.middleware.require_role.extract_auth_context_typed",
+            return_value=mock_ctx,
+        ):
+            response = client.post(
+                "/api/v2/admin/sessions/revoke",
+                json={"user_ids": ["user-1"], "reason": "test"},
+            )
+            assert response.status_code == 403
+            assert response.json()["detail"] == "Access denied"
+
+    def test_revoke_with_paid_role_returns_403(self, client: TestClient) -> None:
+        """Paid users without operator role should still get 403."""
+        mock_ctx = mock_auth_context(roles=["free", "paid"])
+
+        with patch(
+            "src.lambdas.shared.middleware.require_role.extract_auth_context_typed",
+            return_value=mock_ctx,
+        ):
+            response = client.post(
+                "/api/v2/admin/sessions/revoke",
+                json={"user_ids": ["user-1"], "reason": "test"},
+            )
+            assert response.status_code == 403
+            assert response.json()["detail"] == "Access denied"
+
+    def test_revoke_with_operator_role_succeeds(
+        self, client: TestClient, mock_users_table: MagicMock
+    ) -> None:
+        """Operators should be able to access the revoke endpoint."""
+        mock_ctx = mock_auth_context(roles=["free", "operator"])
+
+        # Mock the auth service to return a successful response
+        with (
+            patch(
+                "src.lambdas.shared.middleware.require_role.extract_auth_context_typed",
+                return_value=mock_ctx,
+            ),
+            patch(
+                "src.lambdas.dashboard.router_v2.auth_service.revoke_sessions_bulk"
+            ) as mock_revoke,
+        ):
+            # Create a mock response
+            mock_response = MagicMock()
+            mock_response.model_dump.return_value = {
+                "revoked_count": 1,
+                "failed_count": 0,
+                "failed_user_ids": [],
+            }
+            mock_revoke.return_value = mock_response
+
+            response = client.post(
+                "/api/v2/admin/sessions/revoke",
+                json={"user_ids": ["user-1"], "reason": "security incident"},
+            )
+            assert response.status_code == 200
+            assert response.json()["revoked_count"] == 1
+
+    def test_error_message_does_not_enumerate_roles(self, client: TestClient) -> None:
+        """403 error should NOT reveal required role (security requirement)."""
+        mock_ctx = mock_auth_context(roles=["free"])
+
+        with patch(
+            "src.lambdas.shared.middleware.require_role.extract_auth_context_typed",
+            return_value=mock_ctx,
+        ):
+            response = client.post(
+                "/api/v2/admin/sessions/revoke",
+                json={"user_ids": ["user-1"], "reason": "test"},
+            )
+            detail = response.json()["detail"]
+            # Must NOT contain the required role name
+            assert "operator" not in detail.lower()
+            assert detail == "Access denied"
+
+    def test_expired_token_returns_401(self, client: TestClient) -> None:
+        """Expired JWT tokens should return 401."""
+        # Simulate expired token by returning anonymous context with no user
+        mock_ctx = mock_auth_context(
+            user_id=None,
+            auth_type=AuthType.ANONYMOUS,
+            roles=None,
+        )
+
+        with patch(
+            "src.lambdas.shared.middleware.require_role.extract_auth_context_typed",
+            return_value=mock_ctx,
+        ):
+            response = client.post(
+                "/api/v2/admin/sessions/revoke",
+                json={"user_ids": ["user-1"], "reason": "test"},
+            )
+            assert response.status_code == 401
+
+
+class TestAdminSessionsRevokeIntegration:
+    """Integration tests for bulk revocation with proper authorization."""
+
+    def test_bulk_revocation_with_multiple_users(
+        self, client: TestClient, mock_users_table: MagicMock
+    ) -> None:
+        """Operators can revoke multiple sessions at once."""
+        mock_ctx = mock_auth_context(roles=["free", "operator"])
+
+        with (
+            patch(
+                "src.lambdas.shared.middleware.require_role.extract_auth_context_typed",
+                return_value=mock_ctx,
+            ),
+            patch(
+                "src.lambdas.dashboard.router_v2.auth_service.revoke_sessions_bulk"
+            ) as mock_revoke,
+        ):
+            mock_response = MagicMock()
+            mock_response.model_dump.return_value = {
+                "revoked_count": 3,
+                "failed_count": 1,
+                "failed_user_ids": ["user-4"],
+            }
+            mock_revoke.return_value = mock_response
+
+            response = client.post(
+                "/api/v2/admin/sessions/revoke",
+                json={
+                    "user_ids": ["user-1", "user-2", "user-3", "user-4"],
+                    "reason": "security incident response",
+                },
+            )
+            assert response.status_code == 200
+            data = response.json()
+            assert data["revoked_count"] == 3
+            assert data["failed_count"] == 1
+            assert data["failed_user_ids"] == ["user-4"]
+
+    def test_revocation_reason_passed_to_service(
+        self, client: TestClient, mock_users_table: MagicMock
+    ) -> None:
+        """Revocation reason should be passed to the service layer."""
+        mock_ctx = mock_auth_context(roles=["free", "operator"])
+
+        with (
+            patch(
+                "src.lambdas.shared.middleware.require_role.extract_auth_context_typed",
+                return_value=mock_ctx,
+            ),
+            patch(
+                "src.lambdas.dashboard.router_v2.auth_service.revoke_sessions_bulk"
+            ) as mock_revoke,
+        ):
+            mock_response = MagicMock()
+            mock_response.model_dump.return_value = {
+                "revoked_count": 1,
+                "failed_count": 0,
+                "failed_user_ids": [],
+            }
+            mock_revoke.return_value = mock_response
+
+            response = client.post(
+                "/api/v2/admin/sessions/revoke",
+                json={
+                    "user_ids": ["user-1"],
+                    "reason": "Compromised credentials detected",
+                },
+            )
+            assert response.status_code == 200
+
+            # Verify the reason was passed correctly
+            mock_revoke.assert_called_once()
+            call_kwargs = mock_revoke.call_args.kwargs
+            assert call_kwargs["reason"] == "Compromised credentials detected"
+            assert call_kwargs["user_ids"] == ["user-1"]


### PR DESCRIPTION
## Summary
- Applied `@require_role("operator")` decorator to `/admin/sessions/revoke` endpoint
- Endpoint was previously unprotected (CVSS ~8.0 authorization bypass)
- Added comprehensive unit tests for auth scenarios (401/403/200)

## Security
- Generic error messages prevent role enumeration (FR-004)
- Uses existing, tested `@require_role` decorator from Feature 1130

## Test Plan
- [x] Unit tests: 8 passing (401 without JWT, 403 without role, 200 with operator)
- [x] Error messages verified generic ("Access denied")
- [x] No regression in existing revocation functionality

## Phase
Phase 1.5 (RBAC Infrastructure)

Refs: #1148

🤖 Generated with [Claude Code](https://claude.com/claude-code)