### PR TITLE
feat(docs): Apply dark theme to mermaid diagrams for readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A cloud-hosted Sentiment Analyzer service built with serverless AWS architecture
 [![Deploy Pipeline](https://github.com/traylorre/sentiment-analyzer-gsk/actions/workflows/deploy.yml/badge.svg)](https://github.com/traylorre/sentiment-analyzer-gsk/actions/workflows/deploy.yml)
 
 ```mermaid
+%%{init: {"theme": "dark", "themeVariables": {"primaryColor": "#4A90A4", "tertiaryColor": "#2d2d2d", "lineColor": "#88CCFF", "primaryTextColor": "#FFFFFF", "clusterBkg": "#2d2d2d", "clusterBorder": "#555555"}, "flowchart": {"curve": "basis", "nodeSpacing": 50, "rankSpacing": 60}}}%%
 flowchart LR
     subgraph Build["Build Stage"]
         build["Build Lambda<br/>Packages"]
@@ -48,10 +49,10 @@ flowchart LR
     deploy_prod --> canary
     canary --> summary
 
-    classDef buildNode fill:#a8d5a2,stroke:#4a7c4e,stroke-width:2px
-    classDef imageNode fill:#b39ddb,stroke:#673ab7,stroke-width:2px
-    classDef preprodNode fill:#ffb74d,stroke:#c77800,stroke-width:2px
-    classDef prodNode fill:#ef5350,stroke:#b71c1c,stroke-width:2px,color:#fff
+    classDef buildNode fill:#3D5C3D,stroke:#4a7c4e,stroke-width:2px,color:#FFFFFF
+    classDef imageNode fill:#4A3D6B,stroke:#673ab7,stroke-width:2px,color:#FFFFFF
+    classDef preprodNode fill:#8B5A00,stroke:#c77800,stroke-width:2px,color:#FFFFFF
+    classDef prodNode fill:#6B2020,stroke:#b71c1c,stroke-width:2px,color:#FFFFFF
 
     class build,test buildNode
     class sse_img,analysis_img imageNode
@@ -188,6 +189,7 @@ Ingests financial news from external sources (Tiingo, Finnhub) and returns senti
 ### High-Level System Architecture
 
 ```mermaid
+%%{init: {"theme": "dark", "themeVariables": {"primaryColor": "#4A90A4", "tertiaryColor": "#2d2d2d", "lineColor": "#88CCFF", "primaryTextColor": "#FFFFFF", "clusterBkg": "#2d2d2d", "clusterBorder": "#555555"}, "flowchart": {"curve": "basis", "nodeSpacing": 50, "rankSpacing": 60}}}%%
 graph TB
     subgraph External["External Sources"]
         Tiingo[Tiingo API<br/>Financial News]
@@ -293,15 +295,15 @@ graph TB
     Dashboard -.->|Logs| CW
     SSELambda -.->|Logs| CW
 
-    %% Styles - preserved color scheme
-    classDef layerBox fill:#fff8e1,stroke:#c9a227,stroke-width:3px,color:#333
-    classDef lambdaStyle fill:#7ec8e3,stroke:#3a7ca5,stroke-width:3px,color:#1a3a4a
-    classDef storageStyle fill:#a8d5a2,stroke:#4a7c4e,stroke-width:3px,color:#1e3a1e
-    classDef messagingStyle fill:#b39ddb,stroke:#673ab7,stroke-width:3px,color:#1a0a3e
-    classDef monitoringStyle fill:#ffb74d,stroke:#c77800,stroke-width:3px,color:#4a2800
-    classDef externalStyle fill:#ef5350,stroke:#b71c1c,stroke-width:3px,color:#fff
-    classDef edgeStyle fill:#ffccbc,stroke:#ff5722,stroke-width:3px,color:#4a1a00
-    classDef authStyle fill:#e1bee7,stroke:#8e24aa,stroke-width:3px,color:#4a148c
+    %% Styles - Dark theme with white text
+    classDef layerBox fill:#2d2d2d,stroke:#555555,stroke-width:2px,color:#FFFFFF
+    classDef lambdaStyle fill:#2B5F7C,stroke:#4A90A4,stroke-width:2px,color:#FFFFFF
+    classDef storageStyle fill:#3D6B3D,stroke:#7ED321,stroke-width:2px,color:#FFFFFF
+    classDef messagingStyle fill:#4A3D6B,stroke:#673ab7,stroke-width:2px,color:#FFFFFF
+    classDef monitoringStyle fill:#8B5A00,stroke:#c77800,stroke-width:2px,color:#FFFFFF
+    classDef externalStyle fill:#6B2020,stroke:#b71c1c,stroke-width:2px,color:#FFFFFF
+    classDef edgeStyle fill:#8B4513,stroke:#ff5722,stroke-width:2px,color:#FFFFFF
+    classDef authStyle fill:#5C3D6B,stroke:#8e24aa,stroke-width:2px,color:#FFFFFF
 
     class External,AWS,AuthLayer,EdgeLayer,IngestionLayer,ProcessingLayer,APILayer,StorageLayer,MonitoringLayer,Users layerBox
     class Ingestion,Analysis,Dashboard,SSELambda,Metrics,Notification lambdaStyle
@@ -324,6 +326,7 @@ graph TB
 ### Environment Promotion Pipeline
 
 ```mermaid
+%%{init: {"theme": "dark", "themeVariables": {"primaryColor": "#4A90A4", "tertiaryColor": "#2d2d2d", "lineColor": "#88CCFF", "primaryTextColor": "#FFFFFF", "clusterBkg": "#2d2d2d", "clusterBorder": "#555555"}, "flowchart": {"curve": "basis", "nodeSpacing": 50, "rankSpacing": 60}}}%%
 graph LR
     subgraph Source["Source"]
         Code[Feature Branch]
@@ -358,11 +361,11 @@ graph LR
     ProdDeploy --> Canary
     Canary --> ProdMonitor
 
-    classDef sourceNode fill:#b39ddb,stroke:#673ab7,stroke-width:2px
-    classDef buildNode fill:#a8d5a2,stroke:#4a7c4e,stroke-width:2px
-    classDef preprodNode fill:#ffb74d,stroke:#c77800,stroke-width:2px
-    classDef prodNode fill:#ef5350,stroke:#b71c1c,stroke-width:2px,color:#fff
-    classDef gateStyle fill:#ffcc80,stroke:#e65100,stroke-width:2px
+    classDef sourceNode fill:#4A3D6B,stroke:#673ab7,stroke-width:2px,color:#FFFFFF
+    classDef buildNode fill:#3D5C3D,stroke:#4a7c4e,stroke-width:2px,color:#FFFFFF
+    classDef preprodNode fill:#8B5A00,stroke:#c77800,stroke-width:2px,color:#FFFFFF
+    classDef prodNode fill:#6B2020,stroke:#b71c1c,stroke-width:2px,color:#FFFFFF
+    classDef gateStyle fill:#8B4500,stroke:#e65100,stroke-width:2px,color:#FFFFFF
 
     class Code sourceNode
     class GHA,Artifact buildNode
@@ -374,6 +377,7 @@ graph LR
 ### Data Flow: Real-Time Sentiment Processing
 
 ```mermaid
+%%{init: {"theme": "dark", "themeVariables": {"primaryColor": "#4A90A4", "lineColor": "#88CCFF", "primaryTextColor": "#FFFFFF", "actorTextColor": "#FFFFFF", "actorBkg": "#2B5F7C", "actorBorder": "#4A90A4", "signalColor": "#88CCFF", "signalTextColor": "#FFFFFF", "noteBkgColor": "#3D3D3D", "noteTextColor": "#FFFFFF", "activationBkgColor": "#2d2d2d"}}}%%
 sequenceDiagram
     participant EB as EventBridge
     participant Ing as Ingestion Lambda
@@ -489,6 +493,7 @@ This service uses **4 DynamoDB tables** with single-table design patterns:
 Post-Phase 0 security hardening with httpOnly cookies:
 
 ```mermaid
+%%{init: {"theme": "dark", "themeVariables": {"primaryColor": "#4A90A4", "lineColor": "#88CCFF", "primaryTextColor": "#FFFFFF", "actorTextColor": "#FFFFFF", "actorBkg": "#2B5F7C", "actorBorder": "#4A90A4", "signalColor": "#88CCFF", "signalTextColor": "#FFFFFF", "noteBkgColor": "#3D3D3D", "noteTextColor": "#FFFFFF", "activationBkgColor": "#2d2d2d"}}}%%
 sequenceDiagram
     participant Browser
     participant Frontend as Next.js Frontend<br/>(Amplify)
@@ -496,7 +501,7 @@ sequenceDiagram
     participant Cognito as Cognito User Pool
     participant Users as sentiment-users
 
-    rect rgb(240, 248, 255)
+    rect rgb(30, 40, 60)
         Note over Browser,Users: Anonymous Session Flow
         Browser->>Frontend: Visit site (no auth)
         Frontend->>Dashboard: POST /api/v2/auth/anonymous
@@ -505,7 +510,7 @@ sequenceDiagram
         Note right of Frontend: Anonymous user can:<br/>• View public sentiment<br/>• Create 1 config<br/>• No alerts
     end
 
-    rect rgb(255, 248, 240)
+    rect rgb(60, 40, 30)
         Note over Browser,Users: OAuth Flow (Google/GitHub)
         Browser->>Cognito: Redirect to hosted UI
         Cognito->>Cognito: OAuth with provider
@@ -520,7 +525,7 @@ sequenceDiagram
         Note right of Frontend: Authenticated user can:<br/>• 2 configs (free) / 5+ (paid)<br/>• Alerts + digests<br/>• Full API access
     end
 
-    rect rgb(248, 255, 240)
+    rect rgb(30, 50, 30)
         Note over Browser,Users: Magic Link Flow
         Browser->>Frontend: Enter email
         Frontend->>Dashboard: POST /api/v2/auth/magic-link
@@ -537,7 +542,7 @@ sequenceDiagram
         end
     end
 
-    rect rgb(255, 240, 245)
+    rect rgb(50, 30, 35)
         Note over Browser,Users: Token Refresh (Silent)
         Frontend->>Dashboard: GET /api/v2/auth/refresh (cookie auto-sent)
         Dashboard->>Dashboard: Validate JWT (aud, nbf, exp)

--- a/docs/diagrams/TEMPLATE.md
+++ b/docs/diagrams/TEMPLATE.md
@@ -1,0 +1,117 @@
+# Mermaid Diagram Templates
+
+Standard dark theme templates for consistent diagram styling across the project.
+
+## Flowchart Template
+
+Use this for architecture diagrams, pipelines, and data flow diagrams.
+
+```mermaid
+%%{init: {"theme": "dark", "themeVariables": {"primaryColor": "#4A90A4", "secondaryColor": "#F5A623", "tertiaryColor": "#2d2d2d", "lineColor": "#88CCFF", "primaryTextColor": "#FFFFFF", "secondaryTextColor": "#FFFFFF", "tertiaryTextColor": "#FFFFFF", "nodeTextColor": "#FFFFFF", "edgeLabelBackground": "#333333", "clusterBkg": "#2d2d2d", "clusterBorder": "#555555"}, "flowchart": {"curve": "basis", "nodeSpacing": 60, "rankSpacing": 100}}}%%
+flowchart TB
+    subgraph Example["Example Subgraph"]
+        A["Node A"] --> B["Node B"]
+        B --> C["Node C"]
+    end
+
+    %% Standard classDef styles - Dark fills with white text
+    classDef external fill:#8B6914,stroke:#F5A623,stroke-width:2px,color:#FFFFFF
+    classDef lambda fill:#2B5F7C,stroke:#4A90A4,stroke-width:2px,color:#FFFFFF
+    classDef storage fill:#3D6B3D,stroke:#7ED321,stroke-width:2px,color:#FFFFFF
+    classDef messaging fill:#8B4513,stroke:#D0021B,stroke-width:2px,color:#FFFFFF
+    classDef monitoring fill:#4B3D6B,stroke:#9013FE,stroke-width:2px,color:#FFFFFF
+    classDef cdn fill:#6B3D5C,stroke:#E91E63,stroke-width:2px,color:#FFFFFF
+    classDef frontend fill:#2B6B6B,stroke:#00BCD4,stroke-width:2px,color:#FFFFFF
+    classDef auth fill:#8B3D3D,stroke:#FF5252,stroke-width:2px,color:#FFFFFF
+    classDef gateway fill:#3D3D6B,stroke:#3F51B5,stroke-width:2px,color:#FFFFFF
+
+    %% Pipeline-specific styles
+    classDef buildNode fill:#3D5C3D,stroke:#4a7c4e,stroke-width:2px,color:#FFFFFF
+    classDef imageNode fill:#4A3D6B,stroke:#673ab7,stroke-width:2px,color:#FFFFFF
+    classDef preprodNode fill:#8B5A00,stroke:#c77800,stroke-width:2px,color:#FFFFFF
+    classDef prodNode fill:#6B2020,stroke:#b71c1c,stroke-width:2px,color:#FFFFFF
+    classDef gateStyle fill:#8B4500,stroke:#e65100,stroke-width:2px,color:#FFFFFF
+
+    class A lambda
+    class B storage
+    class C external
+```
+
+## Sequence Diagram Template
+
+Use this for interaction flows, API sequences, and authentication flows.
+
+```mermaid
+%%{init: {"theme": "dark", "themeVariables": {"primaryColor": "#4A90A4", "lineColor": "#88CCFF", "primaryTextColor": "#FFFFFF", "actorTextColor": "#FFFFFF", "actorBkg": "#2B5F7C", "actorBorder": "#4A90A4", "signalColor": "#88CCFF", "signalTextColor": "#FFFFFF", "noteBkgColor": "#3D3D3D", "noteTextColor": "#FFFFFF", "activationBkgColor": "#2d2d2d"}}}%%
+sequenceDiagram
+    participant A as Service A
+    participant B as Service B
+    participant C as Database
+
+    rect rgb(30, 40, 60)
+        Note over A,C: Flow Section 1 (blue tint)
+        A->>B: Request
+        B->>C: Query
+        C-->>B: Response
+        B-->>A: Result
+    end
+
+    rect rgb(60, 40, 30)
+        Note over A,C: Flow Section 2 (orange tint)
+        A->>C: Direct query
+        C-->>A: Data
+    end
+
+    rect rgb(30, 50, 30)
+        Note over A,C: Flow Section 3 (green tint)
+        A->>B: Another request
+        B-->>A: Another response
+    end
+```
+
+## Color Reference
+
+### Node Fill Colors (Dark theme)
+
+| Purpose    | Fill Color | Stroke Color | Usage                    |
+| ---------- | ---------- | ------------ | ------------------------ |
+| External   | `#8B6914`  | `#F5A623`    | External APIs, services  |
+| Lambda     | `#2B5F7C`  | `#4A90A4`    | Lambda functions         |
+| Storage    | `#3D6B3D`  | `#7ED321`    | DynamoDB, S3, databases  |
+| Messaging  | `#8B4513`  | `#D0021B`    | SNS, SQS, queues         |
+| Monitoring | `#4B3D6B`  | `#9013FE`    | CloudWatch, alerts       |
+| CDN        | `#6B3D5C`  | `#E91E63`    | CloudFront, edge         |
+| Frontend   | `#2B6B6B`  | `#00BCD4`    | S3 static, Amplify       |
+| Auth       | `#8B3D3D`  | `#FF5252`    | Cognito, auth services   |
+| Gateway    | `#3D3D6B`  | `#3F51B5`    | API Gateway, load balancer|
+
+### Rect Colors for Sequence Diagrams
+
+| Tint   | RGB Value         | Usage              |
+| ------ | ----------------- | ------------------ |
+| Blue   | `rgb(30, 40, 60)` | Primary flows      |
+| Orange | `rgb(60, 40, 30)` | OAuth/auth flows   |
+| Green  | `rgb(30, 50, 30)` | Success/data flows |
+| Red    | `rgb(50, 30, 35)` | Error/refresh flows|
+
+## mermaid.live URLs
+
+To view diagrams in mermaid.live with full pan/zoom, the URL must be encoded. Use this Python snippet:
+
+```python
+import zlib
+import base64
+import json
+
+def generate_mermaid_url(diagram_code: str) -> str:
+    payload = {
+        "code": diagram_code,
+        "mermaid": {"theme": "dark"},
+        "autoSync": True,
+        "updateDiagram": True
+    }
+    json_str = json.dumps(payload)
+    compressed = zlib.compress(json_str.encode('utf-8'), 9)
+    encoded = base64.urlsafe_b64encode(compressed).decode('utf-8').rstrip('=')
+    return f"https://mermaid.live/view#pako:{encoded}"
+```

--- a/docs/diagrams/architecture.mmd
+++ b/docs/diagrams/architecture.mmd
@@ -1,4 +1,4 @@
-%%{init: {'theme': 'base', 'themeVariables': { 'primaryColor': '#4A90A4', 'secondaryColor': '#F5A623', 'tertiaryColor': '#7ED321'}}}%%
+%%{init: {"theme": "dark", "themeVariables": {"primaryColor": "#4A90A4", "secondaryColor": "#F5A623", "tertiaryColor": "#2d2d2d", "lineColor": "#88CCFF", "primaryTextColor": "#FFFFFF", "secondaryTextColor": "#FFFFFF", "tertiaryTextColor": "#FFFFFF", "nodeTextColor": "#FFFFFF", "edgeLabelBackground": "#333333", "clusterBkg": "#2d2d2d", "clusterBorder": "#555555"}, "flowchart": {"curve": "basis", "nodeSpacing": 60, "rankSpacing": 100}}}%%
 flowchart TB
     subgraph External["External Services"]
         NewsAPI["NewsAPI<br/>News Articles"]
@@ -100,16 +100,16 @@ flowchart TB
     SSE -->|Logs| CloudWatch
     CloudWatch -->|Triggers| Alarms
 
-    %% Styling
-    classDef external fill:#FFE4B5,stroke:#F5A623,stroke-width:2px
-    classDef lambda fill:#D4E8F2,stroke:#4A90A4,stroke-width:2px
-    classDef storage fill:#D4F2D4,stroke:#7ED321,stroke-width:2px
-    classDef messaging fill:#F2E4D4,stroke:#D0021B,stroke-width:2px
-    classDef monitoring fill:#E8E4F2,stroke:#9013FE,stroke-width:2px
-    classDef cdn fill:#F2D4E8,stroke:#E91E63,stroke-width:2px
-    classDef frontend fill:#D4F2F2,stroke:#00BCD4,stroke-width:2px
-    classDef auth fill:#FFD4D4,stroke:#FF5252,stroke-width:2px
-    classDef gateway fill:#D4D4FF,stroke:#3F51B5,stroke-width:2px
+    %% Styling - Dark theme with white text
+    classDef external fill:#8B6914,stroke:#F5A623,stroke-width:2px,color:#FFFFFF
+    classDef lambda fill:#2B5F7C,stroke:#4A90A4,stroke-width:2px,color:#FFFFFF
+    classDef storage fill:#3D6B3D,stroke:#7ED321,stroke-width:2px,color:#FFFFFF
+    classDef messaging fill:#8B4513,stroke:#D0021B,stroke-width:2px,color:#FFFFFF
+    classDef monitoring fill:#4B3D6B,stroke:#9013FE,stroke-width:2px,color:#FFFFFF
+    classDef cdn fill:#6B3D5C,stroke:#E91E63,stroke-width:2px,color:#FFFFFF
+    classDef frontend fill:#2B6B6B,stroke:#00BCD4,stroke-width:2px,color:#FFFFFF
+    classDef auth fill:#8B3D3D,stroke:#FF5252,stroke-width:2px,color:#FFFFFF
+    classDef gateway fill:#3D3D6B,stroke:#3F51B5,stroke-width:2px,color:#FFFFFF
 
     class NewsAPI,OAuthProviders external
     class Ingestion,Analysis,AuthLambda,Dashboard,SSE lambda


### PR DESCRIPTION
## Summary
- Apply v7 dark theme to architecture.mmd (dark subgraphs, white text, light blue lines)
- Update all 5 README.md mermaid diagrams with consistent dark theme
- Add docs/diagrams/TEMPLATE.md with reusable templates and color reference

## Test plan
- [ ] View README.md diagrams in GitHub - verify dark theme renders correctly
- [ ] Check architecture.mmd renders with readable text on dark background
- [ ] Verify TEMPLATE.md examples are valid mermaid syntax

🤖 Generated with [Claude Code](https://claude.com/claude-code)