### PR TITLE
chore: Format test files with black 26.1.0

### DIFF
--- a/tests/e2e/test_auth_magic_link.py
+++ b/tests/e2e/test_auth_magic_link.py
@@ -79,7 +79,12 @@ async def test_magic_link_request_rate_limited(
 
     # 500 is a server error - test should fail, not skip
     assert (
-        first_response.status_code in (200, 202, 204)
+        first_response.status_code
+        in (
+            200,
+            202,
+            204,
+        )
     ), f"Magic link request failed: {first_response.status_code} - {first_response.text}"
 
     # Make rapid follow-up requests - try more requests for preprod
@@ -126,7 +131,12 @@ async def test_magic_link_verification(
 
     # 500 is a server error - test should fail, not skip
     assert (
-        request_response.status_code in (200, 202, 204)
+        request_response.status_code
+        in (
+            200,
+            202,
+            204,
+        )
     ), f"Magic link request failed: {request_response.status_code} - {request_response.text}"
 
     # Get synthetic token from handler
@@ -231,7 +241,12 @@ async def test_anonymous_data_merge(
 
     # 500 is a server error - test should fail, not skip
     assert (
-        magic_response.status_code in (200, 202, 204)
+        magic_response.status_code
+        in (
+            200,
+            202,
+            204,
+        )
     ), f"Magic link request failed: {magic_response.status_code} - {magic_response.text}"
 
     # Step 4: Get synthetic token and verify with anonymous session
@@ -333,7 +348,12 @@ async def test_full_anonymous_to_authenticated_journey(
 
     # 500 is a server error - test should fail, not skip
     assert (
-        magic_response.status_code in (200, 202, 204)
+        magic_response.status_code
+        in (
+            200,
+            202,
+            204,
+        )
     ), f"Magic link request failed: {magic_response.status_code} - {magic_response.text}"
 
     # === Phase 4: Verify Magic Link ===

--- a/tests/e2e/test_live_update_latency.py
+++ b/tests/e2e/test_live_update_latency.py
@@ -275,12 +275,10 @@ class TestLiveUpdateLatency:
                 break
 
             # Get current samples
-            result = await page.evaluate(
-                """() => ({
+            result = await page.evaluate("""() => ({
                     samples: window.latencySamples.slice(),
                     lastMetrics: window.lastLatencyMetrics
-                })"""
-            )
+                })""")
 
             samples = result.get("samples", [])
 

--- a/tests/e2e/test_rate_limiting.py
+++ b/tests/e2e/test_rate_limiting.py
@@ -300,7 +300,12 @@ async def test_magic_link_rate_limit(
     # 500 is a server error - test should fail, not skip
     # Should succeed
     assert (
-        first_response.status_code in (200, 202, 204)
+        first_response.status_code
+        in (
+            200,
+            202,
+            204,
+        )
     ), f"Magic link request failed: {first_response.status_code} - {first_response.text}"
 
     # Make rapid follow-up requests


### PR DESCRIPTION
## Summary

Follow-up to PR #665 (black 25.12.0 → 26.1.0).

Applied black 26.1.0 and ruff formatting to test files that had outdated formatting.

## Files Updated
- tests/e2e/test_anonymous_restrictions.py
- tests/e2e/test_auth_magic_link.py
- tests/e2e/test_rate_limiting.py

## Test plan
- [x] Pre-commit hooks pass (ruff, ruff-format, pytest)
- [x] No functional changes, formatting only

🤖 Generated with [Claude Code](https://claude.ai/code)