### PR TITLE
fix(1166): Complete HMAC removal for magic link tokens

### DIFF
--- a/specs/1166-complete-hmac-removal/plan.md
+++ b/specs/1166-complete-hmac-removal/plan.md
@@ -1,0 +1,61 @@
+# Feature 1166: Implementation Plan
+
+## Overview
+
+Complete the HMAC removal that was started in Feature 1164. Delete signature generation functions and update magic link flow to use random tokens only.
+
+## Implementation Steps
+
+### Step 1: Update MagicLinkToken Model
+
+File: `src/lambdas/shared/models/magic_link_token.py`
+
+Make `signature` field optional for backwards compatibility with any existing tokens in database:
+
+```python
+signature: str | None = None  # Deprecated, kept for backwards compat
+```
+
+### Step 2: Delete HMAC Functions from auth.py
+
+File: `src/lambdas/dashboard/auth.py`
+
+Delete these functions entirely:
+- `_get_magic_link_secret()` (lines 1104-1116)
+- `_generate_magic_link_signature()` (lines 1119-1126)
+
+### Step 3: Update request_magic_link()
+
+File: `src/lambdas/dashboard/auth.py`
+
+In `request_magic_link()`:
+- Remove: `signature = _generate_magic_link_signature(token_id, email)`
+- Remove: `signature=signature` from MagicLinkToken instantiation
+- Remove: signature from email callback if present
+
+### Step 4: Update Tests
+
+File: `tests/unit/lambdas/dashboard/test_auth_us2.py`
+
+- Remove `MAGIC_LINK_SECRET` from test fixtures
+- Remove tests that specifically test signature generation
+- Keep tests for token creation, expiry, atomic consumption
+
+## Risk Assessment
+
+**Low Risk**:
+- HMAC verification was already dead code
+- Token security comes from randomness + atomic DB operations
+- No breaking changes to API contracts
+
+## Rollback Plan
+
+If issues arise:
+1. Revert commit
+2. Add `MAGIC_LINK_SECRET` to Lambda env vars as temporary fix
+
+## Testing Strategy
+
+1. Unit tests: Verify token creation without HMAC
+2. Integration tests: Verify full magic link flow
+3. E2E tests: `test_auth_magic_link.py` should pass

--- a/specs/1166-complete-hmac-removal/spec.md
+++ b/specs/1166-complete-hmac-removal/spec.md
@@ -1,0 +1,64 @@
+# Feature 1166: Complete HMAC Removal for Magic Link Tokens
+
+## Problem Statement
+
+Feature 1164 removed the hardcoded `MAGIC_LINK_SECRET` fallback but left the HMAC infrastructure in place. The preprod Lambda now fails with 500 errors because `_get_magic_link_secret()` raises `RuntimeError` when the environment variable is not set.
+
+Per spec-v2.md (lines 1755-1771), the HMAC code should have been deleted entirely. The current verification already uses atomic DynamoDB consumption - HMAC signatures are generated but never verified.
+
+## Root Cause
+
+- `_get_magic_link_secret()` fails at runtime (no env var)
+- `_generate_magic_link_signature()` is called but result is never used for verification
+- `verify_and_consume_token()` uses DynamoDB conditional update, not HMAC
+
+## Solution
+
+Delete all HMAC-related code since verification is already token-based:
+
+1. Delete `_get_magic_link_secret()` function
+2. Delete `_generate_magic_link_signature()` function
+3. Remove signature generation from `request_magic_link()`
+4. Update `MagicLinkToken` model to make `signature` optional (backwards compat)
+5. Remove signature from email callback parameters
+
+## Security Analysis
+
+**Current security model (unchanged):**
+- 256-bit random token via `secrets.token_urlsafe(32)` - cryptographically unguessable
+- Atomic DynamoDB consumption via `ConditionExpression="used = :false"` - no replay
+- 1-hour expiry - limited window
+- Rate limiting - 5/email/hour, 20/IP/hour
+
+HMAC provides no additional security since:
+- Token is already unguessable (256-bit random)
+- HMAC was never verified during consumption
+- Signature just added complexity without value
+
+## Files Changed
+
+1. `src/lambdas/dashboard/auth.py`
+   - Delete lines 1104-1126: `_get_magic_link_secret()`, `_generate_magic_link_signature()`
+   - Update line 1162: Remove signature generation
+   - Update lines 1166-1175: Remove signature from token creation
+
+2. `src/lambdas/shared/models/magic_link_token.py`
+   - Make `signature` field `Optional[str] = None`
+
+3. `tests/unit/lambdas/dashboard/test_auth_us2.py`
+   - Remove any tests that check signature generation
+   - Remove `MAGIC_LINK_SECRET` from test fixtures
+
+## Acceptance Criteria
+
+- [ ] `request_magic_link()` succeeds without `MAGIC_LINK_SECRET` env var
+- [ ] Magic link tokens are verified via database lookup only
+- [ ] No HMAC-related functions remain in auth.py
+- [ ] Unit tests pass
+- [ ] Preprod E2E tests pass (no more 500 errors)
+
+## References
+
+- spec-v2.md lines 1755-1771: "HMAC code has been DELETED"
+- Feature 1164: Partial removal (hardcoded fallback only)
+- Feature 1129: Atomic token consumption implementation

--- a/specs/1166-complete-hmac-removal/tasks.md
+++ b/specs/1166-complete-hmac-removal/tasks.md
@@ -1,0 +1,19 @@
+# Feature 1166: Tasks
+
+## Implementation Tasks
+
+- [ ] T001: Make signature field optional in MagicLinkToken model
+- [ ] T002: Delete _get_magic_link_secret() function from auth.py
+- [ ] T003: Delete _generate_magic_link_signature() function from auth.py
+- [ ] T004: Remove signature generation from request_magic_link()
+- [ ] T005: Remove signature from MagicLinkToken instantiation
+- [ ] T006: Remove MAGIC_LINK_SECRET from test fixtures
+- [ ] T007: Update/remove signature-related unit tests
+- [ ] T008: Run unit tests and fix any failures
+- [ ] T009: Create PR and verify preprod tests pass
+
+## Verification
+
+- [ ] Unit tests pass locally
+- [ ] No references to MAGIC_LINK_SECRET in auth.py
+- [ ] Magic link E2E tests pass in preprod

--- a/tests/integration/test_session_race_conditions.py
+++ b/tests/integration/test_session_race_conditions.py
@@ -77,7 +77,7 @@ class TestConcurrentTokenVerification:
         token = MagicLinkToken(
             token_id=token_id,
             email="concurrent@example.com",
-            signature="test-signature",
+            # Feature 1166: signature removed
             created_at=now,
             expires_at=now + timedelta(hours=1),
             used=False,
@@ -131,7 +131,7 @@ class TestConcurrentTokenVerification:
         token = MagicLinkToken(
             token_id=token_id,
             email="first-ip@example.com",
-            signature="test-signature",
+            # Feature 1166: signature removed
             created_at=now,
             expires_at=now + timedelta(hours=1),
             used=False,
@@ -167,7 +167,7 @@ class TestConcurrentTokenVerification:
         token = MagicLinkToken(
             token_id=token_id,
             email="expired@example.com",
-            signature="test-signature",
+            # Feature 1166: signature removed
             created_at=now - timedelta(hours=2),
             expires_at=now - timedelta(hours=1),  # Expired 1 hour ago
             used=False,
@@ -199,7 +199,7 @@ class TestAtomicTokenState:
         token = MagicLinkToken(
             token_id=token_id,
             email="atomic@example.com",
-            signature="test-signature",
+            # Feature 1166: signature removed
             created_at=now,
             expires_at=now + timedelta(hours=1),
             used=False,
@@ -237,7 +237,7 @@ class TestAtomicTokenState:
         token = MagicLinkToken(
             token_id=token_id,
             email="audit@example.com",
-            signature="test-signature",
+            # Feature 1166: signature removed
             created_at=now,
             expires_at=now + timedelta(hours=1),
             used=False,

--- a/tests/unit/lambdas/dashboard/test_auth_us2.py
+++ b/tests/unit/lambdas/dashboard/test_auth_us2.py
@@ -12,7 +12,6 @@ from src.lambdas.dashboard.auth import (
     LinkAccountsRequest,
     MagicLinkRequest,
     OAuthCallbackRequest,
-    _generate_magic_link_signature,
     check_email_conflict,
     get_merge_status_endpoint,
     get_oauth_urls,
@@ -30,52 +29,14 @@ from src.lambdas.shared.errors.session_errors import (
 )
 from src.lambdas.shared.models.user import User
 
-
-class TestMagicLinkSignature:
-    """Tests for magic link signature generation.
-
-    Feature 1164: Removed _verify_magic_link_signature tests (function deleted).
-    Verification now uses atomic DynamoDB consumption, not HMAC validation.
-    """
-
-    @pytest.fixture(autouse=True)
-    def set_magic_link_secret(self, monkeypatch):
-        """Set MAGIC_LINK_SECRET for signature generation tests."""
-        monkeypatch.setenv(
-            "MAGIC_LINK_SECRET", "test-secret-minimum-32-chars-for-testing"
-        )
-
-    def test_generate_signature(self):
-        """Generates consistent HMAC signature."""
-        sig1 = _generate_magic_link_signature("token123", "user@example.com")
-        sig2 = _generate_magic_link_signature("token123", "user@example.com")
-
-        assert sig1 == sig2
-        assert len(sig1) == 64  # SHA256 hex length
-
-    def test_different_inputs_different_signature(self):
-        """Different inputs produce different signatures."""
-        sig1 = _generate_magic_link_signature("token123", "user@example.com")
-        sig2 = _generate_magic_link_signature("token456", "user@example.com")
-
-        assert sig1 != sig2
-
-    def test_missing_secret_raises_error(self, monkeypatch):
-        """Feature 1164: Raises RuntimeError if secret not set."""
-        monkeypatch.delenv("MAGIC_LINK_SECRET", raising=False)
-        with pytest.raises(RuntimeError, match="MAGIC_LINK_SECRET.*required"):
-            _generate_magic_link_signature("token", "email@test.com")
+# Feature 1166: TestMagicLinkSignature class removed - HMAC functions deleted.
+# Token security now relies on random UUID + atomic DynamoDB consumption.
 
 
 class TestRequestMagicLink:
     """Tests for T090: request_magic_link."""
 
-    @pytest.fixture(autouse=True)
-    def set_magic_link_secret(self, monkeypatch):
-        """Feature 1164: Set MAGIC_LINK_SECRET for request tests."""
-        monkeypatch.setenv(
-            "MAGIC_LINK_SECRET", "test-secret-minimum-32-chars-for-testing"
-        )
+    # Feature 1166: Removed set_magic_link_secret fixture - HMAC removed
 
     def test_creates_token_and_stores(self):
         """Creates token and stores in DynamoDB."""

--- a/tests/unit/lambdas/shared/auth/test_atomic_token_verification.py
+++ b/tests/unit/lambdas/shared/auth/test_atomic_token_verification.py
@@ -37,7 +37,7 @@ class TestAtomicTokenVerification:
         token = MagicLinkToken(
             token_id=token_id,
             email="test@example.com",
-            signature="valid-signature",
+            # Feature 1166: signature removed
             created_at=now - timedelta(minutes=5),
             expires_at=now + timedelta(hours=1),
             used=False,
@@ -73,7 +73,7 @@ class TestAtomicTokenVerification:
         token = MagicLinkToken(
             token_id=token_id,
             email="test@example.com",
-            signature="valid-signature",
+            # Feature 1166: signature removed
             created_at=now - timedelta(minutes=5),
             expires_at=now + timedelta(hours=1),
             used=False,
@@ -134,7 +134,7 @@ class TestTokenAlreadyUsedError:
         token = MagicLinkToken(
             token_id=token_id,
             email="test@example.com",
-            signature="valid-signature",
+            # Feature 1166: signature removed
             created_at=now - timedelta(minutes=10),
             expires_at=now + timedelta(hours=1),
             used=True,
@@ -164,7 +164,7 @@ class TestTokenAlreadyUsedError:
         token = MagicLinkToken(
             token_id=token_id,
             email="test@example.com",
-            signature="valid-signature",
+            # Feature 1166: signature removed
             created_at=now - timedelta(minutes=5),
             expires_at=now + timedelta(hours=1),
             used=False,
@@ -220,7 +220,7 @@ class TestTokenExpiredError:
         token = MagicLinkToken(
             token_id=token_id,
             email="test@example.com",
-            signature="valid-signature",
+            # Feature 1166: signature removed
             created_at=now - timedelta(hours=2),
             expires_at=now - timedelta(minutes=30),
             used=False,
@@ -249,7 +249,7 @@ class TestTokenExpiredError:
         token = MagicLinkToken(
             token_id=token_id,
             email="test@example.com",
-            signature="valid-signature",
+            # Feature 1166: signature removed
             created_at=now - timedelta(hours=2),
             expires_at=now - timedelta(minutes=1),
             used=False,
@@ -289,7 +289,7 @@ class TestMagicLinkTokenModel:
         token = MagicLinkToken(
             token_id=str(uuid.uuid4()),
             email="test@example.com",
-            signature="sig",
+            # Feature 1166: signature removed
             created_at=now,
             expires_at=now + timedelta(hours=1),
             used=True,
@@ -311,7 +311,8 @@ class TestMagicLinkTokenModel:
             "SK": "MAGIC_LINK",
             "token_id": "abc123",
             "email": "test@example.com",
-            "signature": "sig",
+            # Feature 1166: signature optional - testing backwards compat with old tokens
+            "signature": "legacy-sig",
             "created_at": now.isoformat(),
             "expires_at": (now + timedelta(hours=1)).isoformat(),
             "used": True,
@@ -328,10 +329,10 @@ class TestMagicLinkTokenModel:
     def test_token_without_audit_fields_defaults_to_none(self):
         """Tokens without audit fields default to None."""
         now = datetime.now(UTC)
+        # Feature 1166: Test new tokens without signature field
         item = {
             "token_id": "abc123",
             "email": "test@example.com",
-            "signature": "sig",
             "created_at": now.isoformat(),
             "expires_at": (now + timedelta(hours=1)).isoformat(),
             "used": False,


### PR DESCRIPTION
## Summary
- Complete the HMAC removal started in Feature 1164
- Delete `_get_magic_link_secret()` and `_generate_magic_link_signature()` functions
- Remove signature generation from `request_magic_link()`
- Make `MagicLinkToken.signature` optional for backwards compatibility
- Update all tests to use token-only verification

## Problem
Feature 1164 removed the hardcoded `MAGIC_LINK_SECRET` fallback but left HMAC infrastructure in place. Preprod Lambda fails with 500 errors because `_get_magic_link_secret()` raises RuntimeError when the environment variable is not set.

## Root Cause
Per spec-v2.md lines 1755-1771, HMAC code should have been deleted entirely. The verification already uses atomic DynamoDB consumption via `ConditionExpression`, not HMAC signature validation.

## Security Analysis
Token security is maintained via:
1. 256-bit random token (`secrets.token_urlsafe(32)`) - cryptographically unguessable
2. Atomic DynamoDB consumption (`ConditionExpression="used = :false"`) - no replay
3. 1-hour expiry + rate limiting (5/email/hour, 20/IP/hour)

## Test Plan
- [x] Unit tests pass (34 tests)
- [x] Ruff check passes
- [ ] Preprod E2E tests pass (magic link endpoints return 200 instead of 500)

Refs: #1166

🤖 Generated with [Claude Code](https://claude.com/claude-code)