### PR TITLE
deps(deps): Bump stripe from 11.4.1 to 14.1.0

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -83,4 +83,4 @@ PyJWT==2.10.1
 tenacity==9.0.0
 
 # Stripe - Feature 1191 (mid-session tier upgrade)
-stripe==11.4.1
+stripe==14.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,4 +54,4 @@ PyJWT==2.10.1
 tenacity==9.0.0
 
 # Stripe - Feature 1191 (mid-session tier upgrade)
-stripe==11.4.1
+stripe==14.1.0


### PR DESCRIPTION
Rebased version of #656 (dependabot couldn't rebase due to previous manual edits).

## Changes
- Bumps stripe from 11.4.1 to 14.1.0 (3 major versions)

## Impact Analysis
- Only used for webhook signature verification (`stripe.Webhook.construct_event()`)
- No direct API calls to Stripe servers
- Breaking changes in v14 (array parameter serialization) do NOT affect this codebase
- Safe to upgrade

## Test plan
- [x] Verified stripe usage is limited to webhook validation
- [ ] CI tests should pass without modification

🤖 Generated with [Claude Code](https://claude.com/claude-code)