### PR TITLE
fix(deps): Add aws-lambda-powertools to Analysis Lambda container

### DIFF
--- a/src/lambdas/analysis/requirements.txt
+++ b/src/lambdas/analysis/requirements.txt
@@ -21,3 +21,6 @@ python-json-logger>=2.0.0,<3.0.0
 
 # AWS X-Ray distributed tracing (FR-035 Day 1 mandatory)
 aws-xray-sdk>=2.14.0,<3.0.0
+
+# AWS Lambda Powertools - Tracer for X-Ray instrumentation (1219)
+aws-lambda-powertools>=3.23.0,<4.0.0


### PR DESCRIPTION
## Summary
- Deploy smoke test fails: Analysis Lambda container missing `aws-lambda-powertools`
- X-Ray migration (PR #710) added Tracer import but the Analysis Lambda's container `requirements.txt` was not updated
- Adds `aws-lambda-powertools>=3.23.0,<4.0.0` to `src/lambdas/analysis/requirements.txt`

## Test plan
- [ ] Deploy pipeline passes (Analysis Lambda Docker build + smoke test)
- [ ] X-Ray traces visible in CloudWatch after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)