### PR TITLE
deps(deps): Bump the aws-sdk group with 2 updates

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -13,8 +13,8 @@
 #   - This file saves ~15min in CI by excluding 2GB+ torch
 
 # AWS SDK - Lambda runtime includes boto3, but we pin for local testing
-boto3==1.42.17
-botocore==1.42.17
+boto3==1.42.26
+botocore==1.42.26
 
 # Web Framework - Dashboard Lambda
 fastapi==0.127.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,8 +11,8 @@
 # - See requirements-dev.txt for test dependencies
 
 # AWS SDK - Lambda runtime includes boto3, but we pin for local testing
-boto3==1.42.17
-botocore==1.42.17
+boto3==1.42.26
+botocore==1.42.26
 
 # ML/NLP - DistilBERT sentiment analysis
 # Note: torch is large (~2GB); Lambda layer built separately


### PR DESCRIPTION
Rebased version of #653 (dependabot couldn't rebase due to previous manual edits).

## Changes
Bumps the aws-sdk group:
- botocore
- boto3

## Test plan
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)