### PR TITLE
fix(blind-spots): Address 4 critical infrastructure gaps

### DIFF
--- a/infrastructure/terraform/modules/secrets/outputs.tf
+++ b/infrastructure/terraform/modules/secrets/outputs.tf
@@ -49,3 +49,14 @@ output "hcaptcha_secret_name" {
   description = "Name of the hCaptcha secret"
   value       = aws_secretsmanager_secret.hcaptcha.name
 }
+
+# Stripe Webhook Secret
+output "stripe_webhook_secret_arn" {
+  description = "ARN of the Stripe webhook secret for signature verification"
+  value       = aws_secretsmanager_secret.stripe_webhook.arn
+}
+
+output "stripe_webhook_secret_name" {
+  description = "Name of the Stripe webhook secret"
+  value       = aws_secretsmanager_secret.stripe_webhook.name
+}

--- a/src/lambdas/notification/handler.py
+++ b/src/lambdas/notification/handler.py
@@ -36,7 +36,8 @@ SENDGRID_SECRET_ARN = os.environ.get("SENDGRID_SECRET_ARN", "")
 DYNAMODB_TABLE = os.environ["DATABASE_TABLE"]
 ENVIRONMENT = os.environ.get("ENVIRONMENT", "dev")
 FROM_EMAIL = os.environ.get("FROM_EMAIL", "noreply@sentiment-analyzer.com")
-DASHBOARD_URL = os.environ.get("DASHBOARD_URL", "https://sentiment-analyzer.com")
+# Blind spot fix: Use localhost as fallback (matches Terraform dev default, not hardcoded prod URL)
+DASHBOARD_URL = os.environ.get("DASHBOARD_URL", "http://localhost:3000")
 
 
 def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:

--- a/src/lambdas/shared/middleware/security_headers.py
+++ b/src/lambdas/shared/middleware/security_headers.py
@@ -30,7 +30,8 @@ from typing import Any
 
 # Environment
 ENVIRONMENT = os.environ.get("ENVIRONMENT", "dev")
-DASHBOARD_URL = os.environ.get("DASHBOARD_URL", "https://sentiment-analyzer.com")
+# Blind spot fix: Use localhost as fallback (matches Terraform dev default, not hardcoded prod URL)
+DASHBOARD_URL = os.environ.get("DASHBOARD_URL", "http://localhost:3000")
 
 # Security headers configuration
 SECURITY_HEADERS = {

--- a/tests/unit/dashboard/conftest.py
+++ b/tests/unit/dashboard/conftest.py
@@ -13,9 +13,27 @@ For Developers:
     - Test-specific fixtures belong in individual test files
 """
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
+
+
+@pytest.fixture(autouse=True)
+def mock_stripe_webhook_secret():
+    """
+    Auto-mock get_secret for Stripe webhook secret retrieval.
+
+    This fixture ensures that tests don't require actual AWS Secrets Manager
+    access. The STRIPE_WEBHOOK_SECRET_ARN env var points to a test ARN,
+    and this mock returns the test secret value.
+
+    Feature: 1191 - Mid-Session Tier Upgrade
+    """
+    with patch("src.lambdas.shared.secrets.get_secret") as mock_get_secret:
+        mock_get_secret.return_value = {
+            "webhook_secret": "whsec_test_secret_for_unit_tests"
+        }
+        yield mock_get_secret
 
 
 @pytest.fixture

--- a/tests/unit/dashboard/test_stripe_webhook.py
+++ b/tests/unit/dashboard/test_stripe_webhook.py
@@ -9,8 +9,12 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-# Set STRIPE_WEBHOOK_SECRET before importing modules that need it
-os.environ.setdefault("STRIPE_WEBHOOK_SECRET", "whsec_test_secret_for_unit_tests")
+# Set STRIPE_WEBHOOK_SECRET_ARN before importing modules that need it
+# The actual secret value will be mocked via get_secret patch
+os.environ.setdefault(
+    "STRIPE_WEBHOOK_SECRET_ARN",
+    "arn:aws:secretsmanager:us-east-1:123456789012:secret:test/stripe-webhook",
+)
 
 from src.lambdas.shared.models.webhook_event import WebhookEvent
 


### PR DESCRIPTION
## Summary
- Fix missing Cognito OAuth environment variables (COGNITO_DOMAIN, COGNITO_REDIRECT_URI)
- Add Stripe webhook secret to Secrets Manager with ARN pattern
- Replace hardcoded production URL fallbacks with localhost default
- Add Terraform check block to fail plan if CORS empty in prod

## Test plan
- [x] Unit tests pass (15 passed in test_stripe_webhook.py)
- [x] Ruff linting passes
- [x] Pre-commit hooks pass
- [ ] Terraform plan succeeds in dev environment
- [ ] PR CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)