### PR TITLE
fix(deps): Add orjson to requirements.txt for deploy pipeline

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,6 +27,7 @@ httpx==0.28.1  # Async HTTP client for financial APIs
 
 # Data Validation - Input/output schemas
 pydantic==2.12.5
+orjson==3.11.5  # Fast JSON serialization for API responses
 email-validator==2.3.0  # Required for Pydantic EmailStr type
 
 # Logging - Structured JSON logs for CloudWatch


### PR DESCRIPTION
## Summary
- Deploy pipeline failed with ModuleNotFoundError: No module named orjson (exit code 4)
- orjson was in pyproject.toml and requirements-ci.txt but missing from requirements.txt
- Deploy workflow installs requirements-dev.txt which pulls requirements.txt (no orjson) for unit tests

## Test plan
- [ ] Deploy pipeline passes unit test job
- [ ] orjson appears in installed packages list

Generated with Claude Code