### PR TITLE
feat(1172): Add federation fields to /api/v2/auth/me response

### DIFF
--- a/specs/1172-api-me-endpoint-federation/checklists/requirements.md
+++ b/specs/1172-api-me-endpoint-federation/checklists/requirements.md
@@ -1,0 +1,30 @@
+# Requirements Checklist: Feature 1172
+
+## Functional Requirements
+
+- [ ] FR-1: /api/v2/auth/me response includes `role` field
+- [ ] FR-2: Response includes `linked_providers` list
+- [ ] FR-3: Response includes `verification` status
+- [ ] FR-4: Response includes `last_provider_used` (nullable)
+- [ ] FR-5: Existing fields unchanged (backward compatible)
+
+## Non-Functional Requirements
+
+- [ ] NFR-1: No new security fields exposed (no IDs, tokens, timestamps)
+- [ ] NFR-2: Default values for all new fields
+- [ ] NFR-3: Unit test coverage for new fields
+
+## Security Requirements
+
+- [ ] SR-1: No internal IDs exposed (user_id, cognito_sub)
+- [ ] SR-2: No OAuth secrets or tokens exposed
+- [ ] SR-3: No unmasked emails exposed
+- [ ] SR-4: Response still includes Cache-Control headers
+
+## Testing Evidence
+
+- [ ] TE-1: Unit test `test_me_response_includes_role` passes
+- [ ] TE-2: Unit test `test_me_response_includes_linked_providers` passes
+- [ ] TE-3: Unit test `test_me_response_includes_verification` passes
+- [ ] TE-4: Unit test `test_me_response_includes_last_provider` passes
+- [ ] TE-5: All existing /me endpoint tests still pass

--- a/specs/1172-api-me-endpoint-federation/plan.md
+++ b/specs/1172-api-me-endpoint-federation/plan.md
@@ -1,0 +1,55 @@
+# Implementation Plan: Feature 1172
+
+## Overview
+
+Add federation fields to `/api/v2/auth/me` response. Backend-only, non-breaking change.
+
+## Implementation Steps
+
+### Step 1: Update UserMeResponse Model
+
+**File:** `src/lambdas/shared/response_models.py`
+**Location:** Lines 50-58 (UserMeResponse class)
+
+Add four new fields:
+- `role: str = "anonymous"`
+- `linked_providers: list[str] = Field(default_factory=list)`
+- `verification: str = "none"`
+- `last_provider_used: str | None = None`
+
+### Step 2: Update Endpoint Handler
+
+**File:** `src/lambdas/dashboard/router_v2.py`
+**Location:** Lines 1918-1923 (response construction)
+
+Pass new fields from user object to response:
+- `role=user.role`
+- `linked_providers=user.linked_providers`
+- `verification=user.verification`
+- `last_provider_used=user.last_provider_used`
+
+### Step 3: Add Unit Tests
+
+**File:** `tests/unit/dashboard/test_me_endpoint_federation.py`
+
+Create new test file following router_v2 test patterns.
+
+## File Changes
+
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `src/lambdas/shared/response_models.py` | Edit | Add 4 fields to UserMeResponse |
+| `src/lambdas/dashboard/router_v2.py` | Edit | Pass federation fields to response |
+| `tests/unit/dashboard/test_me_endpoint_federation.py` | New | Unit tests |
+
+## Validation
+
+- [ ] All existing tests pass
+- [ ] New tests pass
+- [ ] Ruff lint passes
+- [ ] Type checking passes
+- [ ] Pre-commit hooks pass
+
+## Rollback
+
+Non-breaking change. New fields have defaults, so existing frontend code continues working until Feature 1173/1174 are deployed.

--- a/specs/1172-api-me-endpoint-federation/spec.md
+++ b/specs/1172-api-me-endpoint-federation/spec.md
@@ -1,0 +1,127 @@
+# Feature 1172: API /me Endpoint Federation Fields
+
+## Problem Statement
+
+The `/api/v2/auth/me` endpoint currently returns minimal user info (`auth_type`, `email_masked`, `configs_count`, `max_configs`, `session_expires_in_seconds`). It's missing federation fields needed for frontend RBAC-aware UI decisions:
+
+- `role`: Authorization tier (anonymous/free/paid/operator)
+- `linked_providers`: List of connected auth providers
+- `verification`: Email verification status (none/pending/verified)
+- `last_provider_used`: Most recent auth provider (for avatar selection)
+
+Without these fields, the frontend cannot:
+- Display role-specific UI elements
+- Show which providers are linked
+- Gate features based on verification status
+- Select the correct avatar from linked providers
+
+## Root Cause
+
+Feature 1162 added federation fields to the User model, but the `/api/v2/auth/me` response model (`UserMeResponse`) was not updated to include them. The fields exist in the backend but aren't exposed to the frontend.
+
+## Solution
+
+Extend `UserMeResponse` to include non-sensitive federation fields:
+
+1. **Add fields to response model** (response_models.py)
+2. **Extract from User in handler** (router_v2.py)
+3. **Update tests** to verify new fields
+
+## Technical Specification
+
+### Response Model Changes
+
+**File:** `src/lambdas/shared/response_models.py`
+
+```python
+class UserMeResponse(BaseModel):
+    """Minimal /api/v2/auth/me response - only what frontend needs."""
+
+    auth_type: str  # anonymous, email, google, github
+    email_masked: str | None = None  # j***@example.com
+    configs_count: int
+    max_configs: int = 2
+    session_expires_in_seconds: int | None = None
+    # NEW: Federation fields (Feature 1172)
+    role: str = "anonymous"  # anonymous, free, paid, operator
+    linked_providers: list[str] = Field(default_factory=list)  # ["google", "github"]
+    verification: str = "none"  # none, pending, verified
+    last_provider_used: str | None = None  # Most recent provider
+```
+
+### Handler Changes
+
+**File:** `src/lambdas/dashboard/router_v2.py`
+
+```python
+response = UserMeResponse(
+    auth_type=user.auth_type,
+    email_masked=mask_email(user.email),
+    configs_count=config_count,
+    max_configs=2,
+    session_expires_in_seconds=seconds_until(user.session_expires_at),
+    # NEW: Federation fields (Feature 1172)
+    role=user.role,
+    linked_providers=user.linked_providers,
+    verification=user.verification,
+    last_provider_used=user.last_provider_used,
+)
+```
+
+### Security Analysis
+
+| Field | Sensitivity | Justification |
+|-------|-------------|---------------|
+| `role` | Low | Authorization tier, needed for RBAC UI |
+| `linked_providers` | Low | Already in SessionInfoMinimalResponse |
+| `verification` | Low | Status indicator, no PII |
+| `last_provider_used` | Low | Provider name only, no OAuth tokens |
+
+None of these fields expose:
+- Internal IDs (user_id, cognito_sub)
+- OAuth secrets or tokens
+- Unmasked emails
+- Timestamps that could enable timing attacks
+
+## Acceptance Criteria
+
+1. `/api/v2/auth/me` response includes `role` field
+2. Response includes `linked_providers` list
+3. Response includes `verification` status
+4. Response includes `last_provider_used` (nullable)
+5. Existing fields (`auth_type`, `email_masked`, etc.) unchanged
+6. Unit tests verify all new fields
+7. OpenAPI schema updated automatically via pydantic
+
+## Out of Scope
+
+- Frontend consumption of these fields (Feature 1173, 1174)
+- Role-based access control in backend (separate feature)
+- Changing existing field types or names
+
+## Dependencies
+
+- **Requires:** Features 1169-1171 (backend federation fields) - MERGED
+- **Blocks:** Feature 1173 (frontend User type), Feature 1174 (frontend auth store)
+
+## Testing Strategy
+
+### Unit Tests
+
+1. `test_me_response_includes_role` - Verify role field in response
+2. `test_me_response_includes_linked_providers` - Verify list field
+3. `test_me_response_includes_verification` - Verify status field
+4. `test_me_response_includes_last_provider` - Verify nullable field
+5. `test_me_response_backward_compatible` - Existing fields unchanged
+
+### Test Pattern
+
+Follow existing `/api/v2/auth/me` test patterns in:
+`tests/unit/dashboard/test_router_v2.py`
+
+## References
+
+- Feature 1162: User Model Federation Fields
+- `src/lambdas/dashboard/router_v2.py:1890-1926` (endpoint)
+- `src/lambdas/shared/response_models.py:50-58` (model)
+- `src/lambdas/shared/response_models.py:116-123` (similar pattern)

--- a/specs/1172-api-me-endpoint-federation/tasks.md
+++ b/specs/1172-api-me-endpoint-federation/tasks.md
@@ -1,0 +1,35 @@
+# Tasks: Feature 1172
+
+## Implementation Tasks
+
+- [ ] 1. Update UserMeResponse model
+  - Add role field with default "anonymous"
+  - Add linked_providers list field
+  - Add verification field with default "none"
+  - Add last_provider_used nullable field
+
+- [ ] 2. Update /me endpoint handler
+  - Pass user.role to response
+  - Pass user.linked_providers to response
+  - Pass user.verification to response
+  - Pass user.last_provider_used to response
+
+- [ ] 3. Create unit tests
+  - Test role field in response
+  - Test linked_providers field
+  - Test verification field
+  - Test last_provider_used field
+  - Test backward compatibility
+
+- [ ] 4. Validate
+  - Run existing tests
+  - Run new tests
+  - Lint check
+  - Type check
+
+## Completion Criteria
+
+- All tests pass
+- Ruff passes
+- Pre-commit hooks pass
+- Feature committed and PR created

--- a/src/lambdas/dashboard/router_v2.py
+++ b/src/lambdas/dashboard/router_v2.py
@@ -1921,6 +1921,11 @@ async def get_current_user(
         configs_count=config_count,
         max_configs=2,
         session_expires_in_seconds=seconds_until(user.session_expires_at),
+        # Feature 1172: Federation fields for RBAC-aware UI
+        role=user.role,
+        linked_providers=user.linked_providers,
+        verification=user.verification,
+        last_provider_used=user.last_provider_used,
     )
 
     return JSONResponse(response.model_dump())

--- a/src/lambdas/shared/response_models.py
+++ b/src/lambdas/shared/response_models.py
@@ -14,7 +14,7 @@ For On-Call Engineers:
 
 from datetime import UTC, datetime
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 def mask_email(email: str | None) -> str | None:
@@ -55,6 +55,11 @@ class UserMeResponse(BaseModel):
     configs_count: int
     max_configs: int = 2
     session_expires_in_seconds: int | None = None
+    # Feature 1172: Federation fields for RBAC-aware UI
+    role: str = "anonymous"  # anonymous, free, paid, operator
+    linked_providers: list[str] = Field(default_factory=list)  # ["google", "github"]
+    verification: str = "none"  # none, pending, verified
+    last_provider_used: str | None = None  # Most recent provider for avatar
 
 
 class SessionValidResponse(BaseModel):

--- a/tests/unit/dashboard/test_me_endpoint_federation.py
+++ b/tests/unit/dashboard/test_me_endpoint_federation.py
@@ -1,0 +1,283 @@
+"""Unit tests for /api/v2/auth/me federation fields (Feature 1172).
+
+Tests that the /me endpoint returns federation fields needed for RBAC-aware UI.
+"""
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from src.lambdas.shared.models.user import User
+from src.lambdas.shared.response_models import UserMeResponse
+
+
+class TestUserMeResponseModel:
+    """Tests for UserMeResponse model with federation fields."""
+
+    def test_model_includes_role_field(self) -> None:
+        """Response model accepts role field."""
+        response = UserMeResponse(
+            auth_type="google",
+            configs_count=0,
+            role="free",
+        )
+        assert response.role == "free"
+
+    def test_model_includes_linked_providers_field(self) -> None:
+        """Response model accepts linked_providers field."""
+        response = UserMeResponse(
+            auth_type="google",
+            configs_count=0,
+            linked_providers=["google", "github"],
+        )
+        assert response.linked_providers == ["google", "github"]
+
+    def test_model_includes_verification_field(self) -> None:
+        """Response model accepts verification field."""
+        response = UserMeResponse(
+            auth_type="google",
+            configs_count=0,
+            verification="verified",
+        )
+        assert response.verification == "verified"
+
+    def test_model_includes_last_provider_used_field(self) -> None:
+        """Response model accepts last_provider_used field."""
+        response = UserMeResponse(
+            auth_type="google",
+            configs_count=0,
+            last_provider_used="google",
+        )
+        assert response.last_provider_used == "google"
+
+    def test_model_defaults_for_federation_fields(self) -> None:
+        """Federation fields have sensible defaults."""
+        response = UserMeResponse(
+            auth_type="anonymous",
+            configs_count=0,
+        )
+        assert response.role == "anonymous"
+        assert response.linked_providers == []
+        assert response.verification == "none"
+        assert response.last_provider_used is None
+
+    def test_model_serialization_includes_all_fields(self) -> None:
+        """model_dump() includes federation fields."""
+        response = UserMeResponse(
+            auth_type="google",
+            email_masked="j***@example.com",
+            configs_count=1,
+            max_configs=2,
+            session_expires_in_seconds=3600,
+            role="free",
+            linked_providers=["google"],
+            verification="verified",
+            last_provider_used="google",
+        )
+        data = response.model_dump()
+        assert "role" in data
+        assert "linked_providers" in data
+        assert "verification" in data
+        assert "last_provider_used" in data
+
+
+class TestUserMeResponseBackwardCompatibility:
+    """Tests that existing fields remain unchanged."""
+
+    def test_auth_type_field_unchanged(self) -> None:
+        """auth_type field still works as before."""
+        response = UserMeResponse(
+            auth_type="anonymous",
+            configs_count=0,
+        )
+        assert response.auth_type == "anonymous"
+
+    def test_email_masked_field_unchanged(self) -> None:
+        """email_masked field still works as before."""
+        response = UserMeResponse(
+            auth_type="google",
+            email_masked="j***@example.com",
+            configs_count=0,
+        )
+        assert response.email_masked == "j***@example.com"
+
+    def test_configs_count_field_unchanged(self) -> None:
+        """configs_count field still works as before."""
+        response = UserMeResponse(
+            auth_type="google",
+            configs_count=5,
+        )
+        assert response.configs_count == 5
+
+    def test_max_configs_default_unchanged(self) -> None:
+        """max_configs default value is still 2."""
+        response = UserMeResponse(
+            auth_type="google",
+            configs_count=0,
+        )
+        assert response.max_configs == 2
+
+    def test_session_expires_in_seconds_field_unchanged(self) -> None:
+        """session_expires_in_seconds field still works as before."""
+        response = UserMeResponse(
+            auth_type="google",
+            configs_count=0,
+            session_expires_in_seconds=3600,
+        )
+        assert response.session_expires_in_seconds == 3600
+
+
+class TestMeEndpointFederationFields:
+    """Integration tests for /me endpoint federation fields."""
+
+    def _create_test_user(
+        self,
+        role: str = "anonymous",
+        verification: str | None = None,
+        linked_providers: list[str] | None = None,
+        last_provider_used: str | None = None,
+    ) -> User:
+        """Create a test User with federation fields.
+
+        Respects role-verification state machine invariant:
+        - anonymous: can have any verification state
+        - free/paid/operator: must have verification="verified"
+        """
+        # Apply state machine invariant: non-anonymous roles require verified
+        if verification is None:
+            verification = "verified" if role != "anonymous" else "none"
+
+        return User(
+            user_id=str(uuid.uuid4()),
+            email="test@example.com",
+            cognito_sub="cognito-123",
+            auth_type="google",
+            role=role,
+            verification=verification,
+            linked_providers=linked_providers or [],
+            last_provider_used=last_provider_used,
+            created_at=datetime.now(UTC),
+            last_active_at=datetime.now(UTC),
+            session_expires_at=datetime.now(UTC) + timedelta(days=30),
+            provider_metadata={},
+        )
+
+    def test_endpoint_returns_user_role(self) -> None:
+        """Endpoint includes user's role in response."""
+        user = self._create_test_user(role="free")
+        response = UserMeResponse(
+            auth_type=user.auth_type,
+            configs_count=0,
+            role=user.role,
+            linked_providers=user.linked_providers,
+            verification=user.verification,
+            last_provider_used=user.last_provider_used,
+        )
+        assert response.role == "free"
+
+    def test_endpoint_returns_linked_providers(self) -> None:
+        """Endpoint includes user's linked_providers in response."""
+        user = self._create_test_user(linked_providers=["google", "github"])
+        response = UserMeResponse(
+            auth_type=user.auth_type,
+            configs_count=0,
+            role=user.role,
+            linked_providers=user.linked_providers,
+            verification=user.verification,
+            last_provider_used=user.last_provider_used,
+        )
+        assert response.linked_providers == ["google", "github"]
+
+    def test_endpoint_returns_verification_status(self) -> None:
+        """Endpoint includes user's verification status in response."""
+        user = self._create_test_user(verification="verified")
+        response = UserMeResponse(
+            auth_type=user.auth_type,
+            configs_count=0,
+            role=user.role,
+            linked_providers=user.linked_providers,
+            verification=user.verification,
+            last_provider_used=user.last_provider_used,
+        )
+        assert response.verification == "verified"
+
+    def test_endpoint_returns_last_provider_used(self) -> None:
+        """Endpoint includes user's last_provider_used in response."""
+        user = self._create_test_user(last_provider_used="github")
+        response = UserMeResponse(
+            auth_type=user.auth_type,
+            configs_count=0,
+            role=user.role,
+            linked_providers=user.linked_providers,
+            verification=user.verification,
+            last_provider_used=user.last_provider_used,
+        )
+        assert response.last_provider_used == "github"
+
+    @pytest.mark.parametrize(
+        "role",
+        ["anonymous", "free", "paid", "operator"],
+    )
+    def test_all_role_values_serialized(self, role: str) -> None:
+        """All role values are properly serialized in response."""
+        user = self._create_test_user(role=role)
+        response = UserMeResponse(
+            auth_type=user.auth_type,
+            configs_count=0,
+            role=user.role,
+            linked_providers=user.linked_providers,
+            verification=user.verification,
+            last_provider_used=user.last_provider_used,
+        )
+        data = response.model_dump()
+        assert data["role"] == role
+
+    @pytest.mark.parametrize(
+        "verification",
+        ["none", "pending", "verified"],
+    )
+    def test_all_verification_values_serialized(self, verification: str) -> None:
+        """All verification values are properly serialized in response."""
+        user = self._create_test_user(verification=verification)
+        response = UserMeResponse(
+            auth_type=user.auth_type,
+            configs_count=0,
+            role=user.role,
+            linked_providers=user.linked_providers,
+            verification=user.verification,
+            last_provider_used=user.last_provider_used,
+        )
+        data = response.model_dump()
+        assert data["verification"] == verification
+
+
+class TestMeEndpointSecurityConstraints:
+    """Tests that response doesn't expose sensitive data."""
+
+    def test_no_user_id_in_response(self) -> None:
+        """user_id is NOT in response model."""
+        response = UserMeResponse(
+            auth_type="google",
+            configs_count=0,
+        )
+        data = response.model_dump()
+        assert "user_id" not in data
+
+    def test_no_cognito_sub_in_response(self) -> None:
+        """cognito_sub is NOT in response model."""
+        response = UserMeResponse(
+            auth_type="google",
+            configs_count=0,
+        )
+        data = response.model_dump()
+        assert "cognito_sub" not in data
+
+    def test_no_provider_metadata_in_response(self) -> None:
+        """provider_metadata (with OAuth secrets) is NOT in response model."""
+        response = UserMeResponse(
+            auth_type="google",
+            configs_count=0,
+        )
+        data = response.model_dump()
+        assert "provider_metadata" not in data


### PR DESCRIPTION
## Summary
- Extend `UserMeResponse` to include federation fields for RBAC-aware UI
- Add `role`, `linked_providers`, `verification`, `last_provider_used` to response
- Backend-only, non-breaking change (new fields have defaults)

## Changes
- `src/lambdas/shared/response_models.py`: Add 4 fields to UserMeResponse
- `src/lambdas/dashboard/router_v2.py`: Pass User fields to response
- `tests/unit/dashboard/test_me_endpoint_federation.py`: 25 unit tests
- `specs/1172-api-me-endpoint-federation/`: Full spec, plan, tasks

## Security
No sensitive data exposed:
- No internal IDs (user_id, cognito_sub)
- No OAuth tokens or secrets
- No unmasked emails

## Test Plan
- [x] Unit tests pass (25 new, 2791 total)
- [x] Ruff lint passes
- [x] Pre-commit hooks pass
- [ ] E2E: Verify /me response includes new fields

Refs: #1172

🤖 Generated with [Claude Code](https://claude.com/claude-code)