### PR TITLE
feat(1183): Add OAuth-to-OAuth auto-link (Federation Flow 5)

### DIFF
--- a/specs/1183-oauth-to-oauth-link/plan.md
+++ b/specs/1183-oauth-to-oauth-link/plan.md
@@ -1,0 +1,46 @@
+# Implementation Plan: OAuth-to-OAuth Link (Flow 5)
+
+**Branch**: `1183-oauth-to-oauth-link` | **Date**: 2026-01-09 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/1183-oauth-to-oauth-link/spec.md`
+
+## Summary
+
+Implement Federation Flow 5: when an existing OAuth user authenticates with a different OAuth provider, auto-link both accounts. This extends the existing `handle_oauth_callback()` to detect existing OAuth users and link new providers automatically.
+
+## Technical Context
+
+**Language/Version**: Python 3.13
+**Primary Dependencies**: FastAPI 0.127.0, boto3 1.42.17, pydantic 2.12.5
+**Storage**: DynamoDB with provider_sub GSI for collision detection
+**Testing**: pytest 7.4.3+ with moto, 80% coverage requirement
+**Target Platform**: AWS Lambda with Mangum ASGI adapter
+**Project Type**: Web application (backend Lambda)
+**Performance Goals**: P90 ≤ 500ms for OAuth callback handling
+**Constraints**: Atomic operations for race condition prevention, GSI for O(1) lookups
+
+## Constitution Check
+
+| Gate | Status | Notes |
+|------|--------|-------|
+| Parameterized queries | ✅ PASS | DynamoDB uses ExpressionAttributeValues |
+| Secrets management | ✅ PASS | OAuth secrets in Secrets Manager |
+| TLS in transit | ✅ PASS | HTTPS enforced |
+| Unit tests required | ✅ PASS | Will add tests for auto-link logic |
+| No pipeline bypass | ✅ PASS | Standard PR workflow |
+
+## Project Structure
+
+### Source Code Changes
+
+```text
+src/lambdas/
+├── dashboard/
+│   └── auth.py          # Extend handle_oauth_callback() for Flow 5
+
+tests/
+├── unit/
+│   └── dashboard/
+│       └── test_oauth_to_oauth_link.py  # New test file for Flow 5
+```
+
+**Structure Decision**: Minimal change - extend existing handle_oauth_callback() function with Flow 5 detection logic.

--- a/specs/1183-oauth-to-oauth-link/spec.md
+++ b/specs/1183-oauth-to-oauth-link/spec.md
@@ -1,0 +1,98 @@
+# Feature Specification: OAuth-to-OAuth Link (Federation Flow 5)
+
+**Feature Branch**: `1183-oauth-to-oauth-link`
+**Created**: 2026-01-09
+**Status**: Draft
+**Input**: User description: "Feature 1183: OAuth-to-OAuth Link (Federation Flow 5). Auto-link when user with one OAuth provider tries another OAuth provider."
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 - OAuth User Links Second OAuth Provider (Priority: P1)
+
+A user authenticated via Google OAuth later signs in via GitHub OAuth. The system automatically links both accounts since both OAuth providers verify their emails.
+
+**Why this priority**: Core feature - enables seamless multi-provider authentication without friction.
+
+**Independent Test**: User with Google account signs in with GitHub, accounts auto-link.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user authenticated via Google OAuth, **When** they sign in via GitHub OAuth with the same verified email, **Then** both providers are linked to the same user account
+2. **Given** OAuth-to-OAuth auto-link succeeds, **When** the user views their account, **Then** both providers appear in linked_providers
+3. **Given** OAuth-to-OAuth auto-link succeeds, **When** the user logs out, **Then** they can sign in with either Google or GitHub
+
+---
+
+### User Story 2 - Prevent Duplicate OAuth Linking (Priority: P1)
+
+When a user tries to link an OAuth account (`provider:sub`) that already belongs to a different user, the system rejects the link to prevent account hijacking.
+
+**Why this priority**: Critical for security - prevents unauthorized access.
+
+**Independent Test**: Attempt to link OAuth sub already owned by different user, receive error.
+
+**Acceptance Scenarios**:
+
+1. **Given** OAuth sub "github:123" is linked to user A, **When** user B tries to authenticate with the same GitHub account, **Then** AUTH_023 error is returned
+2. **Given** AUTH_023 error occurs, **When** the user sees the error, **Then** they receive guidance on account recovery
+
+---
+
+### User Story 3 - Handle Unverified OAuth Email (Priority: P2)
+
+When an OAuth provider returns `email_verified=false`, the system does not auto-link and requires manual verification.
+
+**Why this priority**: Security boundary - prevents email spoofing attacks.
+
+**Independent Test**: OAuth with unverified email triggers prompt/rejection.
+
+**Acceptance Scenarios**:
+
+1. **Given** OAuth provider returns email_verified=false, **When** auto-link is attempted, **Then** AUTH_022 error is returned
+2. **Given** OAuth email is not verified, **When** the user sees the error, **Then** they are prompted to verify their email first
+
+---
+
+### Edge Cases
+
+- What happens when user has Google linked and tries GitHub with different email?
+  - Auto-link proceeds (OAuth-to-OAuth is trusted regardless of email domain)
+- What happens when OAuth sub is already linked to same user?
+  - Update last_provider_used, no error
+- What happens when OAuth provider doesn't return email at all?
+  - Still auto-link based on email_verified claim (email field is optional)
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+- **FR-001**: System MUST auto-link when existing OAuth user authenticates with different OAuth provider
+- **FR-002**: System MUST check provider_sub uniqueness before linking to prevent account hijacking
+- **FR-003**: System MUST reject auto-link with AUTH_023 if provider_sub belongs to different user
+- **FR-004**: System MUST reject auto-link with AUTH_022 if email_verified=false
+- **FR-005**: System MUST add new provider to linked_providers on successful auto-link
+- **FR-006**: System MUST create provider_metadata entry for new OAuth provider
+- **FR-007**: System MUST update last_provider_used to the newly linked provider
+- **FR-008**: System MUST log AUTH_METHOD_LINKED audit event with link_type="auto"
+
+### Key Entities
+
+- **User.linked_providers**: List updated to include new OAuth provider (e.g., ["google", "github"])
+- **User.provider_metadata**: Dict with metadata for each provider (sub, email, avatar, linked_at)
+- **User.last_provider_used**: Updated to most recently used provider
+- **provider_sub GSI**: Global secondary index for O(1) provider_sub collision detection
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**: OAuth-to-OAuth auto-link completes in under 500ms (P90)
+- **SC-002**: 100% of valid OAuth-to-OAuth links succeed without user intervention
+- **SC-003**: 0% of invalid provider_sub links succeed (collision prevention)
+- **SC-004**: All auto-link events are logged with full audit trail
+
+## Assumptions
+
+- OAuth providers (Google, GitHub) reliably return email_verified claim
+- provider_sub GSI exists and is indexed for efficient collision detection
+- Existing handle_oauth_callback() function can be extended for Flow 5 logic

--- a/specs/1183-oauth-to-oauth-link/tasks.md
+++ b/specs/1183-oauth-to-oauth-link/tasks.md
@@ -1,0 +1,22 @@
+# Tasks: OAuth-to-OAuth Link (Flow 5)
+
+**Input**: Design documents from `/specs/1183-oauth-to-oauth-link/`
+**Status**: Implementation complete
+
+## Phase 1: Implementation
+
+- [x] T001 Add Flow 5 OAuth-to-OAuth auto-link detection in handle_oauth_callback()
+- [x] T002 Add oauth_providers set for detecting OAuth auth types
+- [x] T003 Add logging for Flow 5 auto-link events
+
+## Phase 2: Testing
+
+- [x] T010 Unit test: Google user links GitHub auto
+- [x] T011 Unit test: GitHub user links Google auto
+- [x] T012 Unit test: Rejects unverified email (AUTH_022)
+- [x] T013 Unit test: Rejects duplicate provider_sub (AUTH_023)
+- [x] T014 Unit test: Logs Flow 5 auto-link event
+
+## Summary
+
+All tasks complete. 5 unit tests passing.

--- a/tests/unit/dashboard/test_oauth_to_oauth_link.py
+++ b/tests/unit/dashboard/test_oauth_to_oauth_link.py
@@ -1,0 +1,359 @@
+"""Unit tests for Flow 5: OAuth-to-OAuth Auto-Link.
+
+Tests for automatic linking when OAuth user authenticates with different OAuth provider.
+"""
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from freezegun import freeze_time
+
+from src.lambdas.dashboard.auth import (
+    OAuthCallbackRequest,
+    handle_oauth_callback,
+)
+from src.lambdas.shared.auth.cognito import CognitoTokens
+from src.lambdas.shared.models.user import ProviderMetadata, User
+
+
+@pytest.fixture
+def mock_table():
+    """Create a mock DynamoDB table."""
+    table = MagicMock()
+    table.meta = MagicMock()
+    table.meta.client = MagicMock()
+    table.meta.client.exceptions = MagicMock()
+    table.meta.client.exceptions.ConditionalCheckFailedException = Exception
+    return table
+
+
+@pytest.fixture
+def google_oauth_user():
+    """Create a test user authenticated via Google OAuth."""
+    now = datetime.now(UTC)
+    return User(
+        user_id=str(uuid4()),
+        email="user@gmail.com",
+        auth_type="google",
+        role="free",
+        verification="verified",
+        linked_providers=["google"],
+        provider_metadata={
+            "google": ProviderMetadata(
+                sub="google-123456",
+                email="user@gmail.com",
+                avatar=None,
+                linked_at=now,
+                verified_at=now,
+            )
+        },
+        pending_email=None,
+        primary_email="user@gmail.com",
+        created_at=now,
+        last_active_at=now,
+        session_expires_at=now + timedelta(days=30),
+    )
+
+
+@pytest.fixture
+def github_oauth_user():
+    """Create a test user authenticated via GitHub OAuth."""
+    now = datetime.now(UTC)
+    return User(
+        user_id=str(uuid4()),
+        email="user@github.com",
+        auth_type="github",
+        role="free",
+        verification="verified",
+        linked_providers=["github"],
+        provider_metadata={
+            "github": ProviderMetadata(
+                sub="github-789012",
+                email="user@github.com",
+                avatar=None,
+                linked_at=now,
+                verified_at=now,
+            )
+        },
+        pending_email=None,
+        primary_email="user@github.com",
+        created_at=now,
+        last_active_at=now,
+        session_expires_at=now + timedelta(days=30),
+    )
+
+
+class TestOAuthToOAuthAutoLink:
+    """Tests for Flow 5: OAuth-to-OAuth auto-linking."""
+
+    @freeze_time("2026-01-09 12:00:00")
+    def test_google_user_links_github_auto(self, mock_table, google_oauth_user):
+        """Google OAuth user logging in with GitHub auto-links without conflict."""
+        request = OAuthCallbackRequest(
+            provider="github",
+            code="github-auth-code",
+            state="test-state",
+        )
+
+        # Mock Cognito token exchange
+        github_claims = {
+            "sub": "github-new-sub-456",
+            "email": "user@gmail.com",
+            "email_verified": True,
+            "picture": "https://github.com/avatar.jpg",
+        }
+
+        # Mock existing user lookup by email
+        mock_table.query.return_value = {
+            "Items": [google_oauth_user.to_dynamodb_item()]
+        }
+        mock_table.get_item.return_value = {}  # No existing provider_sub
+        mock_table.update_item.return_value = {}
+        mock_table.put_item.return_value = {}
+
+        with patch(
+            "src.lambdas.dashboard.auth.exchange_code_for_tokens"
+        ) as mock_exchange:
+            mock_exchange.return_value = CognitoTokens(
+                id_token="mock-id-token",
+                access_token="mock-access-token",
+            )
+
+            with patch("src.lambdas.dashboard.auth.decode_id_token") as mock_decode:
+                mock_decode.return_value = github_claims
+
+                with patch(
+                    "src.lambdas.dashboard.auth.get_user_by_email_gsi"
+                ) as mock_get_user:
+                    mock_get_user.return_value = google_oauth_user
+
+                    with patch(
+                        "src.lambdas.dashboard.auth.get_user_by_provider_sub"
+                    ) as mock_get_by_sub:
+                        mock_get_by_sub.return_value = None  # No collision
+
+                        result = handle_oauth_callback(
+                            table=mock_table,
+                            request=request,
+                        )
+
+        # Should succeed, not return conflict
+        assert result.status == "authenticated"
+        assert result.conflict is not True
+
+    @freeze_time("2026-01-09 12:00:00")
+    def test_github_user_links_google_auto(self, mock_table, github_oauth_user):
+        """GitHub OAuth user logging in with Google auto-links without conflict."""
+        request = OAuthCallbackRequest(
+            provider="google",
+            code="google-auth-code",
+            state="test-state",
+        )
+
+        google_claims = {
+            "sub": "google-new-sub-789",
+            "email": "user@github.com",
+            "email_verified": True,
+            "picture": "https://google.com/avatar.jpg",
+        }
+
+        mock_table.query.return_value = {
+            "Items": [github_oauth_user.to_dynamodb_item()]
+        }
+        mock_table.get_item.return_value = {}
+        mock_table.update_item.return_value = {}
+        mock_table.put_item.return_value = {}
+
+        with patch(
+            "src.lambdas.dashboard.auth.exchange_code_for_tokens"
+        ) as mock_exchange:
+            mock_exchange.return_value = CognitoTokens(
+                id_token="mock-id-token",
+                access_token="mock-access-token",
+            )
+
+            with patch("src.lambdas.dashboard.auth.decode_id_token") as mock_decode:
+                mock_decode.return_value = google_claims
+
+                with patch(
+                    "src.lambdas.dashboard.auth.get_user_by_email_gsi"
+                ) as mock_get_user:
+                    mock_get_user.return_value = github_oauth_user
+
+                    with patch(
+                        "src.lambdas.dashboard.auth.get_user_by_provider_sub"
+                    ) as mock_get_by_sub:
+                        mock_get_by_sub.return_value = None
+
+                        result = handle_oauth_callback(
+                            table=mock_table,
+                            request=request,
+                        )
+
+        assert result.status == "authenticated"
+        assert result.conflict is not True
+
+    @freeze_time("2026-01-09 12:00:00")
+    def test_oauth_to_oauth_rejects_unverified_email(
+        self, mock_table, google_oauth_user
+    ):
+        """OAuth-to-OAuth link rejects if new provider's email is not verified."""
+        request = OAuthCallbackRequest(
+            provider="github",
+            code="github-auth-code",
+            state="test-state",
+        )
+
+        github_claims = {
+            "sub": "github-new-sub-456",
+            "email": "user@gmail.com",
+            "email_verified": False,  # NOT verified
+            "picture": None,
+        }
+
+        with patch(
+            "src.lambdas.dashboard.auth.exchange_code_for_tokens"
+        ) as mock_exchange:
+            mock_exchange.return_value = CognitoTokens(
+                id_token="mock-id-token",
+                access_token="mock-access-token",
+            )
+
+            with patch("src.lambdas.dashboard.auth.decode_id_token") as mock_decode:
+                mock_decode.return_value = github_claims
+
+                with patch(
+                    "src.lambdas.dashboard.auth.get_user_by_email_gsi"
+                ) as mock_get_user:
+                    mock_get_user.return_value = google_oauth_user
+
+                    with patch(
+                        "src.lambdas.dashboard.auth.get_user_by_provider_sub"
+                    ) as mock_get_by_sub:
+                        mock_get_by_sub.return_value = None
+
+                        result = handle_oauth_callback(
+                            table=mock_table,
+                            request=request,
+                        )
+
+        assert result.status == "error"
+        assert result.error == "AUTH_022"
+
+    @freeze_time("2026-01-09 12:00:00")
+    def test_oauth_to_oauth_rejects_duplicate_sub(self, mock_table, google_oauth_user):
+        """OAuth-to-OAuth link rejects if provider_sub already linked to different user."""
+        request = OAuthCallbackRequest(
+            provider="github",
+            code="github-auth-code",
+            state="test-state",
+        )
+
+        github_claims = {
+            "sub": "github-already-linked-sub",
+            "email": "user@gmail.com",
+            "email_verified": True,
+        }
+
+        # Different user already has this GitHub sub
+        different_user = User(
+            user_id=str(uuid4()),  # Different user ID
+            email="other@example.com",
+            auth_type="github",
+            role="free",
+            verification="verified",
+            linked_providers=["github"],
+            provider_metadata={},
+            pending_email=None,
+            primary_email="other@example.com",
+            created_at=datetime.now(UTC),
+            last_active_at=datetime.now(UTC),
+            session_expires_at=datetime.now(UTC) + timedelta(days=30),
+        )
+
+        with patch(
+            "src.lambdas.dashboard.auth.exchange_code_for_tokens"
+        ) as mock_exchange:
+            mock_exchange.return_value = CognitoTokens(
+                id_token="mock-id-token",
+                access_token="mock-access-token",
+            )
+
+            with patch("src.lambdas.dashboard.auth.decode_id_token") as mock_decode:
+                mock_decode.return_value = github_claims
+
+                with patch(
+                    "src.lambdas.dashboard.auth.get_user_by_email_gsi"
+                ) as mock_get_user:
+                    mock_get_user.return_value = google_oauth_user
+
+                    with patch(
+                        "src.lambdas.dashboard.auth.get_user_by_provider_sub"
+                    ) as mock_get_by_sub:
+                        mock_get_by_sub.return_value = different_user  # Collision!
+
+                        result = handle_oauth_callback(
+                            table=mock_table,
+                            request=request,
+                        )
+
+        assert result.status == "error"
+        assert result.error == "AUTH_023"
+
+    @freeze_time("2026-01-09 12:00:00")
+    def test_oauth_to_oauth_logs_auto_link_event(self, mock_table, google_oauth_user):
+        """OAuth-to-OAuth auto-link logs the appropriate audit event."""
+        request = OAuthCallbackRequest(
+            provider="github",
+            code="github-auth-code",
+            state="test-state",
+        )
+
+        github_claims = {
+            "sub": "github-new-sub-456",
+            "email": "user@gmail.com",
+            "email_verified": True,
+        }
+
+        mock_table.query.return_value = {
+            "Items": [google_oauth_user.to_dynamodb_item()]
+        }
+        mock_table.get_item.return_value = {}
+        mock_table.update_item.return_value = {}
+        mock_table.put_item.return_value = {}
+
+        with patch(
+            "src.lambdas.dashboard.auth.exchange_code_for_tokens"
+        ) as mock_exchange:
+            mock_exchange.return_value = CognitoTokens(
+                id_token="mock-id-token",
+                access_token="mock-access-token",
+            )
+
+            with patch("src.lambdas.dashboard.auth.decode_id_token") as mock_decode:
+                mock_decode.return_value = github_claims
+
+                with patch(
+                    "src.lambdas.dashboard.auth.get_user_by_email_gsi"
+                ) as mock_get_user:
+                    mock_get_user.return_value = google_oauth_user
+
+                    with patch(
+                        "src.lambdas.dashboard.auth.get_user_by_provider_sub"
+                    ) as mock_get_by_sub:
+                        mock_get_by_sub.return_value = None
+
+                        with patch("src.lambdas.dashboard.auth.logger") as mock_logger:
+                            handle_oauth_callback(
+                                table=mock_table,
+                                request=request,
+                            )
+
+                            # Check that Flow 5 auto-link was logged
+                            info_calls = list(mock_logger.info.call_args_list)
+                            flow5_logged = any(
+                                "Flow 5" in str(call) for call in info_calls
+                            )
+                            assert flow5_logged, "Flow 5 auto-link should be logged"


### PR DESCRIPTION
## Summary
- Implement Federation Flow 5: OAuth-to-OAuth auto-link
- When an existing OAuth user (Google/GitHub) authenticates with a different OAuth provider, automatically link both accounts
- Add oauth_providers set for detecting OAuth auth types
- Add Flow 5 auto-link detection in handle_oauth_callback()
- Add logging for Flow 5 auto-link events
- Update existing test to reflect Flow 5 behavior

## Test Plan
- [x] Unit test: Google user links GitHub auto (5 new tests)
- [x] Unit test: GitHub user links Google auto
- [x] Unit test: Rejects unverified email (AUTH_022)
- [x] Unit test: Rejects duplicate provider_sub (AUTH_023)
- [x] Unit test: Logs Flow 5 auto-link event
- [x] Updated federation test for Flow 5 behavior

Refs: #1183

🤖 Generated with [Claude Code](https://claude.com/claude-code)