### PR TITLE
docs(1209): Remove CloudFront references from documentation

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -17,7 +17,7 @@ CTRL+7,8,9 keyboard shortcuts navigate to wrong sections compared to hamburger m
 ONE URL dashboard shows "Disconnected" because SSE stream endpoint routes to wrong Lambda.
 - Dashboard Lambda has BUFFERED mode
 - SSE requires RESPONSE_STREAM mode
-- Need CloudFront routing fix or graceful fallback
+- ~~Need CloudFront routing fix or graceful fallback~~ *(Superseded: CloudFront removed in Feature 1203)*
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **SendGrid** - Email notifications for magic links and alerts
 - **AWS X-Ray** - Day 1 mandatory distributed tracing (all 4 Lambdas)
 - **CloudWatch RUM** - Client-side user behavior analytics
-- **CloudFront + S3** - CDN for dashboard static assets
+- **CloudFront + S3** - CDN for dashboard static assets *(Note: CloudFront removed in Feature 1203; now using AWS Amplify)*
 
 ### Migration Notes
 
@@ -64,7 +64,7 @@ Target: <$100/month with 50% headroom (~$50/month estimated)
 | Cognito | ~$5 |
 | Lambda (4 functions) | ~$10 |
 | DynamoDB | ~$15 |
-| CloudFront | ~$10 |
+| CloudFront | ~$10 | *(Removed in Feature 1203)*
 | S3 | ~$2 |
 | CloudWatch RUM | ~$5 |
 | X-Ray | ~$3 |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,9 +78,11 @@ Auto-generated from all feature plans. Last updated: 2025-11-26
 - DynamoDB (existing tables: Users, Sessions) (1191-mid-session-tier-upgrade)
 - Terraform 1.5+ with AWS Provider ~> 5.0 + AWS CloudFront, S3, IAM, CloudWatch RUM (1203-remove-cloudfront-module)
 - N/A (infrastructure deletion) (1203-remove-cloudfront-module)
+- Markdown, Mermaid (documentation syntax) + N/A (documentation-only, no code dependencies) (1209-remove-cloudfront-docs)
+- N/A (file-based documentation) (1209-remove-cloudfront-docs)
 
 - **Python 3.13** with FastAPI, boto3, pydantic, aws-lambda-powertools, httpx
-- **AWS Services**: DynamoDB (single-table design), S3, Lambda, SNS, EventBridge, Cognito, CloudFront
+- **AWS Services**: DynamoDB (single-table design), S3, Lambda, SNS, EventBridge, Cognito, Amplify
 - **External APIs**: Tiingo (primary), Finnhub (secondary) for financial news sentiment
 - **Email**: SendGrid (100/day free tier)
 - **Bot Protection**: hCaptcha
@@ -141,7 +143,7 @@ tests/
 └── e2e/                 # Full E2E with synthetic data
 infrastructure/
 └── terraform/
-    └── modules/         # Lambda, DynamoDB, Cognito, CloudFront, etc.
+    └── modules/         # Lambda, DynamoDB, Cognito, Amplify, etc.
 ```
 
 ## Commands
@@ -855,9 +857,9 @@ aws cloudwatch get-metric-data --metric-data-queries '[...]' --start-time ... --
 ```
 
 ## Recent Changes
+- 1209-remove-cloudfront-docs: Added Markdown, Mermaid (documentation syntax) + N/A (documentation-only, no code dependencies)
 - 1203-remove-cloudfront-module: Added Terraform 1.5+ with AWS Provider ~> 5.0 + AWS CloudFront, S3, IAM, CloudWatch RUM
 - 1191-mid-session-tier-upgrade: Added Python 3.13 (backend), TypeScript 5.x (frontend) + FastAPI, boto3 (DynamoDB), Zustand (state), BroadcastChannel API
-- 1190-security-headers-error-codes: Added Python 3.13 (backend), TypeScript/Next.js (frontend) + FastAPI (Response headers), Next.js middleware
 
 <!-- MANUAL ADDITIONS START -->
 

--- a/DEMO_URLS.local.md
+++ b/DEMO_URLS.local.md
@@ -87,7 +87,7 @@ curl -s "$API/api/v2/configurations/{CONFIG_ID}/sentiment" \
 
 - **Serverless**: AWS Lambda (Python 3.13)
 - **Database**: DynamoDB single-table design
-- **CDN**: CloudFront (d2z9uvoj5xlbd2.cloudfront.net)
+- **Frontend**: AWS Amplify (Next.js SSR)
 - **Auth**: Anonymous, Magic Link, OAuth (Google/GitHub)
 - **External APIs**: Tiingo, Finnhub
 - **CI/CD**: GitHub Actions with GPG-signed commits

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Ingests financial news from external sources (Tiingo, Finnhub) and returns senti
 
 ### Architecture
 
-- **Edge/CDN**: CloudFront with multi-origin routing (S3, API Gateway, SSE Lambda)
+- **Frontend**: AWS Amplify (Next.js SSR) with direct Lambda Function URL access
 - **Compute**: AWS Lambda (Python 3.13) - 5 functions (Ingestion, Analysis, Dashboard, SSE, Metrics)
 - **Real-time**: SSE Lambda with Lambda Web Adapter for RESPONSE_STREAM mode
 - **Orchestration**: EventBridge, SNS, SQS
@@ -173,9 +173,9 @@ Ingests financial news from external sources (Tiingo, Finnhub) and returns senti
 
 ✅ **Promotion pipeline** - Automated artifact promotion with validation gates
 
-✅ **Real-time streaming** - SSE Lambda with CloudFront multi-origin routing
+✅ **Real-time streaming** - SSE Lambda with Lambda Function URL (RESPONSE_STREAM mode)
 
-✅ **CDN-delivered UI** - Interview Dashboard served via CloudFront edge
+✅ **Amplify-hosted UI** - Interview Dashboard served via AWS Amplify (Next.js SSR)
 
 ---
 
@@ -205,9 +205,8 @@ graph TB
             Secrets[Secrets Manager<br/>API Keys + JWT Secret]
         end
 
-        subgraph EdgeLayer["Edge Layer"]
-            CF[CloudFront<br/>Multi-Origin CDN]
-            Amplify[Amplify<br/>Next.js SSR<br/>Optional]
+        subgraph EdgeLayer["Frontend Layer"]
+            Amplify[Amplify<br/>Next.js SSR]
         end
 
         subgraph IngestionLayer["Ingestion Layer"]
@@ -492,9 +491,8 @@ Post-Phase 0 security hardening with httpOnly cookies:
 ```mermaid
 sequenceDiagram
     participant Browser
-    participant Frontend as Next.js Frontend
-    participant CF as CloudFront
-    participant Dashboard as Dashboard Lambda
+    participant Frontend as Next.js Frontend<br/>(Amplify)
+    participant Dashboard as Dashboard Lambda<br/>(Function URL)
     participant Cognito as Cognito User Pool
     participant Users as sentiment-users
 
@@ -1012,7 +1010,6 @@ See [SECURITY.md](./SECURITY.md) for full security policy.
 | **Security Flow** | Trust zones and data sanitization | [security-flow.mmd](./docs/diagrams/security-flow.mmd) |
 | **Auth Use Cases** | Authentication flows (UC3) | [USE-CASE-DIAGRAMS.md](./docs/USE-CASE-DIAGRAMS.md#uc3-user-authentication-flow-v30) |
 | **SSE Streaming** | Real-time event streaming architecture | [sse-lambda-streaming.mmd](./docs/diagrams/sse-lambda-streaming.mmd) |
-| **CloudFront Routing** | Multi-origin CDN configuration | [cloudfront-multi-origin.mmd](./docs/diagrams/cloudfront-multi-origin.mmd) |
 
 ### Operations Documentation
 

--- a/docs/API_GATEWAY_GAP_ANALYSIS.md
+++ b/docs/API_GATEWAY_GAP_ANALYSIS.md
@@ -1,5 +1,7 @@
 # API Gateway Gap Analysis: Why We Actually Need It
 
+> **Note**: This document analyzes protection options including CloudFront. CloudFront is **not currently deployed** (removed in Feature 1203). The current architecture uses AWS Amplify for frontend hosting and Lambda Function URLs for API access. CloudFront references below are *proposed future enhancement options*.
+
 **Question**: Do we not already have IP-based blocking? Where is the gap?
 
 **Answer**: You have **PARTIAL** protection (SSE connections only), but **ZERO** protection against the #1 budget threat.
@@ -178,7 +180,7 @@ But wait! Per-IP rate limiting (100 req/5min):
 - Botnet becomes EXPENSIVE ($50-100/month for 30 residential IPs)
 - Makes attack economically UNVIABLE
 
-With WAF + CloudFront:
+With WAF + CloudFront (proposed option):
 - DDoS protection at edge (Shield Standard: FREE)
 - Geographic blocking (block countries you don't serve)
 - IP reputation lists (block known bad actors)
@@ -238,7 +240,7 @@ With WAF + CloudFront:
 - S3: ~$1
 - **API Gateway**: $3.50/million requests (~$0.10 for your traffic)
 - **WAF**: $5/month (1 web ACL) + $1/rule ($1 for rate limiting)
-- CloudFront: $1/month (caching + Shield)
+- CloudFront (optional): $1/month (caching + Shield)
 - **Total**: ~$19/month
 
 **Risk Costs** (10% probability with mitigations):
@@ -435,7 +437,7 @@ boto3==1.41.0        # AWS SDK
    - Your dashboard is **public** (external users)
 
 4. **Future-Proof**
-   - Enables CloudFront (DDoS protection)
+   - Enables CloudFront option (DDoS protection)
    - Enables WAF (advanced filtering)
    - Enables custom authorizers (JWT rotation)
    - Enables API versioning

--- a/docs/DASHBOARD_SECURITY_ANALYSIS.md
+++ b/docs/DASHBOARD_SECURITY_ANALYSIS.md
@@ -164,7 +164,7 @@ function_url_auth_type = "NONE"  # Anyone can invoke Lambda
 **Mitigation**:
 - Change to `auth_type = "AWS_IAM"`
 - Use API Gateway with custom authorizer (API key validation)
-- Implement CloudFront signed URLs for static content
+- (Future option) Implement CloudFront signed URLs for static content
 
 **Priority**: **CRITICAL** - Implement with P0-1 (API Gateway migration)
 
@@ -317,6 +317,8 @@ T+60s:  All dashboard functionality unavailable
 
 ## Recommended Architecture
 
+> **Note**: This diagram shows a *proposed future architecture*. CloudFront is **not currently deployed** (removed in Feature 1203). The current architecture uses AWS Amplify for frontend hosting and Lambda Function URLs for API access. The recommendations below are options for future security enhancements.
+
 ```mermaid
 %%{init: {'theme':'base', 'themeVariables': {'primaryColor':'#fff8e1', 'primaryTextColor':'#333', 'primaryBorderColor':'#c9a227', 'lineColor':'#555'}}}%%
 graph TB
@@ -367,7 +369,7 @@ graph TB
 
 ### Phase 3: High Priority (Deploy within 2 weeks)
 
-- [ ] Add CloudFront CDN for DDoS protection
+- [ ] (Optional) Add CloudFront CDN for DDoS protection (not currently deployed)
 - [ ] Implement AWS WAF with IP-based rate limiting
 - [ ] **P2-1**: Add request quotas per API key
 - [ ] Create incident response runbook for attacks

--- a/docs/PRODUCTION_PREFLIGHT_CHECKLIST.md
+++ b/docs/PRODUCTION_PREFLIGHT_CHECKLIST.md
@@ -54,7 +54,7 @@
   - Production: Restrict to specific domains
 - [ ] Dashboard handler CORS in `src/lambdas/dashboard/handler.py:109`
   - Current: `allow_origins=["*"]`
-  - Production: Restrict to CloudFront domain or specific origins
+  - Production: Restrict to Amplify domain or specific origins
 
 #### API Keys & Secrets
 - [ ] NewsAPI key is valid and has production quota

--- a/docs/USE-CASE-DIAGRAMS.md
+++ b/docs/USE-CASE-DIAGRAMS.md
@@ -223,7 +223,7 @@ sequenceDiagram
     autonumber
     actor User
     participant Browser
-    participant CF as CloudFront
+    participant Amplify as Amplify<br/>(Next.js SSR)
     participant API as API Gateway
     participant Auth as Auth Lambda
     participant DDB as DynamoDB
@@ -231,9 +231,9 @@ sequenceDiagram
     participant Cognito as Cognito
 
     User->>Browser: Visit dashboard URL
-    Browser->>CF: GET /
-    CF-->>Browser: SPA bundle (index.html)
-    Browser->>Browser: Initialize React app
+    Browser->>Amplify: GET /
+    Amplify-->>Browser: Next.js SSR page
+    Browser->>Browser: Hydrate React app
 
     Browser->>API: POST /api/v2/auth/anonymous
     API->>Auth: Invoke handler

--- a/docs/architecture.mmd
+++ b/docs/architecture.mmd
@@ -9,8 +9,8 @@ flowchart TB
         Schedule["Schedule Rule<br/>(5 min)"]
     end
 
-    subgraph CDN["CloudFront CDN"]
-        CF["CloudFront Distribution<br/>Multi-Origin Routing<br/>Forwards: Authorization, Cookies"]
+    subgraph AmplifyFE["Amplify Frontend"]
+        AmplifyApp["Amplify App<br/>Next.js SSR<br/>Auto-deploy from GitHub"]
     end
 
     subgraph APIGateway["API Gateway"]
@@ -53,13 +53,13 @@ flowchart TB
         Browser["Web Browser"]
     end
 
-    %% User Request Flow (via CloudFront → API Gateway)
-    Browser -->|HTTPS| CF
-    CF -->|"/static/*"| S3
-    CF -->|"/api/*"| APIGW
+    %% User Request Flow (via Amplify + Lambda Function URLs)
+    Browser -->|HTTPS| AmplifyApp
+    AmplifyApp -->|Static assets| S3
+    Browser -->|API calls| APIGW
     APIGW -->|"/api/v2/auth/*"| AuthLambda
     APIGW -->|"/api/v2/*"| Dashboard
-    CF -->|"/api/v2/stream*"| SSE
+    Browser -->|"/api/v2/stream*"| SSE
 
     %% Authentication Flow
     AuthLambda -->|OAuth redirect| Cognito

--- a/docs/diagrams/dataflow-all-flows.mmd
+++ b/docs/diagrams/dataflow-all-flows.mmd
@@ -16,9 +16,8 @@ flowchart TB
         SSEClient[SSE Client<br/>EventSource]
     end
 
-    subgraph Edge["Edge Layer"]
-        CF[CloudFront CDN]
-        Amplify[Amplify SSR]
+    subgraph Edge["Frontend Layer"]
+        Amplify[Amplify SSR<br/>Next.js]
     end
 
     subgraph Auth["Authentication Boundary"]
@@ -116,8 +115,7 @@ flowchart TB
     %% FLOW 3: DASHBOARD DATA RETRIEVAL (User-facing API)
     %% ═══════════════════════════════════════════════════════════════════════
 
-    UI ==>|HTTPS| CF
-    CF ==>|/api/*| Dashboard
+    UI ==>|HTTPS| Dashboard
     Dashboard -->|Validate JWT| Secrets
     Dashboard ==>|Query by_tag GSI| Items
     Dashboard -->|User configs| Users
@@ -128,8 +126,7 @@ flowchart TB
     %% FLOW 4: REAL-TIME SSE STREAMING (Live updates)
     %% ═══════════════════════════════════════════════════════════════════════
 
-    SSEClient ==>|EventSource| CF
-    CF ==>|/api/v2/stream*| SSE
+    SSEClient ==>|EventSource| SSE
     SSE -->|Validate session| Secrets
 
     SSE -->|"Poll every 5s"| Items
@@ -162,7 +159,7 @@ flowchart TB
 
     class Tiingo,Finnhub,SendGrid,OAuthProviders external
     class UI,AuthStore,SSEClient browser
-    class CF,Amplify edge
+    class Amplify edge
     class Cognito,Secrets auth
     class Ingestion,Analysis,Dashboard,SSE,Notification compute
     class SNS,DLQ,EB messaging

--- a/docs/diagrams/security-flow.mmd
+++ b/docs/diagrams/security-flow.mmd
@@ -1,6 +1,7 @@
 graph TB
-    subgraph Zone0[" ZONE 0: EDGE - CloudFront Security Boundary "]
-        CFront[CloudFront Distribution<br/>✓ DDoS protection<br/>✓ TLS 1.2+ only<br/>✓ Origin access control<br/>✓ Geographic restrictions<br/>✓ WAF integration ready]
+    subgraph Zone0[" ZONE 0: EDGE - Lambda Function URL + Amplify "]
+        Amplify[Amplify Frontend<br/>✓ Managed TLS<br/>✓ Next.js SSR<br/>✓ Global CDN]
+        LambdaURL[Lambda Function URL<br/>✓ IAM auth support<br/>✓ TLS 1.2+ only<br/>✓ CORS configured<br/>✓ 15-min timeout]
         BrowserReq[Browser Request<br/>⚠ XSS payloads<br/>⚠ CSRF attempts<br/>⚠ Token theft]
     end
 
@@ -44,11 +45,12 @@ graph TB
         S3Static[S3 Static Assets<br/>✓ OAC access only<br/>✓ No public access<br/>✓ Versioning enabled]
     end
 
-    %% CloudFront Edge Flow
-    BrowserReq -->|HTTPS only| CFront
-    CFront -->|/api/v2/stream*| SSEReq
-    CFront -->|/api/*| AdminReq
-    CFront -->|/static/*| S3Static
+    %% Edge Flow (Lambda Function URL + Amplify)
+    BrowserReq -->|HTTPS| Amplify
+    Amplify -->|Static assets| S3Static
+    BrowserReq -->|API calls| LambdaURL
+    LambdaURL -->|/api/v2/stream*| SSEReq
+    LambdaURL -->|/api/*| AdminReq
 
     %% Data Flow
     TwitterAPI -->|HTTP Response<br/>TAINTED| IngestT

--- a/docs/diagrams/sse-lambda-streaming.mmd
+++ b/docs/diagrams/sse-lambda-streaming.mmd
@@ -2,8 +2,7 @@
 sequenceDiagram
     autonumber
     participant Browser as Browser<br/>(EventSource API)
-    participant CF as CloudFront<br/>(Edge CDN)
-    participant LWA as Lambda Web Adapter<br/>(HTTP/1.1 ↔ Lambda)
+    participant LWA as Lambda Function URL<br/>(Lambda Web Adapter)
     participant Handler as FastAPI Handler<br/>(sse_streaming)
     participant Pool as Connection Manager<br/>(Max 100)
     participant DDB as DynamoDB<br/>(sentiment-items)
@@ -14,9 +13,7 @@ sequenceDiagram
     %% Connection Establishment
     rect rgb(232, 245, 233)
         Note right of Browser: Phase 1: Connection Setup
-        Browser->>+CF: GET /api/v2/stream<br/>Accept: text/event-stream
-        CF->>CF: Route via cache behavior<br/>TTL=0, no-cache
-        CF->>+LWA: Forward request<br/>Origin timeout: 60s
+        Browser->>+LWA: GET /api/v2/stream<br/>Accept: text/event-stream
         LWA->>LWA: Translate HTTP/1.1 → Lambda<br/>RESPONSE_STREAM invoke mode
         LWA->>+Handler: HTTP Request
         Handler->>+Pool: acquire_connection(user_id)
@@ -24,14 +21,12 @@ sequenceDiagram
         alt Connection Pool Full (100 max)
             Pool-->>Handler: ConnectionPoolExhausted
             Handler-->>LWA: 503 Service Unavailable<br/>Retry-After: 30
-            LWA-->>CF: 503 Response
-            CF-->>Browser: 503 + Retry-After header
+            LWA-->>Browser: 503 + Retry-After header
         else Connection Available
             Pool->>Pool: Create SSEConnection<br/>UUID, filters, timestamp
             Pool-->>Handler: connection_id
             Handler-->>LWA: 200 OK<br/>Content-Type: text/event-stream
-            LWA-->>CF: Begin streaming response
-            CF-->>Browser: Connection established
+            LWA-->>Browser: Connection established
         end
     end
 
@@ -45,8 +40,7 @@ sequenceDiagram
             alt New Items Found
                 Handler->>Handler: Format SSE event<br/>event: sentiment_update<br/>id: uuid<br/>data: JSON
                 Handler-->>LWA: yield event bytes
-                LWA-->>CF: Stream chunk
-                CF-->>Browser: SSE event
+                LWA-->>Browser: SSE event
                 Browser->>Browser: onmessage handler<br/>Update dashboard UI
             end
         end
@@ -54,9 +48,8 @@ sequenceDiagram
         loop Every 30 seconds (heartbeat)
             Handler->>Handler: Generate heartbeat<br/>event: heartbeat<br/>id: uuid<br/>data: {}
             Handler-->>LWA: yield heartbeat bytes
-            LWA-->>CF: Stream chunk
-            CF-->>Browser: Heartbeat event
-            Note over CF: Keeps CloudFront<br/>60s timeout alive
+            LWA-->>Browser: Heartbeat event
+            Note over LWA: Lambda Function URL<br/>supports 15min timeout
         end
 
         Handler->>+CW: PutMetricData<br/>ConnectionCount, Latency
@@ -67,12 +60,11 @@ sequenceDiagram
     rect rgb(255, 243, 224)
         Note right of Browser: Phase 3: Disconnect & Cleanup
         alt User Closes Tab
-            Browser-xCF: Connection closed
-            CF-xLWA: Connection closed
+            Browser-xLWA: Connection closed
             LWA-xHandler: Request cancelled
         else Network Error
-            CF-xLWA: Timeout after 60s
-            LWA-xHandler: Request terminated
+            LWA-xHandler: Timeout after 15min
+            Handler->>Handler: Connection terminated
         else Client Reconnect
             Browser->>Browser: EventSource auto-reconnect<br/>with Last-Event-ID
         end
@@ -83,7 +75,6 @@ sequenceDiagram
         Handler->>CW: PutMetricData<br/>ConnectionClosed
         deactivate Handler
         deactivate LWA
-        deactivate CF
     end
 
     Note over Browser,CW: Config-Specific Streams
@@ -91,8 +82,7 @@ sequenceDiagram
     %% Config Stream Variant
     rect rgb(243, 229, 245)
         Note right of Browser: Authenticated Config Stream
-        Browser->>CF: GET /api/v2/configurations/{id}/stream<br/>?user_token=xxx
-        CF->>LWA: Forward with query params
+        Browser->>LWA: GET /api/v2/configurations/{id}/stream<br/>?user_token=xxx
         LWA->>Handler: Request with auth
         Handler->>+DDB: GetItem config<br/>Validate user access
         DDB-->>-Handler: Config with ticker_filters

--- a/docs/runbooks/scaling.md
+++ b/docs/runbooks/scaling.md
@@ -10,7 +10,7 @@ The system uses AWS serverless architecture:
 |-----------|---------|--------------|------------------|
 | API | Lambda | Auto (concurrent) | 1000 concurrent |
 | Database | DynamoDB | On-demand | Auto |
-| CDN | CloudFront | Auto | Global |
+| Frontend | Amplify | Auto | Global |
 | Ingestion | Lambda + EventBridge | Scheduled | Every 15 min |
 
 ## Monitoring Dashboards
@@ -198,7 +198,7 @@ k6 run --env API_URL=$PREPROD_API_URL --env STAGE=stress tests/load/api-load-tes
 | Increase Lambda memory | +$$ | CPU-bound operations |
 | Provisioned concurrency | +$$$ | Cold start sensitive |
 | DynamoDB provisioned | -$ at scale | Predictable traffic |
-| CloudFront caching | -$ | Static content |
+| Amplify caching | -$ | Static content |
 | Reserved capacity | -30% | Long-term commitment |
 
 ## Contacts

--- a/specs/1209-remove-cloudfront-docs/checklists/requirements.md
+++ b/specs/1209-remove-cloudfront-docs/checklists/requirements.md
@@ -1,0 +1,38 @@
+# Specification Quality Checklist: Remove CloudFront References from Documentation
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-01-19
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation
+- Spec is ready for `/speckit.clarify` or `/speckit.plan`
+- 11 files identified for update, 16 functional requirements defined
+- Mermaid syntax validation explicitly required (FR-015)
+- Documentation link validation explicitly required (FR-016)

--- a/specs/1209-remove-cloudfront-docs/plan.md
+++ b/specs/1209-remove-cloudfront-docs/plan.md
@@ -1,0 +1,173 @@
+# Implementation Plan: Remove CloudFront References from Documentation
+
+**Branch**: `1209-remove-cloudfront-docs` | **Date**: 2026-01-19 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/1209-remove-cloudfront-docs/spec.md`
+
+## Summary
+
+Remove all references to CloudFront as an actively-deployed component from documentation files. CloudFront was removed in Features 1203-1207 and replaced by AWS Amplify for frontend hosting. Lambda Function URLs are now the direct API entry points. This is a documentation-only update affecting 11 files including README.md, architecture diagrams, operational runbooks, and security analysis documents.
+
+## Technical Context
+
+**Language/Version**: Markdown, Mermaid (documentation syntax)
+**Primary Dependencies**: N/A (documentation-only, no code dependencies)
+**Storage**: N/A (file-based documentation)
+**Testing**: Mermaid syntax validation (npx @mermaid-js/mermaid-cli), markdown link checking
+**Target Platform**: Documentation files (GitHub-rendered markdown)
+**Project Type**: Documentation update
+**Performance Goals**: N/A
+**Constraints**: All Mermaid diagrams must render valid syntax after modifications
+**Scale/Scope**: 11 documentation files, ~40 CloudFront references total
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Constitution Section | Applicable? | Status | Notes |
+|---------------------|-------------|--------|-------|
+| 1) Functional Requirements | No | N/A | Documentation-only change |
+| 2) Non-Functional Requirements | No | N/A | No service changes |
+| 3) Security & Access Control | No | N/A | No code changes |
+| 4) Data & Model Requirements | No | N/A | No data changes |
+| 5) Deployment Requirements | No | N/A | No infrastructure changes |
+| 6) Observability & Monitoring | No | N/A | No telemetry changes |
+| 7) Testing & Validation | Partial | PASS | Mermaid syntax validation required |
+| 8) Git Workflow & CI/CD Rules | Yes | PASS | GPG-signed commits, feature branch |
+| Design & Diagrams (Canva preferred) | Partial | PASS | Updating existing Mermaid diagrams |
+
+**Gate Status**: PASS - Documentation-only change with minimal constitution overlap.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/1209-remove-cloudfront-docs/
+├── spec.md              # Feature specification
+├── plan.md              # This file
+├── research.md          # Phase 0 output (diagram analysis)
+├── checklists/          # Validation checklists
+│   └── requirements.md  # Spec quality checklist
+└── tasks.md             # Phase 2 output (/speckit.tasks command)
+```
+
+### Target Files (repository root)
+
+```text
+# Files to Update (11 total)
+
+# Primary Documentation
+README.md                                    # 6 CloudFront references
+DEMO_URLS.local.md                          # 1 CloudFront URL reference
+
+# Architecture Diagrams (Mermaid)
+docs/diagrams/sse-lambda-streaming.mmd      # CloudFront participant
+docs/diagrams/security-flow.mmd            # ZONE 0 CloudFront boundary
+docs/diagrams/dataflow-all-flows.mmd       # CloudFront in Edge Layer
+docs/architecture.mmd                       # CloudFront CDN subgraph
+
+# Security Analysis (Clarifications needed)
+docs/DASHBOARD_SECURITY_ANALYSIS.md         # CloudFront recommendations
+docs/API_GATEWAY_GAP_ANALYSIS.md           # CloudFront cost options
+
+# Operational Documentation
+docs/runbooks/scaling.md                    # CloudFront in architecture table
+docs/PRODUCTION_PREFLIGHT_CHECKLIST.md     # CloudFront CORS reference
+
+# Use Case Diagrams
+docs/USE-CASE-DIAGRAMS.md                   # CloudFront in auth sequence
+```
+
+**Structure Decision**: Documentation-only update. No source code changes required.
+
+## Complexity Tracking
+
+No complexity violations - this is a straightforward documentation update.
+
+## Phase 0: Research Summary
+
+### R-001: Current Amplify Architecture
+
+**Decision**: Document frontend as "AWS Amplify (Next.js SSR)" serving directly to users.
+**Rationale**: Terraform confirms `module.amplify_frontend[0]` with `platform = "WEB_COMPUTE"` for SSR.
+**Alternatives Considered**: None - Amplify is the deployed solution.
+
+### R-002: Lambda Function URL Direct Access
+
+**Decision**: Document APIs as "Lambda Function URLs" without CDN layer.
+**Rationale**: Dashboard and SSE Lambda both expose Function URLs directly. No API Gateway or CloudFront in front.
+**Alternatives Considered**: None - this is the current deployed architecture.
+
+### R-003: Security Boundary Redesign
+
+**Decision**: Replace "ZONE 0: CloudFront" with "Edge: Lambda Function URL IAM + Amplify".
+**Rationale**: Lambda Function URLs have IAM auth_type, Amplify provides managed HTTPS. Security boundary is at Lambda/Amplify level.
+**Alternatives Considered**: Could mark as "No Edge CDN" but this is less descriptive.
+
+### R-004: SSE Streaming Timeout Handling
+
+**Decision**: Remove CloudFront 60s timeout references. Lambda Function URLs have 15-minute timeout by default.
+**Rationale**: Lambda Web Adapter handles RESPONSE_STREAM mode with longer timeouts than CloudFront supported.
+**Alternatives Considered**: None - CloudFront timeout workarounds are no longer needed.
+
+### R-005: Gap Analysis Documents Treatment
+
+**Decision**: Add "Note: CloudFront is not currently deployed" clarification; keep recommendations as future options.
+**Rationale**: Gap analysis documents are planning documents. Removing CloudFront options would reduce future flexibility.
+**Alternatives Considered**: Could remove CloudFront sections entirely, but this loses valuable cost analysis.
+
+## Phase 1: Design
+
+### Data Model
+
+N/A - Documentation-only change. No data entities affected.
+
+### Contracts
+
+N/A - No API contracts affected. This is documentation update only.
+
+### Diagram Update Strategy
+
+For each Mermaid diagram:
+
+1. **sse-lambda-streaming.mmd**: Remove `participant CF` and update flow to show Browser → Lambda Function URL directly
+2. **security-flow.mmd**: Replace ZONE 0 CloudFront subgraph with "Lambda Function URL Security" (IAM, CORS, HTTPS)
+3. **dataflow-all-flows.mmd**: Remove CF from Edge Layer, keep Amplify as frontend delivery
+4. **architecture.mmd**: Remove CloudFront CDN subgraph, update flows to show direct Lambda connections
+5. **USE-CASE-DIAGRAMS.md**: Update auth sequence to show Amplify serving SPA, then direct Lambda calls
+
+### Validation Requirements
+
+1. **Mermaid Syntax**: Run `npx @mermaid-js/mermaid-cli -i <file> -o /tmp/test.svg` for each .mmd file
+2. **Link Checking**: Verify no broken internal links after removing CloudFront routing diagram reference
+3. **Visual Review**: Render each diagram to confirm flows make logical sense
+
+## Quickstart
+
+### Prerequisites
+
+- Access to sentiment-analyzer-gsk repository
+- Mermaid CLI for validation: `npm install -g @mermaid-js/mermaid-cli`
+
+### Steps
+
+1. Update README.md architecture section (6 references)
+2. Update DEMO_URLS.local.md (1 reference)
+3. Update each Mermaid diagram (4 files)
+4. Add clarifications to security analysis docs (2 files)
+5. Update operational docs (2 files)
+6. Update USE-CASE-DIAGRAMS.md (1 file)
+7. Validate all Mermaid diagrams render correctly
+8. Verify no broken links
+
+### Validation
+
+```bash
+# Validate Mermaid syntax for all diagrams
+for f in docs/diagrams/*.mmd docs/architecture.mmd; do
+  npx @mermaid-js/mermaid-cli -i "$f" -o /tmp/$(basename "$f" .mmd).svg && echo "✓ $f" || echo "✗ $f"
+done
+
+# Check for remaining CloudFront-as-deployed references
+grep -rn "CloudFront" README.md docs/ --include="*.md" --include="*.mmd" | grep -v "proposed\|future\|option\|recommend"
+```

--- a/specs/1209-remove-cloudfront-docs/research.md
+++ b/specs/1209-remove-cloudfront-docs/research.md
@@ -1,0 +1,120 @@
+# Research: Remove CloudFront References from Documentation
+
+**Feature**: 1209-remove-cloudfront-docs
+**Date**: 2026-01-19
+
+## Context
+
+CloudFront was removed from the sentiment-analyzer-gsk infrastructure in Features 1203-1207. The frontend is now served by AWS Amplify and APIs are exposed via Lambda Function URLs directly. Documentation still references CloudFront as an active component, causing confusion.
+
+## Research Tasks
+
+### R-001: Current Amplify Architecture
+
+**Question**: What is the current frontend hosting architecture?
+
+**Finding**: AWS Amplify with Next.js SSR (Server-Side Rendering)
+
+**Evidence**:
+- `/infrastructure/terraform/main.tf` line 940-942: Comment confirms Next.js frontend via Amplify
+- `/infrastructure/terraform/modules/amplify/main.tf`: `platform = "WEB_COMPUTE"` for SSR support
+- Amplify connects to GitHub repo and auto-builds on push
+- Default domain: `main.d*.amplifyapp.com`
+
+**Decision**: Document frontend as "AWS Amplify (Next.js SSR)" serving directly to users.
+
+**Rationale**: Terraform confirms this is the deployed architecture. No CloudFront distribution exists.
+
+---
+
+### R-002: Lambda Function URL Direct Access
+
+**Question**: How are APIs exposed to the frontend?
+
+**Finding**: Lambda Function URLs without CDN or API Gateway
+
+**Evidence**:
+- `/infrastructure/terraform/main.tf` lines 408, 961: Lambda modules expose Function URLs
+- `module.dashboard_lambda.function_url` and `module.sse_streaming_lambda.function_url` passed to Amplify
+- No `aws_cloudfront_distribution` or `aws_apigateway_*` resources in Terraform
+- Feature 1203 explicitly removed CloudFront module
+
+**Decision**: Document APIs as "Lambda Function URLs" without CDN layer.
+
+**Rationale**: Direct Lambda access is the deployed pattern. This simplifies architecture but removes edge caching.
+
+---
+
+### R-003: Security Boundary Redesign
+
+**Question**: How should security diagrams represent the edge layer without CloudFront?
+
+**Finding**: Security boundary is now at Lambda Function URL and Amplify level
+
+**Evidence**:
+- Lambda Function URLs support IAM auth_type for authentication
+- Amplify provides managed HTTPS termination
+- No WAF, no geographic restrictions (CloudFront features that are gone)
+- CORS configuration is at Lambda level, not CloudFront
+
+**Decision**: Replace "ZONE 0: CloudFront" with "Edge: Lambda Function URL + Amplify".
+
+**Rationale**: The security boundary still exists but at a different layer. Lambda IAM auth provides request-level security, Amplify handles TLS.
+
+**Implications**:
+- DDoS protection is now AWS-managed at Lambda/Amplify level (not as configurable as CloudFront Shield)
+- No edge caching - all requests hit Lambda
+- CORS is enforced at Lambda, not edge
+
+---
+
+### R-004: SSE Streaming Timeout Handling
+
+**Question**: How do SSE streaming timeouts work without CloudFront?
+
+**Finding**: Lambda Function URLs have better timeout support than CloudFront
+
+**Evidence**:
+- CloudFront had 60-second origin timeout (required keepalive workarounds)
+- Lambda Function URLs support up to 15-minute timeout by default
+- Lambda Web Adapter handles RESPONSE_STREAM mode natively
+- Feature 1207 removed CloudFront timeout workaround code
+
+**Decision**: Remove CloudFront 60s timeout references. Document Lambda Function URL 15-minute default.
+
+**Rationale**: This is actually an improvement - longer streaming sessions without keepalive hacks.
+
+---
+
+### R-005: Gap Analysis Documents Treatment
+
+**Question**: Should CloudFront be removed from security/cost analysis docs?
+
+**Finding**: Keep as proposed future enhancement with clarification
+
+**Evidence**:
+- `docs/DASHBOARD_SECURITY_ANALYSIS.md` recommends CloudFront for DDoS protection
+- `docs/API_GATEWAY_GAP_ANALYSIS.md` includes CloudFront in cost analysis
+- These are planning documents, not architecture documentation
+- CloudFront could be re-added in future if needed
+
+**Decision**: Add "Note: CloudFront is not currently deployed" clarification; keep recommendations.
+
+**Rationale**: Gap analysis should show options available. Removing CloudFront entirely loses valuable cost/security analysis.
+
+**Implementation**:
+- Add note at top of CloudFront sections: "Note: CloudFront is not currently deployed (removed in Feature 1203). The following represents potential future enhancement options."
+
+---
+
+## Summary
+
+| Task | Decision | Impact |
+|------|----------|--------|
+| R-001 | Document Amplify as frontend | README, diagrams |
+| R-002 | Document Lambda Function URLs | README, diagrams |
+| R-003 | Replace ZONE 0 CloudFront | security-flow.mmd |
+| R-004 | Remove timeout workarounds | sse-lambda-streaming.mmd |
+| R-005 | Clarify gap analysis docs | 2 security docs |
+
+All research tasks complete. No NEEDS CLARIFICATION items remain.

--- a/specs/1209-remove-cloudfront-docs/spec.md
+++ b/specs/1209-remove-cloudfront-docs/spec.md
@@ -1,0 +1,119 @@
+# Feature Specification: Remove CloudFront References from Documentation
+
+**Feature Branch**: `1209-remove-cloudfront-docs`
+**Created**: 2026-01-19
+**Status**: Draft
+**Input**: User description: "Remove CloudFront references from remaining documentation files. CloudFront was removed in Features 1203-1207 and Amplify now serves frontend directly."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Developer Reads Accurate Architecture (Priority: P1)
+
+A developer new to the project reads the README and documentation to understand how the system works. They need accurate information about the current architecture to make informed decisions about code changes and troubleshooting.
+
+**Why this priority**: Inaccurate documentation leads to wasted time, incorrect assumptions, and potential production issues. README.md is the first thing developers see.
+
+**Independent Test**: Can be fully tested by reading README.md and verifying all architecture descriptions match the deployed infrastructure (Amplify frontend, Lambda Function URLs).
+
+**Acceptance Scenarios**:
+
+1. **Given** a developer opens README.md, **When** they read the Architecture section, **Then** they see Amplify described as the frontend hosting solution with no CloudFront references as active components.
+2. **Given** a developer views the architecture diagram in README.md, **When** they trace the request flow, **Then** the diagram shows requests going to Amplify and Lambda Function URLs (not through CloudFront).
+
+---
+
+### User Story 2 - Operations Engineer Uses Runbooks (Priority: P2)
+
+An operations engineer uses scaling runbooks and preflight checklists during incident response or deployment preparation. They need documentation that reflects actual infrastructure components.
+
+**Why this priority**: Inaccurate operational docs during an incident causes confusion and delays resolution. Incorrect component lists lead to troubleshooting non-existent services.
+
+**Independent Test**: Can be tested by following scaling runbook procedures and verifying all referenced components exist in the deployed infrastructure.
+
+**Acceptance Scenarios**:
+
+1. **Given** an ops engineer opens docs/runbooks/scaling.md, **When** they review the architecture table, **Then** they see Amplify listed for frontend hosting (not CloudFront as CDN).
+2. **Given** an ops engineer opens docs/PRODUCTION_PREFLIGHT_CHECKLIST.md, **When** they review CORS configuration items, **Then** instructions reference Amplify domain restrictions (not CloudFront domain).
+
+---
+
+### User Story 3 - Architect Reviews Security Diagrams (Priority: P2)
+
+An architect reviews security flow and dataflow diagrams to understand the current security boundaries and request routing. They need diagrams that accurately represent the deployed architecture.
+
+**Why this priority**: Security diagrams inform threat modeling and compliance audits. Incorrect boundaries lead to missed vulnerabilities or unnecessary controls.
+
+**Independent Test**: Can be tested by comparing diagram flows against actual AWS resource configurations.
+
+**Acceptance Scenarios**:
+
+1. **Given** an architect opens docs/diagrams/security-flow.mmd, **When** they review the Edge Layer, **Then** the diagram shows Lambda Function URLs and Amplify as entry points (not CloudFront as ZONE 0).
+2. **Given** an architect opens docs/diagrams/dataflow-all-flows.mmd, **When** they trace API request paths, **Then** flows show direct connections to Lambda Function URLs (not routing through CloudFront).
+
+---
+
+### User Story 4 - Security Analyst Reviews Gap Analysis (Priority: P3)
+
+A security analyst reviews gap analysis documents to understand current security posture and recommended improvements. They need clarity on what is currently deployed versus what is proposed for future enhancement.
+
+**Why this priority**: Confusion between current state and recommendations leads to incorrect risk assessments and misallocated security investment.
+
+**Independent Test**: Can be tested by verifying gap analysis documents clearly distinguish "current state" from "proposed enhancements."
+
+**Acceptance Scenarios**:
+
+1. **Given** an analyst reads docs/DASHBOARD_SECURITY_ANALYSIS.md, **When** they review CloudFront recommendations, **Then** the document clearly states CloudFront is a proposed future enhancement (not currently deployed).
+2. **Given** an analyst reads docs/API_GATEWAY_GAP_ANALYSIS.md, **When** they review cost comparisons including CloudFront, **Then** the document indicates these are options for consideration (not current architecture).
+
+---
+
+### Edge Cases
+
+- What happens when Mermaid diagram syntax is invalidated by removing nodes? Diagrams must render correctly after changes.
+- How does the system handle internal documentation links that reference removed CloudFront diagrams? All links must remain valid or be updated.
+- What happens to SSE streaming timeout documentation that references CloudFront-specific behavior? Must be updated to reflect Lambda Function URL timeout behavior.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: README.md MUST describe Amplify as the frontend hosting solution in the Architecture section.
+- **FR-002**: README.md architecture diagram MUST show Amplify in the Edge Layer without CloudFront as an active component.
+- **FR-003**: README.md Key Features section MUST remove references to CloudFront-delivered UI and CloudFront multi-origin routing.
+- **FR-004**: README.md auth flow diagram MUST remove CloudFront participant and show direct Amplify-to-Lambda flow.
+- **FR-005**: DEMO_URLS.local.md MUST replace CloudFront URL with Amplify URL in the Architecture Highlights section.
+- **FR-006**: docs/diagrams/sse-lambda-streaming.mmd MUST remove CloudFront participant and show browser connecting directly to Lambda Function URL.
+- **FR-007**: docs/diagrams/security-flow.mmd MUST remove ZONE 0 CloudFront boundary and show Lambda Function URL security controls as the edge layer.
+- **FR-008**: docs/diagrams/dataflow-all-flows.mmd MUST remove CloudFront from Edge Layer and show Amplify as the frontend delivery component.
+- **FR-009**: docs/architecture.mmd MUST remove CloudFront CDN subgraph and update request flows to show direct Lambda Function URL connections.
+- **FR-010**: docs/DASHBOARD_SECURITY_ANALYSIS.md MUST add clarification that CloudFront recommendations are proposed future enhancements, not current state.
+- **FR-011**: docs/API_GATEWAY_GAP_ANALYSIS.md MUST add clarification that CloudFront cost options are for consideration, not currently deployed.
+- **FR-012**: docs/runbooks/scaling.md MUST update architecture table to show Amplify for frontend delivery instead of CloudFront.
+- **FR-013**: docs/PRODUCTION_PREFLIGHT_CHECKLIST.md MUST update CORS configuration guidance to reference Amplify domain.
+- **FR-014**: docs/USE-CASE-DIAGRAMS.md MUST remove CloudFront participant from auth sequence diagram and show Amplify serving the SPA bundle.
+- **FR-015**: All Mermaid diagrams MUST render valid syntax after modifications.
+- **FR-016**: All internal documentation links MUST remain valid after changes.
+
+### Key Entities
+
+- **Documentation File**: A markdown or Mermaid file that describes system architecture or operational procedures.
+- **Architecture Diagram**: A Mermaid flowchart or sequence diagram representing system components and their interactions.
+- **Security Boundary**: A conceptual zone in security documentation representing a layer of defense.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Zero documentation files contain CloudFront as a currently-deployed active component (currently 11 files have such references).
+- **SC-002**: 100% of Mermaid diagrams render without syntax errors after modifications.
+- **SC-003**: Developer reading README.md can accurately describe the frontend hosting architecture within 2 minutes of reading.
+- **SC-004**: Zero broken internal documentation links after changes (validated by link checker).
+- **SC-005**: Security gap analysis documents clearly distinguish between "current state" and "proposed enhancements" for any CloudFront mentions.
+
+## Assumptions
+
+- Amplify URL format follows pattern: `main.d*.amplifyapp.com`
+- Lambda Function URLs are the primary API entry points (no API Gateway in front)
+- SSE streaming uses Lambda Web Adapter with response streaming (no CloudFront timeout workarounds needed)
+- The removal is documentation-only; no infrastructure code changes required
+- Existing audit trail comments ("Feature 1203: CloudFront removed") in code should be preserved

--- a/specs/1209-remove-cloudfront-docs/tasks.md
+++ b/specs/1209-remove-cloudfront-docs/tasks.md
@@ -1,0 +1,230 @@
+# Tasks: Remove CloudFront References from Documentation
+
+**Input**: Design documents from `/specs/1209-remove-cloudfront-docs/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md
+
+**Tests**: No test tasks included - this is documentation-only update. Validation is via Mermaid syntax checking and link verification.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3, US4)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+- All paths are relative to repository root `/home/zeebo/projects/sentiment-analyzer-gsk/`
+- Documentation files in `docs/` and root level
+- Mermaid diagrams in `docs/diagrams/` and `docs/`
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: No setup required - documentation-only change
+
+*No tasks in this phase - proceed directly to Phase 2*
+
+---
+
+## Phase 2: Foundational
+
+**Purpose**: No foundational tasks required - each user story can be completed independently
+
+*No tasks in this phase - proceed directly to User Stories*
+
+---
+
+## Phase 3: User Story 1 - Developer Reads Accurate Architecture (Priority: P1) 🎯 MVP
+
+**Goal**: Update README.md and DEMO_URLS.local.md so developers see accurate architecture (Amplify frontend, Lambda Function URLs)
+
+**Independent Test**: Read README.md and verify architecture descriptions show Amplify as frontend hosting with no CloudFront references as active components
+
+### Implementation for User Story 1
+
+- [x] T001 [P] [US1] Update Architecture section to describe Amplify as frontend hosting in README.md:151
+- [x] T002 [P] [US1] Update Key Features to remove CloudFront-delivered UI reference in README.md:176-178
+- [x] T003 [P] [US1] Update Edge Layer in architecture diagram to show Amplify without CloudFront in README.md:207-210
+- [x] T004 [P] [US1] Remove CloudFront participant from auth flow diagram in README.md:496
+- [x] T005 [P] [US1] Remove or update CloudFront Routing documentation reference in README.md:1015
+- [x] T006 [P] [US1] Replace CloudFront URL with Amplify URL in Architecture Highlights in DEMO_URLS.local.md:90
+
+**Checkpoint**: README.md and DEMO_URLS.local.md accurately describe Amplify architecture with no CloudFront as active component
+
+---
+
+## Phase 4: User Story 2 - Operations Engineer Uses Runbooks (Priority: P2)
+
+**Goal**: Update operational documentation so ops engineers have accurate component references during incidents
+
+**Independent Test**: Review scaling runbook and preflight checklist, verify all component references match deployed infrastructure
+
+### Implementation for User Story 2
+
+- [x] T007 [P] [US2] Update architecture table to show Amplify instead of CloudFront in docs/runbooks/scaling.md:13
+- [x] T008 [P] [US2] Update cost considerations table CloudFront reference in docs/runbooks/scaling.md:201
+- [x] T009 [P] [US2] Update CORS configuration guidance to reference Amplify domain in docs/PRODUCTION_PREFLIGHT_CHECKLIST.md:57
+
+**Checkpoint**: Operational docs reference Amplify and Lambda Function URLs, not CloudFront
+
+---
+
+## Phase 5: User Story 3 - Architect Reviews Security Diagrams (Priority: P2)
+
+**Goal**: Update all architecture and security diagrams to accurately show request flows without CloudFront
+
+**Independent Test**: Compare diagram flows against actual AWS resource configurations (Amplify, Lambda Function URLs)
+
+### Implementation for User Story 3
+
+- [x] T010 [P] [US3] Remove CloudFront participant and update SSE flow to show Browser → Lambda Function URL in docs/diagrams/sse-lambda-streaming.mmd:5,59
+- [x] T011 [P] [US3] Replace ZONE 0 CloudFront boundary with Lambda Function URL security controls in docs/diagrams/security-flow.mmd:2-3,47
+- [x] T012 [P] [US3] Remove CloudFront from Edge Layer, keep Amplify in docs/diagrams/dataflow-all-flows.mmd:20
+- [x] T013 [P] [US3] Remove CloudFront CDN subgraph and update request flows in docs/architecture.mmd:12-13,56
+- [x] T014 [P] [US3] Remove CloudFront participant from auth sequence and show Amplify serving SPA in docs/USE-CASE-DIAGRAMS.md:226
+
+**Checkpoint**: All diagrams show Amplify and Lambda Function URLs as entry points, no CloudFront in request flows
+
+---
+
+## Phase 6: User Story 4 - Security Analyst Reviews Gap Analysis (Priority: P3)
+
+**Goal**: Add clarifications to security analysis documents distinguishing current state from proposed enhancements
+
+**Independent Test**: Read gap analysis docs and verify CloudFront sections clearly state it is a proposed future enhancement, not current architecture
+
+### Implementation for User Story 4
+
+- [x] T015 [P] [US4] Add clarification note that CloudFront is proposed future enhancement in docs/DASHBOARD_SECURITY_ANALYSIS.md:167,323-341,370
+- [x] T016 [P] [US4] Add clarification note that CloudFront cost options are for consideration in docs/API_GATEWAY_GAP_ANALYSIS.md:181,241,438
+
+**Checkpoint**: Gap analysis documents clearly distinguish "current state" from "proposed enhancements" for CloudFront
+
+---
+
+## Phase 7: Polish & Validation
+
+**Purpose**: Validate all changes and ensure no broken links or invalid Mermaid syntax
+
+- [x] T017 [P] Validate Mermaid syntax for docs/diagrams/sse-lambda-streaming.mmd
+- [x] T018 [P] Validate Mermaid syntax for docs/diagrams/security-flow.mmd
+- [x] T019 [P] Validate Mermaid syntax for docs/diagrams/dataflow-all-flows.mmd
+- [x] T020 [P] Validate Mermaid syntax for docs/architecture.mmd
+- [x] T021 [P] Validate Mermaid syntax for embedded diagrams in README.md
+- [x] T022 [P] Validate Mermaid syntax for embedded diagrams in docs/USE-CASE-DIAGRAMS.md
+- [x] T023 Check for broken internal documentation links after changes
+- [x] T024 Final scan for remaining CloudFront-as-deployed references across all files
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: Skipped - no setup required
+- **Foundational (Phase 2)**: Skipped - no blocking prerequisites
+- **User Stories (Phase 3-6)**: All user stories are independent - can proceed in any order or parallel
+- **Polish (Phase 7)**: Depends on all user story phases being complete
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: No dependencies - can start immediately
+- **User Story 2 (P2)**: No dependencies - can start immediately, parallel with US1
+- **User Story 3 (P2)**: No dependencies - can start immediately, parallel with US1/US2
+- **User Story 4 (P3)**: No dependencies - can start immediately, parallel with others
+
+### Within Each User Story
+
+- All tasks within a user story are marked [P] (parallel) since they modify different files
+- Each task is atomic and can be completed independently
+
+### Parallel Opportunities
+
+- **Maximum Parallelization**: All tasks T001-T016 can run in parallel (all modify different files)
+- **Per-Story Parallelization**: All tasks within each user story can run in parallel
+- **Validation Phase**: All T017-T022 can run in parallel, then T023-T024 sequentially
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Launch all README.md and DEMO_URLS.local.md updates together:
+Task: "Update Architecture section in README.md:151"
+Task: "Update Key Features in README.md:176-178"
+Task: "Update Edge Layer diagram in README.md:207-210"
+Task: "Remove CloudFront from auth flow in README.md:496"
+Task: "Update CloudFront Routing reference in README.md:1015"
+Task: "Replace CloudFront URL in DEMO_URLS.local.md:90"
+```
+
+---
+
+## Parallel Example: User Story 3 (Diagrams)
+
+```bash
+# Launch all Mermaid diagram updates together:
+Task: "Update SSE flow diagram in docs/diagrams/sse-lambda-streaming.mmd"
+Task: "Update security flow diagram in docs/diagrams/security-flow.mmd"
+Task: "Update dataflow diagram in docs/diagrams/dataflow-all-flows.mmd"
+Task: "Update architecture diagram in docs/architecture.mmd"
+Task: "Update auth sequence in docs/USE-CASE-DIAGRAMS.md"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 3: User Story 1 (README.md + DEMO_URLS.local.md)
+2. **STOP and VALIDATE**: Verify README.md accurately describes Amplify architecture
+3. Deploy/demo if ready - developers can now see correct architecture
+
+### Incremental Delivery
+
+1. Add User Story 1 → Test independently → Primary docs accurate (MVP!)
+2. Add User Story 2 → Test independently → Ops docs accurate
+3. Add User Story 3 → Test independently → All diagrams accurate
+4. Add User Story 4 → Test independently → Gap analysis clarified
+5. Complete Phase 7 → All validation passes
+
+### Recommended Execution Order
+
+Given all tasks can run in parallel, recommended order for single-developer execution:
+
+1. **US1** (T001-T006): Highest impact - README is first thing developers see
+2. **US3** (T010-T014): Second highest impact - diagrams inform architecture understanding
+3. **US2** (T007-T009): Operational docs for incident response
+4. **US4** (T015-T016): Lowest priority - clarifications only
+5. **Validation** (T017-T024): Must be last
+
+---
+
+## Summary
+
+| Phase | User Story | Tasks | Files |
+|-------|------------|-------|-------|
+| 3 | US1 - Developer Reads Accurate Architecture | T001-T006 (6) | README.md, DEMO_URLS.local.md |
+| 4 | US2 - Operations Engineer Uses Runbooks | T007-T009 (3) | scaling.md, PRODUCTION_PREFLIGHT_CHECKLIST.md |
+| 5 | US3 - Architect Reviews Security Diagrams | T010-T014 (5) | 4 .mmd files + USE-CASE-DIAGRAMS.md |
+| 6 | US4 - Security Analyst Reviews Gap Analysis | T015-T016 (2) | DASHBOARD_SECURITY_ANALYSIS.md, API_GATEWAY_GAP_ANALYSIS.md |
+| 7 | Validation | T017-T024 (8) | All modified files |
+
+**Total Tasks**: 24
+**Parallel Opportunities**: 16/24 tasks can run fully parallel (T001-T016)
+**MVP Scope**: User Story 1 only (6 tasks)
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- Each user story is independently completable and testable
+- Commit after each task or logical group
+- Stop at any checkpoint to validate story independently
+- All Mermaid diagrams must render valid syntax after modifications


### PR DESCRIPTION
## Summary
- Update all documentation to reflect current architecture (Amplify + Lambda Function URLs)
- CloudFront was removed in Features 1203-1207; documentation still showed it as deployed
- Fix 14 files including README.md, Mermaid diagrams, and security analysis docs

## Changes
- **README.md**: Updated architecture section, diagrams, feature list (6 changes)
- **DEMO_URLS.local.md**: Changed CDN reference to Amplify frontend
- **docs/diagrams/*.mmd**: Updated all Mermaid diagrams to show Amplify flow
- **docs/DASHBOARD_SECURITY_ANALYSIS.md**: Added clarification notes (CF as future option)
- **docs/API_GATEWAY_GAP_ANALYSIS.md**: Marked CloudFront as proposed enhancement
- **docs/runbooks/scaling.md**: Updated architecture table
- **docs/USE-CASE-DIAGRAMS.md**: Updated auth sequence diagram
- **CLAUDE.md**: Updated AWS services list (Amplify replaces CloudFront)
- **CHANGELOG.md**: Added historical context note for Feature 006
- **BACKLOG.md**: Marked obsolete CloudFront issue as superseded

## Test plan
- [x] Validate Mermaid syntax for all modified diagrams
- [x] Check for broken internal documentation links
- [x] Final scan for remaining CloudFront-as-deployed references
- [ ] CI passes all checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)