### PR TITLE
feat(1175): Add role assignment audit trail helper

### DIFF
--- a/specs/1175-role-assignment-audit-trail/checklists/requirements.md
+++ b/specs/1175-role-assignment-audit-trail/checklists/requirements.md
@@ -1,0 +1,20 @@
+# Requirements Checklist: Feature 1175
+
+## Functional Requirements
+
+- [ ] FR-1: create_role_audit_entry() function exists
+- [ ] FR-2: Function returns dict with role_assigned_at and role_assigned_by
+- [ ] FR-3: role_assigned_by format is {source}:{identifier}
+- [ ] FR-4: Supports oauth, stripe, admin sources
+
+## Non-Functional Requirements
+
+- [ ] NFR-1: Timestamp in UTC ISO 8601 format
+- [ ] NFR-2: Unit test coverage for all sources
+
+## Testing Evidence
+
+- [ ] TE-1: Unit test test_oauth_source_format passes
+- [ ] TE-2: Unit test test_stripe_source_format passes
+- [ ] TE-3: Unit test test_admin_source_format passes
+- [ ] TE-4: All existing role tests still pass

--- a/specs/1175-role-assignment-audit-trail/plan.md
+++ b/specs/1175-role-assignment-audit-trail/plan.md
@@ -1,0 +1,42 @@
+# Implementation Plan: Feature 1175
+
+## Overview
+
+Create audit helper function for role assignment tracking.
+
+## Implementation Steps
+
+### Step 1: Create audit.py Module
+
+**File:** `src/lambdas/shared/auth/audit.py` (new file)
+
+Create module with `create_role_audit_entry()` function.
+
+### Step 2: Add Unit Tests
+
+**File:** `tests/unit/shared/auth/test_audit.py` (new file)
+
+Test all source types and timestamp format.
+
+### Step 3: (Optional) Refactor _advance_role()
+
+Update to use the new helper for consistency.
+
+## File Changes
+
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `src/lambdas/shared/auth/audit.py` | New | Audit helper function |
+| `tests/unit/shared/auth/test_audit.py` | New | Unit tests |
+| `src/lambdas/dashboard/auth.py` | Edit (optional) | Refactor to use helper |
+
+## Validation
+
+- [ ] All existing tests pass
+- [ ] New tests pass
+- [ ] Ruff lint passes
+- [ ] Type checking passes
+
+## Rollback
+
+New module with no dependencies - simply delete files if needed.

--- a/specs/1175-role-assignment-audit-trail/spec.md
+++ b/specs/1175-role-assignment-audit-trail/spec.md
@@ -1,0 +1,118 @@
+# Feature 1175: Role Assignment Audit Trail
+
+## Problem Statement
+
+Role changes need consistent audit trail tracking for compliance. Currently:
+- `_advance_role()` (Feature 1170) sets `role_assigned_at` and `role_assigned_by` correctly
+- Future role change sources (Stripe, admin) will need the same pattern
+- No centralized helper to ensure consistency
+
+## Root Cause
+
+Role assignment audit logic is currently embedded in `_advance_role()`. As more role change sources are added (Stripe webhooks, admin operations), this pattern needs to be extracted into a reusable helper.
+
+## Solution
+
+Create `create_role_audit_entry()` helper function that:
+1. Generates consistent audit field values
+2. Supports multiple sources (oauth, stripe, admin)
+3. Returns dict ready for DynamoDB update expressions
+
+## Technical Specification
+
+### New Helper Function
+
+**File:** `src/lambdas/shared/auth/audit.py` (new file)
+
+```python
+from datetime import UTC, datetime
+from typing import Literal
+
+RoleChangeSource = Literal["oauth", "stripe", "admin"]
+
+def create_role_audit_entry(
+    source: RoleChangeSource,
+    identifier: str,
+) -> dict[str, str]:
+    """Create audit trail entry for role changes.
+
+    Args:
+        source: Origin of role change (oauth, stripe, admin)
+        identifier: Provider name (oauth) or admin user ID
+
+    Returns:
+        Dict with role_assigned_at and role_assigned_by
+
+    Examples:
+        >>> create_role_audit_entry("oauth", "google")
+        {'role_assigned_at': '2026-01-08T...', 'role_assigned_by': 'oauth:google'}
+
+        >>> create_role_audit_entry("stripe", "subscription_activated")
+        {'role_assigned_at': '2026-01-08T...', 'role_assigned_by': 'stripe:subscription_activated'}
+
+        >>> create_role_audit_entry("admin", "admin-user-123")
+        {'role_assigned_at': '2026-01-08T...', 'role_assigned_by': 'admin:admin-user-123'}
+    """
+    now = datetime.now(UTC)
+    return {
+        "role_assigned_at": now.isoformat(),
+        "role_assigned_by": f"{source}:{identifier}",
+    }
+```
+
+### Refactor _advance_role()
+
+Update `_advance_role()` to use the new helper:
+
+```python
+from src.lambdas.shared.auth.audit import create_role_audit_entry
+
+# In _advance_role():
+audit = create_role_audit_entry("oauth", provider)
+table.update_item(
+    Key={"PK": user.pk, "SK": user.sk},
+    UpdateExpression="SET #role = :new_role, role_assigned_at = :assigned_at, role_assigned_by = :assigned_by",
+    ExpressionAttributeNames={"#role": "role"},
+    ExpressionAttributeValues={
+        ":new_role": "free",
+        ":assigned_at": audit["role_assigned_at"],
+        ":assigned_by": audit["role_assigned_by"],
+    },
+)
+```
+
+## Acceptance Criteria
+
+1. `create_role_audit_entry()` function exists in `audit.py`
+2. Function returns dict with `role_assigned_at` and `role_assigned_by`
+3. `role_assigned_by` format is `{source}:{identifier}`
+4. `_advance_role()` uses the new helper (optional refactor)
+5. Unit tests cover all source types
+6. Existing role advancement tests still pass
+
+## Out of Scope
+
+- Stripe webhook implementation (separate feature)
+- Admin role change UI (separate feature)
+- Role downgrade logic
+
+## Dependencies
+
+- **Requires:** Feature 1170 (role advancement) - MERGED
+- **Blocks:** Stripe subscription feature, admin role management
+
+## Testing Strategy
+
+### Unit Tests
+
+Create `tests/unit/shared/auth/test_audit.py`:
+1. `test_oauth_source_format` - oauth:google format
+2. `test_stripe_source_format` - stripe:subscription_activated format
+3. `test_admin_source_format` - admin:user-id format
+4. `test_timestamp_is_utc_iso` - ISO 8601 format
+
+## References
+
+- Feature 1170: Role Advancement
+- `src/lambdas/dashboard/auth.py:1784-1844` (_advance_role)
+- `src/lambdas/shared/models/user.py:110-115` (audit fields)

--- a/specs/1175-role-assignment-audit-trail/tasks.md
+++ b/specs/1175-role-assignment-audit-trail/tasks.md
@@ -1,0 +1,29 @@
+# Tasks: Feature 1175
+
+## Implementation Tasks
+
+- [ ] 1. Create audit.py module
+  - Add create_role_audit_entry() function
+  - Support oauth, stripe, admin sources
+  - Return dict with role_assigned_at and role_assigned_by
+
+- [ ] 2. Create unit tests
+  - Test oauth source format
+  - Test stripe source format
+  - Test admin source format
+  - Test timestamp format
+
+- [ ] 3. (Optional) Refactor _advance_role()
+  - Import audit helper
+  - Use helper instead of inline logic
+
+- [ ] 4. Validate
+  - Run existing tests
+  - Run new tests
+  - Lint check
+
+## Completion Criteria
+
+- All tests pass
+- Ruff passes
+- PR created with auto-merge

--- a/src/lambdas/shared/auth/audit.py
+++ b/src/lambdas/shared/auth/audit.py
@@ -1,0 +1,46 @@
+"""Role assignment audit trail helpers (Feature 1175).
+
+Provides consistent audit field generation for role changes.
+Supports multiple sources: OAuth, Stripe webhooks, admin operations.
+"""
+
+from datetime import UTC, datetime
+from typing import Literal
+
+RoleChangeSource = Literal["oauth", "stripe", "admin"]
+
+
+def create_role_audit_entry(
+    source: RoleChangeSource,
+    identifier: str,
+) -> dict[str, str]:
+    """Create audit trail entry for role changes.
+
+    Generates role_assigned_at and role_assigned_by fields for DynamoDB updates.
+    Follows consistent format: {source}:{identifier} for attribution.
+
+    Args:
+        source: Origin of role change (oauth, stripe, admin)
+        identifier: Context-specific identifier:
+            - oauth: provider name (google, github)
+            - stripe: event type (subscription_activated, subscription_cancelled)
+            - admin: admin user ID
+
+    Returns:
+        Dict with role_assigned_at (ISO 8601 UTC) and role_assigned_by
+
+    Examples:
+        >>> create_role_audit_entry("oauth", "google")
+        {'role_assigned_at': '2026-01-08T12:00:00+00:00', 'role_assigned_by': 'oauth:google'}
+
+        >>> create_role_audit_entry("stripe", "subscription_activated")
+        {'role_assigned_at': '2026-01-08T12:00:00+00:00', 'role_assigned_by': 'stripe:subscription_activated'}
+
+        >>> create_role_audit_entry("admin", "admin-user-123")
+        {'role_assigned_at': '2026-01-08T12:00:00+00:00', 'role_assigned_by': 'admin:admin-user-123'}
+    """
+    now = datetime.now(UTC)
+    return {
+        "role_assigned_at": now.isoformat(),
+        "role_assigned_by": f"{source}:{identifier}",
+    }

--- a/tests/unit/shared/auth/test_audit.py
+++ b/tests/unit/shared/auth/test_audit.py
@@ -1,0 +1,95 @@
+"""Unit tests for role assignment audit trail (Feature 1175)."""
+
+from datetime import UTC, datetime
+from unittest.mock import patch
+
+import pytest
+
+from src.lambdas.shared.auth.audit import create_role_audit_entry
+
+
+class TestCreateRoleAuditEntry:
+    """Tests for create_role_audit_entry() function."""
+
+    def test_oauth_source_format(self) -> None:
+        """OAuth source produces oauth:{provider} format."""
+        result = create_role_audit_entry("oauth", "google")
+        assert result["role_assigned_by"] == "oauth:google"
+
+    def test_oauth_github_provider(self) -> None:
+        """OAuth works with github provider."""
+        result = create_role_audit_entry("oauth", "github")
+        assert result["role_assigned_by"] == "oauth:github"
+
+    def test_stripe_source_format(self) -> None:
+        """Stripe source produces stripe:{event} format."""
+        result = create_role_audit_entry("stripe", "subscription_activated")
+        assert result["role_assigned_by"] == "stripe:subscription_activated"
+
+    def test_stripe_cancellation_event(self) -> None:
+        """Stripe works with cancellation events."""
+        result = create_role_audit_entry("stripe", "subscription_cancelled")
+        assert result["role_assigned_by"] == "stripe:subscription_cancelled"
+
+    def test_admin_source_format(self) -> None:
+        """Admin source produces admin:{user_id} format."""
+        result = create_role_audit_entry("admin", "admin-user-123")
+        assert result["role_assigned_by"] == "admin:admin-user-123"
+
+    def test_returns_both_audit_fields(self) -> None:
+        """Result contains both role_assigned_at and role_assigned_by."""
+        result = create_role_audit_entry("oauth", "google")
+        assert "role_assigned_at" in result
+        assert "role_assigned_by" in result
+
+    def test_timestamp_is_iso_format(self) -> None:
+        """Timestamp is in ISO 8601 format."""
+        result = create_role_audit_entry("oauth", "google")
+        timestamp = result["role_assigned_at"]
+        # Should be parseable as ISO format
+        parsed = datetime.fromisoformat(timestamp)
+        assert parsed is not None
+
+    def test_timestamp_is_utc(self) -> None:
+        """Timestamp is in UTC timezone."""
+        with patch("src.lambdas.shared.auth.audit.datetime") as mock_dt:
+            mock_now = datetime(2026, 1, 8, 12, 0, 0, tzinfo=UTC)
+            mock_dt.now.return_value = mock_now
+            mock_dt.now.side_effect = None
+
+            result = create_role_audit_entry("oauth", "google")
+            assert result["role_assigned_at"] == mock_now.isoformat()
+
+    def test_timestamp_includes_timezone(self) -> None:
+        """Timestamp includes timezone indicator."""
+        result = create_role_audit_entry("oauth", "google")
+        timestamp = result["role_assigned_at"]
+        # Should contain + for timezone offset
+        assert "+" in timestamp or "Z" in timestamp
+
+
+class TestAuditFieldConsistency:
+    """Tests for consistency with existing patterns."""
+
+    def test_matches_advance_role_pattern(self) -> None:
+        """Output matches pattern used in _advance_role()."""
+        result = create_role_audit_entry("oauth", "google")
+        # _advance_role uses "oauth:{provider}" format
+        assert result["role_assigned_by"].startswith("oauth:")
+
+    @pytest.mark.parametrize(
+        "source,identifier,expected_prefix",
+        [
+            ("oauth", "google", "oauth:"),
+            ("oauth", "github", "oauth:"),
+            ("stripe", "sub_123", "stripe:"),
+            ("admin", "user-456", "admin:"),
+        ],
+    )
+    def test_all_sources_have_consistent_format(
+        self, source: str, identifier: str, expected_prefix: str
+    ) -> None:
+        """All sources follow {source}:{identifier} format."""
+        result = create_role_audit_entry(source, identifier)  # type: ignore[arg-type]
+        assert result["role_assigned_by"].startswith(expected_prefix)
+        assert result["role_assigned_by"] == f"{source}:{identifier}"


### PR DESCRIPTION
## Summary
- Create centralized audit helper for role assignment tracking
- Supports oauth, stripe, admin sources
- Format: `{source}:{identifier}` for `role_assigned_by`
- Timestamp in UTC ISO 8601 format

## Changes
- `src/lambdas/shared/auth/audit.py`: New audit helper module
- `tests/unit/shared/auth/test_audit.py`: 14 unit tests
- `specs/1175-role-assignment-audit-trail/`: Full spec, plan, tasks

## Usage
```python
from src.lambdas.shared.auth.audit import create_role_audit_entry

# OAuth advancement
audit = create_role_audit_entry("oauth", "google")
# {'role_assigned_at': '2026-01-08T...', 'role_assigned_by': 'oauth:google'}

# Stripe subscription
audit = create_role_audit_entry("stripe", "subscription_activated")
# {'role_assigned_by': 'stripe:subscription_activated'}

# Admin change
audit = create_role_audit_entry("admin", "admin-user-123")
# {'role_assigned_by': 'admin:admin-user-123'}
```

## Test Plan
- [x] Ruff lint passes
- [x] 14 new unit tests pass
- [x] Existing role advancement tests pass (10/10)

Refs: #1175

🤖 Generated with [Claude Code](https://claude.com/claude-code)