### PR TITLE
feat(1207): Remove CloudFront from tests and interview HTML

### DIFF
--- a/interview/FUTURE_IMPROVEMENTS.md
+++ b/interview/FUTURE_IMPROVEMENTS.md
@@ -89,12 +89,14 @@ with `if: false`. Pipeline completes after Preprod Integration Tests pass.
 
 ## Completed
 
-### CloudFront ONE URL (Feature 104)
-**Status**: Complete (PR #347)
-**Date**: 2025-12-12
+### CloudFront ONE URL (Feature 104) - SUPERSEDED
+**Status**: Superseded by Feature 1207
+**Date**: 2025-12-12 (Original), 2026-01-18 (Superseded)
 
-Updated "View Live Dashboard" link from Lambda Function URL to CloudFront ONE URL for proper routing to both Dashboard and SSE Lambdas.
+~~Updated "View Live Dashboard" link from Lambda Function URL to CloudFront ONE URL for proper routing to both Dashboard and SSE Lambdas.~~
+
+**Note**: Feature 1207 removed CloudFront entirely. Frontend now served by AWS Amplify.
 
 ---
 
-*Last updated: 2025-12-12*
+*Last updated: 2026-01-18*

--- a/interview/index.html
+++ b/interview/index.html
@@ -1660,7 +1660,7 @@ infrastructure/terraform/modules/<br>
 ├── secrets/   # Secrets Manager<br>
 ├── sns/       # Event fan-out<br>
 ├── cognito/   # User pools<br>
-├── cloudfront/ # CDN<br>
+├── amplify/   # Frontend hosting<br>
 └── eventbridge/ # Schedules
                         </code>
                     </div>
@@ -1712,7 +1712,7 @@ infrastructure/terraform/modules/<br>
                             <td style="padding: 12px; text-align: center;">✅</td>
                         </tr>
                         <tr>
-                            <td style="padding: 12px;">CloudFront CDN</td>
+                            <td style="padding: 12px;">Amplify Hosting</td>
                             <td style="padding: 12px; text-align: center;">❌</td>
                             <td style="padding: 12px; text-align: center;">✅</td>
                             <td style="padding: 12px; text-align: center;">✅</td>
@@ -1732,10 +1732,10 @@ infrastructure/terraform/modules/<br>
     <div id="toast" class="toast"></div>
 
     <script>
-        // Configuration - Use CloudFront "ONE URL" for proper routing to both
+        // Configuration - Feature 1207: Use Amplify URLs (CloudFront removed)
         // Dashboard Lambda (REST API) and SSE Lambda (streaming)
         const ENVIRONMENTS = {
-            preprod: 'https://d2z9uvoj5xlbd2.cloudfront.net',
+            preprod: 'https://main.d29tlmksqcx494.amplifyapp.com',
             prod: 'https://prod.sentiment-analyzer.example.com'  // Update when available
         };
 

--- a/specs/1207-remove-cloudfront-from-tests/spec.md
+++ b/specs/1207-remove-cloudfront-from-tests/spec.md
@@ -1,0 +1,49 @@
+# Feature Specification: Remove CloudFront from Tests
+
+**Feature Branch**: `1207-remove-cloudfront-from-tests`
+**Created**: 2026-01-18
+**Status**: Complete
+**Input**: Part of CloudFront removal workplan (Feature 6 of 8)
+
+## Summary
+
+Remove CloudFront references from test files and update interview HTML to use Amplify URLs.
+
+## Changes
+
+### tests/e2e/test_sse_connection_preprod.py
+- Update comment about Content-Type to remove CloudFront reference
+
+### tests/fixtures/validators/preprod_env_validator.py
+- Replace CloudFront URL pattern with Amplify pattern
+- Update comment to reference Amplify
+- Update error message to mention Amplify instead of CloudFront
+
+### tests/unit/fixtures/test_preprod_env_validator.py
+- Rename test_valid_cloudfront_url to test_valid_amplify_url
+- Update test to use Amplify URL pattern
+
+### tests/unit/interview/test_interview_html.py
+- Update test_preprod_url_defined to check for Amplify URL
+
+### tests/unit/dashboard/test_samesite_none.py
+- Update docstring to reference Amplify instead of CloudFront
+
+### interview/index.html
+- Update ENVIRONMENTS config to use Amplify URL
+- Update directory tree: cloudfront/ -> amplify/
+- Update Environment Parity table: CloudFront CDN -> Amplify Hosting
+
+### interview/FUTURE_IMPROVEMENTS.md
+- Mark CloudFront ONE URL feature as superseded by Feature 1207
+
+## Acceptance Criteria
+
+- [x] No functional CloudFront references in tests directory
+- [x] Interview HTML uses Amplify URL
+- [x] URL validator accepts Amplify URLs
+- [x] Test assertions check for Amplify patterns
+
+## Out of Scope
+
+- Architecture diagrams (Feature 7)

--- a/tests/e2e/test_sse_connection_preprod.py
+++ b/tests/e2e/test_sse_connection_preprod.py
@@ -143,8 +143,7 @@ class TestSSEConnectionHealth:
         Then: Content-Type contains 'event-stream' or 'stream'
 
         EventSource API requires text/event-stream for proper connection.
-        Note: Lambda Function URLs may return application/octet-stream,
-        but CloudFront should preserve the original Content-Type.
+        Note: Lambda Function URLs may return application/octet-stream initially.
         """
         timeout = INITIAL_TIMEOUT
         last_error = None

--- a/tests/fixtures/validators/preprod_env_validator.py
+++ b/tests/fixtures/validators/preprod_env_validator.py
@@ -69,9 +69,10 @@ class PreprodEnvValidator:
     # URL pattern for Lambda function URLs
     URL_PATTERN = re.compile(r"^https://[a-z0-9]+\.lambda-url\.[a-z0-9-]+\.on\.aws/?$")
 
-    # Alternative URL patterns (CloudFront, API Gateway)
+    # Alternative URL patterns (Amplify, API Gateway)
+    # Feature 1207: CloudFront removed - Amplify serves frontend directly
     ALT_URL_PATTERNS = [
-        re.compile(r"^https://[a-z0-9]+\.cloudfront\.net/?.*$"),
+        re.compile(r"^https://[a-z0-9.-]+\.amplifyapp\.com/?.*$"),  # Amplify
         re.compile(r"^https://[a-z0-9]+\.execute-api\.[a-z0-9-]+\.amazonaws\.com/?.*$"),
         re.compile(r"^https?://localhost(:\d+)?/?.*$"),  # Local dev
     ]
@@ -235,7 +236,7 @@ class PreprodEnvValidator:
                         var=var,
                         message=(
                             f"URL format may be invalid: {url}. "
-                            f"Expected Lambda Function URL, CloudFront, or API Gateway URL."
+                            f"Expected Lambda Function URL, Amplify, or API Gateway URL."
                         ),
                         value=url,
                         suggestion=(

--- a/tests/unit/dashboard/test_samesite_none.py
+++ b/tests/unit/dashboard/test_samesite_none.py
@@ -1,7 +1,7 @@
 """Unit tests for Feature 1159: SameSite=None cookie configuration.
 
 Verifies that auth cookies use SameSite=None for cross-origin transmission
-from CloudFront frontend to Lambda Function URL backend.
+from Amplify frontend to Lambda Function URL backend (Feature 1207: CloudFront removed).
 """
 
 from fastapi.responses import JSONResponse

--- a/tests/unit/fixtures/test_preprod_env_validator.py
+++ b/tests/unit/fixtures/test_preprod_env_validator.py
@@ -191,9 +191,9 @@ class TestURLValidation:
 
         assert len(errors) == 0
 
-    def test_valid_cloudfront_url(self, validator, clean_env):
-        """CloudFront URL should pass."""
-        os.environ["PREPROD_DASHBOARD_URL"] = "https://d1234567890.cloudfront.net/"
+    def test_valid_amplify_url(self, validator, clean_env):
+        """Amplify URL should pass (Feature 1207: CloudFront removed)."""
+        os.environ["PREPROD_DASHBOARD_URL"] = "https://main.d1234567890.amplifyapp.com/"
 
         errors = validator._validate_urls()
 

--- a/tests/unit/interview/test_interview_html.py
+++ b/tests/unit/interview/test_interview_html.py
@@ -163,11 +163,11 @@ class TestJavaScript:
         assert "const ENVIRONMENTS = {" in content
 
     def test_preprod_url_defined(self):
-        """Preprod URL should be defined with CloudFront ONE URL."""
+        """Preprod URL should be defined with Amplify URL (Feature 1207: CloudFront removed)."""
         content = get_html_content()
         assert "preprod:" in content
-        # Uses CloudFront "ONE URL" for proper routing to Dashboard and SSE Lambdas
-        assert "d2z9uvoj5xlbd2.cloudfront.net" in content
+        # Uses Amplify URL for frontend hosting
+        assert "amplifyapp.com" in content
 
     def test_required_functions_defined(self):
         """All required JavaScript functions should be defined."""


### PR DESCRIPTION
## Summary
- Update preprod_env_validator: Replace CloudFront URL pattern with Amplify
- Update test files: Test for Amplify URLs instead of CloudFront
- Update interview/index.html: Use Amplify URL, update UI to reflect new architecture
- Mark CloudFront ONE URL feature as superseded
- Part of CloudFront removal workplan (Feature 6 of 8)

## Test plan
- [ ] Verify tests pass with Amplify URL patterns
- [ ] Verify interview page loads with correct Amplify preprod URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)