### PR TITLE
fix(1147): Add JWT_AUDIENCE env var to Lambda functions

### DIFF
--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -422,6 +422,8 @@ module "dashboard_lambda" {
     TIMESERIES_TABLE = module.dynamodb.timeseries_table_name
     # Feature 1054: JWT secret for auth middleware token validation
     JWT_SECRET = var.jwt_secret
+    # Feature 1147: JWT audience for cross-service token replay prevention (CVSS 7.8)
+    JWT_AUDIENCE = var.jwt_audience
     # Feature 1056: OHLC data source secrets for Tiingo/Finnhub adapters
     TIINGO_SECRET_ARN  = module.secrets.tiingo_secret_arn
     FINNHUB_SECRET_ARN = module.secrets.finnhub_secret_arn
@@ -754,6 +756,8 @@ module "sse_streaming_lambda" {
     TIMESERIES_TABLE = module.dynamodb.timeseries_table_name
     # Feature 1054: JWT secret for auth middleware token validation
     JWT_SECRET = var.jwt_secret
+    # Feature 1147: JWT audience for cross-service token replay prevention (CVSS 7.8)
+    JWT_AUDIENCE = var.jwt_audience
   }
 
   # Function URL with RESPONSE_STREAM for true SSE streaming

--- a/infrastructure/terraform/variables.tf
+++ b/infrastructure/terraform/variables.tf
@@ -199,6 +199,14 @@ variable "jwt_secret" {
   # For prod, use a strong, unique secret
 }
 
+variable "jwt_audience" {
+  description = "Expected audience claim for JWT validation (Feature 1147)"
+  type        = string
+  default     = "sentiment-analyzer-api"
+  # CVSS 7.8: Prevents cross-service token replay attacks
+  # Must match the 'aud' claim in tokens issued by auth services
+}
+
 # ===================================================================
 # Feature 1105: AWS Amplify Frontend
 # ===================================================================


### PR DESCRIPTION
## Summary
Complete Feature 1147 by adding the missing `JWT_AUDIENCE` environment variable to both Dashboard and SSE Lambda functions.

## Root Cause
Feature 1147 added `aud` claim validation in the auth middleware, but Terraform was not updated to pass `JWT_AUDIENCE` to the Lambda functions. PyJWT rejects tokens containing an `aud` claim when `jwt.decode()` is called with `audience=None`.

This caused 4 SSE E2E tests to fail with 401 Unauthorized on main.

## Changes
- `variables.tf`: Add `jwt_audience` variable with default `"sentiment-analyzer-api"`
- `main.tf`: Add `JWT_AUDIENCE` to `dashboard_lambda` environment_variables
- `main.tf`: Add `JWT_AUDIENCE` to `sse_streaming_lambda` environment_variables

## Test plan
- [x] Unit tests pass (2585 passed)
- [ ] CI pipeline passes
- [ ] After Terraform apply, 4 SSE E2E tests should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)