### PR TITLE
feat(1177): Wire frontend to consume OAuth federation fields

### DIFF
--- a/frontend/tests/unit/lib/api/auth.test.ts
+++ b/frontend/tests/unit/lib/api/auth.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { authApi } from '@/lib/api/auth';
+import { api } from '@/lib/api/client';
+
+// Mock the API client
+vi.mock('@/lib/api/client', () => ({
+  api: {
+    post: vi.fn(),
+    get: vi.fn(),
+  },
+}));
+
+describe('authApi', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe('exchangeOAuthCode', () => {
+    it('should map successful OAuth response with federation fields', async () => {
+      const mockBackendResponse = {
+        status: 'authenticated',
+        email_masked: 'j***@example.com',
+        auth_type: 'google',
+        tokens: {
+          id_token: 'mock-id-token',
+          access_token: 'mock-access-token',
+          expires_in: 3600,
+        },
+        merged_anonymous_data: false,
+        is_new_user: true,
+        conflict: false,
+        existing_provider: null,
+        message: null,
+        error: null,
+        // Feature 1176: Federation fields
+        role: 'free',
+        verification: 'verified',
+        linked_providers: ['google'],
+        last_provider_used: 'google',
+      };
+
+      vi.mocked(api.post).mockResolvedValue(mockBackendResponse);
+
+      const result = await authApi.exchangeOAuthCode('google', 'mock-code');
+
+      expect(api.post).toHaveBeenCalledWith('/api/v2/auth/oauth/callback', {
+        provider: 'google',
+        code: 'mock-code',
+      });
+
+      // Verify federation fields are mapped correctly
+      expect(result.user.role).toBe('free');
+      expect(result.user.verification).toBe('verified');
+      expect(result.user.linkedProviders).toEqual(['google']);
+      expect(result.user.lastProviderUsed).toBe('google');
+
+      // Verify other fields
+      expect(result.user.authType).toBe('google');
+      expect(result.user.email).toBe('j***@example.com');
+      expect(result.tokens.idToken).toBe('mock-id-token');
+      expect(result.tokens.accessToken).toBe('mock-access-token');
+      expect(result.tokens.expiresIn).toBe(3600);
+    });
+
+    it('should use default federation values when not provided', async () => {
+      const mockBackendResponse = {
+        status: 'authenticated',
+        email_masked: null,
+        auth_type: null,
+        tokens: {
+          id_token: 'mock-id-token',
+          access_token: 'mock-access-token',
+          expires_in: 3600,
+        },
+        merged_anonymous_data: false,
+        is_new_user: false,
+        conflict: false,
+        existing_provider: null,
+        message: null,
+        error: null,
+        // Minimal federation fields (using defaults)
+        role: 'anonymous',
+        verification: 'none',
+        linked_providers: [],
+        last_provider_used: null,
+      };
+
+      vi.mocked(api.post).mockResolvedValue(mockBackendResponse);
+
+      const result = await authApi.exchangeOAuthCode('github', 'mock-code');
+
+      expect(result.user.role).toBe('anonymous');
+      expect(result.user.verification).toBe('none');
+      expect(result.user.linkedProviders).toEqual([]);
+      expect(result.user.lastProviderUsed).toBeUndefined();
+      expect(result.user.authType).toBe('anonymous');
+    });
+
+    it('should throw error on OAuth error response', async () => {
+      const mockErrorResponse = {
+        status: 'error',
+        email_masked: null,
+        auth_type: null,
+        tokens: null,
+        merged_anonymous_data: false,
+        is_new_user: false,
+        conflict: false,
+        existing_provider: null,
+        message: null,
+        error: 'Invalid authorization code',
+        role: 'anonymous',
+        verification: 'none',
+        linked_providers: [],
+        last_provider_used: null,
+      };
+
+      vi.mocked(api.post).mockResolvedValue(mockErrorResponse);
+
+      await expect(authApi.exchangeOAuthCode('google', 'invalid-code')).rejects.toThrow(
+        'Invalid authorization code'
+      );
+    });
+
+    it('should throw error on OAuth conflict response', async () => {
+      const mockConflictResponse = {
+        status: 'conflict',
+        email_masked: 'j***@example.com',
+        auth_type: null,
+        tokens: null,
+        merged_anonymous_data: false,
+        is_new_user: false,
+        conflict: true,
+        existing_provider: 'google',
+        message: 'An account with this email exists via google',
+        error: null,
+        role: 'anonymous',
+        verification: 'none',
+        linked_providers: [],
+        last_provider_used: null,
+      };
+
+      vi.mocked(api.post).mockResolvedValue(mockConflictResponse);
+
+      await expect(authApi.exchangeOAuthCode('github', 'mock-code')).rejects.toThrow(
+        'An account with this email exists via google'
+      );
+    });
+
+    it('should map GitHub OAuth response correctly', async () => {
+      const mockBackendResponse = {
+        status: 'authenticated',
+        email_masked: 'u***@github.com',
+        auth_type: 'github',
+        tokens: {
+          id_token: 'github-id-token',
+          access_token: 'github-access-token',
+          expires_in: 7200,
+        },
+        merged_anonymous_data: true,
+        is_new_user: false,
+        conflict: false,
+        existing_provider: null,
+        message: null,
+        error: null,
+        role: 'free',
+        verification: 'verified',
+        linked_providers: ['google', 'github'],
+        last_provider_used: 'github',
+      };
+
+      vi.mocked(api.post).mockResolvedValue(mockBackendResponse);
+
+      const result = await authApi.exchangeOAuthCode('github', 'github-code');
+
+      expect(result.user.authType).toBe('github');
+      expect(result.user.linkedProviders).toEqual(['google', 'github']);
+      expect(result.user.lastProviderUsed).toBe('github');
+    });
+  });
+});

--- a/specs/1177-frontend-oauth-federation-wiring/checklists/requirements.md
+++ b/specs/1177-frontend-oauth-federation-wiring/checklists/requirements.md
@@ -1,0 +1,32 @@
+# Requirements Checklist: Frontend OAuth Federation Wiring
+
+**Feature**: 1177-frontend-oauth-federation-wiring
+**Date**: 2025-01-09
+
+## Functional Requirements
+
+| ID | Requirement | Status | Implementation |
+|----|-------------|--------|----------------|
+| FR-001 | Frontend MUST define `OAuthCallbackResponse` interface matching backend snake_case fields | DONE | `auth.ts:39-59` |
+| FR-002 | Frontend MUST map OAuth callback response to User type with federation fields | DONE | `auth.ts:85-127` |
+| FR-003 | `exchangeOAuthCode` MUST return properly typed response with federation fields | DONE | `auth.ts:190-193` |
+| FR-004 | Auth store MUST receive and store federation fields from OAuth response | DONE | Uses existing `setUser()` |
+| FR-005 | Frontend MUST handle missing federation fields gracefully (defaults) | DONE | Lines 108-111 with defaults |
+
+## Success Criteria
+
+| ID | Criterion | Status | Evidence |
+|----|-----------|--------|----------|
+| SC-001 | OAuth callback response federation fields mapped to User type | DONE | `mapOAuthCallbackResponse()` |
+| SC-002 | Auth store contains correct federation state after OAuth | DONE | `setUser(data.user)` in store |
+| SC-003 | Existing frontend tests still pass | DONE | 419/419 tests pass |
+| SC-004 | New unit tests verify federation field mapping | DONE | `auth.test.ts` (5 tests) |
+
+## Test Coverage
+
+- `frontend/tests/unit/lib/api/auth.test.ts`: 5 tests
+  - Successful OAuth response mapping with federation fields
+  - Default federation values when not provided
+  - Error response handling
+  - Conflict response handling
+  - GitHub OAuth response mapping

--- a/specs/1177-frontend-oauth-federation-wiring/plan.md
+++ b/specs/1177-frontend-oauth-federation-wiring/plan.md
@@ -1,0 +1,94 @@
+# Implementation Plan: Frontend OAuth Federation Wiring
+
+**Branch**: `1177-frontend-oauth-federation-wiring` | **Date**: 2025-01-09 | **Spec**: [spec.md](./spec.md)
+
+## Summary
+
+Add mapping from backend `OAuthCallbackResponse` (snake_case) to frontend `User` type (camelCase) so federation fields are properly extracted and stored in auth store after OAuth authentication.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x
+**Primary Dependencies**: React, Zustand (auth-store)
+**Testing**: Jest/Vitest
+**Project Type**: Next.js frontend
+
+## Implementation Approach
+
+### Step 1: Add Backend Response Interface
+
+Add `OAuthCallbackResponse` interface in `frontend/src/lib/api/auth.ts`:
+
+```typescript
+interface OAuthCallbackResponse {
+  status: string;
+  email_masked: string | null;
+  auth_type: string | null;
+  tokens: {
+    id_token: string;
+    access_token: string;
+    expires_in: number;
+  } | null;
+  merged_anonymous_data: boolean;
+  is_new_user: boolean;
+  conflict: boolean;
+  existing_provider: string | null;
+  message: string | null;
+  error: string | null;
+  // Feature 1176: Federation fields
+  role: string;
+  verification: string;
+  linked_providers: string[];
+  last_provider_used: string | null;
+}
+```
+
+### Step 2: Add Mapping Function
+
+Add `mapOAuthCallbackResponse()` function:
+
+```typescript
+function mapOAuthCallbackResponse(response: OAuthCallbackResponse): AuthResponse {
+  return {
+    user: {
+      userId: '', // Not provided in OAuth response
+      authType: (response.auth_type ?? 'anonymous') as User['authType'],
+      email: response.email_masked ?? undefined,
+      createdAt: new Date().toISOString(), // Not provided
+      configurationCount: 0, // Not provided
+      alertCount: 0, // Not provided
+      emailNotificationsEnabled: false, // Not provided
+      // Feature 1177: Federation fields
+      role: response.role as User['role'],
+      linkedProviders: response.linked_providers as User['linkedProviders'],
+      verification: response.verification as User['verification'],
+      lastProviderUsed: (response.last_provider_used ?? undefined) as User['lastProviderUsed'],
+    },
+    tokens: response.tokens ? {
+      idToken: response.tokens.id_token,
+      accessToken: response.tokens.access_token,
+      expiresIn: response.tokens.expires_in,
+    } : { idToken: '', accessToken: '', expiresIn: 0 },
+  };
+}
+```
+
+### Step 3: Update exchangeOAuthCode
+
+```typescript
+exchangeOAuthCode: async (provider: 'google' | 'github', code: string) => {
+  const response = await api.post<OAuthCallbackResponse>('/api/v2/auth/oauth/callback', { provider, code });
+  return mapOAuthCallbackResponse(response);
+},
+```
+
+### Step 4: Add Unit Tests
+
+Create tests in `frontend/tests/unit/lib/test-auth-api.ts` (or similar) to verify mapping.
+
+## Files to Modify
+
+| File | Changes |
+|------|---------|
+| `frontend/src/lib/api/auth.ts` | Add interface + mapping function + update exchangeOAuthCode |
+| `frontend/tests/unit/lib/test-auth-api.ts` | Add unit tests for mapping (new file if needed) |

--- a/specs/1177-frontend-oauth-federation-wiring/spec.md
+++ b/specs/1177-frontend-oauth-federation-wiring/spec.md
@@ -1,0 +1,84 @@
+# Feature Specification: Frontend OAuth Federation Wiring
+
+**Feature Branch**: `1177-frontend-oauth-federation-wiring`
+**Created**: 2025-01-09
+**Status**: Draft
+**Input**: Wire frontend to consume federation fields from OAuth callback response.
+**Depends On**: Feature 1176 (backend now returns federation fields in OAuthCallbackResponse)
+
+## User Scenarios & Testing
+
+### User Story 1 - Receive Federation State After OAuth (Priority: P1)
+
+After authenticating via OAuth, the frontend auth store receives and stores the user's role, verification status, linked providers, and last provider used. This enables RBAC-aware UI decisions.
+
+**Why this priority**: Core gap - backend now sends federation fields but frontend doesn't extract them.
+
+**Independent Test**: After OAuth callback, auth store contains correct `role`, `verification`, `linkedProviders`, `lastProviderUsed`.
+
+**Acceptance Scenarios**:
+
+1. **Given** anonymous user authenticating via Google, **When** OAuth callback completes, **Then** auth store has `role="free"`, `verification="verified"`, `linkedProviders=["google"]`, `lastProviderUsed="google"`
+
+2. **Given** existing user re-authenticating, **When** OAuth callback completes, **Then** auth store preserves existing role and adds provider to linkedProviders
+
+---
+
+### Edge Cases
+
+- What happens on conflict response? Frontend should handle `status="conflict"` gracefully without crashing.
+- What happens if federation fields are missing? Frontend should use defaults (backward compatibility).
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: Frontend MUST define `OAuthCallbackResponse` interface matching backend snake_case fields
+- **FR-002**: Frontend MUST map OAuth callback response to User type with federation fields
+- **FR-003**: `exchangeOAuthCode` MUST return properly typed response with federation fields
+- **FR-004**: Auth store MUST receive and store federation fields from OAuth response
+- **FR-005**: Frontend MUST handle missing federation fields gracefully (defaults)
+
+### Key Entities
+
+- **OAuthCallbackResponse**: Backend response type (snake_case)
+- **User**: Frontend user type (camelCase, includes federation fields from 1173)
+- **mapOAuthCallbackResponse**: New mapping function
+
+## Success Criteria
+
+- **SC-001**: OAuth callback response federation fields mapped to User type
+- **SC-002**: Auth store contains correct federation state after OAuth
+- **SC-003**: Existing frontend tests still pass
+- **SC-004**: New unit tests verify federation field mapping
+
+## Technical Context
+
+### Current State
+
+**Backend response** (`OAuthCallbackResponse` from auth.py):
+```python
+status: str
+email_masked: str | None
+auth_type: str | None
+tokens: dict | None
+role: str = "anonymous"  # Feature 1176
+verification: str = "none"  # Feature 1176
+linked_providers: list[str] = []  # Feature 1176
+last_provider_used: str | None  # Feature 1176
+```
+
+**Frontend expects** (`AuthResponse` from auth.ts):
+```typescript
+user: User;
+tokens: AuthTokens;
+```
+
+**Gap**: No mapping from backend snake_case OAuth response to frontend camelCase User type.
+
+### Required Changes
+
+1. Add `OAuthCallbackResponse` interface in `auth.ts`
+2. Add `mapOAuthCallbackResponse()` function
+3. Update `exchangeOAuthCode` to use the mapping
+4. Add unit tests for the mapping

--- a/specs/1177-frontend-oauth-federation-wiring/tasks.md
+++ b/specs/1177-frontend-oauth-federation-wiring/tasks.md
@@ -1,0 +1,47 @@
+# Tasks: Frontend OAuth Federation Wiring
+
+**Branch**: `1177-frontend-oauth-federation-wiring` | **Date**: 2025-01-09
+
+## Tasks
+
+### Task 1: Add OAuthCallbackResponse Interface
+- [x] Add `OAuthCallbackResponse` interface with all backend fields
+- [x] Include federation fields: role, verification, linked_providers, last_provider_used
+
+**File**: `frontend/src/lib/api/auth.ts` (lines 39-59)
+
+### Task 2: Add mapOAuthCallbackResponse Function
+- [x] Create mapping function from snake_case backend response to camelCase User type
+- [x] Handle null/undefined fields with sensible defaults
+- [x] Map tokens from snake_case to camelCase
+- [x] Handle error and conflict responses by throwing errors
+
+**File**: `frontend/src/lib/api/auth.ts` (lines 85-127)
+
+### Task 3: Update exchangeOAuthCode
+- [x] Change to async function with explicit return type
+- [x] Call `mapOAuthCallbackResponse()` to transform response
+- [x] Return `AuthResponse` with mapped User and tokens
+
+**File**: `frontend/src/lib/api/auth.ts` (lines 190-193)
+
+### Task 4: Add Unit Tests
+- [x] Test: mapOAuthCallbackResponse correctly maps all fields
+- [x] Test: Federation fields (role, verification, linkedProviders, lastProviderUsed) mapped
+- [x] Test: Default values used when fields are minimal
+- [x] Test: Error response throws error
+- [x] Test: Conflict response throws error
+
+**File**: `frontend/tests/unit/lib/api/auth.test.ts` (5 tests)
+
+## Verification
+
+```bash
+cd frontend
+npm run typecheck  # TypeScript passes
+npm run test       # 419/419 tests pass
+```
+
+## Status: COMPLETE
+
+All tasks completed. 5 new tests, 419/419 frontend tests passing.


### PR DESCRIPTION
## Summary
- Add `OAuthCallbackResponse` interface matching backend snake_case response
- Add `mapOAuthCallbackResponse()` mapping function with error handling
- Update `exchangeOAuthCode` to use the new mapping
- Add 5 unit tests for OAuth callback mapping

## Problem
Backend now returns federation fields (role, verification, linked_providers, last_provider_used) in OAuth callback response (Feature 1176), but frontend wasn't extracting them.

## Solution
Create proper type mapping from backend snake_case `OAuthCallbackResponse` to frontend camelCase `AuthResponse` with User federation fields.

## Test Plan
- [x] TypeScript compilation passes
- [x] 5 new unit tests for OAuth callback mapping
- [x] 419/419 frontend tests pass
- [x] Pre-commit hooks pass

## Files Changed
- `frontend/src/lib/api/auth.ts` - Interface, mapping function, updated API call
- `frontend/tests/unit/lib/api/auth.test.ts` - New unit tests
- `specs/1177-frontend-oauth-federation-wiring/` - Spec, plan, tasks

Depends on: #627 (1176)
Refs: #1177

🤖 Generated with [Claude Code](https://claude.com/claude-code)