### PR TITLE
feat(1206): Remove CloudFront from application code

### DIFF
--- a/specs/1206-remove-cloudfront-from-app-code/spec.md
+++ b/specs/1206-remove-cloudfront-from-app-code/spec.md
@@ -1,0 +1,29 @@
+# Feature Specification: Remove CloudFront from Application Code
+
+**Feature Branch**: `1206-remove-cloudfront-from-app-code`
+**Created**: 2026-01-18
+**Status**: Complete
+**Input**: Part of CloudFront removal workplan (Feature 5 of 8)
+
+## Summary
+
+Remove CloudFront references from Python application code comments.
+
+## Changes
+
+### src/lambdas/shared/middleware/rate_limit.py
+- Update docstring: "API Gateway/CloudFront" -> "API Gateway/ALB"
+- Update comment: "from CloudFront/ALB" -> "from ALB/API Gateway"
+
+### src/lambdas/dashboard/router_v2.py
+- Update cookie comments (2 occurrences): "CloudFront -> Lambda" -> "Amplify -> Lambda"
+
+## Acceptance Criteria
+
+- [x] No CloudFront references remain in src/ directory
+- [x] Comments reference appropriate alternatives (Amplify, ALB, API Gateway)
+
+## Out of Scope
+
+- Test file changes (Feature 6)
+- Documentation/diagrams (Feature 7)

--- a/src/lambdas/dashboard/router_v2.py
+++ b/src/lambdas/dashboard/router_v2.py
@@ -501,7 +501,7 @@ async def verify_magic_link(
     response = JSONResponse(response_data)
 
     # Set refresh_token as HttpOnly, Secure cookie (NOT in response body)
-    # Feature 1159: SameSite=None for cross-origin cookie transmission (CloudFront → Lambda)
+    # Feature 1159: SameSite=None for cross-origin cookie transmission (Amplify → Lambda)
     if refresh_token:
         response.set_cookie(
             key="refresh_token",
@@ -572,7 +572,7 @@ async def handle_oauth_callback(
     response = JSONResponse(response_data)
 
     # Set refresh_token as HttpOnly, Secure cookie (NOT in response body)
-    # Feature 1159: SameSite=None for cross-origin cookie transmission (CloudFront → Lambda)
+    # Feature 1159: SameSite=None for cross-origin cookie transmission (Amplify → Lambda)
     if refresh_token:
         response.set_cookie(
             key="refresh_token",

--- a/src/lambdas/shared/middleware/rate_limit.py
+++ b/src/lambdas/shared/middleware/rate_limit.py
@@ -8,7 +8,7 @@ For On-Call Engineers:
     When rate limit is exceeded, 429 Too Many Requests is returned.
 
 Security Notes:
-    - IP address is extracted from X-Forwarded-For header (API Gateway/CloudFront)
+    - IP address is extracted from X-Forwarded-For header (API Gateway/ALB)
     - Rate limits are per-IP, per-action
     - Anonymous users have stricter limits than authenticated users
 """
@@ -94,7 +94,7 @@ def get_client_ip(event: dict[str, Any]) -> str:
     if "sourceIp" in request_context:
         return request_context["sourceIp"]
 
-    # X-Forwarded-For header (from CloudFront/ALB)
+    # X-Forwarded-For header (from ALB/API Gateway)
     headers = event.get("headers", {})
     forwarded_for = headers.get("x-forwarded-for") or headers.get("X-Forwarded-For")
     if forwarded_for:


### PR DESCRIPTION
## Summary
- Update rate_limit.py: Remove CloudFront from header extraction comments
- Update router_v2.py: Update cookie comments to reference Amplify
- Part of CloudFront removal workplan (Feature 5 of 8)

## Test plan
- [ ] Verify no CloudFront references remain in src/ directory
- [ ] Verify code comments reference appropriate alternatives

🤖 Generated with [Claude Code](https://claude.com/claude-code)