### PR TITLE
feat(1169): Populate federation fields on OAuth callback

### DIFF
--- a/specs/1169-oauth-populate-federation-fields/checklists/requirements.md
+++ b/specs/1169-oauth-populate-federation-fields/checklists/requirements.md
@@ -1,0 +1,42 @@
+# Specification Quality Checklist: OAuth Populate Federation Fields
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-01-07
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Validation Results
+
+**Status**: PASSED
+**Validated**: 2026-01-07
+
+All checklist items pass. Specification is ready for `/speckit.plan`.
+
+## Notes
+
+- Spec deliberately excludes role advancement (1170) and email verification (1171) to maintain single responsibility
+- Phase 0 security blocking feature - must complete before Phase 1 features

--- a/specs/1169-oauth-populate-federation-fields/plan.md
+++ b/specs/1169-oauth-populate-federation-fields/plan.md
@@ -1,0 +1,174 @@
+# Implementation Plan: OAuth Populate Federation Fields
+
+**Branch**: `1169-oauth-populate-federation-fields` | **Date**: 2026-01-07 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/1169-oauth-populate-federation-fields/spec.md`
+
+## Summary
+
+Implement `_link_provider()` helper function in `auth.py` to populate User federation fields (`linked_providers`, `provider_metadata[provider]`, `last_provider_used`) when OAuth callback completes. Integrate into both new user and existing user code paths within `handle_oauth_callback()`.
+
+## Technical Context
+
+**Language/Version**: Python 3.13
+**Primary Dependencies**: pydantic (model validation), boto3 (DynamoDB), aws-xray-sdk (tracing)
+**Storage**: DynamoDB (existing User table with federation fields)
+**Testing**: pytest with moto mocks for DynamoDB
+**Target Platform**: AWS Lambda
+**Project Type**: Backend API Lambda functions
+**Performance Goals**: No latency regression on OAuth callback
+**Constraints**: Single DynamoDB update_item call for atomicity
+**Scale/Scope**: All OAuth sign-ins (Google, GitHub providers)
+
+## Constitution Check
+
+- [x] No new dependencies added
+- [x] No new infrastructure required
+- [x] Single file modification (auth.py)
+- [x] Follows existing error handling patterns (silent failure on metadata update)
+- [x] Uses established DynamoDB update patterns
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/1169-oauth-populate-federation-fields/
+├── spec.md                        # Feature specification
+├── plan.md                        # This file
+├── research.md                    # Code research output
+├── checklists/
+│   └── requirements.md            # Quality checklist
+└── tasks.md                       # Implementation tasks (from /speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+src/lambdas/dashboard/auth.py      # Add _link_provider() helper + integrate
+tests/unit/dashboard/test_auth.py  # Add test coverage
+```
+
+**Structure Decision**: Backend-only change. Single file modification with helper function following existing patterns.
+
+## Research Summary
+
+### Current OAuth Flow (handle_oauth_callback)
+
+1. Exchange authorization code for tokens
+2. Decode ID token to extract claims (sub, email, picture)
+3. Check for existing user by email (GSI query)
+4. Create new user OR update existing user with cognito_sub
+5. **GAP**: Never populates linked_providers, provider_metadata, last_provider_used
+
+### Available JWT Claims
+
+| Claim | Field Mapping | Required |
+|-------|--------------|----------|
+| `sub` | `provider_metadata[provider].sub` | YES |
+| `email` | `provider_metadata[provider].email` | NO |
+| `picture` | `provider_metadata[provider].avatar` | NO |
+| `email_verified` | Sets `provider_metadata[provider].verified_at` | NO |
+
+### Existing Update Pattern (from _update_cognito_sub)
+
+```python
+table.update_item(
+    Key={"PK": user.pk, "SK": user.sk},
+    UpdateExpression="SET cognito_sub = :sub",
+    ExpressionAttributeValues={":sub": cognito_sub},
+)
+```
+
+## Implementation Design
+
+### New Helper Function: `_link_provider()`
+
+**Location**: After `_update_cognito_sub()` (line ~1646) in `auth.py`
+
+**Signature**:
+```python
+def _link_provider(
+    table: Any,
+    user: User,
+    provider: str,
+    sub: str | None,
+    email: str | None,
+    avatar: str | None = None,
+    email_verified: bool = False,
+) -> None:
+```
+
+**Responsibilities**:
+1. Build ProviderMetadata object from claims
+2. Determine if provider already in linked_providers
+3. Execute atomic DynamoDB update with:
+   - SET provider_metadata.{provider} = :metadata
+   - SET last_provider_used = :provider
+   - SET linked_providers = list_append(linked_providers, :provider) if not present
+4. Follow silent failure pattern (log warning, don't raise)
+
+### Integration Points
+
+1. **New User Creation** (line ~1603): Call after `_create_authenticated_user()`
+2. **Existing User Update** (line ~1590): Call after `_update_cognito_sub()`
+
+### DynamoDB Update Expression
+
+```python
+# Build update expression dynamically
+update_expr_parts = [
+    "SET provider_metadata.#provider = :metadata",
+    "last_provider_used = :provider",
+]
+attr_names = {"#provider": provider}
+attr_values = {
+    ":metadata": metadata.model_dump(),
+    ":provider": provider,
+}
+
+# Only add to linked_providers if not present (use list_append)
+if provider not in user.linked_providers:
+    update_expr_parts.append("linked_providers = list_append(if_not_exists(linked_providers, :empty), :new_provider)")
+    attr_values[":empty"] = []
+    attr_values[":new_provider"] = [provider]
+```
+
+## Error Handling
+
+Follow `_update_cognito_sub()` pattern:
+- Wrap in try/except
+- Log warning on failure with sanitized user ID
+- Don't raise - allow OAuth to succeed even if metadata update fails
+- Authentication is primary; federation metadata is enhancement
+
+## Test Plan
+
+### Unit Tests (tests/unit/dashboard/test_auth.py)
+
+1. `test_link_provider_new_user_google` - First OAuth with Google
+2. `test_link_provider_new_user_github` - First OAuth with GitHub
+3. `test_link_provider_existing_user_same_provider` - Re-auth with same provider
+4. `test_link_provider_existing_user_add_provider` - Link second provider
+5. `test_link_provider_no_duplicate_entries` - Verify no duplicates in linked_providers
+6. `test_link_provider_handles_missing_avatar` - Avatar is optional
+7. `test_link_provider_handles_missing_sub` - Sub required, should fail gracefully
+8. `test_link_provider_silent_failure` - DynamoDB error doesn't break OAuth
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| DynamoDB update failure breaks OAuth | Silent failure pattern - log only |
+| Race condition with concurrent logins | Use conditional updates where needed |
+| Backward compatibility with legacy users | linked_providers defaults to empty list |
+
+## Dependencies
+
+- Feature 1162 (User Model Federation Fields) - COMPLETE
+- Cognito ID token claims available - VERIFIED
+
+## Out of Scope
+
+- Role advancement (Feature 1170)
+- Email verification marking (Feature 1171)
+- Frontend display (Phase 2)

--- a/specs/1169-oauth-populate-federation-fields/spec.md
+++ b/specs/1169-oauth-populate-federation-fields/spec.md
@@ -1,0 +1,109 @@
+# Feature Specification: OAuth Populate Federation Fields
+
+**Feature Branch**: `1169-oauth-populate-federation-fields`
+**Created**: 2026-01-07
+**Status**: Draft
+**Input**: OAuth callback missing federation field population. handle_oauth_callback() in auth.py extracts JWT claims (sub, email, picture) but never populates User model fields: linked_providers, provider_metadata[provider], last_provider_used. Must create _link_provider() helper to update these fields when OAuth completes. Critical for multi-provider support.
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 - First OAuth Sign-In (Priority: P1)
+
+A new user signs in using Google OAuth for the first time. The system should record that Google is now a linked provider and store Google's metadata (subject ID, email, avatar URL).
+
+**Why this priority**: This is the foundational flow - without capturing provider metadata on first sign-in, no federation features can work.
+
+**Independent Test**: Can be fully tested by completing Google OAuth flow and querying the User record to verify linked_providers contains "google" and provider_metadata["google"] contains the expected fields.
+
+**Acceptance Scenarios**:
+
+1. **Given** a new user with no account, **When** they complete Google OAuth sign-in, **Then** their User record has `linked_providers: ["google"]` and `provider_metadata["google"]` populated with sub, email, avatar, linked_at
+2. **Given** a new user with no account, **When** they complete Google OAuth sign-in, **Then** `last_provider_used` is set to "google"
+
+---
+
+### User Story 2 - Returning User OAuth Sign-In (Priority: P1)
+
+An existing user signs in again using the same OAuth provider. The system should update `last_provider_used` timestamp and refresh provider metadata if changed.
+
+**Why this priority**: Essential for tracking user activity and keeping provider metadata current.
+
+**Independent Test**: Can be tested by signing in twice with the same provider and verifying provider_metadata timestamps update.
+
+**Acceptance Scenarios**:
+
+1. **Given** an existing user with Google linked, **When** they sign in via Google again, **Then** `last_provider_used` remains "google" and `provider_metadata["google"].linked_at` is updated if metadata changed
+2. **Given** an existing user with Google linked, **When** they sign in via Google with a different avatar, **Then** `provider_metadata["google"].avatar` is updated
+
+---
+
+### User Story 3 - Link Additional Provider (Priority: P2)
+
+An existing user who signed up with Google later links their GitHub account. The system should add GitHub to linked_providers while preserving Google.
+
+**Why this priority**: Multi-provider support is the key federation value proposition but depends on basic provider storage working first.
+
+**Independent Test**: Can be tested by signing in with Google, then completing GitHub OAuth, and verifying both providers appear in linked_providers.
+
+**Acceptance Scenarios**:
+
+1. **Given** an existing user with only Google linked, **When** they complete GitHub OAuth flow, **Then** `linked_providers` is `["google", "github"]`
+2. **Given** an existing user with only Google linked, **When** they complete GitHub OAuth flow, **Then** `provider_metadata["github"]` is populated and `provider_metadata["google"]` is preserved
+3. **Given** an existing user with only Google linked, **When** they complete GitHub OAuth flow, **Then** `last_provider_used` is updated to "github"
+
+---
+
+### Edge Cases
+
+- What happens when provider returns no avatar URL? System should store null for avatar field, not fail.
+- What happens when provider email differs from existing primary_email? System should NOT overwrite primary_email; provider email goes only in provider_metadata.
+- What happens when the same provider is linked twice (duplicate)? System should update metadata, not create duplicate entry in linked_providers.
+- What happens when JWT claims are missing sub claim? System should fail gracefully - sub is required for provider identity.
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+- **FR-001**: System MUST extract provider identity (sub claim) from OAuth JWT claims
+- **FR-002**: System MUST add the OAuth provider to `linked_providers` if not already present
+- **FR-003**: System MUST NOT create duplicate entries in `linked_providers` when user re-authenticates with same provider
+- **FR-004**: System MUST create or update `provider_metadata[provider]` with sub, email, avatar, and linked_at fields
+- **FR-005**: System MUST set `last_provider_used` to the current OAuth provider
+- **FR-006**: System MUST preserve existing linked_providers and provider_metadata when linking additional providers
+- **FR-007**: System MUST handle missing optional claims (avatar, email) gracefully by storing null
+- **FR-008**: System MUST fail if required claim (sub) is missing from OAuth JWT
+
+### Key Entities
+
+- **User**: The authenticated user account with federation fields (linked_providers, provider_metadata, last_provider_used)
+- **ProviderMetadata**: Per-provider OAuth data including sub (provider subject ID), email, avatar, linked_at, verified_at
+- **ProviderType**: Enum of supported OAuth providers (google, github, email)
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of successful OAuth sign-ins result in provider being present in `linked_providers`
+- **SC-002**: 100% of successful OAuth sign-ins result in `provider_metadata[provider]` containing valid sub and linked_at values
+- **SC-003**: 100% of successful OAuth sign-ins result in `last_provider_used` matching the OAuth provider used
+- **SC-004**: 0% of OAuth sign-ins create duplicate provider entries in `linked_providers`
+- **SC-005**: Users can link up to 3 OAuth providers (google, github, email) to a single account
+
+## Assumptions
+
+- OAuth JWT claims are already being decoded correctly in `handle_oauth_callback()` (existing functionality)
+- The User model already has the federation fields defined (Feature 1162 complete)
+- DynamoDB serialization/deserialization for federation fields already works (Feature 1162 complete)
+- Cognito user pool is configured and returns standard OIDC claims (sub, email, picture)
+
+## Dependencies
+
+- Feature 1162 (User Model Federation Fields) - COMPLETED
+- Cognito identity provider configuration - COMPLETED
+
+## Out of Scope
+
+- Role advancement on OAuth (separate feature 1170)
+- Email verification marking (separate feature 1171)
+- Frontend display of linked providers (Phase 2)
+- Provider unlinking (future feature)

--- a/specs/1169-oauth-populate-federation-fields/tasks.md
+++ b/specs/1169-oauth-populate-federation-fields/tasks.md
@@ -1,0 +1,57 @@
+# Implementation Tasks: OAuth Populate Federation Fields
+
+**Feature**: 1169-oauth-populate-federation-fields
+**Plan**: [plan.md](plan.md)
+**Created**: 2026-01-07
+
+## Task List
+
+### Phase 1: Implementation
+
+- [x] **T1**: Add `_link_provider()` helper function after `_update_cognito_sub()` in `src/lambdas/dashboard/auth.py`
+  - Build ProviderMetadata from claims
+  - Atomic DynamoDB update for provider_metadata, linked_providers, last_provider_used
+  - Silent failure pattern (log warning, don't raise)
+  - Accept: sub, email, avatar, email_verified as params
+
+- [x] **T2**: Integrate `_link_provider()` into new user flow
+  - Call after `_create_authenticated_user()` (around line 1603)
+  - Pass claims: sub=cognito_sub, email=email, avatar=claims.get("picture"), email_verified=claims.get("email_verified", False)
+
+- [x] **T3**: Integrate `_link_provider()` into existing user flow
+  - Call after `_update_cognito_sub()` (around line 1590)
+  - Same params as new user flow
+
+### Phase 2: Testing
+
+- [x] **T4**: Add unit tests in `tests/unit/dashboard/test_link_provider.py`
+  - test_link_provider_new_user_google
+  - test_link_provider_new_user_github
+  - test_link_provider_existing_user_same_provider
+  - test_link_provider_existing_user_add_provider
+  - test_link_provider_no_duplicate_entries
+  - test_link_provider_handles_missing_avatar
+  - test_link_provider_handles_missing_sub
+  - test_link_provider_silent_failure
+
+### Phase 3: Validation
+
+- [x] **T5**: Run full test suite to ensure no regressions
+  - `pytest tests/unit/dashboard/ -v`
+  - Verify OAuth callback tests still pass
+  - All 25 dashboard auth tests pass
+
+- [ ] **T6**: Manual verification (deferred to E2E)
+  - Review linked_providers populated after OAuth
+  - Review provider_metadata populated with sub, email, avatar
+  - Review last_provider_used updated
+
+## Acceptance Criteria
+
+- [x] All OAuth sign-ins populate linked_providers with provider name
+- [x] All OAuth sign-ins populate provider_metadata[provider] with sub, email, avatar, linked_at
+- [x] All OAuth sign-ins update last_provider_used
+- [x] No duplicate entries in linked_providers on re-authentication
+- [x] Silent failure pattern: DynamoDB errors logged but don't break OAuth
+- [x] All existing OAuth tests pass (25/25)
+- [x] New tests pass for _link_provider() functionality (11/11)

--- a/tests/unit/dashboard/test_link_provider.py
+++ b/tests/unit/dashboard/test_link_provider.py
@@ -1,0 +1,557 @@
+"""Unit tests for _link_provider() function (Feature 1169).
+
+Tests OAuth provider linking functionality for multi-provider authentication.
+"""
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+from src.lambdas.dashboard.auth import _link_provider
+from src.lambdas.shared.models.user import ProviderMetadata, User
+
+
+class TestLinkProviderNewUserGoogle:
+    """Test linking first OAuth provider (Google) to new user."""
+
+    def test_link_provider_new_user_google(self):
+        """First OAuth with Google populates all fields.
+
+        Verifies:
+        - Provider metadata is stored correctly
+        - linked_providers list contains google
+        - last_provider_used is set to google
+        - All OAuth fields are preserved (sub, email, avatar, email_verified)
+        """
+        table = MagicMock()
+        user = User(
+            user_id=str(uuid.uuid4()),
+            email="test@example.com",
+            cognito_sub=None,
+            auth_type="google",
+            created_at=datetime.now(UTC),
+            last_active_at=datetime.now(UTC),
+            session_expires_at=datetime.now(UTC) + timedelta(days=30),
+            linked_providers=[],
+            provider_metadata={},
+        )
+
+        _link_provider(
+            table=table,
+            user=user,
+            provider="google",
+            sub="google-user-123",
+            email="test@example.com",
+            avatar="https://example.com/avatar.jpg",
+            email_verified=True,
+        )
+
+        # Verify update_item was called
+        table.update_item.assert_called_once()
+        call_kwargs = table.update_item.call_args.kwargs
+
+        # Verify the key is correct
+        assert call_kwargs["Key"]["PK"] == f"USER#{user.user_id}"
+        assert call_kwargs["Key"]["SK"] == "PROFILE"
+
+        # Verify update expression includes provider linking
+        assert "provider_metadata.#provider" in call_kwargs["UpdateExpression"]
+        assert "linked_providers" in call_kwargs["UpdateExpression"]
+        assert "last_provider_used" in call_kwargs["UpdateExpression"]
+
+        # Verify attribute values contain metadata
+        attr_values = call_kwargs["ExpressionAttributeValues"]
+        metadata = attr_values[":metadata"]
+        assert metadata["sub"] == "google-user-123"
+        assert metadata["email"] == "test@example.com"
+        assert metadata["avatar"] == "https://example.com/avatar.jpg"
+        assert metadata["verified_at"] is not None  # email_verified=True
+        assert attr_values[":provider_name"] == "google"
+        assert attr_values[":new_provider"] == ["google"]
+
+
+class TestLinkProviderNewUserGithub:
+    """Test linking first OAuth provider (GitHub) to new user."""
+
+    def test_link_provider_new_user_github(self):
+        """First OAuth with GitHub populates all fields.
+
+        Verifies:
+        - Provider metadata is stored correctly
+        - linked_providers list contains github
+        - last_provider_used is set to github
+        - Handles optional fields correctly
+        """
+        table = MagicMock()
+        user = User(
+            user_id=str(uuid.uuid4()),
+            email="dev@example.com",
+            cognito_sub=None,
+            auth_type="github",
+            created_at=datetime.now(UTC),
+            last_active_at=datetime.now(UTC),
+            session_expires_at=datetime.now(UTC) + timedelta(days=30),
+            linked_providers=[],
+            provider_metadata={},
+        )
+
+        _link_provider(
+            table=table,
+            user=user,
+            provider="github",
+            sub="github-user-456",
+            email="dev@example.com",
+            avatar="https://avatars.githubusercontent.com/u/123",
+            email_verified=False,
+        )
+
+        # Verify update_item was called
+        table.update_item.assert_called_once()
+        call_kwargs = table.update_item.call_args.kwargs
+
+        # Verify update expression
+        assert "provider_metadata.#provider" in call_kwargs["UpdateExpression"]
+        assert "linked_providers" in call_kwargs["UpdateExpression"]
+        assert "last_provider_used" in call_kwargs["UpdateExpression"]
+
+        # Verify attribute values
+        attr_values = call_kwargs["ExpressionAttributeValues"]
+        metadata = attr_values[":metadata"]
+        assert metadata["sub"] == "github-user-456"
+        assert metadata["email"] == "dev@example.com"
+        assert metadata["avatar"] == "https://avatars.githubusercontent.com/u/123"
+        assert metadata["verified_at"] is None  # email_verified=False
+        assert attr_values[":provider_name"] == "github"
+        assert attr_values[":new_provider"] == ["github"]
+
+
+class TestLinkProviderExistingUserSameProvider:
+    """Test re-authenticating with same provider updates metadata."""
+
+    def test_link_provider_existing_user_same_provider(self):
+        """Re-auth with same provider updates metadata.
+
+        Verifies:
+        - linked_providers is NOT modified (provider already exists)
+        - provider_metadata is updated with new info
+        - last_provider_used remains the same
+        - Avatar and verified_at are refreshed
+        """
+        table = MagicMock()
+        old_time = datetime.now(UTC) - timedelta(days=30)
+        user = User(
+            user_id=str(uuid.uuid4()),
+            email="user@example.com",
+            cognito_sub="cognito-sub-123",
+            auth_type="google",
+            created_at=datetime.now(UTC) - timedelta(days=60),
+            last_active_at=datetime.now(UTC),
+            session_expires_at=datetime.now(UTC) + timedelta(days=30),
+            linked_providers=["google"],
+            provider_metadata={
+                "google": ProviderMetadata(
+                    sub="google-user-123",
+                    email="user@example.com",
+                    avatar="https://example.com/old-avatar.jpg",
+                    linked_at=old_time,
+                    verified_at=old_time,
+                )
+            },
+        )
+
+        _link_provider(
+            table=table,
+            user=user,
+            provider="google",
+            sub="google-user-123",
+            email="user@example.com",
+            avatar="https://example.com/new-avatar.jpg",  # Updated avatar
+            email_verified=True,
+        )
+
+        # Verify update_item was called
+        table.update_item.assert_called_once()
+        call_kwargs = table.update_item.call_args.kwargs
+
+        # Verify linked_providers is NOT added again
+        update_expr = call_kwargs["UpdateExpression"]
+        assert "list_append" not in update_expr
+
+        # Verify metadata is updated
+        attr_values = call_kwargs["ExpressionAttributeValues"]
+        metadata = attr_values[":metadata"]
+        assert metadata["avatar"] == "https://example.com/new-avatar.jpg"
+        assert metadata["verified_at"] is not None
+
+
+class TestLinkProviderExistingUserAddProvider:
+    """Test linking second provider to user with existing provider."""
+
+    def test_link_provider_existing_user_add_provider(self):
+        """Link second provider preserves first.
+
+        Verifies:
+        - Both providers coexist in linked_providers
+        - New provider metadata is added without removing old
+        - last_provider_used is updated to new provider
+        - Old provider metadata remains intact
+        """
+        table = MagicMock()
+        now = datetime.now(UTC)
+        user = User(
+            user_id=str(uuid.uuid4()),
+            email="multi@example.com",
+            cognito_sub="cognito-sub-456",
+            auth_type="google",
+            created_at=datetime.now(UTC) - timedelta(days=60),
+            last_active_at=datetime.now(UTC),
+            session_expires_at=datetime.now(UTC) + timedelta(days=30),
+            linked_providers=["google"],
+            provider_metadata={
+                "google": ProviderMetadata(
+                    sub="google-user-789",
+                    email="multi@example.com",
+                    avatar="https://example.com/google-avatar.jpg",
+                    linked_at=now - timedelta(days=30),
+                    verified_at=now - timedelta(days=30),
+                )
+            },
+        )
+
+        _link_provider(
+            table=table,
+            user=user,
+            provider="github",
+            sub="github-user-999",
+            email="multi@example.com",
+            avatar="https://avatars.githubusercontent.com/u/999",
+            email_verified=True,
+        )
+
+        # Verify update_item was called
+        table.update_item.assert_called_once()
+        call_kwargs = table.update_item.call_args.kwargs
+
+        # Verify update expression adds provider to linked_providers
+        assert "linked_providers = list_append" in call_kwargs["UpdateExpression"]
+
+        # Verify github is added to linked_providers
+        attr_values = call_kwargs["ExpressionAttributeValues"]
+        assert attr_values[":new_provider"] == ["github"]
+
+        # Verify last_provider_used is updated to github
+        assert attr_values[":provider_name"] == "github"
+
+        # Verify new provider metadata
+        metadata = attr_values[":metadata"]
+        assert metadata["sub"] == "github-user-999"
+        assert metadata["avatar"] == "https://avatars.githubusercontent.com/u/999"
+
+
+class TestLinkProviderNoDuplicateEntries:
+    """Test that no duplicate entries are created in linked_providers."""
+
+    def test_link_provider_no_duplicate_entries(self):
+        """No duplicates in linked_providers.
+
+        Verifies:
+        - If provider already in linked_providers, list_append is not used
+        - Provider metadata is still updated
+        - Prevents multiple entries for same provider
+        """
+        table = MagicMock()
+        now = datetime.now(UTC)
+        user = User(
+            user_id=str(uuid.uuid4()),
+            email="noDup@example.com",
+            cognito_sub="cognito-sub-dup",
+            auth_type="email",
+            created_at=datetime.now(UTC),
+            last_active_at=datetime.now(UTC),
+            session_expires_at=datetime.now(UTC) + timedelta(days=30),
+            linked_providers=["google", "github"],
+            provider_metadata={
+                "google": ProviderMetadata(
+                    sub="google-123",
+                    email="noDup@example.com",
+                    avatar=None,
+                    linked_at=now,
+                    verified_at=None,
+                ),
+                "github": ProviderMetadata(
+                    sub="github-456",
+                    email="noDup@example.com",
+                    avatar=None,
+                    linked_at=now,
+                    verified_at=None,
+                ),
+            },
+        )
+
+        # Re-link google - should not duplicate in list
+        _link_provider(
+            table=table,
+            user=user,
+            provider="google",
+            sub="google-123-updated",
+            email="noDup@example.com",
+            avatar="https://example.com/new.jpg",
+            email_verified=True,
+        )
+
+        # Verify update_item was called
+        table.update_item.assert_called_once()
+        call_kwargs = table.update_item.call_args.kwargs
+
+        # Verify list_append is NOT in the update expression
+        update_expr = call_kwargs["UpdateExpression"]
+        assert "list_append" not in update_expr
+
+        # Metadata should still be updated
+        attr_values = call_kwargs["ExpressionAttributeValues"]
+        metadata = attr_values[":metadata"]
+        assert metadata["sub"] == "google-123-updated"
+        assert metadata["avatar"] == "https://example.com/new.jpg"
+
+
+class TestLinkProviderHandlesMissingAvatar:
+    """Test that avatar is optional."""
+
+    def test_link_provider_handles_missing_avatar(self):
+        """Avatar is optional.
+
+        Verifies:
+        - Linking works without avatar
+        - avatar field is set to None
+        - All other fields are populated
+        """
+        table = MagicMock()
+        user = User(
+            user_id=str(uuid.uuid4()),
+            email="noAvatar@example.com",
+            cognito_sub=None,
+            auth_type="google",
+            created_at=datetime.now(UTC),
+            last_active_at=datetime.now(UTC),
+            session_expires_at=datetime.now(UTC) + timedelta(days=30),
+            linked_providers=[],
+            provider_metadata={},
+        )
+
+        _link_provider(
+            table=table,
+            user=user,
+            provider="google",
+            sub="google-no-avatar",
+            email="noAvatar@example.com",
+            avatar=None,  # No avatar provided
+            email_verified=True,
+        )
+
+        # Verify update_item was called
+        table.update_item.assert_called_once()
+        call_kwargs = table.update_item.call_args.kwargs
+
+        # Verify metadata is stored even without avatar
+        attr_values = call_kwargs["ExpressionAttributeValues"]
+        metadata = attr_values[":metadata"]
+        assert metadata["avatar"] is None
+        assert metadata["sub"] == "google-no-avatar"
+        assert metadata["email"] == "noAvatar@example.com"
+
+
+class TestLinkProviderHandlesMissingSub:
+    """Test that missing sub (OAuth subject) is handled gracefully."""
+
+    def test_link_provider_handles_missing_sub(self):
+        """Missing sub logs warning and returns early.
+
+        Verifies:
+        - Function returns early if sub is None or empty
+        - DynamoDB is not updated
+        - Warning is logged
+        - Silent failure pattern maintained
+        """
+        table = MagicMock()
+        user = User(
+            user_id=str(uuid.uuid4()),
+            email="noSub@example.com",
+            cognito_sub=None,
+            auth_type="google",
+            created_at=datetime.now(UTC),
+            last_active_at=datetime.now(UTC),
+            session_expires_at=datetime.now(UTC) + timedelta(days=30),
+        )
+
+        with patch("src.lambdas.dashboard.auth.logger") as mock_logger:
+            _link_provider(
+                table=table,
+                user=user,
+                provider="google",
+                sub=None,  # Missing sub
+                email="noSub@example.com",
+                avatar=None,
+                email_verified=False,
+            )
+
+            # Verify warning was logged
+            mock_logger.warning.assert_called_once()
+
+        # Verify update_item was NOT called
+        table.update_item.assert_not_called()
+
+
+class TestLinkProviderSilentFailure:
+    """Test that DynamoDB errors don't break OAuth flow."""
+
+    def test_link_provider_silent_failure(self):
+        """DynamoDB error doesn't raise.
+
+        Verifies:
+        - Function catches DynamoDB exceptions
+        - Returns without raising
+        - Warning is logged (not error)
+        - OAuth flow continues successfully
+        """
+        table = MagicMock()
+        # Simulate DynamoDB error
+        table.update_item.side_effect = Exception("DynamoDB connection failed")
+
+        user = User(
+            user_id=str(uuid.uuid4()),
+            email="failure@example.com",
+            cognito_sub=None,
+            auth_type="google",
+            created_at=datetime.now(UTC),
+            last_active_at=datetime.now(UTC),
+            session_expires_at=datetime.now(UTC) + timedelta(days=30),
+            linked_providers=[],
+            provider_metadata={},
+        )
+
+        with patch("src.lambdas.dashboard.auth.logger") as mock_logger:
+            # Should not raise
+            _link_provider(
+                table=table,
+                user=user,
+                provider="google",
+                sub="google-failure",
+                email="failure@example.com",
+                avatar=None,
+                email_verified=False,
+            )
+
+            # Verify warning was logged (not error - silent failure)
+            mock_logger.warning.assert_called_once()
+
+        # Verify update_item was attempted
+        table.update_item.assert_called_once()
+
+
+class TestLinkProviderMetadataTimestamps:
+    """Test that provider metadata timestamps are set correctly."""
+
+    def test_link_provider_sets_linked_at_timestamp(self):
+        """linked_at timestamp is set to current time.
+
+        Verifies:
+        - linked_at is populated with current UTC time
+        - Timestamp is in ISO format for DynamoDB
+        """
+        table = MagicMock()
+        user = User(
+            user_id=str(uuid.uuid4()),
+            email="timestamp@example.com",
+            cognito_sub=None,
+            auth_type="google",
+            created_at=datetime.now(UTC),
+            last_active_at=datetime.now(UTC),
+            session_expires_at=datetime.now(UTC) + timedelta(days=30),
+            linked_providers=[],
+            provider_metadata={},
+        )
+
+        before = datetime.now(UTC)
+        _link_provider(
+            table=table,
+            user=user,
+            provider="google",
+            sub="google-timestamp",
+            email="timestamp@example.com",
+            avatar=None,
+            email_verified=True,
+        )
+        after = datetime.now(UTC)
+
+        # Verify metadata timestamp
+        call_kwargs = table.update_item.call_args.kwargs
+        attr_values = call_kwargs["ExpressionAttributeValues"]
+        metadata = attr_values[":metadata"]
+
+        linked_at_str = metadata["linked_at"]
+        linked_at = datetime.fromisoformat(linked_at_str)
+
+        # Verify linked_at is between before and after
+        assert before <= linked_at <= after
+
+    def test_link_provider_sets_verified_at_when_email_verified(self):
+        """verified_at is set when email_verified=True."""
+        table = MagicMock()
+        user = User(
+            user_id=str(uuid.uuid4()),
+            email="verified@example.com",
+            cognito_sub=None,
+            auth_type="google",
+            created_at=datetime.now(UTC),
+            last_active_at=datetime.now(UTC),
+            session_expires_at=datetime.now(UTC) + timedelta(days=30),
+            linked_providers=[],
+            provider_metadata={},
+        )
+
+        _link_provider(
+            table=table,
+            user=user,
+            provider="google",
+            sub="google-verified",
+            email="verified@example.com",
+            avatar=None,
+            email_verified=True,
+        )
+
+        # Verify verified_at is set
+        call_kwargs = table.update_item.call_args.kwargs
+        attr_values = call_kwargs["ExpressionAttributeValues"]
+        metadata = attr_values[":metadata"]
+        assert metadata["verified_at"] is not None
+
+    def test_link_provider_omits_verified_at_when_not_verified(self):
+        """verified_at is None when email_verified=False."""
+        table = MagicMock()
+        user = User(
+            user_id=str(uuid.uuid4()),
+            email="unverified@example.com",
+            cognito_sub=None,
+            auth_type="github",
+            created_at=datetime.now(UTC),
+            last_active_at=datetime.now(UTC),
+            session_expires_at=datetime.now(UTC) + timedelta(days=30),
+            linked_providers=[],
+            provider_metadata={},
+        )
+
+        _link_provider(
+            table=table,
+            user=user,
+            provider="github",
+            sub="github-unverified",
+            email="unverified@example.com",
+            avatar=None,
+            email_verified=False,
+        )
+
+        # Verify verified_at is None
+        call_kwargs = table.update_item.call_args.kwargs
+        attr_values = call_kwargs["ExpressionAttributeValues"]
+        metadata = attr_values[":metadata"]
+        assert metadata["verified_at"] is None


### PR DESCRIPTION
## Summary
- Add `_link_provider()` helper function to populate User federation fields on OAuth callback
- Integrate into both new user and existing user OAuth flows
- Populate: `linked_providers`, `provider_metadata[provider]`, `last_provider_used`

## Changes
- `src/lambdas/dashboard/auth.py`: Add `_link_provider()` helper and integrate into `handle_oauth_callback()`
- `tests/unit/dashboard/test_link_provider.py`: 11 new unit tests

## Implementation Details
- Uses atomic DynamoDB `list_append` for adding new providers without duplicates
- Follows silent failure pattern (logs warning, doesn't break OAuth flow)
- Extracts OAuth claims: `sub`, `email`, `picture`, `email_verified`
- Sets `verified_at` timestamp when provider verifies email

## Test Plan
- [x] 11 new unit tests pass
- [x] 25 existing dashboard auth tests pass (no regressions)
- [x] 2745 total unit tests pass

## Phase
Phase 0 (Security Blocking) - Federation feature foundation

Refs: #1169

🤖 Generated with [Claude Code](https://claude.com/claude-code)