### PR TITLE
fix(codeql): Restore thin arrow syntax validation with lgtm suppression

### DIFF
--- a/scripts/regenerate-mermaid-url.py
+++ b/scripts/regenerate-mermaid-url.py
@@ -77,7 +77,11 @@ def validate_mermaid_syntax(code: str) -> list[str]:
             f"Unbalanced parentheses: {code.count('(')} opening, {code.count(')')} closing"
         )
 
-    # Check for common syntax errors
+    # Check for common Mermaid syntax errors (not HTML filtering)
+    # CodeQL py/bad-tag-filter: False positive - validates Mermaid arrow syntax, not HTML
+    if re.search(r"-->\s*$", code, re.MULTILINE):  # lgtm[py/bad-tag-filter]
+        errors.append("Arrow without target node (line ends with -->)")
+
     if re.search(r"==>\s*$", code, re.MULTILINE):
         errors.append("Thick arrow without target node (line ends with ==>)")
 


### PR DESCRIPTION
## Summary

- Restores the thin arrow (`-->`) syntax validation that was removed in PR #671
- Adds proper `lgtm[py/bad-tag-filter]` suppression comment to address CodeQL false positive
- The regex validates Mermaid diagram arrow syntax, not HTML comment filtering

## Background

PR #671 addressed 28 CodeQL findings but over-corrected by removing the thin arrow check entirely. This PR restores the validation while properly suppressing the false positive.

**Supersedes PR #676** which became stale with merge conflicts after PR #677 merged.

## Test plan

- [x] Pre-commit hooks pass (ruff, bandit, pytest)
- [x] Verify validation catches `A --> ` (arrow without target)
- [x] Verify thick arrow validation still works: `A ==> `

🤖 Generated with [Claude Code](https://claude.ai/code)