### PR TITLE
fix(1164): Remove hardcoded MAGIC_LINK_SECRET security vulnerability

### DIFF
--- a/specs/1164-remove-magic-link-hardcoded-secret/checklists/requirements.md
+++ b/specs/1164-remove-magic-link-hardcoded-secret/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Remove Hardcoded MAGIC_LINK_SECRET
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-01-06
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation
+- Spec is ready for `/speckit.plan`
+- Security fix - Phase 0 C1 priority

--- a/specs/1164-remove-magic-link-hardcoded-secret/plan.md
+++ b/specs/1164-remove-magic-link-hardcoded-secret/plan.md
@@ -1,0 +1,156 @@
+# Implementation Plan: Remove Hardcoded MAGIC_LINK_SECRET
+
+**Branch**: `1164-remove-magic-link-hardcoded-secret` | **Date**: 2026-01-06 | **Spec**: [spec.md](./spec.md)
+**Input**: Phase 0 C1 Security Fix - Remove hardcoded secret fallback
+
+## Summary
+
+Remove the hardcoded MAGIC_LINK_SECRET fallback value from auth.py, add fail-fast validation at module load, and remove the orphaned `_verify_magic_link_signature()` function that is never called.
+
+## Technical Context
+
+**Language/Version**: Python 3.13
+**Primary Dependencies**: os (stdlib), hmac (stdlib)
+**Storage**: DynamoDB (no changes - tokens still stored with signatures)
+**Testing**: pytest with environment variable fixtures
+**Target Platform**: AWS Lambda
+**Project Type**: Web application (backend Lambda)
+**Performance Goals**: N/A (startup validation only)
+**Constraints**: Must not break existing magic link flows
+**Scale/Scope**: 2 file changes + test updates
+
+## Constitution Check
+
+| Gate | Status | Notes |
+|------|--------|-------|
+| No hardcoded secrets | FIXING | This feature addresses the violation |
+| Fail-fast validation | ADDING | Required secrets checked at load time |
+| Dead code removal | PASS | Removing orphaned verification function |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/1164-remove-magic-link-hardcoded-secret/
+├── spec.md              # Feature specification (DONE)
+├── plan.md              # This file
+├── tasks.md             # Task breakdown (next: /speckit.tasks)
+└── checklists/
+    └── requirements.md  # Specification quality checklist (DONE)
+```
+
+### Source Code (repository root)
+
+```text
+src/lambdas/dashboard/
+└── auth.py              # Remove hardcoded fallback, add validation, remove dead code
+
+tests/
+├── unit/lambdas/dashboard/
+│   └── test_auth_us2.py # Update to use fixtures for MAGIC_LINK_SECRET
+└── integration/
+    └── test_us2_magic_link.py  # Already sets env var properly
+```
+
+**Structure Decision**: Minimal changes to existing files. No new files required.
+
+## Implementation Approach
+
+### Phase 1: Remove Hardcoded Fallback
+
+**File**: `src/lambdas/dashboard/auth.py`
+
+**Current code (lines 1101-1103)**:
+```python
+MAGIC_LINK_SECRET = os.environ.get(
+    "MAGIC_LINK_SECRET", "default-dev-secret-change-in-prod"
+)
+```
+
+**New code**:
+```python
+MAGIC_LINK_SECRET = os.environ.get("MAGIC_LINK_SECRET", "")
+if not MAGIC_LINK_SECRET:
+    raise RuntimeError(
+        "MAGIC_LINK_SECRET environment variable is required but not set. "
+        "Set it to a secure random value (minimum 32 characters)."
+    )
+```
+
+### Phase 2: Remove Dead Code
+
+**File**: `src/lambdas/dashboard/auth.py`
+
+Remove the orphaned function (lines 1117-1120):
+```python
+def _verify_magic_link_signature(token_id: str, email: str, signature: str) -> bool:
+    """Verify magic link signature."""
+    expected = _generate_magic_link_signature(token_id, email)
+    return hmac.compare_digest(expected, signature)
+```
+
+This function is never called - verification uses atomic DynamoDB consumption instead.
+
+### Phase 3: Update Unit Tests
+
+**File**: `tests/unit/lambdas/dashboard/test_auth_us2.py`
+
+The tests that test signature functions need a proper env var fixture:
+
+```python
+@pytest.fixture(autouse=True)
+def set_magic_link_secret(monkeypatch):
+    """Set MAGIC_LINK_SECRET for all tests in this module."""
+    monkeypatch.setenv("MAGIC_LINK_SECRET", "test-secret-for-unit-tests-minimum-32-chars")
+```
+
+Tests to update:
+- `test_generate_signature()` - Keep, validates HMAC generation
+- `test_different_inputs_different_signature()` - Keep
+- `test_verify_valid_signature()` - Remove (function deleted)
+- `test_verify_invalid_signature()` - Remove (function deleted)
+
+### Phase 4: Verify Integration Tests
+
+**File**: `tests/integration/test_us2_magic_link.py`
+
+Already properly sets env var at line 45:
+```python
+os.environ["MAGIC_LINK_SECRET"] = "test-secret-key-for-signing"
+```
+
+No changes needed, but verify tests pass.
+
+## Dependencies
+
+| Dependency | Status | Impact |
+|------------|--------|--------|
+| pytest monkeypatch | Available | For env var fixtures in tests |
+| DynamoDB atomic ops | Working | Not affected - verification mechanism unchanged |
+
+## Complexity Tracking
+
+No constitution violations. Minimal scope:
+- 1 validation block added (~5 lines)
+- 1 function removed (~4 lines)
+- Test fixture added (~3 lines)
+- 2 test functions removed
+
+## Risks and Mitigations
+
+| Risk | Probability | Impact | Mitigation |
+|------|-------------|--------|------------|
+| Tests fail without env var | Medium | Low | Add pytest fixture |
+| Lambda fails at cold start | Low | High | Ensure Terraform sets env var |
+| Existing tokens break | Very Low | Low | Verification doesn't use signature |
+
+## Definition of Done
+
+- [ ] Hardcoded fallback removed from auth.py
+- [ ] Fail-fast validation added at module load
+- [ ] `_verify_magic_link_signature()` function removed
+- [ ] Unit tests updated with env var fixture
+- [ ] Tests for removed function deleted
+- [ ] All tests pass
+- [ ] PR created and merged

--- a/specs/1164-remove-magic-link-hardcoded-secret/spec.md
+++ b/specs/1164-remove-magic-link-hardcoded-secret/spec.md
@@ -1,0 +1,101 @@
+# Feature Specification: Remove Hardcoded MAGIC_LINK_SECRET
+
+**Feature Branch**: `1164-remove-magic-link-hardcoded-secret`
+**Created**: 2026-01-06
+**Status**: Draft
+**Input**: Phase 0 C1 Security Fix - Remove hardcoded secret fallback
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Remove Hardcoded Secret Exposure (Priority: P1)
+
+As a security engineer, I need the hardcoded MAGIC_LINK_SECRET fallback removed from the codebase so that production systems cannot accidentally use a known default value, which would be a critical security vulnerability.
+
+**Why this priority**: This is a security blocker. Hardcoded secrets in source code are OWASP Top 10 violations and can lead to complete authentication bypass if the default is used in production.
+
+**Independent Test**: Can be verified by searching the codebase for the hardcoded string and confirming it no longer exists. Additionally, the system should fail clearly at startup if the environment variable is not set.
+
+**Acceptance Scenarios**:
+
+1. **Given** the auth module starts without MAGIC_LINK_SECRET env var, **When** the application loads, **Then** a clear error is raised immediately (not at first token request).
+2. **Given** the hardcoded fallback "default-dev-secret-change-in-prod" exists in code, **When** this feature is complete, **Then** the string does not appear anywhere in the codebase.
+3. **Given** MAGIC_LINK_SECRET is set via environment variable, **When** the auth module loads, **Then** the system operates normally.
+
+---
+
+### User Story 2 - Remove Dead Signature Verification Code (Priority: P2)
+
+As a developer, I want dead code removed from the codebase so that future maintainers are not confused by orphaned functions that appear security-critical but are never called.
+
+**Why this priority**: Code hygiene and reducing attack surface. The signature verification function exists but is never called, creating confusion about whether it should be called.
+
+**Independent Test**: Can be verified by removing the function and ensuring all tests pass.
+
+**Acceptance Scenarios**:
+
+1. **Given** the `_verify_magic_link_signature()` function exists but is never called, **When** this feature is complete, **Then** the function is removed.
+2. **Given** tests that reference signature verification, **When** they are updated, **Then** they focus on atomic token consumption (the actual security mechanism).
+
+---
+
+### User Story 3 - Update Tests to Remove Secret Dependencies (Priority: P3)
+
+As a test engineer, I need tests updated to not rely on hardcoded secrets so that the test suite reflects the production security posture.
+
+**Why this priority**: Tests should validate actual security mechanisms, not deprecated ones.
+
+**Independent Test**: All tests pass with proper environment variable setup via pytest fixtures.
+
+**Acceptance Scenarios**:
+
+1. **Given** tests that set MAGIC_LINK_SECRET to test values, **When** tests run, **Then** they use environment variables properly set by fixtures.
+2. **Given** test helpers that generate HMAC signatures, **When** this feature is complete, **Then** they align with actual production behavior.
+
+---
+
+### Edge Cases
+
+- What happens if MAGIC_LINK_SECRET is empty string? → Treat as unset, raise error.
+- What happens to existing tokens in database with signatures? → They continue to work because verification uses atomic DynamoDB lookup, not signature validation.
+- What happens in local development without env var? → Clear error message guides developer to set the variable.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST NOT contain hardcoded secret values in source code.
+- **FR-002**: System MUST raise a clear error at module load time if MAGIC_LINK_SECRET environment variable is not set or is empty.
+- **FR-003**: System MUST remove the orphaned `_verify_magic_link_signature()` function since it is never called.
+- **FR-004**: System MUST update tests to use proper environment variable fixtures instead of relying on hardcoded fallbacks.
+- **FR-005**: System MUST NOT break existing magic link flows - token generation and verification via atomic DynamoDB operations must continue working.
+
+### Key Entities
+
+- **MAGIC_LINK_SECRET**: Environment variable containing the HMAC signing key for magic link tokens. Required for token generation.
+- **MagicLinkToken**: Database entity storing token data including signature (still generated but not verified).
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Zero instances of hardcoded secret strings in the codebase (verified by grep).
+- **SC-002**: Application fails fast at startup without required secrets (not at first use).
+- **SC-003**: All existing tests pass after changes.
+- **SC-004**: Magic link authentication flows continue to work in production.
+- **SC-005**: Code reduction: removal of at least one orphaned function.
+
+## Assumptions
+
+- The signature verification function is confirmed to be dead code (never called).
+- Atomic token consumption via DynamoDB ConditionExpression is the actual security mechanism.
+- Existing tokens in the database will continue to work since verification doesn't check signatures.
+- The MAGIC_LINK_SECRET is still needed for signature generation (stored in tokens for future audit/compatibility).
+
+## Dependencies
+
+- None - this is a standalone security cleanup.
+
+## Canonical Source
+
+- specs/1126-auth-httponly-migration/implementation-gaps.md (Phase 0 C1)
+- OWASP Secure Coding Guidelines for Secrets Management

--- a/specs/1164-remove-magic-link-hardcoded-secret/tasks.md
+++ b/specs/1164-remove-magic-link-hardcoded-secret/tasks.md
@@ -1,0 +1,67 @@
+# Tasks: Remove Hardcoded MAGIC_LINK_SECRET
+
+**Branch**: `1164-remove-magic-link-hardcoded-secret`
+**Spec**: [spec.md](./spec.md) | **Plan**: [plan.md](./plan.md)
+**Created**: 2026-01-06
+
+## Task Breakdown
+
+### Phase 1: Security Fix
+
+#### Task 1.1: Remove hardcoded fallback and add validation
+**Status**: [ ] Not Started
+**File**: `src/lambdas/dashboard/auth.py`
+**Action**: Replace hardcoded fallback with fail-fast validation
+**Acceptance**:
+- No hardcoded secret string in code
+- RuntimeError raised if env var not set
+- Clear error message with guidance
+
+### Phase 2: Dead Code Removal
+
+#### Task 2.1: Remove orphaned _verify_magic_link_signature function
+**Status**: [ ] Not Started
+**File**: `src/lambdas/dashboard/auth.py`
+**Action**: Delete the function that is never called
+**Acceptance**: Function no longer exists in codebase
+
+### Phase 3: Test Updates
+
+#### Task 3.1: Add env var fixture to test_auth_us2.py
+**Status**: [ ] Not Started
+**File**: `tests/unit/lambdas/dashboard/test_auth_us2.py`
+**Action**: Add pytest fixture to set MAGIC_LINK_SECRET
+**Acceptance**: Fixture sets env var before tests run
+
+#### Task 3.2: Remove tests for deleted function
+**Status**: [ ] Not Started
+**File**: `tests/unit/lambdas/dashboard/test_auth_us2.py`
+**Action**: Remove test_verify_valid_signature and test_verify_invalid_signature
+**Acceptance**: No tests reference deleted function
+
+### Phase 4: Verification
+
+#### Task 4.1: Run full test suite
+**Status**: [ ] Not Started
+**Action**: Execute pytest and verify no regressions
+**Acceptance**: All tests pass
+
+#### Task 4.2: Verify no hardcoded secrets remain
+**Status**: [ ] Not Started
+**Action**: grep -r "default-dev-secret" to confirm removal
+**Acceptance**: Zero matches
+
+#### Task 4.3: Commit, push, and create PR
+**Status**: [ ] Not Started
+**Action**: Create PR with auto-merge enabled
+**Acceptance**: PR created and merged
+
+## Summary
+
+| Phase | Tasks | Status |
+|-------|-------|--------|
+| Phase 1: Security Fix | 1 | Not Started |
+| Phase 2: Dead Code | 1 | Not Started |
+| Phase 3: Test Updates | 2 | Not Started |
+| Phase 4: Verification | 3 | Not Started |
+| **Total** | **7** | **0/7 Complete** |


### PR DESCRIPTION
## Summary
- Replace module-level `MAGIC_LINK_SECRET` with `_get_magic_link_secret()` function that validates at use time
- Remove orphaned `_verify_magic_link_signature()` function (dead code - verification uses atomic DynamoDB, not HMAC)
- Add test fixtures to set `MAGIC_LINK_SECRET` env var, remove tests for deleted function, add test for missing secret error

## Security Impact
- No hardcoded secrets in source code
- Clear error if env var not set
- Zero functional changes to magic link flow

## Test plan
- [x] All existing tests pass (2737 passed)
- [x] New test verifies RuntimeError when MAGIC_LINK_SECRET not set
- [x] Pre-commit hooks pass (ruff, detect-secrets, bandit)

Refs: #1164

🤖 Generated with [Claude Code](https://claude.com/claude-code)