### PR TITLE
fix(deploy): Fix PYTHONPATH mismatch in SSE smoke test and Terraform

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -510,7 +510,7 @@ jobs:
           # configured in Terraform. Docker ENV alone doesn't work because Lambda
           # Web Adapter subprocess doesn't inherit container environment reliably.
           # Feature 1043: USERS_TABLE for config queries, SENTIMENTS_TABLE for sentiment data
-          docker run --rm -e PYTHONPATH=/app/packages:/app -e USERS_TABLE=preprod-sentiment-users -e SENTIMENTS_TABLE=preprod-sentiment-items --entrypoint python "$IMAGE" -c "
+          docker run --rm -e PYTHONPATH=/var/task/packages:/var/task -e USERS_TABLE=preprod-sentiment-users -e SENTIMENTS_TABLE=preprod-sentiment-items --entrypoint python "$IMAGE" -c "
           import sys
           print('Testing imports...')
 
@@ -1476,7 +1476,7 @@ jobs:
 
           # Note: PYTHONPATH matches Lambda environment variable in Terraform
           # Feature 1043: USERS_TABLE for config queries, SENTIMENTS_TABLE for sentiment data
-          docker run --rm -e PYTHONPATH=/app/packages:/app -e USERS_TABLE=prod-sentiment-users -e SENTIMENTS_TABLE=prod-sentiment-items --entrypoint python "$IMAGE" -c "
+          docker run --rm -e PYTHONPATH=/var/task/packages:/var/task -e USERS_TABLE=prod-sentiment-users -e SENTIMENTS_TABLE=prod-sentiment-items --entrypoint python "$IMAGE" -c "
           import sys
           from handler import handler
           from config import config_lookup_service

--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -733,7 +733,7 @@ module "sse_streaming_lambda" {
   # inherit container environment variables.
   # Feature 1043: Clear env var naming - USERS_TABLE for configs, SENTIMENTS_TABLE for sentiment data
   environment_variables = {
-    PYTHONPATH             = "/app/packages:/app"
+    PYTHONPATH             = "/var/task/packages:/var/task"
     USERS_TABLE            = module.dynamodb.feature_006_users_table_name # configs, sessions
     SENTIMENTS_TABLE       = module.dynamodb.table_name                   # sentiment items
     SSE_HEARTBEAT_INTERVAL = tostring(var.sse_heartbeat_interval)
@@ -741,11 +741,11 @@ module "sse_streaming_lambda" {
     SSE_POLL_INTERVAL      = tostring(var.sse_poll_interval)
     ENVIRONMENT            = var.environment
     # Feature 1219/T051: OTel SDK env vars for ADOT Extension tracing
-    OTEL_SERVICE_NAME                   = "sentiment-analyzer-sse"
-    OTEL_EXPORTER_OTLP_ENDPOINT         = "http://localhost:4318"
-    OTEL_SDK_DISABLED                   = "false"
-    OTEL_EXPORTER_OTLP_TRACES_TIMEOUT   = "2"
-    OPENTELEMETRY_COLLECTOR_CONFIG_FILE = "/opt/collector-config/config.yaml"
+    OTEL_SERVICE_NAME                 = "sentiment-analyzer-sse"
+    OTEL_EXPORTER_OTLP_ENDPOINT       = "http://localhost:4318"
+    OTEL_SDK_DISABLED                 = "false"
+    OTEL_EXPORTER_OTLP_TRACES_TIMEOUT = "2"
+    # OPENTELEMETRY_COLLECTOR_CONFIG_FILE removed — ADOT collector not in container (see Dockerfile TODO)
     # Feature 1009: Time-series table for multi-resolution queries and streaming
     TIMESERIES_TABLE = module.dynamodb.timeseries_table_name
     # Feature 1054: JWT secret for auth middleware token validation


### PR DESCRIPTION
## Summary
- SSE Lambda deploy smoke test fails with `ModuleNotFoundError: No module named 'aws_lambda_powertools'`
- Root cause: PYTHONPATH was set to `/app/packages:/app` but packages are installed at `/var/task/packages`
- The bootstrap script masked this bug by manually adding correct paths to `sys.path`, but the smoke test runs `python -c` directly
- Also removes stale `OPENTELEMETRY_COLLECTOR_CONFIG_FILE` env var (collector config removed in PR #713)

## Changes
- `deploy.yml`: Fix smoke test PYTHONPATH to `/var/task/packages:/var/task` (preprod + prod)
- `main.tf`: Fix SSE Lambda PYTHONPATH to match Dockerfile layout
- `main.tf`: Remove `OPENTELEMETRY_COLLECTOR_CONFIG_FILE` (collector not in container)

## Test plan
- [ ] SSE Lambda Docker image build + smoke test passes
- [ ] Full deploy pipeline completes
- [ ] SSE Lambda functions correctly after Terraform applies new env vars

🤖 Generated with [Claude Code](https://claude.com/claude-code)