### PR TITLE
feat(1170): Add OAuth role advancement from anonymous to free

### DIFF
--- a/specs/1170-oauth-role-advancement/checklists/requirements.md
+++ b/specs/1170-oauth-role-advancement/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: OAuth Role Advancement
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-01-07
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All checklist items pass
+- Spec is ready for `/speckit.plan`
+- Related to Feature 1169 (_link_provider) which handles federation fields
+- This feature specifically handles role advancement during OAuth flow

--- a/specs/1170-oauth-role-advancement/plan.md
+++ b/specs/1170-oauth-role-advancement/plan.md
@@ -1,0 +1,99 @@
+# Implementation Plan: OAuth Role Advancement
+
+**Branch**: `1170-oauth-role-advancement` | **Date**: 2026-01-07 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/1170-oauth-role-advancement/spec.md`
+
+## Summary
+
+Add role advancement logic to OAuth flow. When users complete OAuth authentication with role="anonymous", advance them to role="free" and populate audit fields (`role_assigned_at`, `role_assigned_by`). Preserve higher roles (free/paid/operator) without modification.
+
+## Technical Context
+
+**Language/Version**: Python 3.13
+**Primary Dependencies**: FastAPI, boto3 (DynamoDB), pydantic
+**Storage**: DynamoDB (existing User table)
+**Testing**: pytest with moto mocks
+**Target Platform**: AWS Lambda
+**Project Type**: Web application (backend focus for this feature)
+**Performance Goals**: Role advancement must complete within OAuth callback (<100ms added latency)
+**Constraints**: Must be atomic with OAuth completion - no partial states
+**Scale/Scope**: Affects all OAuth users (~1000s per day)
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Gate | Status | Notes |
+|------|--------|-------|
+| No quick fixes | PASS | Full speckit workflow followed |
+| No workspace destruction | PASS | Modifying existing code, not deleting |
+| GPG signing | PASS | Will sign commits |
+| Cost sensitivity | PASS | No new AWS resources |
+| No implementation in spec | PASS | Spec is technology-agnostic |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/1170-oauth-role-advancement/
+├── spec.md              # Feature specification
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── tasks.md             # Phase 2 output
+└── checklists/
+    └── requirements.md  # Specification quality checklist
+```
+
+### Source Code (repository root)
+
+```text
+src/lambdas/dashboard/
+└── auth.py              # Modify: handle_oauth_callback(), add _advance_role()
+
+tests/unit/dashboard/
+└── test_role_advancement.py  # New: unit tests for role advancement
+```
+
+**Structure Decision**: Backend-only change. Modifying existing `auth.py` which already contains `handle_oauth_callback()` and `_link_provider()` functions.
+
+## Implementation Approach
+
+### Option A: Integrate into _link_provider() (REJECTED)
+
+Add role advancement to the existing `_link_provider()` function.
+
+**Rejected because**: `_link_provider()` has a specific responsibility (federation field population). Adding role logic violates single responsibility principle and would make the function harder to test and maintain.
+
+### Option B: Create _advance_role() helper (SELECTED)
+
+Create a new `_advance_role()` helper function called from `handle_oauth_callback()` after `_link_provider()`.
+
+**Selected because**:
+- Single responsibility: role advancement logic is isolated
+- Testable: can unit test independently
+- Follows pattern established by `_link_provider()` and `_update_cognito_sub()`
+- Clear audit trail with dedicated function
+
+### Implementation Details
+
+1. **Create `_advance_role()` function** (~lines 1740-1790):
+   - Parameters: `user: User`, `provider: str`, `dynamodb_client`
+   - Check if `user.role == "anonymous"`
+   - If yes: update role to "free", set `role_assigned_at` to `datetime.now(UTC)`, set `role_assigned_by` to `f"oauth:{provider}"`
+   - Use same DynamoDB update pattern as `_link_provider()`
+   - Return updated user or original if no change needed
+
+2. **Call from `handle_oauth_callback()`** (after `_link_provider()` call):
+   - Both for new users and existing users linking OAuth
+   - Apply to both paths in the function
+
+3. **Unit tests** in `tests/unit/dashboard/test_role_advancement.py`:
+   - Test: anonymous → free advancement
+   - Test: free/paid/operator preservation
+   - Test: audit fields populated correctly
+   - Test: DynamoDB update called correctly
+
+## Complexity Tracking
+
+No violations. Simple feature with clear scope.

--- a/specs/1170-oauth-role-advancement/research.md
+++ b/specs/1170-oauth-role-advancement/research.md
@@ -1,0 +1,26 @@
+# Research: OAuth Role Advancement
+
+**Feature**: 1170-oauth-role-advancement
+**Date**: 2026-01-07
+
+## Summary
+
+No external research required. All context available from existing codebase:
+
+1. **Role hierarchy**: Confirmed from User model - `RoleType = Literal["anonymous", "free", "paid", "operator"]`
+2. **Audit fields**: Confirmed - `role_assigned_at: datetime | None`, `role_assigned_by: str | None`
+3. **Implementation pattern**: Follows `_link_provider()` pattern from Feature 1169
+4. **DynamoDB update pattern**: Existing pattern in auth.py uses `UpdateItem` with `SET` expressions
+
+## Decisions
+
+| Topic | Decision | Rationale |
+|-------|----------|-----------|
+| Function placement | Separate `_advance_role()` helper | Single responsibility, testable, follows existing patterns |
+| Audit trail format | `role_assigned_by = "oauth:{provider}"` | Consistent with existing `role_assigned_by` examples ("stripe_webhook", "admin:{user_id}") |
+| Role comparison | Direct string comparison (`role == "anonymous"`) | Simple, clear, matches existing code patterns |
+| Error handling | Silent failure with logging | Follows `_link_provider()` pattern - OAuth must not fail for role issues |
+
+## Alternatives Considered
+
+None applicable - straightforward feature with clear implementation path from existing code patterns.

--- a/specs/1170-oauth-role-advancement/spec.md
+++ b/specs/1170-oauth-role-advancement/spec.md
@@ -1,0 +1,93 @@
+# Feature Specification: OAuth Role Advancement
+
+**Feature Branch**: `1170-oauth-role-advancement`
+**Created**: 2026-01-07
+**Status**: Draft
+**Input**: User description: "OAuth users stay role=anonymous. After OAuth success, users should advance from anonymous to free. Set role_assigned_at and role_assigned_by for audit trail."
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 - OAuth User Gets Free Role (Priority: P1)
+
+A user authenticates via OAuth (Google or GitHub) and receives the "free" role instead of remaining "anonymous". This enables them to access features reserved for authenticated users.
+
+**Why this priority**: Core functionality - without role advancement, OAuth users cannot access any RBAC-protected features despite being authenticated.
+
+**Independent Test**: Can be tested by completing OAuth flow and verifying the user's role field equals "free" in the database.
+
+**Acceptance Scenarios**:
+
+1. **Given** an anonymous user, **When** they complete OAuth authentication via Google, **Then** their role is set to "free"
+2. **Given** an anonymous user, **When** they complete OAuth authentication via GitHub, **Then** their role is set to "free"
+3. **Given** an existing user with role "anonymous", **When** they link an OAuth provider, **Then** their role advances to "free"
+
+---
+
+### User Story 2 - Audit Trail for Role Assignment (Priority: P1)
+
+When a user's role changes due to OAuth authentication, the system records when the role was assigned and what triggered the assignment for compliance and debugging purposes.
+
+**Why this priority**: Critical for compliance - role changes must be auditable to trace privilege escalation.
+
+**Independent Test**: After OAuth completes, verify `role_assigned_at` contains a valid ISO timestamp and `role_assigned_by` contains "oauth:{provider}".
+
+**Acceptance Scenarios**:
+
+1. **Given** a user completing OAuth, **When** their role is set to "free", **Then** `role_assigned_at` is set to the current UTC timestamp
+2. **Given** a user completing OAuth, **When** their role is set to "free", **Then** `role_assigned_by` is set to "oauth:google" or "oauth:github" based on provider
+
+---
+
+### User Story 3 - Preserve Higher Roles (Priority: P2)
+
+If a user already has a role higher than "free" (e.g., "paid" or "operator"), OAuth authentication should not demote them.
+
+**Why this priority**: Prevents accidental privilege loss for existing paid or operator users.
+
+**Independent Test**: Complete OAuth for a user with role="paid" and verify role remains "paid".
+
+**Acceptance Scenarios**:
+
+1. **Given** a user with role "paid", **When** they complete OAuth authentication, **Then** their role remains "paid"
+2. **Given** a user with role "operator", **When** they complete OAuth authentication, **Then** their role remains "operator"
+3. **Given** a user with role "free", **When** they complete OAuth authentication again, **Then** their role remains "free" (no change needed)
+
+---
+
+### Edge Cases
+
+- What happens when OAuth fails midway? Role should not change (atomic operation).
+- What happens if `role_assigned_at` already has a value? Only update if role actually changes.
+- What happens for new users created during OAuth? They should get role="free" directly.
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+- **FR-001**: System MUST set role to "free" when a user completes OAuth authentication and their current role is "anonymous"
+- **FR-002**: System MUST set `role_assigned_at` to current UTC timestamp when role changes
+- **FR-003**: System MUST set `role_assigned_by` to "oauth:{provider}" where provider is "google" or "github"
+- **FR-004**: System MUST NOT modify role if current role is "free", "paid", or "operator" (higher privilege)
+- **FR-005**: System MUST NOT modify `role_assigned_at` or `role_assigned_by` if role does not change
+- **FR-006**: System MUST apply role advancement for both new users created during OAuth and existing users linking OAuth
+
+### Key Entities
+
+- **User**: Contains `role` (RoleType), `role_assigned_at` (datetime|None), `role_assigned_by` (str|None)
+- **RoleType**: Literal type with values "anonymous", "free", "paid", "operator" in ascending privilege order
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of users completing OAuth with role="anonymous" have role="free" after callback completes
+- **SC-002**: 100% of role advancements have both `role_assigned_at` and `role_assigned_by` populated
+- **SC-003**: 0% of users with role="paid" or "operator" are demoted after OAuth authentication
+- **SC-004**: Role advancement occurs in the same transaction as OAuth completion (no partial states)
+
+## Assumptions
+
+- Role hierarchy is: anonymous < free < paid < operator (ascending privilege)
+- OAuth providers are limited to "google" and "github" in current implementation
+- The `_link_provider()` function (Feature 1169) handles federation fields; this feature handles role advancement
+- Role advancement should integrate into `handle_oauth_callback()` flow, not as a separate operation

--- a/specs/1170-oauth-role-advancement/tasks.md
+++ b/specs/1170-oauth-role-advancement/tasks.md
@@ -1,0 +1,74 @@
+# Tasks: OAuth Role Advancement
+
+**Feature**: 1170-oauth-role-advancement
+**Date**: 2026-01-07
+**Spec**: [spec.md](spec.md) | **Plan**: [plan.md](plan.md)
+
+## Summary
+
+| Phase | Tasks | Description |
+|-------|-------|-------------|
+| 1 | 0 | Setup (N/A - existing project) |
+| 2 | 1 | Foundational - create _advance_role() helper |
+| 3 | 2 | US1/US2 - integrate into OAuth flow + tests |
+| 4 | 1 | Polish - verify edge cases |
+
+**Total Tasks**: 4
+**Parallel Opportunities**: T003 and T004 can run in parallel (tests and integration)
+
+## Phase 2: Foundational
+
+### Goal: Create the _advance_role() helper function
+
+- [ ] T001 Create `_advance_role()` function in `src/lambdas/dashboard/auth.py` after `_link_provider()` (~line 1740)
+  - Parameters: `user: User`, `provider: str`, `table: dynamodb.Table`
+  - If `user.role == "anonymous"`: update to "free", set `role_assigned_at`, set `role_assigned_by = f"oauth:{provider}"`
+  - If role is already "free"/"paid"/"operator": return user unchanged
+  - Use same DynamoDB update pattern as `_link_provider()`
+  - Follow silent failure pattern (log warning, don't break OAuth)
+
+## Phase 3: User Stories 1 & 2 - Role Advancement + Audit Trail
+
+### Goal: Integrate role advancement into OAuth callback and add tests
+
+**Independent Test**: Complete OAuth as anonymous user, verify role="free" and audit fields populated
+
+- [ ] T002 Integrate `_advance_role()` call in `handle_oauth_callback()` in `src/lambdas/dashboard/auth.py`
+  - Call after `_link_provider()` for both new and existing user paths
+  - Pass provider name (google/github) for audit trail
+
+- [ ] T003 [P] Create unit tests in `tests/unit/dashboard/test_role_advancement.py`
+  - Test: anonymous → free advancement (role changes, audit fields set)
+  - Test: free user stays free (no update called)
+  - Test: paid user stays paid (no update called)
+  - Test: operator stays operator (no update called)
+  - Test: role_assigned_by format is "oauth:google" or "oauth:github"
+  - Test: role_assigned_at is valid ISO timestamp
+  - Test: DynamoDB UpdateItem called with correct parameters
+
+## Phase 4: Polish
+
+### Goal: Verify edge cases and error handling
+
+- [ ] T004 [P] Verify edge case handling in `src/lambdas/dashboard/auth.py`
+  - Ensure role advancement failure doesn't break OAuth flow
+  - Ensure logging captures role advancement events
+  - Ensure existing users linking OAuth also get role advancement
+
+## Dependencies
+
+```text
+T001 (create function)
+  ↓
+T002 (integrate into OAuth)
+  ↓
+T003, T004 (parallel: tests + edge cases)
+```
+
+## Implementation Strategy
+
+1. **MVP**: T001 + T002 = working role advancement
+2. **Quality**: T003 = test coverage
+3. **Hardening**: T004 = edge case verification
+
+All tasks modify existing `auth.py` or create one new test file. No new dependencies required.

--- a/tests/unit/dashboard/test_role_advancement.py
+++ b/tests/unit/dashboard/test_role_advancement.py
@@ -1,0 +1,256 @@
+"""Unit tests for _advance_role() function (Feature 1170).
+
+Tests role advancement from anonymous to free during OAuth authentication,
+and preservation of higher roles (free/paid/operator).
+"""
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+from src.lambdas.dashboard.auth import _advance_role
+from src.lambdas.shared.models.user import User
+
+
+class TestAdvanceRoleAnonymousToFree:
+    """Test role advancement from anonymous to free."""
+
+    def test_advances_anonymous_to_free(self) -> None:
+        """Anonymous user role is advanced to free."""
+        table = MagicMock()
+        user = User(
+            user_id=str(uuid.uuid4()),
+            email="test@example.com",
+            cognito_sub="cognito-123",
+            auth_type="google",
+            role="anonymous",
+            created_at=datetime.now(UTC),
+            last_active_at=datetime.now(UTC),
+            session_expires_at=datetime.now(UTC) + timedelta(days=30),
+            linked_providers=["google"],
+            provider_metadata={},
+        )
+
+        _advance_role(table=table, user=user, provider="google")
+
+        table.update_item.assert_called_once()
+        call_kwargs = table.update_item.call_args.kwargs
+        assert call_kwargs["Key"]["PK"] == f"USER#{user.user_id}"
+        assert call_kwargs["Key"]["SK"] == "PROFILE"
+        assert call_kwargs["ExpressionAttributeValues"][":new_role"] == "free"
+
+    def test_sets_role_assigned_at(self) -> None:
+        """role_assigned_at is set to current timestamp."""
+        table = MagicMock()
+        user = User(
+            user_id=str(uuid.uuid4()),
+            email="test@example.com",
+            cognito_sub="cognito-123",
+            auth_type="google",
+            role="anonymous",
+            created_at=datetime.now(UTC),
+            last_active_at=datetime.now(UTC),
+            session_expires_at=datetime.now(UTC) + timedelta(days=30),
+            linked_providers=[],
+            provider_metadata={},
+        )
+
+        with patch("src.lambdas.dashboard.auth.datetime") as mock_dt:
+            mock_now = datetime(2026, 1, 7, 12, 0, 0, tzinfo=UTC)
+            mock_dt.now.return_value = mock_now
+
+            _advance_role(table=table, user=user, provider="google")
+
+        call_kwargs = table.update_item.call_args.kwargs
+        assert (
+            call_kwargs["ExpressionAttributeValues"][":assigned_at"]
+            == mock_now.isoformat()
+        )
+
+    def test_sets_role_assigned_by_google(self) -> None:
+        """role_assigned_by is set to oauth:google for Google provider."""
+        table = MagicMock()
+        user = User(
+            user_id=str(uuid.uuid4()),
+            email="test@example.com",
+            cognito_sub="cognito-123",
+            auth_type="google",
+            role="anonymous",
+            created_at=datetime.now(UTC),
+            last_active_at=datetime.now(UTC),
+            session_expires_at=datetime.now(UTC) + timedelta(days=30),
+            linked_providers=[],
+            provider_metadata={},
+        )
+
+        _advance_role(table=table, user=user, provider="google")
+
+        call_kwargs = table.update_item.call_args.kwargs
+        assert (
+            call_kwargs["ExpressionAttributeValues"][":assigned_by"] == "oauth:google"
+        )
+
+    def test_sets_role_assigned_by_github(self) -> None:
+        """role_assigned_by is set to oauth:github for GitHub provider."""
+        table = MagicMock()
+        user = User(
+            user_id=str(uuid.uuid4()),
+            email="test@example.com",
+            cognito_sub="cognito-123",
+            auth_type="github",
+            role="anonymous",
+            created_at=datetime.now(UTC),
+            last_active_at=datetime.now(UTC),
+            session_expires_at=datetime.now(UTC) + timedelta(days=30),
+            linked_providers=[],
+            provider_metadata={},
+        )
+
+        _advance_role(table=table, user=user, provider="github")
+
+        call_kwargs = table.update_item.call_args.kwargs
+        assert (
+            call_kwargs["ExpressionAttributeValues"][":assigned_by"] == "oauth:github"
+        )
+
+
+class TestAdvanceRolePreservesHigherRoles:
+    """Test that higher roles are preserved without modification."""
+
+    def test_free_role_unchanged(self) -> None:
+        """Free role is not modified."""
+        table = MagicMock()
+        user = User(
+            user_id=str(uuid.uuid4()),
+            email="test@example.com",
+            cognito_sub="cognito-123",
+            auth_type="google",
+            role="free",
+            verification="verified",  # Required for free role
+            created_at=datetime.now(UTC),
+            last_active_at=datetime.now(UTC),
+            session_expires_at=datetime.now(UTC) + timedelta(days=30),
+            linked_providers=["google"],
+            provider_metadata={},
+        )
+
+        _advance_role(table=table, user=user, provider="google")
+
+        table.update_item.assert_not_called()
+
+    def test_paid_role_unchanged(self) -> None:
+        """Paid role is not modified."""
+        table = MagicMock()
+        user = User(
+            user_id=str(uuid.uuid4()),
+            email="test@example.com",
+            cognito_sub="cognito-123",
+            auth_type="google",
+            role="paid",
+            verification="verified",  # Required for paid role
+            created_at=datetime.now(UTC),
+            last_active_at=datetime.now(UTC),
+            session_expires_at=datetime.now(UTC) + timedelta(days=30),
+            linked_providers=["google"],
+            provider_metadata={},
+        )
+
+        _advance_role(table=table, user=user, provider="google")
+
+        table.update_item.assert_not_called()
+
+    def test_operator_role_unchanged(self) -> None:
+        """Operator role is not modified."""
+        table = MagicMock()
+        user = User(
+            user_id=str(uuid.uuid4()),
+            email="test@example.com",
+            cognito_sub="cognito-123",
+            auth_type="google",
+            role="operator",
+            verification="verified",  # Required for operator role
+            created_at=datetime.now(UTC),
+            last_active_at=datetime.now(UTC),
+            session_expires_at=datetime.now(UTC) + timedelta(days=30),
+            linked_providers=["google"],
+            provider_metadata={},
+        )
+
+        _advance_role(table=table, user=user, provider="google")
+
+        table.update_item.assert_not_called()
+
+
+class TestAdvanceRoleErrorHandling:
+    """Test error handling - OAuth must not fail due to role advancement errors."""
+
+    def test_dynamo_error_does_not_raise(self) -> None:
+        """DynamoDB errors are logged but do not raise exceptions."""
+        table = MagicMock()
+        table.update_item.side_effect = Exception("DynamoDB error")
+        user = User(
+            user_id=str(uuid.uuid4()),
+            email="test@example.com",
+            cognito_sub="cognito-123",
+            auth_type="google",
+            role="anonymous",
+            created_at=datetime.now(UTC),
+            last_active_at=datetime.now(UTC),
+            session_expires_at=datetime.now(UTC) + timedelta(days=30),
+            linked_providers=[],
+            provider_metadata={},
+        )
+
+        # Should not raise
+        _advance_role(table=table, user=user, provider="google")
+
+        table.update_item.assert_called_once()
+
+
+class TestAdvanceRoleUpdateExpression:
+    """Test DynamoDB UpdateExpression structure."""
+
+    def test_update_expression_sets_all_fields(self) -> None:
+        """UpdateExpression includes role, role_assigned_at, and role_assigned_by."""
+        table = MagicMock()
+        user = User(
+            user_id=str(uuid.uuid4()),
+            email="test@example.com",
+            cognito_sub="cognito-123",
+            auth_type="google",
+            role="anonymous",
+            created_at=datetime.now(UTC),
+            last_active_at=datetime.now(UTC),
+            session_expires_at=datetime.now(UTC) + timedelta(days=30),
+            linked_providers=[],
+            provider_metadata={},
+        )
+
+        _advance_role(table=table, user=user, provider="google")
+
+        call_kwargs = table.update_item.call_args.kwargs
+        update_expr = call_kwargs["UpdateExpression"]
+        assert "#role" in update_expr
+        assert "role_assigned_at" in update_expr
+        assert "role_assigned_by" in update_expr
+
+    def test_uses_expression_attribute_name_for_role(self) -> None:
+        """Uses ExpressionAttributeNames for 'role' (reserved word handling)."""
+        table = MagicMock()
+        user = User(
+            user_id=str(uuid.uuid4()),
+            email="test@example.com",
+            cognito_sub="cognito-123",
+            auth_type="google",
+            role="anonymous",
+            created_at=datetime.now(UTC),
+            last_active_at=datetime.now(UTC),
+            session_expires_at=datetime.now(UTC) + timedelta(days=30),
+            linked_providers=[],
+            provider_metadata={},
+        )
+
+        _advance_role(table=table, user=user, provider="google")
+
+        call_kwargs = table.update_item.call_args.kwargs
+        assert call_kwargs["ExpressionAttributeNames"]["#role"] == "role"


### PR DESCRIPTION
## Summary
- Add `_advance_role()` function in auth.py that promotes users from anonymous to free role
- Called from both OAuth callback paths (existing user link + new user creation)
- Sets role="free", role_assigned_at=now, role_assigned_by="oauth:{provider}"
- Prerequisite for RBAC checks to work for authenticated users

## Changes
- `src/lambdas/dashboard/auth.py`: Added `_advance_role()` function after `_link_provider()`
- `tests/unit/lambdas/dashboard/test_advance_role.py`: 10 unit tests covering all paths

## Test Plan
- [x] Unit tests pass (10/10)
- [ ] E2E: OAuth user should have role=free after login
- [ ] E2E: role_assigned_at and role_assigned_by populated

Refs: #1170

🤖 Generated with [Claude Code](https://claude.com/claude-code)