### PR TITLE
feat(1176): Add federation fields to OAuthCallbackResponse

### DIFF
--- a/specs/1176-oauth-callback-federation-response/checklists/requirements.md
+++ b/specs/1176-oauth-callback-federation-response/checklists/requirements.md
@@ -1,0 +1,32 @@
+# Requirements Checklist: OAuth Callback Federation Response
+
+**Feature**: 1176-oauth-callback-federation-response
+**Date**: 2025-01-09
+
+## Functional Requirements
+
+| ID | Requirement | Status | Implementation |
+|----|-------------|--------|----------------|
+| FR-001 | `OAuthCallbackResponse` MUST include `role: str` field with default "anonymous" | DONE | `auth.py:1019` |
+| FR-002 | `OAuthCallbackResponse` MUST include `verification: str` field with default "none" | DONE | `auth.py:1020` |
+| FR-003 | `OAuthCallbackResponse` MUST include `linked_providers: list[str]` field with default empty list | DONE | `auth.py:1021` |
+| FR-004 | `OAuthCallbackResponse` MUST include `last_provider_used: str \| None` field with default None | DONE | `auth.py:1022` |
+| FR-005 | `handle_oauth_callback()` MUST populate federation fields from updated User state | DONE | `auth.py:1660-1694` |
+| FR-006 | Error and conflict responses MAY omit federation fields (use defaults) | DONE | Verified by test |
+| FR-007 | New fields MUST be optional to maintain backward compatibility | DONE | All fields have defaults |
+
+## Success Criteria
+
+| ID | Criterion | Status | Evidence |
+|----|-----------|--------|----------|
+| SC-001 | All existing OAuth unit tests pass without modification | DONE | No changes to existing tests |
+| SC-002 | All existing OAuth contract tests pass without modification | DONE | Contract tests unmodified |
+| SC-003 | New unit tests verify federation fields in OAuth response | DONE | `test_oauth_callback_federation.py` (12 tests) |
+| SC-004 | Frontend can read `role` from OAuth response | DONE | Field present in response |
+
+## Test Coverage
+
+- `tests/unit/dashboard/test_oauth_callback_federation.py`: 12 tests
+  - Model field existence and defaults: 3 tests
+  - New user federation fields: 5 tests
+  - Existing user federation fields: 4 tests

--- a/specs/1176-oauth-callback-federation-response/plan.md
+++ b/specs/1176-oauth-callback-federation-response/plan.md
@@ -1,0 +1,110 @@
+# Implementation Plan: OAuth Callback Federation Response
+
+**Branch**: `1176-oauth-callback-federation-response` | **Date**: 2025-01-09 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/1176-oauth-callback-federation-response/spec.md`
+
+## Summary
+
+Add four federation fields (`role`, `verification`, `linked_providers`, `last_provider_used`) to `OAuthCallbackResponse` model and populate them in the `handle_oauth_callback()` return path. This closes the gap where backend updates DynamoDB with federation data but doesn't return it to frontend.
+
+## Technical Context
+
+**Language/Version**: Python 3.13
+**Primary Dependencies**: Pydantic (BaseModel), existing auth.py infrastructure
+**Storage**: DynamoDB (already handled by existing helper functions)
+**Testing**: pytest with moto mocks
+**Target Platform**: AWS Lambda
+**Project Type**: Web application (backend-only for this feature)
+**Performance Goals**: No change - adding 4 fields to existing response
+**Constraints**: Backward compatible - all new fields must be optional with defaults
+**Scale/Scope**: Single file change (auth.py) + unit tests
+
+## Constitution Check
+
+_GATE: Must pass before implementation._
+
+- [x] No quick fixes - full speckit workflow
+- [x] No workspace file destruction
+- [x] Backward compatible (additive fields only)
+- [x] Unit tests required
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/1176-oauth-callback-federation-response/
+├── spec.md              # Feature specification (done)
+├── plan.md              # This file
+├── tasks.md             # Implementation tasks
+└── checklists/
+    └── requirements.md  # Requirements checklist
+```
+
+### Source Code (repository root)
+
+```text
+src/lambdas/dashboard/
+└── auth.py              # OAuthCallbackResponse model + handle_oauth_callback()
+
+tests/unit/dashboard/
+└── test_oauth_callback_federation.py  # New unit tests for federation fields
+```
+
+**Structure Decision**: Backend-only change. Single file modification + new test file.
+
+## Implementation Approach
+
+### Step 1: Extend OAuthCallbackResponse Model
+
+Add 4 optional fields at lines 999-1017 in `auth.py`:
+
+```python
+class OAuthCallbackResponse(BaseModel):
+    # ... existing fields ...
+
+    # Federation fields (Feature 1176)
+    role: str = "anonymous"
+    verification: str = "none"
+    linked_providers: list[str] = Field(default_factory=list)
+    last_provider_used: str | None = None
+```
+
+### Step 2: Populate Fields in handle_oauth_callback()
+
+At lines 1654-1668, after the helper functions have updated DynamoDB, the User object contains the updated federation state. Add federation fields to the return:
+
+```python
+return OAuthCallbackResponse(
+    status="authenticated",
+    email_masked=_mask_email(email),
+    # ... existing fields ...
+
+    # Federation fields from updated user
+    role=user.role,
+    verification=user.verification,
+    linked_providers=user.linked_providers,
+    last_provider_used=user.last_provider_used,
+)
+```
+
+### Step 3: Unit Tests
+
+Create `tests/unit/dashboard/test_oauth_callback_federation.py` with tests:
+- Test federation fields present in successful OAuth response
+- Test role advancement reflected in response
+- Test verification marking reflected in response
+- Test linked_providers updated in response
+- Test defaults used for conflict/error responses
+
+## Risk Assessment
+
+- **Low Risk**: Additive change - new optional fields with defaults
+- **No Security Impact**: Federation fields already validated in User model
+- **No Database Changes**: Just returning existing data that's already stored
+- **Backward Compatible**: Existing code ignores unknown fields
+
+## Dependencies
+
+- None. This is Phase 1 (Backend Non-Breaking). Does not depend on other features.
+- Feature 1177 depends on this feature.

--- a/specs/1176-oauth-callback-federation-response/spec.md
+++ b/specs/1176-oauth-callback-federation-response/spec.md
@@ -1,0 +1,116 @@
+# Feature Specification: OAuth Callback Federation Response
+
+**Feature Branch**: `1176-oauth-callback-federation-response`
+**Created**: 2025-01-09
+**Status**: Draft
+**Input**: Add federation fields to OAuthCallbackResponse so frontend receives updated federation state after OAuth authentication.
+
+## User Scenarios & Testing
+
+### User Story 1 - Receive Federation State After OAuth (Priority: P1)
+
+A user authenticates via OAuth (Google/GitHub). After successful authentication, the frontend receives the updated federation state (role, verification status, linked providers) directly in the OAuth callback response, enabling immediate RBAC-aware UI decisions without a separate API call.
+
+**Why this priority**: This is the core gap blocking federation functionality. Backend updates DynamoDB but response doesn't include the data.
+
+**Independent Test**: After OAuth callback, response body contains `role`, `verification`, `linked_providers`, `last_provider_used` fields with correct values.
+
+**Acceptance Scenarios**:
+
+1. **Given** anonymous user with no linked providers, **When** user authenticates via Google OAuth with verified email, **Then** response contains `role="free"`, `verification="verified"`, `linked_providers=["google"]`, `last_provider_used="google"`
+
+2. **Given** existing free user with Google linked, **When** user authenticates via GitHub OAuth, **Then** response contains `role="free"` (unchanged), `linked_providers=["google", "github"]`, `last_provider_used="github"`
+
+3. **Given** user with unverified email from OAuth provider, **When** user completes OAuth callback, **Then** response contains `verification="none"` (not auto-verified)
+
+---
+
+### User Story 2 - Contract Backward Compatibility (Priority: P2)
+
+Existing frontend code continues working. New fields are optional/additive - no breaking changes to existing response schema.
+
+**Why this priority**: Must not break existing OAuth flows during migration.
+
+**Independent Test**: Existing contract tests pass without modification. New fields are all optional with defaults.
+
+**Acceptance Scenarios**:
+
+1. **Given** existing frontend consuming OAuth response, **When** response includes new federation fields, **Then** frontend ignores unknown fields gracefully (standard JSON behavior)
+
+2. **Given** OAuthCallbackResponse model, **When** serialized to JSON, **Then** all new fields have defaults (role="anonymous", verification="none", linked_providers=[], last_provider_used=None)
+
+---
+
+### Edge Cases
+
+- What happens when `_advance_role()` fails to update DynamoDB but `_link_provider()` succeeds? Response should still include whatever state was successfully written.
+- What happens during conflict flow? Conflict responses don't go through full federation logic; federation fields should be omitted or use defaults.
+- What happens for magic link auth? This feature is OAuth-specific; magic link uses different response model.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: `OAuthCallbackResponse` MUST include `role: str` field with default "anonymous"
+- **FR-002**: `OAuthCallbackResponse` MUST include `verification: str` field with default "none"
+- **FR-003**: `OAuthCallbackResponse` MUST include `linked_providers: list[str]` field with default empty list
+- **FR-004**: `OAuthCallbackResponse` MUST include `last_provider_used: str | None` field with default None
+- **FR-005**: `handle_oauth_callback()` MUST populate federation fields from the updated User object after calling `_link_provider()`, `_mark_email_verified()`, `_advance_role()`
+- **FR-006**: Error and conflict responses MAY omit federation fields (use defaults)
+- **FR-007**: New fields MUST be optional to maintain backward compatibility
+
+### Key Entities
+
+- **OAuthCallbackResponse**: Pydantic model at `auth.py:999-1017` - add federation fields
+- **User**: Source of federation data after DynamoDB updates
+- **Federation fields**: role, verification, linked_providers, last_provider_used
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: All existing OAuth unit tests pass without modification
+- **SC-002**: All existing OAuth contract tests pass without modification
+- **SC-003**: New unit tests verify federation fields are populated correctly in successful OAuth response
+- **SC-004**: Frontend can read `role` from OAuth response to make RBAC decisions
+
+## Technical Context
+
+### Current State (Lines from auth.py)
+
+**OAuthCallbackResponse (lines 999-1017):**
+```python
+class OAuthCallbackResponse(BaseModel):
+    status: str
+    email_masked: str | None = None
+    auth_type: str | None = None
+    tokens: dict | None = None
+    refresh_token_for_cookie: str | None = None
+    merged_anonymous_data: bool = False
+    is_new_user: bool = False
+    conflict: bool = False
+    existing_provider: str | None = None
+    message: str | None = None
+    error: str | None = None
+    # MISSING: role, verification, linked_providers, last_provider_used
+```
+
+**handle_oauth_callback return (lines 1654-1668):**
+```python
+return OAuthCallbackResponse(
+    status="authenticated",
+    email_masked=_mask_email(email),
+    auth_type=f"oauth:{provider_name}",
+    tokens={"access_token": access_token},
+    refresh_token_for_cookie=refresh_token,
+    merged_anonymous_data=merged_anonymous,
+    is_new_user=is_new_user,
+    # MISSING: federation fields from updated user
+)
+```
+
+### Required Changes
+
+1. Add 4 fields to `OAuthCallbackResponse` (lines 999-1017)
+2. Populate fields in successful return at lines 1654-1668 from User object
+3. Add unit tests for federation field population

--- a/specs/1176-oauth-callback-federation-response/tasks.md
+++ b/specs/1176-oauth-callback-federation-response/tasks.md
@@ -1,0 +1,52 @@
+# Tasks: OAuth Callback Federation Response
+
+**Branch**: `1176-oauth-callback-federation-response` | **Date**: 2025-01-09
+
+## Tasks
+
+### Task 1: Extend OAuthCallbackResponse Model
+- [x] Add `role: str = "anonymous"` field
+- [x] Add `verification: str = "none"` field
+- [x] Add `linked_providers: list[str] = Field(default_factory=list)` field
+- [x] Add `last_provider_used: str | None = None` field
+- [x] Add docstring comment noting Feature 1176
+
+**File**: `src/lambdas/dashboard/auth.py` (lines 1018-1022)
+
+### Task 2: Populate Federation Fields in handle_oauth_callback()
+- [x] Compute federation state after mutations (not re-fetch from DB)
+- [x] Add `role=final_role` to return statement
+- [x] Add `verification=final_verification` to return statement
+- [x] Add `linked_providers=final_linked_providers` to return statement
+- [x] Add `last_provider_used=request.provider` to return statement
+
+**File**: `src/lambdas/dashboard/auth.py` (lines 1660-1694)
+
+### Task 3: Add Unit Tests
+- [x] Create `tests/unit/dashboard/test_oauth_callback_federation.py`
+- [x] Test: federation fields present in successful OAuth response
+- [x] Test: role="free" after role advancement for anonymous user
+- [x] Test: verification="verified" after email verification marking
+- [x] Test: linked_providers contains provider after linking
+- [x] Test: last_provider_used matches OAuth provider
+- [x] Test: defaults used for conflict responses
+
+**File**: `tests/unit/dashboard/test_oauth_callback_federation.py` (12 tests)
+
+### Task 4: Requirements Checklist
+- [x] Create `specs/1176-oauth-callback-federation-response/checklists/requirements.md`
+- [x] Map each FR-00X to implementation
+
+## Verification
+
+```bash
+# Run unit tests
+MAGIC_LINK_SECRET="test-secret-key-at-least-32-characters-long-for-testing" python -m pytest tests/unit/dashboard/test_oauth_callback_federation.py -xvs
+
+# Run existing OAuth tests (must still pass)
+MAGIC_LINK_SECRET="test-secret-key-at-least-32-characters-long-for-testing" python -m pytest tests/unit/dashboard/test_auth.py -xvs -k oauth
+```
+
+## Status: COMPLETE
+
+All tasks completed. 12/12 unit tests passing.

--- a/tests/unit/dashboard/test_oauth_callback_federation.py
+++ b/tests/unit/dashboard/test_oauth_callback_federation.py
@@ -1,0 +1,425 @@
+"""Unit tests for OAuth callback federation response (Feature 1176).
+
+Tests that OAuthCallbackResponse includes federation fields (role, verification,
+linked_providers, last_provider_used) populated from user state after mutations.
+"""
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+from src.lambdas.dashboard.auth import (
+    OAuthCallbackRequest,
+    OAuthCallbackResponse,
+    handle_oauth_callback,
+)
+from src.lambdas.shared.auth.cognito import CognitoTokens
+from src.lambdas.shared.models.user import User
+
+
+class TestOAuthCallbackResponseModel:
+    """Test OAuthCallbackResponse model federation fields."""
+
+    def test_federation_fields_exist(self) -> None:
+        """OAuthCallbackResponse has federation fields with defaults."""
+        response = OAuthCallbackResponse(status="authenticated")
+
+        assert hasattr(response, "role")
+        assert hasattr(response, "verification")
+        assert hasattr(response, "linked_providers")
+        assert hasattr(response, "last_provider_used")
+
+    def test_federation_defaults(self) -> None:
+        """Federation fields have correct defaults."""
+        response = OAuthCallbackResponse(status="authenticated")
+
+        assert response.role == "anonymous"
+        assert response.verification == "none"
+        assert response.linked_providers == []
+        assert response.last_provider_used is None
+
+    def test_federation_fields_can_be_set(self) -> None:
+        """Federation fields can be set to custom values."""
+        response = OAuthCallbackResponse(
+            status="authenticated",
+            role="free",
+            verification="verified",
+            linked_providers=["google", "github"],
+            last_provider_used="google",
+        )
+
+        assert response.role == "free"
+        assert response.verification == "verified"
+        assert response.linked_providers == ["google", "github"]
+        assert response.last_provider_used == "google"
+
+
+class TestOAuthCallbackFederationFieldsNewUser:
+    """Test federation fields for new OAuth users."""
+
+    def _create_test_user(self, role: str = "anonymous") -> User:
+        """Create a test user with specified role."""
+        return User(
+            user_id=str(uuid.uuid4()),
+            email="test@example.com",
+            cognito_sub="cognito-123",
+            auth_type="google",
+            role=role,
+            verification="none",
+            created_at=datetime.now(UTC),
+            last_active_at=datetime.now(UTC),
+            session_expires_at=datetime.now(UTC) + timedelta(days=30),
+            linked_providers=[],
+            provider_metadata={},
+        )
+
+    def _mock_tokens(self) -> CognitoTokens:
+        """Create mock Cognito tokens."""
+        return CognitoTokens(
+            id_token="mock-id-token",
+            access_token="mock-access-token",
+            refresh_token="mock-refresh-token",
+            expires_in=3600,
+        )
+
+    @patch("src.lambdas.dashboard.auth._create_authenticated_user")
+    @patch("src.lambdas.dashboard.auth._update_cognito_sub")
+    @patch("src.lambdas.dashboard.auth._link_provider")
+    @patch("src.lambdas.dashboard.auth._mark_email_verified")
+    @patch("src.lambdas.dashboard.auth._advance_role")
+    @patch("src.lambdas.dashboard.auth.get_user_by_email_gsi")
+    @patch("src.lambdas.dashboard.auth.exchange_code_for_tokens")
+    @patch("src.lambdas.dashboard.auth.decode_id_token")
+    def test_new_user_role_advanced_to_free(
+        self,
+        mock_decode_id_token: MagicMock,
+        mock_exchange: MagicMock,
+        mock_get_user: MagicMock,
+        mock_advance_role: MagicMock,
+        mock_mark_verified: MagicMock,
+        mock_link_provider: MagicMock,
+        mock_update_sub: MagicMock,
+        mock_create_user: MagicMock,
+    ) -> None:
+        """New anonymous user gets role=free in response."""
+        table = MagicMock()
+        user = self._create_test_user(role="anonymous")
+        mock_create_user.return_value = user
+        mock_get_user.return_value = None  # New user
+        mock_exchange.return_value = self._mock_tokens()
+        mock_decode_id_token.return_value = {
+            "email": "test@example.com",
+            "sub": "google-123",
+            "email_verified": True,
+        }
+
+        request = OAuthCallbackRequest(code="auth-code", provider="google")
+        response = handle_oauth_callback(table, request)
+
+        assert response.role == "free"
+
+    @patch("src.lambdas.dashboard.auth._create_authenticated_user")
+    @patch("src.lambdas.dashboard.auth._update_cognito_sub")
+    @patch("src.lambdas.dashboard.auth._link_provider")
+    @patch("src.lambdas.dashboard.auth._mark_email_verified")
+    @patch("src.lambdas.dashboard.auth._advance_role")
+    @patch("src.lambdas.dashboard.auth.get_user_by_email_gsi")
+    @patch("src.lambdas.dashboard.auth.exchange_code_for_tokens")
+    @patch("src.lambdas.dashboard.auth.decode_id_token")
+    def test_new_user_verification_verified_when_email_verified(
+        self,
+        mock_decode_id_token: MagicMock,
+        mock_exchange: MagicMock,
+        mock_get_user: MagicMock,
+        mock_advance_role: MagicMock,
+        mock_mark_verified: MagicMock,
+        mock_link_provider: MagicMock,
+        mock_update_sub: MagicMock,
+        mock_create_user: MagicMock,
+    ) -> None:
+        """New user with verified email gets verification=verified."""
+        table = MagicMock()
+        user = self._create_test_user()
+        mock_create_user.return_value = user
+        mock_get_user.return_value = None
+        mock_exchange.return_value = self._mock_tokens()
+        mock_decode_id_token.return_value = {
+            "email": "test@example.com",
+            "sub": "google-123",
+            "email_verified": True,
+        }
+
+        request = OAuthCallbackRequest(code="auth-code", provider="google")
+        response = handle_oauth_callback(table, request)
+
+        assert response.verification == "verified"
+
+    @patch("src.lambdas.dashboard.auth._create_authenticated_user")
+    @patch("src.lambdas.dashboard.auth._update_cognito_sub")
+    @patch("src.lambdas.dashboard.auth._link_provider")
+    @patch("src.lambdas.dashboard.auth._mark_email_verified")
+    @patch("src.lambdas.dashboard.auth._advance_role")
+    @patch("src.lambdas.dashboard.auth.get_user_by_email_gsi")
+    @patch("src.lambdas.dashboard.auth.exchange_code_for_tokens")
+    @patch("src.lambdas.dashboard.auth.decode_id_token")
+    def test_new_user_verification_none_when_email_not_verified(
+        self,
+        mock_decode_id_token: MagicMock,
+        mock_exchange: MagicMock,
+        mock_get_user: MagicMock,
+        mock_advance_role: MagicMock,
+        mock_mark_verified: MagicMock,
+        mock_link_provider: MagicMock,
+        mock_update_sub: MagicMock,
+        mock_create_user: MagicMock,
+    ) -> None:
+        """New user without verified email keeps verification=none."""
+        table = MagicMock()
+        user = self._create_test_user()
+        mock_create_user.return_value = user
+        mock_get_user.return_value = None
+        mock_exchange.return_value = self._mock_tokens()
+        mock_decode_id_token.return_value = {
+            "email": "test@example.com",
+            "sub": "google-123",
+            "email_verified": False,
+        }
+
+        request = OAuthCallbackRequest(code="auth-code", provider="google")
+        response = handle_oauth_callback(table, request)
+
+        assert response.verification == "none"
+
+    @patch("src.lambdas.dashboard.auth._create_authenticated_user")
+    @patch("src.lambdas.dashboard.auth._update_cognito_sub")
+    @patch("src.lambdas.dashboard.auth._link_provider")
+    @patch("src.lambdas.dashboard.auth._mark_email_verified")
+    @patch("src.lambdas.dashboard.auth._advance_role")
+    @patch("src.lambdas.dashboard.auth.get_user_by_email_gsi")
+    @patch("src.lambdas.dashboard.auth.exchange_code_for_tokens")
+    @patch("src.lambdas.dashboard.auth.decode_id_token")
+    def test_new_user_linked_providers_includes_provider(
+        self,
+        mock_decode_id_token: MagicMock,
+        mock_exchange: MagicMock,
+        mock_get_user: MagicMock,
+        mock_advance_role: MagicMock,
+        mock_mark_verified: MagicMock,
+        mock_link_provider: MagicMock,
+        mock_update_sub: MagicMock,
+        mock_create_user: MagicMock,
+    ) -> None:
+        """New user gets provider added to linked_providers."""
+        table = MagicMock()
+        user = self._create_test_user()
+        mock_create_user.return_value = user
+        mock_get_user.return_value = None
+        mock_exchange.return_value = self._mock_tokens()
+        mock_decode_id_token.return_value = {
+            "email": "test@example.com",
+            "sub": "google-123",
+            "email_verified": True,
+        }
+
+        request = OAuthCallbackRequest(code="auth-code", provider="google")
+        response = handle_oauth_callback(table, request)
+
+        assert "google" in response.linked_providers
+
+    @patch("src.lambdas.dashboard.auth._create_authenticated_user")
+    @patch("src.lambdas.dashboard.auth._update_cognito_sub")
+    @patch("src.lambdas.dashboard.auth._link_provider")
+    @patch("src.lambdas.dashboard.auth._mark_email_verified")
+    @patch("src.lambdas.dashboard.auth._advance_role")
+    @patch("src.lambdas.dashboard.auth.get_user_by_email_gsi")
+    @patch("src.lambdas.dashboard.auth.exchange_code_for_tokens")
+    @patch("src.lambdas.dashboard.auth.decode_id_token")
+    def test_new_user_last_provider_used_set(
+        self,
+        mock_decode_id_token: MagicMock,
+        mock_exchange: MagicMock,
+        mock_get_user: MagicMock,
+        mock_advance_role: MagicMock,
+        mock_mark_verified: MagicMock,
+        mock_link_provider: MagicMock,
+        mock_update_sub: MagicMock,
+        mock_create_user: MagicMock,
+    ) -> None:
+        """New user gets last_provider_used set to the OAuth provider."""
+        table = MagicMock()
+        user = self._create_test_user()
+        mock_create_user.return_value = user
+        mock_get_user.return_value = None
+        mock_exchange.return_value = self._mock_tokens()
+        mock_decode_id_token.return_value = {
+            "email": "test@example.com",
+            "sub": "google-123",
+            "email_verified": True,
+        }
+
+        request = OAuthCallbackRequest(code="auth-code", provider="google")
+        response = handle_oauth_callback(table, request)
+
+        assert response.last_provider_used == "google"
+
+
+class TestOAuthCallbackFederationFieldsExistingUser:
+    """Test federation fields for existing OAuth users."""
+
+    def _create_existing_user(self) -> User:
+        """Create an existing user with google already linked."""
+        return User(
+            user_id=str(uuid.uuid4()),
+            email="test@example.com",
+            cognito_sub="cognito-123",
+            auth_type="google",
+            role="free",
+            verification="verified",
+            created_at=datetime.now(UTC),
+            last_active_at=datetime.now(UTC),
+            session_expires_at=datetime.now(UTC) + timedelta(days=30),
+            linked_providers=["google"],
+            provider_metadata={},
+        )
+
+    def _mock_tokens(self) -> CognitoTokens:
+        """Create mock Cognito tokens."""
+        return CognitoTokens(
+            id_token="mock-id-token",
+            access_token="mock-access-token",
+            refresh_token="mock-refresh-token",
+            expires_in=3600,
+        )
+
+    @patch("src.lambdas.dashboard.auth._link_provider")
+    @patch("src.lambdas.dashboard.auth._mark_email_verified")
+    @patch("src.lambdas.dashboard.auth._advance_role")
+    @patch("src.lambdas.dashboard.auth.get_user_by_email_gsi")
+    @patch("src.lambdas.dashboard.auth.exchange_code_for_tokens")
+    @patch("src.lambdas.dashboard.auth.decode_id_token")
+    def test_existing_user_role_preserved(
+        self,
+        mock_decode_id_token: MagicMock,
+        mock_exchange: MagicMock,
+        mock_get_user: MagicMock,
+        mock_advance_role: MagicMock,
+        mock_mark_verified: MagicMock,
+        mock_link_provider: MagicMock,
+    ) -> None:
+        """Existing free user keeps role=free."""
+        table = MagicMock()
+        user = self._create_existing_user()
+        mock_get_user.return_value = user
+        mock_exchange.return_value = self._mock_tokens()
+        mock_decode_id_token.return_value = {
+            "email": "test@example.com",
+            "sub": "google-123",
+            "email_verified": True,
+        }
+
+        request = OAuthCallbackRequest(code="auth-code", provider="google")
+        response = handle_oauth_callback(table, request)
+
+        assert response.role == "free"
+
+    @patch("src.lambdas.dashboard.auth._link_provider")
+    @patch("src.lambdas.dashboard.auth._mark_email_verified")
+    @patch("src.lambdas.dashboard.auth._advance_role")
+    @patch("src.lambdas.dashboard.auth.get_user_by_email_gsi")
+    @patch("src.lambdas.dashboard.auth.exchange_code_for_tokens")
+    @patch("src.lambdas.dashboard.auth.decode_id_token")
+    def test_existing_user_new_provider_triggers_conflict(
+        self,
+        mock_decode_id_token: MagicMock,
+        mock_exchange: MagicMock,
+        mock_get_user: MagicMock,
+        mock_advance_role: MagicMock,
+        mock_mark_verified: MagicMock,
+        mock_link_provider: MagicMock,
+    ) -> None:
+        """Existing user with different provider triggers conflict response.
+
+        When a Google user tries to authenticate with GitHub, it triggers a
+        conflict flow requiring user confirmation. Federation fields use defaults
+        in conflict responses.
+        """
+        table = MagicMock()
+        user = self._create_existing_user()  # Has google linked
+        mock_get_user.return_value = user
+        mock_exchange.return_value = self._mock_tokens()
+        mock_decode_id_token.return_value = {
+            "email": "test@example.com",
+            "sub": "github-123",
+            "email_verified": True,
+        }
+
+        request = OAuthCallbackRequest(code="auth-code", provider="github")
+        response = handle_oauth_callback(table, request)
+
+        # Conflict response uses defaults for federation fields
+        assert response.status == "conflict"
+        assert response.existing_provider == "google"
+        assert response.role == "anonymous"  # Default, not populated in conflict
+        assert response.linked_providers == []  # Default, not populated in conflict
+
+    @patch("src.lambdas.dashboard.auth._link_provider")
+    @patch("src.lambdas.dashboard.auth._mark_email_verified")
+    @patch("src.lambdas.dashboard.auth._advance_role")
+    @patch("src.lambdas.dashboard.auth.get_user_by_email_gsi")
+    @patch("src.lambdas.dashboard.auth.exchange_code_for_tokens")
+    @patch("src.lambdas.dashboard.auth.decode_id_token")
+    def test_existing_user_same_provider_no_duplicate(
+        self,
+        mock_decode_id_token: MagicMock,
+        mock_exchange: MagicMock,
+        mock_get_user: MagicMock,
+        mock_advance_role: MagicMock,
+        mock_mark_verified: MagicMock,
+        mock_link_provider: MagicMock,
+    ) -> None:
+        """Re-authenticating with same provider doesn't duplicate."""
+        table = MagicMock()
+        user = self._create_existing_user()  # Has google linked
+        mock_get_user.return_value = user
+        mock_exchange.return_value = self._mock_tokens()
+        mock_decode_id_token.return_value = {
+            "email": "test@example.com",
+            "sub": "google-123",
+            "email_verified": True,
+        }
+
+        request = OAuthCallbackRequest(code="auth-code", provider="google")
+        response = handle_oauth_callback(table, request)
+
+        assert response.linked_providers == ["google"]
+
+    @patch("src.lambdas.dashboard.auth._link_provider")
+    @patch("src.lambdas.dashboard.auth._mark_email_verified")
+    @patch("src.lambdas.dashboard.auth._advance_role")
+    @patch("src.lambdas.dashboard.auth.get_user_by_email_gsi")
+    @patch("src.lambdas.dashboard.auth.exchange_code_for_tokens")
+    @patch("src.lambdas.dashboard.auth.decode_id_token")
+    def test_last_provider_used_updated(
+        self,
+        mock_decode_id_token: MagicMock,
+        mock_exchange: MagicMock,
+        mock_get_user: MagicMock,
+        mock_advance_role: MagicMock,
+        mock_mark_verified: MagicMock,
+        mock_link_provider: MagicMock,
+    ) -> None:
+        """last_provider_used set to current OAuth provider on re-auth."""
+        table = MagicMock()
+        user = self._create_existing_user()  # Has google linked
+        mock_get_user.return_value = user
+        mock_exchange.return_value = self._mock_tokens()
+        mock_decode_id_token.return_value = {
+            "email": "test@example.com",
+            "sub": "google-123",  # Same provider for successful re-auth
+            "email_verified": True,
+        }
+
+        request = OAuthCallbackRequest(code="auth-code", provider="google")
+        response = handle_oauth_callback(table, request)
+
+        assert response.last_provider_used == "google"


### PR DESCRIPTION
## Summary
- Add `role`, `verification`, `linked_providers`, `last_provider_used` fields to `OAuthCallbackResponse`
- Populate federation fields in `handle_oauth_callback()` return value
- Compute federation state after mutations to avoid extra DB read

## Problem
Backend updates DynamoDB with federation data via `_link_provider()`, `_mark_email_verified()`, `_advance_role()` but the OAuth response didn't include these fields. Frontend received OAuth callback without knowing user's updated federation state.

## Solution
Add 4 optional federation fields to `OAuthCallbackResponse` model with defaults for backward compatibility. Compute expected federation state after mutations and include in successful OAuth responses.

## Test Plan
- [x] 12 new unit tests for federation response fields
- [x] All existing OAuth tests still pass
- [x] Pre-commit hooks pass

## Files Changed
- `src/lambdas/dashboard/auth.py` - Model + handler changes
- `tests/unit/dashboard/test_oauth_callback_federation.py` - New tests
- `specs/1176-oauth-callback-federation-response/` - Spec, plan, tasks

Refs: #1176

🤖 Generated with [Claude Code](https://claude.com/claude-code)