### PR TITLE
feat(1171): Mark email verified from OAuth provider JWT

### DIFF
--- a/specs/1171-oauth-email-verification-marking/checklists/requirements.md
+++ b/specs/1171-oauth-email-verification-marking/checklists/requirements.md
@@ -1,0 +1,32 @@
+# Requirements Checklist: Feature 1171
+
+## Functional Requirements
+
+- [ ] FR-1: OAuth login with `email_verified=true` sets `verification="verified"`
+- [ ] FR-2: OAuth login with `email_verified=false` leaves `verification` unchanged
+- [ ] FR-3: Already-verified users are not re-marked (idempotent)
+- [ ] FR-4: `primary_email` set to OAuth email when marking verified
+- [ ] FR-5: Audit fields (`verification_marked_at`, `verification_marked_by`) populated
+
+## Non-Functional Requirements
+
+- [ ] NFR-1: Silent failure pattern - OAuth flow succeeds even if marking fails
+- [ ] NFR-2: Called BEFORE role advancement to maintain state machine invariant
+- [ ] NFR-3: Unit test coverage 100% for new function
+- [ ] NFR-4: No changes to existing behavior when `email_verified=false`
+
+## Security Requirements
+
+- [ ] SR-1: User ID prefix sanitized in logs
+- [ ] SR-2: Email not logged in full
+- [ ] SR-3: No exceptions leak to client
+
+## Testing Evidence
+
+- [ ] TE-1: Unit test `test_mark_verified_when_provider_verified` passes
+- [ ] TE-2: Unit test `test_skip_when_provider_not_verified` passes
+- [ ] TE-3: Unit test `test_skip_when_already_verified` passes
+- [ ] TE-4: Unit test `test_sets_primary_email` passes
+- [ ] TE-5: Unit test `test_sets_audit_fields` passes
+- [ ] TE-6: Unit test `test_silent_failure_on_dynamodb_error` passes
+- [ ] TE-7: All existing auth tests still pass

--- a/specs/1171-oauth-email-verification-marking/plan.md
+++ b/specs/1171-oauth-email-verification-marking/plan.md
@@ -1,0 +1,83 @@
+# Implementation Plan: Feature 1171
+
+## Overview
+
+Add `_mark_email_verified()` helper function to propagate OAuth provider's email verification status to the user-level `verification` field.
+
+## Implementation Steps
+
+### Step 1: Add Helper Function
+
+**File:** `src/lambdas/dashboard/auth.py`
+**Location:** After `_advance_role()` function (~line 1829)
+
+```python
+def _mark_email_verified(
+    table: Any,
+    user: User,
+    provider: str,
+    email: str,
+    email_verified: bool,
+) -> None:
+    """Mark email as verified from OAuth provider (Feature 1171).
+
+    Updates user.verification field based on JWT email_verified claim.
+    Must be called BEFORE _advance_role() to maintain state machine invariant.
+
+    Args:
+        table: DynamoDB table resource
+        user: User object to update
+        provider: OAuth provider name (google, github)
+        email: Email from OAuth JWT
+        email_verified: email_verified claim from OAuth JWT
+    """
+```
+
+### Step 2: Implement Logic
+
+1. Early return if `email_verified=False`
+2. Early return if `user.verification == "verified"`
+3. DynamoDB update with verification fields
+4. Try/except with warning log on failure
+
+### Step 3: Integrate in OAuth Callback
+
+**Existing User Path (~line 1604):**
+- After `_link_provider()` call
+- Before `_advance_role()` call
+
+**New User Path (~line 1629):**
+- After `_link_provider()` call
+- Before `_advance_role()` call
+
+### Step 4: Add Unit Tests
+
+**File:** `tests/unit/dashboard/test_mark_email_verified.py`
+
+Tests following `test_role_advancement.py` pattern:
+1. Happy path - provider verified
+2. Skip path - provider not verified
+3. Skip path - already verified
+4. Audit fields populated
+5. Primary email set
+6. Silent failure on error
+7. Integration with full OAuth flow
+
+## File Changes
+
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `src/lambdas/dashboard/auth.py` | Edit | Add `_mark_email_verified()`, integrate in callback |
+| `tests/unit/dashboard/test_mark_email_verified.py` | New | Unit tests |
+
+## Validation
+
+- [ ] All existing tests pass
+- [ ] New tests pass with 100% coverage
+- [ ] Ruff lint passes
+- [ ] Type checking passes
+- [ ] Pre-commit hooks pass
+
+## Rollback
+
+No rollback needed - new function with silent failure pattern. If issues arise, the OAuth flow continues working as before (email verification just isn't marked).

--- a/specs/1171-oauth-email-verification-marking/spec.md
+++ b/specs/1171-oauth-email-verification-marking/spec.md
@@ -1,0 +1,142 @@
+# Feature 1171: OAuth Email Verification Marking
+
+## Problem Statement
+
+When users authenticate via OAuth (Google/GitHub), the provider JWT contains an `email_verified` claim indicating whether the provider has verified the user's email. Currently, this claim is:
+
+1. **Extracted** from the JWT in `decode_id_token()`
+2. **Passed** to `_link_provider()` which stores it as `ProviderMetadata.verified_at`
+3. **NOT copied** to the user-level `verification` field
+
+This creates a gap where OAuth-authenticated users with provider-verified emails remain at `verification="none"`, blocking:
+- Role upgrades requiring verified email (per Feature 1163 role-verification state machine)
+- RBAC checks that depend on verification status
+- Frontend UI that relies on verification state
+
+## Root Cause
+
+Feature 1169 (`_link_provider()`) stores verification per-provider as a timestamp, but doesn't propagate to the canonical user-level `verification` field. The two-level model (provider-level vs user-level verification) was intentionally designed but the propagation step was missing.
+
+## Solution
+
+Add `_mark_email_verified()` helper function following the `_advance_role()` pattern (Feature 1170):
+
+1. **Create helper function** that updates `verification` field based on OAuth JWT claim
+2. **Call from both OAuth paths** (existing user + new user) in `handle_oauth_callback()`
+3. **Call BEFORE role advancement** to respect state machine invariant
+4. **Follow silent failure pattern** - log warning but don't break OAuth flow
+
+## Technical Specification
+
+### New Function: `_mark_email_verified()`
+
+**Signature:**
+```python
+def _mark_email_verified(
+    table: Any,
+    user: User,
+    provider: str,
+    email: str,
+    email_verified: bool,
+) -> None:
+```
+
+**Logic:**
+1. If `email_verified=False`, skip with debug log
+2. If `user.verification` already `"verified"`, skip with debug log
+3. Update DynamoDB: set `verification="verified"`, `primary_email=email`
+4. Add audit field `verification_marked_at` and `verification_marked_by`
+5. Wrap in try/except, log warning on failure, don't raise
+
+### Integration Points
+
+**Existing User Path (line ~1604):**
+```python
+_link_provider(...)
+_mark_email_verified(
+    table=table,
+    user=user,
+    provider=request.provider,
+    email=email,
+    email_verified=claims.get("email_verified", False),
+)
+_advance_role(...)
+```
+
+**New User Path (line ~1629):**
+```python
+_link_provider(...)
+_mark_email_verified(
+    table=table,
+    user=user,
+    provider=request.provider,
+    email=email,
+    email_verified=claims.get("email_verified", False),
+)
+_advance_role(...)
+```
+
+### State Machine Compliance
+
+Per Feature 1163 role-verification invariant:
+- `anonymous:none` → Mark verified → `anonymous:verified` → `_advance_role()` → `free:verified`
+- This order ensures the state machine validator never sees invalid intermediate states
+
+### DynamoDB Update Expression
+
+```python
+UpdateExpression="SET verification = :verified, primary_email = :email, verification_marked_at = :marked_at, verification_marked_by = :marked_by"
+ExpressionAttributeValues={
+    ":verified": "verified",
+    ":email": email,
+    ":marked_at": now.isoformat(),
+    ":marked_by": f"oauth:{provider}",
+}
+```
+
+## Acceptance Criteria
+
+1. OAuth login with `email_verified=true` sets `user.verification="verified"`
+2. OAuth login with `email_verified=false` leaves `user.verification` unchanged
+3. Already-verified users are not re-marked (idempotent)
+4. `primary_email` is set to the OAuth email when marking verified
+5. Audit fields (`verification_marked_at`, `verification_marked_by`) populated
+6. OAuth flow succeeds even if marking fails (silent failure pattern)
+7. Unit tests cover all paths with 100% coverage
+
+## Out of Scope
+
+- Magic link verification flow (separate feature)
+- Manual email verification flow
+- Removing/changing verification status
+- Provider-level verification display in UI (Feature 1172+)
+
+## Dependencies
+
+- **Requires:** Feature 1169 (OAuth federation fields) - MERGED
+- **Requires:** Feature 1170 (role advancement) - MERGED
+- **Blocks:** Features 1172-1175 (frontend federation)
+
+## Testing Strategy
+
+### Unit Tests
+
+1. `test_mark_verified_when_provider_verified` - Happy path
+2. `test_skip_when_provider_not_verified` - email_verified=False
+3. `test_skip_when_already_verified` - user already verified
+4. `test_sets_primary_email` - Confirm email field updated
+5. `test_sets_audit_fields` - Confirm timestamps/attribution
+6. `test_silent_failure_on_dynamodb_error` - Don't break OAuth flow
+7. `test_integration_with_role_advancement` - Full OAuth callback flow
+
+### Test Pattern
+
+Follow `tests/unit/dashboard/test_role_advancement.py` structure.
+
+## References
+
+- Feature 1163: Role-Verification State Machine
+- Feature 1169: OAuth Federation Fields
+- Feature 1170: Role Advancement Pattern
+- `src/lambdas/dashboard/auth.py:1526-1652` (OAuth callback)
+- `src/lambdas/shared/models/user.py:92-100` (verification field)

--- a/specs/1171-oauth-email-verification-marking/tasks.md
+++ b/specs/1171-oauth-email-verification-marking/tasks.md
@@ -1,0 +1,50 @@
+# Tasks: Feature 1171
+
+## Implementation Tasks
+
+- [ ] 1. Add `_mark_email_verified()` function in `auth.py`
+  - Location: After `_advance_role()` (~line 1829)
+  - Follow same pattern as `_advance_role()`
+  - Include docstring with Feature 1171 reference
+
+- [ ] 2. Implement function logic
+  - Early return if `email_verified=False`
+  - Early return if already verified
+  - DynamoDB update expression
+  - Try/except with warning log
+
+- [ ] 3. Integrate in existing user OAuth path
+  - Call after `_link_provider()` (~line 1604)
+  - Call before `_advance_role()`
+  - Pass email_verified from claims
+
+- [ ] 4. Integrate in new user OAuth path
+  - Call after `_link_provider()` (~line 1629)
+  - Call before `_advance_role()`
+  - Pass email_verified from claims
+
+- [ ] 5. Create unit test file
+  - File: `tests/unit/dashboard/test_mark_email_verified.py`
+  - Follow `test_role_advancement.py` structure
+
+- [ ] 6. Implement unit tests
+  - Test happy path (provider verified)
+  - Test skip when not verified
+  - Test skip when already verified
+  - Test audit fields set
+  - Test primary_email set
+  - Test silent failure
+  - Test integration with callback
+
+- [ ] 7. Validate
+  - Run existing tests
+  - Run new tests
+  - Lint check
+  - Type check
+
+## Completion Criteria
+
+- All tests pass
+- Ruff passes
+- Pre-commit hooks pass
+- Feature committed and PR created

--- a/tests/unit/dashboard/test_mark_email_verified.py
+++ b/tests/unit/dashboard/test_mark_email_verified.py
@@ -1,0 +1,334 @@
+"""Unit tests for _mark_email_verified() (Feature 1171).
+
+Tests email verification marking from OAuth provider JWT claims.
+"""
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.lambdas.dashboard.auth import _mark_email_verified
+from src.lambdas.shared.models.user import User
+
+
+class TestMarkEmailVerifiedHappyPath:
+    """Tests for successful email verification marking."""
+
+    def test_marks_verified_when_provider_verified(self) -> None:
+        """Email marked verified when provider says email_verified=True."""
+        table = MagicMock()
+        user = User(
+            user_id=str(uuid.uuid4()),
+            email="test@example.com",
+            cognito_sub="cognito-123",
+            auth_type="google",
+            role="anonymous",
+            verification="none",
+            created_at=datetime.now(UTC),
+            last_active_at=datetime.now(UTC),
+            session_expires_at=datetime.now(UTC) + timedelta(days=30),
+            linked_providers=["google"],
+            provider_metadata={},
+        )
+
+        _mark_email_verified(
+            table=table,
+            user=user,
+            provider="google",
+            email="test@example.com",
+            email_verified=True,
+        )
+
+        table.update_item.assert_called_once()
+        call_kwargs = table.update_item.call_args.kwargs
+        assert call_kwargs["ExpressionAttributeValues"][":verified"] == "verified"
+
+    def test_sets_primary_email(self) -> None:
+        """primary_email is set to the OAuth email."""
+        table = MagicMock()
+        user = User(
+            user_id=str(uuid.uuid4()),
+            email="test@example.com",
+            cognito_sub="cognito-123",
+            auth_type="google",
+            role="anonymous",
+            verification="none",
+            created_at=datetime.now(UTC),
+            last_active_at=datetime.now(UTC),
+            session_expires_at=datetime.now(UTC) + timedelta(days=30),
+            linked_providers=["google"],
+            provider_metadata={},
+        )
+
+        _mark_email_verified(
+            table=table,
+            user=user,
+            provider="google",
+            email="verified@gmail.com",
+            email_verified=True,
+        )
+
+        call_kwargs = table.update_item.call_args.kwargs
+        assert (
+            call_kwargs["ExpressionAttributeValues"][":email"] == "verified@gmail.com"
+        )
+
+    def test_sets_audit_fields(self) -> None:
+        """Audit fields verification_marked_at and verification_marked_by are set."""
+        table = MagicMock()
+        user = User(
+            user_id=str(uuid.uuid4()),
+            email="test@example.com",
+            cognito_sub="cognito-123",
+            auth_type="github",
+            role="anonymous",
+            verification="none",
+            created_at=datetime.now(UTC),
+            last_active_at=datetime.now(UTC),
+            session_expires_at=datetime.now(UTC) + timedelta(days=30),
+            linked_providers=["github"],
+            provider_metadata={},
+        )
+
+        with patch("src.lambdas.dashboard.auth.datetime") as mock_dt:
+            mock_now = datetime(2026, 1, 7, 12, 0, 0, tzinfo=UTC)
+            mock_dt.now.return_value = mock_now
+
+            _mark_email_verified(
+                table=table,
+                user=user,
+                provider="github",
+                email="test@github.com",
+                email_verified=True,
+            )
+
+        call_kwargs = table.update_item.call_args.kwargs
+        assert (
+            call_kwargs["ExpressionAttributeValues"][":marked_at"]
+            == mock_now.isoformat()
+        )
+        assert call_kwargs["ExpressionAttributeValues"][":marked_by"] == "oauth:github"
+
+
+class TestMarkEmailVerifiedSkipPaths:
+    """Tests for cases where verification marking is skipped."""
+
+    def test_skip_when_provider_not_verified(self) -> None:
+        """Skip when email_verified=False from provider."""
+        table = MagicMock()
+        user = User(
+            user_id=str(uuid.uuid4()),
+            email="test@example.com",
+            cognito_sub="cognito-123",
+            auth_type="google",
+            role="anonymous",
+            verification="none",
+            created_at=datetime.now(UTC),
+            last_active_at=datetime.now(UTC),
+            session_expires_at=datetime.now(UTC) + timedelta(days=30),
+            linked_providers=["google"],
+            provider_metadata={},
+        )
+
+        _mark_email_verified(
+            table=table,
+            user=user,
+            provider="google",
+            email="test@example.com",
+            email_verified=False,
+        )
+
+        table.update_item.assert_not_called()
+
+    def test_skip_when_already_verified(self) -> None:
+        """Skip when user.verification is already 'verified'."""
+        table = MagicMock()
+        user = User(
+            user_id=str(uuid.uuid4()),
+            email="test@example.com",
+            cognito_sub="cognito-123",
+            auth_type="google",
+            role="free",
+            verification="verified",
+            created_at=datetime.now(UTC),
+            last_active_at=datetime.now(UTC),
+            session_expires_at=datetime.now(UTC) + timedelta(days=30),
+            linked_providers=["google"],
+            provider_metadata={},
+        )
+
+        _mark_email_verified(
+            table=table,
+            user=user,
+            provider="google",
+            email="test@example.com",
+            email_verified=True,
+        )
+
+        table.update_item.assert_not_called()
+
+    def test_marks_when_pending(self) -> None:
+        """Mark verified when current status is 'pending'."""
+        table = MagicMock()
+        user = User(
+            user_id=str(uuid.uuid4()),
+            email="test@example.com",
+            cognito_sub="cognito-123",
+            auth_type="google",
+            role="anonymous",
+            verification="pending",
+            created_at=datetime.now(UTC),
+            last_active_at=datetime.now(UTC),
+            session_expires_at=datetime.now(UTC) + timedelta(days=30),
+            linked_providers=["google"],
+            provider_metadata={},
+        )
+
+        _mark_email_verified(
+            table=table,
+            user=user,
+            provider="google",
+            email="test@example.com",
+            email_verified=True,
+        )
+
+        table.update_item.assert_called_once()
+        call_kwargs = table.update_item.call_args.kwargs
+        assert call_kwargs["ExpressionAttributeValues"][":verified"] == "verified"
+
+
+class TestMarkEmailVerifiedErrorHandling:
+    """Tests for error resilience."""
+
+    def test_silent_failure_on_dynamodb_error(self) -> None:
+        """OAuth flow continues even if DynamoDB update fails."""
+        table = MagicMock()
+        table.update_item.side_effect = Exception("DynamoDB error")
+        user = User(
+            user_id=str(uuid.uuid4()),
+            email="test@example.com",
+            cognito_sub="cognito-123",
+            auth_type="google",
+            role="anonymous",
+            verification="none",
+            created_at=datetime.now(UTC),
+            last_active_at=datetime.now(UTC),
+            session_expires_at=datetime.now(UTC) + timedelta(days=30),
+            linked_providers=["google"],
+            provider_metadata={},
+        )
+
+        # Should NOT raise
+        _mark_email_verified(
+            table=table,
+            user=user,
+            provider="google",
+            email="test@example.com",
+            email_verified=True,
+        )
+
+        table.update_item.assert_called_once()
+
+
+class TestMarkEmailVerifiedDynamoDBStructure:
+    """Tests for DynamoDB update expression structure."""
+
+    def test_correct_key_structure(self) -> None:
+        """DynamoDB key uses correct PK/SK format."""
+        table = MagicMock()
+        user_id = str(uuid.uuid4())
+        user = User(
+            user_id=user_id,
+            email="test@example.com",
+            cognito_sub="cognito-123",
+            auth_type="google",
+            role="anonymous",
+            verification="none",
+            created_at=datetime.now(UTC),
+            last_active_at=datetime.now(UTC),
+            session_expires_at=datetime.now(UTC) + timedelta(days=30),
+            linked_providers=["google"],
+            provider_metadata={},
+        )
+
+        _mark_email_verified(
+            table=table,
+            user=user,
+            provider="google",
+            email="test@example.com",
+            email_verified=True,
+        )
+
+        call_kwargs = table.update_item.call_args.kwargs
+        assert call_kwargs["Key"]["PK"] == f"USER#{user_id}"
+        assert call_kwargs["Key"]["SK"] == "PROFILE"
+
+    def test_update_expression_includes_all_fields(self) -> None:
+        """UpdateExpression sets all required fields."""
+        table = MagicMock()
+        user = User(
+            user_id=str(uuid.uuid4()),
+            email="test@example.com",
+            cognito_sub="cognito-123",
+            auth_type="google",
+            role="anonymous",
+            verification="none",
+            created_at=datetime.now(UTC),
+            last_active_at=datetime.now(UTC),
+            session_expires_at=datetime.now(UTC) + timedelta(days=30),
+            linked_providers=["google"],
+            provider_metadata={},
+        )
+
+        _mark_email_verified(
+            table=table,
+            user=user,
+            provider="google",
+            email="test@example.com",
+            email_verified=True,
+        )
+
+        call_kwargs = table.update_item.call_args.kwargs
+        update_expr = call_kwargs["UpdateExpression"]
+        assert "verification = :verified" in update_expr
+        assert "primary_email = :email" in update_expr
+        assert "verification_marked_at = :marked_at" in update_expr
+        assert "verification_marked_by = :marked_by" in update_expr
+
+
+class TestMarkEmailVerifiedProviders:
+    """Tests for different OAuth providers."""
+
+    @pytest.mark.parametrize("provider", ["google", "github"])
+    def test_works_with_all_providers(self, provider: str) -> None:
+        """Verification marking works for all supported providers."""
+        table = MagicMock()
+        user = User(
+            user_id=str(uuid.uuid4()),
+            email="test@example.com",
+            cognito_sub="cognito-123",
+            auth_type=provider,
+            role="anonymous",
+            verification="none",
+            created_at=datetime.now(UTC),
+            last_active_at=datetime.now(UTC),
+            session_expires_at=datetime.now(UTC) + timedelta(days=30),
+            linked_providers=[provider],
+            provider_metadata={},
+        )
+
+        _mark_email_verified(
+            table=table,
+            user=user,
+            provider=provider,
+            email=f"test@{provider}.com",
+            email_verified=True,
+        )
+
+        call_kwargs = table.update_item.call_args.kwargs
+        assert (
+            call_kwargs["ExpressionAttributeValues"][":marked_by"]
+            == f"oauth:{provider}"
+        )


### PR DESCRIPTION
## Summary
- Add `_mark_email_verified()` helper function in auth.py
- Propagates OAuth provider's `email_verified` JWT claim to user-level `verification` field
- Called BEFORE `_advance_role()` to maintain state machine invariant
- Sets `primary_email` from OAuth JWT
- Adds audit trail: `verification_marked_at`, `verification_marked_by`

## Changes
- `src/lambdas/dashboard/auth.py`: New helper function + integration in both OAuth paths
- `tests/unit/dashboard/test_mark_email_verified.py`: 11 unit tests covering all paths
- `specs/1171-oauth-email-verification-marking/`: Full spec, plan, tasks, requirements checklist

## Test Plan
- [x] Unit tests pass (11/11 new, 21 total auth tests)
- [x] Ruff lint passes
- [x] Pre-commit hooks pass
- [ ] E2E: OAuth user should have verification=verified after login with verified email

Refs: #1171

🤖 Generated with [Claude Code](https://claude.com/claude-code)