### PR TITLE
feat(1204): Remove CloudFront from tfvars

### DIFF
--- a/infrastructure/terraform/preprod.tfvars
+++ b/infrastructure/terraform/preprod.tfvars
@@ -19,10 +19,10 @@ tags = {
 # in the Terraform modules with environment-appropriate defaults.
 # DynamoDB uses on-demand billing (no reserved capacity).
 
-# CORS: Preprod allows the CloudFront dashboard domain, Amplify, GitHub Pages, and localhost for testing.
+# CORS: Preprod allows Amplify frontend, GitHub Pages, and localhost for testing.
 # No wildcard allowed per security policy.
+# Feature 1204: CloudFront URL removed - Amplify serves frontend directly
 cors_allowed_origins = [
-  "https://d2z9uvoj5xlbd2.cloudfront.net",      # CloudFront dashboard (legacy)
   "https://main.d29tlmksqcx494.amplifyapp.com", # AWS Amplify frontend (Feature 1105)
   "https://traylorre.github.io",                # GitHub Pages interview demo
   "http://localhost:3000",                      # Local development

--- a/infrastructure/terraform/prod.tfvars
+++ b/infrastructure/terraform/prod.tfvars
@@ -34,10 +34,11 @@ monthly_budget_limit = 100
 model_layer_arns = []
 
 # CORS: Production requires explicit origins - NO WILDCARDS
-# IMPORTANT: Set this to your CloudFront domain before deploying to production
-# The CloudFront domain is output after first deployment as cloudfront_domain_name
-# Example: ["https://d1234567890.cloudfront.net"]
-# You can also add custom domains: ["https://dashboard.example.com", "https://d1234567890.cloudfront.net"]
+# IMPORTANT: Set this to your Amplify domain before deploying to production
+# The Amplify domain is output after first deployment as amplify_production_url
+# Example: ["https://main.d1234567890.amplifyapp.com"]
+# You can also add custom domains: ["https://dashboard.example.com"]
+# Feature 1204: CloudFront removed - Amplify serves frontend directly
 cors_allowed_origins = []
 
 # Feature 1054: JWT Secret for auth middleware

--- a/specs/1204-remove-cloudfront-from-tfvars/spec.md
+++ b/specs/1204-remove-cloudfront-from-tfvars/spec.md
@@ -1,0 +1,32 @@
+# Feature Specification: Remove CloudFront from tfvars
+
+**Feature Branch**: `1204-remove-cloudfront-from-tfvars`
+**Created**: 2026-01-18
+**Status**: Complete
+**Input**: Part of CloudFront removal workplan (Feature 3 of 8)
+
+## Summary
+
+Remove CloudFront URLs from terraform.tfvars files and update CORS comments to reference Amplify instead of CloudFront.
+
+## Changes
+
+### preprod.tfvars
+- Remove `https://d2z9uvoj5xlbd2.cloudfront.net` from cors_allowed_origins
+- Update CORS comment to reference Amplify instead of CloudFront
+
+### prod.tfvars
+- Update CORS documentation comments to reference Amplify domain
+- Update example URLs to show Amplify format
+
+## Acceptance Criteria
+
+- [ ] No CloudFront URLs remain in cors_allowed_origins
+- [ ] Comments reference Amplify instead of CloudFront
+- [ ] Feature 1204 audit trail comments added
+
+## Out of Scope
+
+- Terraform module changes (Feature 1203)
+- Workflow changes (Feature 4)
+- Application code changes (Feature 5)


### PR DESCRIPTION
## Summary
- Remove CloudFront URL from preprod cors_allowed_origins
- Update CORS comments in preprod.tfvars and prod.tfvars to reference Amplify instead of CloudFront
- Part of CloudFront removal workplan (Feature 3 of 8)

## Test plan
- [ ] Verify preprod CORS only references Amplify and localhost origins
- [ ] Verify prod.tfvars comments correctly reference Amplify domain format

🤖 Generated with [Claude Code](https://claude.com/claude-code)