### PR TITLE
fix(1149): Protect /users/lookup with @require_role("operator")

### DIFF
--- a/specs/1149-protect-users-lookup/plan.md
+++ b/specs/1149-protect-users-lookup/plan.md
@@ -1,0 +1,51 @@
+# Implementation Plan: Feature 1149
+
+## Overview
+
+Apply `@require_role("operator")` decorator to `/users/lookup` endpoint.
+
+## Phase Analysis
+
+This feature is part of **Phase 1.5 (RBAC Infrastructure)**.
+
+## Implementation Steps
+
+### Step 1: Add require_role Import
+
+- **File**: `src/lambdas/dashboard/router_v2.py`
+- **Action**: Add import for `require_role` decorator
+- **Risk**: Low (import only)
+
+### Step 2: Apply Decorator to Endpoint
+
+- **File**: `src/lambdas/dashboard/router_v2.py`
+- **Action**: Add `@require_role("operator")` below `@users_router.get("/lookup")`
+- **Risk**: Low (pattern already proven)
+
+### Step 3: Add Request Parameter
+
+- **File**: `src/lambdas/dashboard/router_v2.py`
+- **Action**: Add `request: Request` parameter to handler function
+- **Risk**: Low
+
+### Step 4: Add Unit Tests
+
+- **File**: `tests/unit/lambdas/dashboard/test_users_lookup_auth.py`
+- **Tests**: Auth scenarios (401/403/200)
+- **Risk**: Low
+
+### Step 5: Run Unit Tests
+
+- **Command**: `pytest tests/unit/lambdas/dashboard/ -v`
+- **Risk**: Low
+
+## Dependency Check
+
+| Dependency | Status |
+|------------|--------|
+| `@require_role` decorator | COMPLETE |
+| JWT `roles` claim | COMPLETE |
+
+## Estimated Complexity
+
+**Low** - Same pattern as Feature 1148.

--- a/specs/1149-protect-users-lookup/spec.md
+++ b/specs/1149-protect-users-lookup/spec.md
@@ -1,0 +1,86 @@
+# Feature 1149: Protect /users/lookup Endpoint
+
+## Problem Statement
+
+The `GET /api/v2/users/lookup` endpoint allows looking up users by email address but is **currently unprotected**. Any request can query whether an email exists in the system, enabling account enumeration attacks (CVSS ~5.3 information disclosure).
+
+## Security Context
+
+- **Phase**: 1.5 (RBAC Infrastructure)
+- **Severity**: Medium - Information disclosure enabling account enumeration
+- **Attack Vector**: Attacker can:
+  1. Harvest valid email addresses from the system
+  2. Build target lists for phishing/credential stuffing attacks
+  3. Determine user existence for social engineering
+
+## Requirements
+
+### Functional Requirements
+
+| ID | Requirement |
+|----|-------------|
+| FR-001 | Endpoint MUST require `operator` role for access |
+| FR-002 | Requests without valid JWT MUST return 401 Unauthorized |
+| FR-003 | Requests with valid JWT but missing `operator` role MUST return 403 Forbidden |
+| FR-004 | Error messages MUST NOT enumerate valid roles (generic messages only) |
+| FR-005 | Existing lookup logic MUST remain unchanged |
+
+### Non-Functional Requirements
+
+| ID | Requirement |
+|----|-------------|
+| NFR-001 | Authorization check MUST use existing `@require_role` decorator |
+| NFR-002 | No new dependencies may be introduced |
+| NFR-003 | Must maintain backward compatibility for authorized callers |
+
+## Technical Design
+
+### Solution: Apply @require_role Decorator
+
+The fix applies the existing `@require_role("operator")` decorator to the endpoint.
+
+### Code Change
+
+**File**: `src/lambdas/dashboard/router_v2.py` (lines 704-736)
+
+```python
+# Before
+@users_router.get("/lookup")
+async def lookup_user_by_email(...):
+
+# After
+from src.lambdas.shared.middleware.require_role import require_role
+
+@users_router.get("/lookup")
+@require_role("operator")
+async def lookup_user_by_email(request: Request, ...):
+```
+
+## Test Plan
+
+### Unit Tests
+
+| Test Case | Expected Outcome |
+|-----------|------------------|
+| No JWT provided | 401 Unauthorized |
+| JWT without roles claim | 403 Forbidden |
+| JWT with `free` role only | 403 Forbidden |
+| JWT with `paid` role only | 403 Forbidden |
+| JWT with `operator` role | 200 OK (handler executes) |
+
+## Dependencies
+
+- Feature 1130: `@require_role` decorator (COMPLETE)
+- JWT `roles` claim support (COMPLETE)
+
+## Acceptance Criteria
+
+1. Endpoint protected with `@require_role("operator")`
+2. All unit tests pass
+3. No regression in lookup functionality
+4. Generic error messages (no role enumeration)
+
+## References
+
+- Similar to Feature 1148: Protect /admin/sessions/revoke
+- Decorator: `src/lambdas/shared/middleware/require_role.py`

--- a/specs/1149-protect-users-lookup/tasks.md
+++ b/specs/1149-protect-users-lookup/tasks.md
@@ -1,0 +1,21 @@
+# Tasks: Feature 1149
+
+## Task Execution Order
+
+### T001: Add require_role Import
+- [ ] Add import statement to router_v2.py
+
+### T002: Apply Decorator to Endpoint
+- [ ] Add `@require_role("operator")` decorator
+
+### T003: Add Request Parameter
+- [ ] Add `request: Request` as first parameter
+
+### T004: Create Unit Tests
+- [ ] Create test file with auth scenarios
+
+### T005: Run Unit Tests
+- [ ] Verify all tests pass
+
+### T006: Commit and Push
+- [ ] Create PR with auto-merge

--- a/src/lambdas/dashboard/router_v2.py
+++ b/src/lambdas/dashboard/router_v2.py
@@ -54,6 +54,7 @@ from src.lambdas.shared.middleware.auth_middleware import (
     AuthType,
     extract_auth_context_typed,
 )
+from src.lambdas.shared.middleware.require_role import require_role
 from src.lambdas.shared.response_models import (
     UserMeResponse,
     mask_email,
@@ -702,14 +703,16 @@ class UserLookupResponse(BaseModel):
 
 
 @users_router.get("/lookup")
+@require_role("operator")
 async def lookup_user_by_email(
+    request: Request,
     email: EmailStr = Query(..., description="Email address to look up"),
     table=Depends(get_users_table),
 ):
     """Look up user by email address (T044).
 
     Feature 014: Uses GSI for O(1) lookup performance.
-    Requires admin authentication in production.
+    Protected by @require_role("operator") - Feature 1149.
 
     Returns:
         UserLookupResponse with found=true if user exists

--- a/tests/unit/lambdas/dashboard/test_users_lookup_auth.py
+++ b/tests/unit/lambdas/dashboard/test_users_lookup_auth.py
@@ -1,0 +1,199 @@
+"""Tests for /users/lookup endpoint authorization (Feature 1149).
+
+Verifies that the user lookup endpoint is properly protected
+by @require_role("operator") decorator.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.lambdas.shared.middleware import AuthContext, AuthType
+
+
+def mock_auth_context(
+    user_id: str | None = "test-user-id",
+    auth_type: AuthType = AuthType.AUTHENTICATED,
+    roles: list[str] | None = None,
+) -> AuthContext:
+    """Create a mock AuthContext for testing."""
+    return AuthContext(
+        user_id=user_id,
+        auth_type=auth_type,
+        auth_method="bearer" if user_id else None,
+        roles=roles,
+    )
+
+
+@pytest.fixture
+def mock_users_table() -> MagicMock:
+    """Mock DynamoDB users table."""
+    return MagicMock()
+
+
+@pytest.fixture
+def app(mock_users_table: MagicMock) -> FastAPI:
+    """Create a FastAPI app with the users router for testing."""
+    from src.lambdas.dashboard.router_v2 import get_users_table, users_router
+
+    test_app = FastAPI()
+    test_app.include_router(users_router)
+
+    # Override the users table dependency
+    test_app.dependency_overrides[get_users_table] = lambda: mock_users_table
+
+    return test_app
+
+
+@pytest.fixture
+def client(app: FastAPI) -> TestClient:
+    """Create a test client for the app."""
+    return TestClient(app, raise_server_exceptions=False)
+
+
+class TestUsersLookupAuth:
+    """Tests for /users/lookup authorization (Feature 1149)."""
+
+    def test_lookup_without_jwt_returns_401(self, client: TestClient) -> None:
+        """Unauthenticated requests should return 401 Authentication required."""
+        mock_ctx = mock_auth_context(user_id=None, roles=None)
+
+        with patch(
+            "src.lambdas.shared.middleware.require_role.extract_auth_context_typed",
+            return_value=mock_ctx,
+        ):
+            response = client.get(
+                "/api/v2/users/lookup",
+                params={"email": "test@example.com"},
+            )
+            assert response.status_code == 401
+            assert response.json()["detail"] == "Authentication required"
+
+    def test_lookup_without_operator_role_returns_403(self, client: TestClient) -> None:
+        """Authenticated users without operator role should get 403."""
+        mock_ctx = mock_auth_context(roles=["free"])
+
+        with patch(
+            "src.lambdas.shared.middleware.require_role.extract_auth_context_typed",
+            return_value=mock_ctx,
+        ):
+            response = client.get(
+                "/api/v2/users/lookup",
+                params={"email": "test@example.com"},
+            )
+            assert response.status_code == 403
+            assert response.json()["detail"] == "Access denied"
+
+    def test_lookup_with_paid_role_returns_403(self, client: TestClient) -> None:
+        """Paid users without operator role should still get 403."""
+        mock_ctx = mock_auth_context(roles=["free", "paid"])
+
+        with patch(
+            "src.lambdas.shared.middleware.require_role.extract_auth_context_typed",
+            return_value=mock_ctx,
+        ):
+            response = client.get(
+                "/api/v2/users/lookup",
+                params={"email": "test@example.com"},
+            )
+            assert response.status_code == 403
+            assert response.json()["detail"] == "Access denied"
+
+    def test_lookup_with_operator_role_succeeds(
+        self, client: TestClient, mock_users_table: MagicMock
+    ) -> None:
+        """Operators should be able to access the lookup endpoint."""
+        mock_ctx = mock_auth_context(roles=["free", "operator"])
+
+        # Mock the auth service to return a found user
+        with (
+            patch(
+                "src.lambdas.shared.middleware.require_role.extract_auth_context_typed",
+                return_value=mock_ctx,
+            ),
+            patch(
+                "src.lambdas.dashboard.router_v2.auth_service.get_user_by_email_gsi"
+            ) as mock_lookup,
+        ):
+            # Create a mock user object
+            mock_user = MagicMock()
+            mock_user.user_id = "found-user-id"
+            mock_user.auth_type = "oauth"
+            mock_user.email = "test@example.com"
+            mock_lookup.return_value = mock_user
+
+            # Mock the mask_email function
+            with patch(
+                "src.lambdas.dashboard.router_v2.auth_service._mask_email",
+                return_value="t***@example.com",
+            ):
+                response = client.get(
+                    "/api/v2/users/lookup",
+                    params={"email": "test@example.com"},
+                )
+                assert response.status_code == 200
+                data = response.json()
+                assert data["found"] is True
+                assert data["user_id"] == "found-user-id"
+
+    def test_lookup_user_not_found_returns_200_with_found_false(
+        self, client: TestClient, mock_users_table: MagicMock
+    ) -> None:
+        """Operators looking up non-existent users should get 200 with found=false."""
+        mock_ctx = mock_auth_context(roles=["free", "operator"])
+
+        with (
+            patch(
+                "src.lambdas.shared.middleware.require_role.extract_auth_context_typed",
+                return_value=mock_ctx,
+            ),
+            patch(
+                "src.lambdas.dashboard.router_v2.auth_service.get_user_by_email_gsi",
+                return_value=None,
+            ),
+        ):
+            response = client.get(
+                "/api/v2/users/lookup",
+                params={"email": "nonexistent@example.com"},
+            )
+            assert response.status_code == 200
+            data = response.json()
+            assert data["found"] is False
+            assert data["user_id"] is None
+
+    def test_error_message_does_not_enumerate_roles(self, client: TestClient) -> None:
+        """403 error should NOT reveal required role (security requirement)."""
+        mock_ctx = mock_auth_context(roles=["free"])
+
+        with patch(
+            "src.lambdas.shared.middleware.require_role.extract_auth_context_typed",
+            return_value=mock_ctx,
+        ):
+            response = client.get(
+                "/api/v2/users/lookup",
+                params={"email": "test@example.com"},
+            )
+            detail = response.json()["detail"]
+            # Must NOT contain the required role name
+            assert "operator" not in detail.lower()
+            assert detail == "Access denied"
+
+    def test_anonymous_token_returns_401(self, client: TestClient) -> None:
+        """Anonymous tokens should return 401."""
+        mock_ctx = mock_auth_context(
+            user_id=None,
+            auth_type=AuthType.ANONYMOUS,
+            roles=None,
+        )
+
+        with patch(
+            "src.lambdas.shared.middleware.require_role.extract_auth_context_typed",
+            return_value=mock_ctx,
+        ):
+            response = client.get(
+                "/api/v2/users/lookup",
+                params={"email": "test@example.com"},
+            )
+            assert response.status_code == 401


### PR DESCRIPTION
## Summary
- Applied `@require_role("operator")` decorator to `/users/lookup` endpoint
- Endpoint was previously unprotected (CVSS ~5.3 information disclosure)
- Added comprehensive unit tests for auth scenarios (401/403/200)

## Security
- Prevents account enumeration attacks via email lookup
- Generic error messages prevent role enumeration

## Test Plan
- [x] Unit tests: 7 passing (401 without JWT, 403 without role, 200 with operator)
- [x] Lookup logic unchanged for authorized callers

## Phase
Phase 1.5 (RBAC Infrastructure)

Refs: #1149

🤖 Generated with [Claude Code](https://claude.com/claude-code)