### PR TITLE
fix(1201): Add stripe dependency to dashboard Lambda requirements

### DIFF
--- a/specs/1201-stripe-lambda-dependency/checklists/requirements.md
+++ b/specs/1201-stripe-lambda-dependency/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Add Stripe Dependency to Dashboard Lambda
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-01-12
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- This is a minimal dependency-addition spec
+- Single user story as this is a blocking infrastructure fix
+- Ready for `/speckit.plan` phase

--- a/specs/1201-stripe-lambda-dependency/plan.md
+++ b/specs/1201-stripe-lambda-dependency/plan.md
@@ -1,0 +1,67 @@
+# Implementation Plan: Add Stripe Dependency to Dashboard Lambda
+
+**Branch**: `1201-stripe-lambda-dependency` | **Date**: 2026-01-12 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/1201-stripe-lambda-dependency/spec.md`
+
+## Summary
+
+Add the `stripe` Python package to the Dashboard Lambda's requirements.txt to resolve the ModuleNotFoundError blocking production deployments.
+
+## Technical Context
+
+**Language/Version**: Python 3.13 (existing Lambda runtime)
+**Primary Dependencies**: stripe>=11.4.1,<12.0.0 (matches root requirements.txt)
+**Testing**: CI/CD smoke test (import verification)
+**Constraints**: Must not conflict with existing Lambda dependencies
+**Scale/Scope**: Single file change (1 line)
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Gate | Status | Notes |
+|------|--------|-------|
+| Secrets stored in managed service | N/A | No secrets involved - dependency only |
+| No secrets in source control | N/A | No secrets involved |
+| TLS in transit | N/A | No network changes |
+| Auth required for management | N/A | No auth changes |
+| Implementation accompaniment (tests) | PASS | CI smoke test verifies imports |
+| Pre-push requirements | PASS | Normal PR workflow |
+| No pipeline bypass | PASS | Normal PR workflow |
+
+**Post-Design Re-check**: All gates pass. No violations.
+
+## Project Structure
+
+```text
+src/lambdas/dashboard/
+├── requirements.txt          # UPDATE: Add stripe>=11.4.1,<12.0.0
+├── Dockerfile               # No change - already installs from requirements.txt
+└── ...
+
+specs/1201-stripe-lambda-dependency/
+├── spec.md                  # Feature specification
+├── plan.md                  # This file
+└── tasks.md                 # To be generated
+```
+
+## Implementation Phases
+
+### Phase 1: Add Dependency
+
+1. Update `src/lambdas/dashboard/requirements.txt`:
+   - Add `stripe>=11.4.1,<12.0.0` with comment referencing the issue
+
+**That's it.** No other changes required.
+
+## Risk Assessment
+
+| Risk | Mitigation |
+|------|------------|
+| Version conflict with other deps | Using same version as root requirements.txt (11.4.1) |
+| Lambda package size increase | Stripe SDK is ~1MB - well within Lambda limits |
+| CI smoke test format change | No change to smoke test - it already tests imports |
+
+## Deliverables
+
+1. Updated `src/lambdas/dashboard/requirements.txt` with stripe dependency

--- a/specs/1201-stripe-lambda-dependency/spec.md
+++ b/specs/1201-stripe-lambda-dependency/spec.md
@@ -1,0 +1,67 @@
+# Feature Specification: Add Stripe Dependency to Dashboard Lambda
+
+**Feature Branch**: `1201-stripe-lambda-dependency`
+**Created**: 2026-01-12
+**Status**: Draft
+**Input**: User description: "Add stripe dependency to dashboard Lambda requirements.txt - deploy is failing with ModuleNotFoundError: No module named stripe"
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 - Dashboard Lambda Deploys Successfully (Priority: P1)
+
+When changes are merged to main, the deployment pipeline should complete successfully. Currently, the Dashboard Lambda image build fails at the smoke test step because the `stripe` module is not available.
+
+**Why this priority**: This is blocking all production deployments. No code changes can reach production until this is resolved.
+
+**Independent Test**: Push any change to main → deployment pipeline completes with all jobs green → Dashboard Lambda is updated in production.
+
+**Acceptance Scenarios**:
+
+1. **Given** code is merged to main, **When** the deployment pipeline runs, **Then** the Dashboard Lambda image smoke test passes with no import errors
+2. **Given** the Dashboard Lambda is deployed, **When** auth endpoints are called that use Stripe functionality, **Then** Stripe-related code executes without ModuleNotFoundError
+
+---
+
+### Edge Cases
+
+- What happens if stripe version conflicts with other dependencies?
+  - Use version constraint compatible with existing dependencies in root requirements.txt
+- What happens if stripe SDK breaks in a future version?
+  - Pin to major version with upper bound (e.g., `>=11.4.1,<12.0.0`)
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+- **FR-001**: The Dashboard Lambda Docker image MUST include the `stripe` Python package
+- **FR-002**: The stripe version MUST be compatible with the version in root requirements.txt (11.4.1)
+- **FR-003**: The Dashboard Lambda MUST pass import smoke tests during CI/CD build
+
+### Key Entities
+
+- **Dashboard Lambda requirements.txt**: Located at `src/lambdas/dashboard/requirements.txt` - lists Python dependencies that are installed in the Lambda Docker image during build
+- **stripe_utils.py**: Shared auth module at `src/lambdas/shared/auth/stripe_utils.py` that imports stripe SDK for webhook verification and subscription handling
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**: Deployment pipeline completes successfully after this change is merged
+- **SC-002**: Dashboard Lambda smoke test step passes with exit code 0
+- **SC-003**: No ModuleNotFoundError for 'stripe' in Lambda execution logs
+
+## Assumptions
+
+- The stripe version 11.4.1 (from root requirements.txt) is compatible with the Lambda runtime (Python 3.13)
+- No other dependencies in the Dashboard Lambda conflict with stripe SDK
+- The stripe import is only used in the auth path, not during initial Lambda cold start
+
+## Scope Boundaries
+
+**In Scope:**
+- Adding stripe to `src/lambdas/dashboard/requirements.txt`
+
+**Out of Scope:**
+- Changes to stripe_utils.py functionality
+- Version upgrades to stripe beyond what's in root requirements.txt
+- Adding stripe to other Lambda requirements files (only Dashboard uses it)

--- a/specs/1201-stripe-lambda-dependency/tasks.md
+++ b/specs/1201-stripe-lambda-dependency/tasks.md
@@ -1,0 +1,23 @@
+# Tasks: Add Stripe Dependency to Dashboard Lambda
+
+**Feature**: 1201-stripe-lambda-dependency
+**Generated**: 2026-01-12
+**Total Tasks**: 1
+
+## Overview
+
+Single-task fix to add missing stripe dependency to Dashboard Lambda requirements.
+
+## Phase 1: Add Dependency
+
+**Goal**: Add stripe to Dashboard Lambda requirements.txt
+
+- [x] T001 Add `stripe>=11.4.1,<12.0.0` to `src/lambdas/dashboard/requirements.txt` with comment
+
+---
+
+## File Manifest
+
+| File | Task | Status |
+|------|------|--------|
+| `src/lambdas/dashboard/requirements.txt` | T001 | Update |

--- a/src/lambdas/dashboard/requirements.txt
+++ b/src/lambdas/dashboard/requirements.txt
@@ -31,3 +31,6 @@ tenacity>=9.0.0,<10.0.0
 
 # Server-Sent Events for real-time streaming (Feature 015)
 sse-starlette>=2.0.0,<3.0.0
+
+# Stripe SDK for payment webhooks and subscriptions (Feature 1191)
+stripe>=11.4.1,<12.0.0


### PR DESCRIPTION
## Summary
Fix blocking deployment failure - Dashboard Lambda smoke test failing with `ModuleNotFoundError: No module named 'stripe'`

## Root Cause
The `stripe_utils.py` module imports the stripe SDK, but the Dashboard Lambda's `requirements.txt` didn't include it. The root `requirements.txt` has stripe for local development, but Lambda installs from its own requirements file during Docker image build.

## Changes
- Add `stripe>=11.4.1,<12.0.0` to `src/lambdas/dashboard/requirements.txt`
- Feature specification in `specs/1201-stripe-lambda-dependency/`

## Test Plan
- [ ] CI smoke test passes (import verification)
- [ ] Deployment pipeline completes successfully
- [ ] No ModuleNotFoundError in Lambda logs

Refs: #1201

🤖 Generated with [Claude Code](https://claude.com/claude-code)