### PR TITLE
fix(1167): Remove X-User-ID header from OHLC API (CVSS 9.1)

### DIFF
--- a/frontend/src/hooks/use-chart-data.ts
+++ b/frontend/src/hooks/use-chart-data.ts
@@ -33,18 +33,19 @@ interface UseChartDataOptions {
  * Supports resolution parameter for intraday data (T015-T017).
  *
  * Feature 1165: No hydration wait - memory-only store initializes immediately.
+ * Feature 1167: Removed X-User-ID - uses Bearer token via client.ts interceptor.
  */
 export function useOHLCData(
   ticker: string | null,
   timeRange: TimeRange = '1M',
   resolution: OHLCResolution = 'D'
 ) {
-  const userId = useAuthStore((state) => state.user?.userId);
+  const hasAccessToken = useAuthStore((state) => !!state.tokens?.accessToken);
 
   return useQuery<OHLCResponse>({
     queryKey: ['ohlc', ticker, timeRange, resolution],
-    queryFn: () => fetchOHLCData(ticker!, { range: timeRange, resolution }, userId!),
-    enabled: !!ticker && !!userId,
+    queryFn: () => fetchOHLCData(ticker!, { range: timeRange, resolution }),
+    enabled: !!ticker && hasAccessToken,
     staleTime: STALE_TIME_MS,
   });
 }
@@ -53,19 +54,20 @@ export function useOHLCData(
  * Hook to fetch sentiment history for a ticker.
  *
  * Feature 1165: No hydration wait - memory-only store initializes immediately.
+ * Feature 1167: Removed X-User-ID - uses Bearer token via client.ts interceptor.
  */
 export function useSentimentHistoryData(
   ticker: string | null,
   timeRange: TimeRange = '1M',
   source: ChartSentimentSource = 'aggregated'
 ) {
-  const userId = useAuthStore((state) => state.user?.userId);
+  const hasAccessToken = useAuthStore((state) => !!state.tokens?.accessToken);
 
   return useQuery<SentimentHistoryResponse>({
     queryKey: ['sentiment-history-chart', ticker, timeRange, source],
     queryFn: () =>
-      fetchSentimentHistory(ticker!, { range: timeRange, source }, userId!),
-    enabled: !!ticker && !!userId,
+      fetchSentimentHistory(ticker!, { range: timeRange, source }),
+    enabled: !!ticker && hasAccessToken,
     staleTime: STALE_TIME_MS,
   });
 }
@@ -78,6 +80,7 @@ export function useSentimentHistoryData(
  * Supports resolution parameter for intraday OHLC data (T015-T017).
  *
  * Feature 1165: No hydration wait - memory-only store initializes immediately.
+ * Feature 1167: Removed X-User-ID - uses Bearer token via client.ts interceptor.
  */
 export function useChartData({
   ticker,
@@ -89,20 +92,20 @@ export function useChartData({
   refetch: () => void;
   isStale: boolean;
 } {
-  const userId = useAuthStore((state) => state.user?.userId);
+  const hasAccessToken = useAuthStore((state) => !!state.tokens?.accessToken);
 
   const ohlcQuery = useQuery<OHLCResponse>({
     queryKey: ['ohlc', ticker, timeRange, resolution],
-    queryFn: () => fetchOHLCData(ticker!, { range: timeRange, resolution }, userId!),
-    enabled: enabled && !!ticker && !!userId,
+    queryFn: () => fetchOHLCData(ticker!, { range: timeRange, resolution }),
+    enabled: enabled && !!ticker && hasAccessToken,
     staleTime: STALE_TIME_MS,
   });
 
   const sentimentQuery = useQuery<SentimentHistoryResponse>({
     queryKey: ['sentiment-history-chart', ticker, timeRange, sentimentSource],
     queryFn: () =>
-      fetchSentimentHistory(ticker!, { range: timeRange, source: sentimentSource }, userId!),
-    enabled: enabled && !!ticker && !!userId,
+      fetchSentimentHistory(ticker!, { range: timeRange, source: sentimentSource }),
+    enabled: enabled && !!ticker && hasAccessToken,
     staleTime: STALE_TIME_MS,
   });
 

--- a/frontend/src/lib/api/ohlc.ts
+++ b/frontend/src/lib/api/ohlc.ts
@@ -28,15 +28,16 @@ interface SentimentHistoryParams {
 /**
  * Fetch OHLC price data for a ticker.
  *
+ * Authentication: Bearer token added by client.ts interceptor.
+ * Feature 1167: Removed X-User-ID header (CVSS 9.1 security fix).
+ *
  * @param ticker - Stock ticker symbol (e.g., AAPL)
  * @param params - Query parameters for time range and resolution (T013-T014)
- * @param userId - User ID for authentication
  * @returns OHLCResponse with candles array
  */
 export async function fetchOHLCData(
   ticker: string,
-  params: OHLCParams = {},
-  userId: string
+  params: OHLCParams = {}
 ): Promise<OHLCResponse> {
   return api.get<OHLCResponse>(`/api/v2/tickers/${ticker}/ohlc`, {
     params: {
@@ -45,24 +46,22 @@ export async function fetchOHLCData(
       start_date: params.start_date,
       end_date: params.end_date,
     },
-    headers: {
-      'X-User-ID': userId,
-    },
   });
 }
 
 /**
  * Fetch sentiment history for a ticker.
  *
+ * Authentication: Bearer token added by client.ts interceptor.
+ * Feature 1167: Removed X-User-ID header (CVSS 9.1 security fix).
+ *
  * @param ticker - Stock ticker symbol (e.g., AAPL)
  * @param params - Query parameters for source and time range
- * @param userId - User ID for authentication
  * @returns SentimentHistoryResponse with history array
  */
 export async function fetchSentimentHistory(
   ticker: string,
-  params: SentimentHistoryParams = {},
-  userId: string
+  params: SentimentHistoryParams = {}
 ): Promise<SentimentHistoryResponse> {
   return api.get<SentimentHistoryResponse>(`/api/v2/tickers/${ticker}/sentiment/history`, {
     params: {
@@ -70,9 +69,6 @@ export async function fetchSentimentHistory(
       range: params.range,
       start_date: params.start_date,
       end_date: params.end_date,
-    },
-    headers: {
-      'X-User-ID': userId,
     },
   });
 }

--- a/frontend/tests/unit/stores/auth-store.test.ts
+++ b/frontend/tests/unit/stores/auth-store.test.ts
@@ -550,9 +550,12 @@ describe('Feature 014: Auto-Session Creation', () => {
       // API client should use: Authorization: Bearer test-access-token
     });
 
-    it('should support X-User-ID header for anonymous sessions', async () => {
+    // Feature 1167: X-User-ID header removed (CVSS 9.1 security fix)
+    // Anonymous sessions now use Bearer token authentication like all other sessions.
+    // The userId is still stored for display purposes, but never sent as a header.
+    it('should store userId for anonymous sessions (display only, not auth)', async () => {
       mockCreateAnonymousSession.mockResolvedValueOnce({
-        userId: 'x-user-id-test',
+        userId: 'anon-user-id',
         authType: 'anonymous',
         createdAt: new Date().toISOString(),
         sessionExpiresAt: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
@@ -561,8 +564,8 @@ describe('Feature 014: Auto-Session Creation', () => {
       await useAuthStore.getState().signInAnonymous();
 
       const state = useAuthStore.getState();
-      expect(state.user?.userId).toBe('x-user-id-test');
-      // API client should use: X-User-ID: x-user-id-test
+      expect(state.user?.userId).toBe('anon-user-id');
+      // Note: API client uses Bearer token (set via setTokens), NOT X-User-ID header
     });
   });
 

--- a/specs/001-1167-remove-x/plan.md
+++ b/specs/001-1167-remove-x/plan.md
@@ -1,0 +1,78 @@
+# Implementation Plan: Remove X-User-ID from OHLC API
+
+**Feature**: 001-1167-remove-x
+**Status**: Ready for Implementation
+
+## Overview
+
+Remove the insecure X-User-ID header from OHLC and sentiment history API calls. The Bearer token authentication is already in place via client.ts interceptor - we just need to stop sending the redundant vulnerable header.
+
+## Implementation Steps
+
+### Step 1: Update ohlc.ts Functions
+
+**File**: `frontend/src/lib/api/ohlc.ts`
+
+1. Remove `userId: string` parameter from `fetchOHLCData` function signature (line 39)
+2. Remove `headers: { 'X-User-ID': userId }` from the request options (lines 48-50)
+3. Remove `userId: string` parameter from `fetchSentimentHistory` function signature (line 65)
+4. Remove `headers: { 'X-User-ID': userId }` from the request options (lines 74-76)
+
+**Verification**: TypeScript will error on callers that still pass userId - this is intentional.
+
+### Step 2: Update useChartData Hook
+
+**File**: `frontend/src/hooks/use-chart-data.ts`
+
+1. Remove `const userId = useAuthStore((state) => state.user?.userId);` (line 92)
+2. Add `const hasAccessToken = useAuthStore((state) => !!state.tokens?.accessToken);`
+3. Update `fetchOHLCData` call to remove userId argument (line 96)
+4. Update `fetchSentimentHistory` call to remove userId argument (line 104)
+5. Change `enabled` condition from `!!userId` to `hasAccessToken`
+
+**Verification**: Hook now gates on actual authentication, not just userId presence.
+
+### Step 3: Update Unit Tests
+
+**File**: `frontend/tests/unit/stores/auth-store.test.ts`
+
+1. Locate test at lines 553-566: "should support X-User-ID header for anonymous sessions"
+2. Remove or update this test - X-User-ID is no longer used
+3. Consider replacing with a test that verifies Bearer token is used instead
+
+**Verification**: `npm run test` passes.
+
+### Step 4: Verify No X-User-ID Remains
+
+**Command**: `grep -r "X-User-ID" frontend/src --include="*.ts" --include="*.tsx"`
+
+Expected: Zero matches in production code (test files may have historical references).
+
+## Dependency Order
+
+```
+Step 1 (ohlc.ts) → Step 2 (use-chart-data.ts) → Step 3 (tests) → Step 4 (verify)
+```
+
+Step 1 must complete first because Step 2 callers will have TypeScript errors until Step 1 removes the parameters.
+
+## Risk Assessment
+
+| Risk | Mitigation |
+|------|------------|
+| Breaking chart functionality | Bearer token already works via client.ts - no new auth flow needed |
+| TypeScript errors in other files | Search for all callers of fetchOHLCData/fetchSentimentHistory before changes |
+| Test failures | Update tests to match new behavior |
+
+## Rollback Plan
+
+If issues discovered post-merge:
+1. Revert the PR
+2. Investigate which callers still depend on userId parameter
+3. Re-implement with proper migration path
+
+## Estimated Scope
+
+- **Files Changed**: 3
+- **Lines Changed**: ~20
+- **Complexity**: Low (removing code, not adding)

--- a/specs/001-1167-remove-x/spec.md
+++ b/specs/001-1167-remove-x/spec.md
@@ -1,0 +1,146 @@
+# Feature Specification: Remove X-User-ID from OHLC API
+
+**Feature Branch**: `001-1167-remove-x`
+**Created**: 2026-01-07
+**Status**: Draft
+**Security Severity**: CRITICAL (CVSS 9.1)
+**Input**: Phase 2 breaking change for 1126-auth-httponly-migration
+
+## Context
+
+Feature 1146 established that X-User-ID header is a CVSS 9.1 vulnerability - it allows session hijacking via header injection. The `client.ts` removal was completed in PR #610, but `ohlc.ts` still contains X-User-ID usage that bypasses the secure Bearer token authentication.
+
+**Related PRs**:
+- PR #610: feat(1159): Enable cross-origin cookie transmission with SameSite=None (removed X-User-ID from client.ts)
+- PR #611: feat(1160): Extract refresh token from httpOnly cookie
+
+**Why This is Critical**: Any endpoint still accepting X-User-ID allows attackers to impersonate users by simply setting a header value. Bearer tokens are cryptographically signed and time-limited.
+
+## User Scenarios & Testing
+
+### User Story 1 - Authenticated User Views Price Chart (Priority: P1)
+
+A logged-in user navigates to a ticker's price chart. The chart loads using their Bearer token for authentication, without exposing their userId in request headers.
+
+**Why this priority**: Core functionality - charts are the primary user interaction. Security is non-negotiable.
+
+**Independent Test**: Load any ticker's chart page while authenticated. Verify network requests use `Authorization: Bearer <token>` instead of `X-User-ID` header.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user is authenticated with valid tokens, **When** they load the price chart for AAPL, **Then** the OHLC API request uses `Authorization: Bearer <accessToken>` header
+2. **Given** a user is authenticated, **When** the chart data loads, **Then** no `X-User-ID` header appears in any network request
+3. **Given** a user's access token is expired, **When** they load a chart, **Then** the token refresh flow triggers before the API call
+
+---
+
+### User Story 2 - Sentiment History Loads Securely (Priority: P1)
+
+When viewing a ticker, the sentiment history overlay loads using Bearer token authentication.
+
+**Why this priority**: Same security criticality as OHLC - both use the same vulnerable pattern.
+
+**Independent Test**: Verify sentiment history API calls use Bearer token.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user is authenticated, **When** sentiment history loads for a ticker, **Then** the request uses `Authorization: Bearer <accessToken>` header
+2. **Given** the sentiment API returns data, **When** inspecting the request, **Then** no `X-User-ID` header is present
+
+---
+
+### User Story 3 - Unauthenticated User Sees Login Prompt (Priority: P2)
+
+A user without valid tokens who tries to view charts is redirected to login.
+
+**Why this priority**: Proper handling of unauthenticated state after removing userId fallback.
+
+**Independent Test**: Clear auth state, navigate to chart page, verify redirect to login.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user has no tokens, **When** they navigate to a chart page, **Then** the query is disabled (enabled: false) and they see login prompt
+2. **Given** a user's session is expired and refresh fails, **When** they try to load a chart, **Then** they are redirected to login
+
+---
+
+### Edge Cases
+
+- What happens when userId exists in store but no accessToken? Query should be disabled.
+- How does system handle Bearer token that returns 401? Triggers token refresh or logout.
+- What if user clears cookies mid-session? Next API call fails, triggers re-auth flow.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: `fetchOHLCData` MUST NOT accept userId parameter
+- **FR-002**: `fetchOHLCData` MUST NOT send X-User-ID header
+- **FR-003**: `fetchSentimentHistory` MUST NOT accept userId parameter
+- **FR-004**: `fetchSentimentHistory` MUST NOT send X-User-ID header
+- **FR-005**: `useChartData` hook MUST NOT extract userId from auth store for API calls
+- **FR-006**: `useChartData` hook MUST disable queries when no accessToken exists (not just userId)
+- **FR-007**: API client interceptor (already configured in client.ts) handles Bearer token injection
+- **FR-008**: Tests MUST be updated to remove X-User-ID expectations
+
+### Files to Modify
+
+| File | Change |
+|------|--------|
+| `frontend/src/lib/api/ohlc.ts` | Remove userId param and X-User-ID header from both functions |
+| `frontend/src/hooks/use-chart-data.ts` | Remove userId extraction, change enabled condition to check accessToken |
+| `frontend/tests/unit/stores/auth-store.test.ts` | Update or remove X-User-ID test (lines 553-566) |
+
+### Key Entities
+
+- **AccessToken**: JWT used for Bearer authentication, injected by client.ts interceptor
+- **useChartData Hook**: Orchestrates OHLC and sentiment queries with proper auth gating
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: Zero X-User-ID headers in any network request from chart components
+- **SC-002**: All chart API calls include `Authorization: Bearer <token>` header
+- **SC-003**: Charts load successfully for authenticated users (no regression)
+- **SC-004**: Unit tests pass without X-User-ID assertions
+- **SC-005**: `npm run typecheck` passes (TypeScript validates parameter removal)
+- **SC-006**: `npm run test` passes (Jest tests updated)
+
+### Security Validation
+
+- **SV-001**: Manual inspection of Network tab shows no X-User-ID header on OHLC requests
+- **SV-002**: Grep codebase for "X-User-ID" returns zero matches in production code (test fixtures excepted)
+
+## Implementation Notes
+
+The `client.ts` API client already has an interceptor that adds `Authorization: Bearer <accessToken>` to all requests when tokens exist. This was implemented in PR #610. The OHLC functions just need to stop adding the redundant (and insecure) X-User-ID header.
+
+**Before (vulnerable)**:
+```typescript
+export async function fetchOHLCData(
+  ticker: string,
+  params: OHLCParams = {},
+  userId: string  // REMOVE
+): Promise<OHLCResponse> {
+  return api.get<OHLCResponse>(`/api/v2/tickers/${ticker}/ohlc`, {
+    params: { ... },
+    headers: {
+      'X-User-ID': userId,  // REMOVE - security vulnerability
+    },
+  });
+}
+```
+
+**After (secure)**:
+```typescript
+export async function fetchOHLCData(
+  ticker: string,
+  params: OHLCParams = {}
+): Promise<OHLCResponse> {
+  return api.get<OHLCResponse>(`/api/v2/tickers/${ticker}/ohlc`, {
+    params: { ... },
+    // Bearer token added by client.ts interceptor
+  });
+}
+```

--- a/specs/001-1167-remove-x/tasks.md
+++ b/specs/001-1167-remove-x/tasks.md
@@ -1,0 +1,20 @@
+# Tasks: Remove X-User-ID from OHLC API
+
+**Feature**: 001-1167-remove-x
+
+## Task List
+
+- [x] **T1**: Update fetchOHLCData - remove userId param and X-User-ID header
+- [x] **T2**: Update fetchSentimentHistory - remove userId param and X-User-ID header
+- [x] **T3**: Update useChartData hook - remove userId, gate on accessToken
+- [x] **T4**: Update auth-store.test.ts - remove X-User-ID test
+- [x] **T5**: Run typecheck and fix any remaining callers
+- [x] **T6**: Run tests and verify all pass
+- [x] **T7**: Grep verify no X-User-ID in production code
+
+## Completion Summary
+
+All tasks completed. X-User-ID header completely removed from OHLC API calls.
+- Typecheck: PASS
+- Tests: PASS (57 tests)
+- Production code grep: Only comments remain (documenting removal)


### PR DESCRIPTION
## Summary
- Remove insecure X-User-ID header from OHLC API calls (CVSS 9.1)
- Gate chart queries on accessToken instead of userId
- All auth now via Bearer token interceptor

## Changes
- `ohlc.ts`: Remove userId param and X-User-ID header
- `use-chart-data.ts`: Gate queries on accessToken
- `auth-store.test.ts`: Update test for Bearer-only auth

## Breaking Change
`fetchOHLCData`/`fetchSentimentHistory` no longer accept userId parameter.

## Test Plan
- [x] npm run typecheck passes
- [x] npm run test passes
- [ ] E2E: Charts load with valid auth
- [ ] E2E: Charts reject without auth

Refs: #1167

🤖 Generated with [Claude Code](https://claude.com/claude-code)