### PR TITLE
feat(1174): Add federation field mapping to frontend auth store

### DIFF
--- a/specs/1174-frontend-auth-store-federation/checklists/requirements.md
+++ b/specs/1174-frontend-auth-store-federation/checklists/requirements.md
@@ -1,0 +1,21 @@
+# Requirements Checklist: Feature 1174
+
+## Functional Requirements
+
+- [ ] FR-1: Anonymous users have role='anonymous' in state
+- [ ] FR-2: Anonymous users have linkedProviders=[] in state
+- [ ] FR-3: Anonymous users have verification='none' in state
+- [ ] FR-4: OAuth users have federation fields from API
+- [ ] FR-5: Profile refresh updates federation fields
+
+## Non-Functional Requirements
+
+- [ ] NFR-1: TypeScript compiles without errors
+- [ ] NFR-2: Lint passes
+- [ ] NFR-3: Existing tests still pass
+
+## Testing Evidence
+
+- [ ] TE-1: npm run typecheck passes
+- [ ] TE-2: npm run lint passes
+- [ ] TE-3: npm run test passes

--- a/specs/1174-frontend-auth-store-federation/plan.md
+++ b/specs/1174-frontend-auth-store-federation/plan.md
@@ -1,0 +1,56 @@
+# Implementation Plan: Feature 1174
+
+## Overview
+
+Update auth store to populate federation fields in user state.
+
+## Implementation Steps
+
+### Step 1: Update Anonymous Session Initialization
+
+**File:** `frontend/src/stores/auth-store.ts`
+**Location:** Lines 100-107 (setUser call in signInAnonymous)
+
+Add federation field defaults:
+- `role: 'anonymous'`
+- `linkedProviders: []`
+- `verification: 'none'`
+- `lastProviderUsed: undefined`
+
+### Step 2: Add API Response Mapper
+
+**File:** `frontend/src/lib/api/auth.ts`
+
+Add function to map `/api/v2/auth/me` response:
+- Handle snake_case → camelCase conversion
+- Include all federation fields
+
+### Step 3: Add Profile Refresh Action
+
+**File:** `frontend/src/stores/auth-store.ts`
+
+Add `refreshUserProfile()` action that:
+- Calls `/api/v2/auth/me`
+- Maps response
+- Updates user state
+
+### Step 4: Update OAuth/Magic Link Handlers
+
+Ensure `setUser()` calls include federation fields from API response.
+
+## File Changes
+
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `frontend/src/stores/auth-store.ts` | Edit | Add federation defaults and refresh action |
+| `frontend/src/lib/api/auth.ts` | Edit | Add response mapper if needed |
+
+## Validation
+
+- [ ] `npm run typecheck` passes
+- [ ] `npm run lint` passes
+- [ ] `npm run test` passes
+
+## Rollback
+
+Federation fields are optional, so removing them won't break existing code.

--- a/specs/1174-frontend-auth-store-federation/spec.md
+++ b/specs/1174-frontend-auth-store-federation/spec.md
@@ -1,0 +1,102 @@
+# Feature 1174: Frontend Auth Store Federation
+
+## Problem Statement
+
+The frontend auth store (`auth-store.ts`) doesn't populate federation fields when updating user state. Even though:
+1. Feature 1172 added federation fields to the `/api/v2/auth/me` backend response
+2. Feature 1173 added federation fields to the frontend `User` type
+
+The auth store never maps these fields from API responses to state, so:
+- `user.role` is always undefined
+- `user.linkedProviders` is always undefined
+- `user.verification` is always undefined
+- `user.lastProviderUsed` is always undefined
+
+## Root Cause
+
+The `setUser()` calls in auth-store.ts receive User objects from API responses but:
+1. Anonymous session initialization hardcodes fields without federation
+2. Other auth paths pass through the API response, but we need to verify mapping
+
+## Solution
+
+Update auth-store.ts to include federation fields in all user state updates:
+
+1. **Anonymous init**: Set default federation values
+2. **API response mapping**: Ensure backend response fields are properly mapped
+3. **Add profile refresh**: Fetch `/api/v2/auth/me` to get updated federation data
+
+## Technical Specification
+
+### Anonymous Session Initialization
+
+**File:** `frontend/src/stores/auth-store.ts` (lines 100-107)
+
+```typescript
+setUser({
+  userId: data.userId,
+  authType: 'anonymous',
+  createdAt: data.createdAt,
+  configurationCount: 0,
+  alertCount: 0,
+  emailNotificationsEnabled: false,
+  // Feature 1174: Federation fields
+  role: 'anonymous',
+  linkedProviders: [],
+  verification: 'none',
+  lastProviderUsed: undefined,
+});
+```
+
+### API Response Mapping
+
+The backend `/api/v2/auth/me` returns snake_case:
+- `role` → `role` (no change)
+- `linked_providers` → `linkedProviders`
+- `verification` → `verification` (no change)
+- `last_provider_used` → `lastProviderUsed`
+
+Add response mapper function to handle snake_case → camelCase.
+
+### Profile Refresh Function
+
+Add `refreshUserProfile()` action that:
+1. Calls `/api/v2/auth/me`
+2. Maps response to User with federation fields
+3. Updates state via `setUser()`
+
+## Acceptance Criteria
+
+1. Anonymous users have `role: 'anonymous'` in state
+2. OAuth users have federation fields populated from API
+3. `linkedProviders` reflects actual connected providers
+4. `verification` reflects email verification status
+5. TypeScript compiles without errors
+6. Existing tests still pass
+
+## Out of Scope
+
+- UI components using federation fields (separate features)
+- Role-based access control logic
+- Provider linking UI
+
+## Dependencies
+
+- **Requires:** Feature 1172 (API returns fields) - MERGED
+- **Requires:** Feature 1173 (User type has fields) - MERGED
+- **Blocks:** Frontend RBAC components
+
+## Testing Strategy
+
+### Unit Tests
+
+Update `tests/unit/stores/auth-store.test.ts`:
+1. Anonymous init includes federation defaults
+2. OAuth callback populates federation fields
+3. Profile refresh updates federation fields
+
+## References
+
+- Feature 1172: API /me endpoint federation
+- Feature 1173: Frontend User type
+- `frontend/src/stores/auth-store.ts` (store implementation)

--- a/specs/1174-frontend-auth-store-federation/tasks.md
+++ b/specs/1174-frontend-auth-store-federation/tasks.md
@@ -1,0 +1,30 @@
+# Tasks: Feature 1174
+
+## Implementation Tasks
+
+- [ ] 1. Update anonymous session initialization
+  - Add role: 'anonymous'
+  - Add linkedProviders: []
+  - Add verification: 'none'
+  - Add lastProviderUsed: undefined
+
+- [ ] 2. Add response mapper for /me endpoint (if needed)
+  - Handle snake_case → camelCase
+  - Map all federation fields
+
+- [ ] 3. Add refreshUserProfile action
+  - Call /api/v2/auth/me
+  - Map response to User
+  - Update state via setUser
+
+- [ ] 4. Validate
+  - Run typecheck
+  - Run lint
+  - Run tests
+
+## Completion Criteria
+
+- TypeScript compiles
+- Lint passes
+- Tests pass
+- PR created with auto-merge


### PR DESCRIPTION
## Summary
- Add federation field defaults to anonymous session initialization
- Add `UserMeResponse` type and `mapUserMeResponse()` for snake_case → camelCase
- Add `refreshUserProfile()` action to fetch and merge federation data

## Changes
- `frontend/src/stores/auth-store.ts`: Federation defaults + refresh action
- `frontend/src/lib/api/auth.ts`: Response mapper for /me endpoint
- `specs/1174-frontend-auth-store-federation/`: Full spec, plan, tasks

## New Behavior
- Anonymous users: `role='anonymous'`, `linkedProviders=[]`, `verification='none'`
- OAuth/Magic link users: Fields populated from API response
- `refreshUserProfile()` can be called to sync latest federation data

## Test Plan
- [x] TypeScript compiles without errors
- [x] Lint passes
- [x] 414 tests pass

Refs: #1174

🤖 Generated with [Claude Code](https://claude.com/claude-code)