### PR TITLE
fix(chart): Correct sentiment line rendering and time range zoom

### DIFF
--- a/frontend/src/components/charts/price-sentiment-chart.tsx
+++ b/frontend/src/components/charts/price-sentiment-chart.tsx
@@ -245,9 +245,9 @@ export function PriceSentimentChart({
     });
 
     // Configure right scale for sentiment range (-1 to +1)
-    // Add padding (0.15) so -1 and +1 values don't sit exactly at the edge
+    // Keep autoScale: true (default) so autoscaleInfoProvider on the series works
+    // Ref: https://tradingview.github.io/lightweight-charts/tutorials/customization/price-scale
     chart.priceScale('right').applyOptions({
-      autoScale: false,
       scaleMargins: { top: 0.15, bottom: 0.15 },
     });
 
@@ -418,19 +418,22 @@ export function PriceSentimentChart({
   useEffect(() => {
     if (!chartRef.current || (!priceData.length && !sentimentData.length)) return;
 
-    // First fit all content
+    // Always fit all content first - especially important when time range changes
     chartRef.current.timeScale().fitContent();
 
-    // For intraday resolutions, limit visible range to show candlesticks clearly
-    const visibleCount = VISIBLE_CANDLES[resolution];
-    const dataLength = priceData.length || sentimentData.length;
+    // For INTRADAY resolutions only, limit visible range to show candlesticks clearly
+    // Daily resolution ('D') should always show full time range (user selected 1W/1M/3M/6M/1Y)
+    if (resolution !== 'D') {
+      const visibleCount = VISIBLE_CANDLES[resolution];
+      const dataLength = priceData.length || sentimentData.length;
 
-    if (visibleCount > 0 && dataLength > visibleCount) {
-      // Show most recent candles (scroll to right edge)
-      chartRef.current.timeScale().setVisibleLogicalRange({
-        from: dataLength - visibleCount,
-        to: dataLength - 1,
-      });
+      if (visibleCount > 0 && dataLength > visibleCount) {
+        // Show most recent candles (scroll to right edge)
+        chartRef.current.timeScale().setVisibleLogicalRange({
+          from: dataLength - visibleCount,
+          to: dataLength - 1,
+        });
+      }
     }
   }, [priceData, sentimentData, resolution]);
 


### PR DESCRIPTION
## Summary

- **Fix sentiment line not rendering**: Removed `autoScale: false` from right price scale. The autoscaleInfoProvider requires autoScale to be true (default) to work correctly.
- **Fix time range auto-zoom**: Daily resolution now shows full selected time range (fitContent). Only intraday resolutions limit visible range to VISIBLE_CANDLES. When user selects 6M, they should see all 6 months, not just last 40 days.

## Root Cause Analysis

### Issue 1: Sentiment Line Not Visible
The sentiment series uses `autoscaleInfoProvider` to force a -1 to +1 scale. However, the price scale had `autoScale: false` set, which **disables** autoscaling and ignores the autoscaleInfoProvider. This caused the sentiment values to be rendered at incorrect coordinates (outside the visible canvas area).

**Fix**: Remove `autoScale: false` from the right price scale configuration. The default `autoScale: true` allows autoscaleInfoProvider to work correctly.

**Reference**: [tradingview.github.io/lightweight-charts/tutorials/customization/price-scale](https://tradingview.github.io/lightweight-charts/tutorials/customization/price-scale)

### Issue 2: Time Range Doesn't Show Full Range
When user selects a time range (e.g., 6M), the chart was zooming to show only the last 40 days due to the `VISIBLE_CANDLES['D'] = 40` logic. This is appropriate for intraday resolutions where you want to see individual candles, but wrong for daily resolution where the user explicitly selected a larger time range.

**Fix**: Only apply `setVisibleLogicalRange` for intraday resolutions (1m, 5m, 15m, 30m, 1h). Daily resolution always uses `fitContent()` to show the full selected range.

## Test Plan

- [ ] Verify sentiment line renders correctly on preprod after deploy
- [ ] Verify time range selection (6M) shows full 6 months of data
- [ ] All 13 sanity tests pass against deployed preprod

🤖 Generated with [Claude Code](https://claude.com/claude-code)