### PR TITLE
feat(1157): Add Cache-Control headers to auth endpoints

### DIFF
--- a/tests/unit/dashboard/test_cache_headers.py
+++ b/tests/unit/dashboard/test_cache_headers.py
@@ -1,0 +1,80 @@
+"""Unit tests for Feature 1157: Auth Cache-Control Headers.
+
+Tests that the no_cache_headers dependency sets correct cache prevention headers
+on all auth endpoint responses per RFC 7234.
+
+Requirements tested:
+- FR-001: Cache-Control: no-store, no-cache, must-revalidate
+- FR-002: Pragma: no-cache (HTTP/1.0 compatibility)
+- FR-003: Expires: 0 (Legacy proxy compatibility)
+"""
+
+import pytest
+from fastapi import Response
+
+from src.lambdas.dashboard.router_v2 import no_cache_headers
+
+
+class TestNoCacheHeaders:
+    """Test suite for no_cache_headers dependency function."""
+
+    @pytest.mark.asyncio
+    async def test_sets_cache_control_header(self) -> None:
+        """Test that Cache-Control header is set correctly (FR-001)."""
+        response = Response()
+        await no_cache_headers(response)
+
+        assert (
+            response.headers.get("Cache-Control")
+            == "no-store, no-cache, must-revalidate"
+        )
+
+    @pytest.mark.asyncio
+    async def test_sets_pragma_header(self) -> None:
+        """Test that Pragma header is set for HTTP/1.0 compatibility (FR-002)."""
+        response = Response()
+        await no_cache_headers(response)
+
+        assert response.headers.get("Pragma") == "no-cache"
+
+    @pytest.mark.asyncio
+    async def test_sets_expires_header(self) -> None:
+        """Test that Expires header is set for legacy proxy compatibility (FR-003)."""
+        response = Response()
+        await no_cache_headers(response)
+
+        assert response.headers.get("Expires") == "0"
+
+    @pytest.mark.asyncio
+    async def test_sets_all_headers_together(self) -> None:
+        """Test that all three headers are set in a single call."""
+        response = Response()
+        await no_cache_headers(response)
+
+        assert (
+            response.headers.get("Cache-Control")
+            == "no-store, no-cache, must-revalidate"
+        )
+        assert response.headers.get("Pragma") == "no-cache"
+        assert response.headers.get("Expires") == "0"
+
+    @pytest.mark.asyncio
+    async def test_overwrites_existing_cache_control(self) -> None:
+        """Test that existing Cache-Control header is overwritten."""
+        response = Response()
+        response.headers["Cache-Control"] = "max-age=3600"
+
+        await no_cache_headers(response)
+
+        assert (
+            response.headers.get("Cache-Control")
+            == "no-store, no-cache, must-revalidate"
+        )
+
+    @pytest.mark.asyncio
+    async def test_returns_none(self) -> None:
+        """Test that the dependency returns None (modifies response in-place)."""
+        response = Response()
+        result = await no_cache_headers(response)
+
+        assert result is None


### PR DESCRIPTION
## Summary
- Add `no_cache_headers` FastAPI dependency to prevent browser/proxy caching of auth responses
- Apply to all 12 auth endpoints via router-level dependency injection
- Add 6 unit tests for header verification

## Security Enhancement
Prevents sensitive authentication data from being cached per RFC 7234:
- `Cache-Control: no-store, no-cache, must-revalidate`
- `Pragma: no-cache` (HTTP/1.0 compatibility)
- `Expires: 0` (legacy proxy compatibility)

## Changes
- `src/lambdas/dashboard/router_v2.py` - Add `no_cache_headers` dependency and apply to auth router
- `tests/unit/dashboard/test_cache_headers.py` - NEW - 6 unit tests

## Test Plan
- [x] Unit tests pass (6 tests)
- [x] Pre-commit hooks pass (17 checks)
- [x] Pre-push tests pass (2635 tests)
- [ ] Manual verification: curl auth endpoint and check response headers

Refs: #1157

🤖 Generated with [Claude Code](https://claude.com/claude-code)