### PR TITLE
fix(terraform): Add missing variable and local declarations from X-Ray PR

### DIFF
--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -914,7 +914,9 @@ module "xray" {
   source = "./modules/xray"
 
   environment = var.environment
-  tags        = local.common_tags
+  tags = {
+    Feature = "1219-xray-exclusive-tracing"
+  }
 }
 
 # ===================================================================
@@ -937,7 +939,9 @@ module "cloudwatch_alarms" {
   source = "./modules/cloudwatch-alarms"
 
   environment = var.environment
-  tags        = local.common_tags
+  tags = {
+    Feature = "1219-xray-exclusive-tracing"
+  }
 
   lambda_function_names = {
     ingestion    = module.ingestion_lambda.function_name

--- a/infrastructure/terraform/modules/iam/variables.tf
+++ b/infrastructure/terraform/modules/iam/variables.tf
@@ -101,3 +101,9 @@ variable "enable_ohlc_cache" {
   type        = bool
   default     = false
 }
+
+variable "enable_canary" {
+  description = "Whether to create canary Lambda IAM resources (T086, FR-051)"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
## Summary
- Deploy to Preprod fails at Terraform refresh with undeclared references
- `local.common_tags` used in xray and cloudwatch_alarms module calls but never defined in root module — replaced with inline tags matching existing pattern
- `var.enable_canary` used in IAM module's canary Lambda resources but variable not declared — added with `default = false`
- Both issues originated in PR #710 (X-Ray implementation)

## Test plan
- [ ] Terraform refresh passes (no undeclared reference errors)
- [ ] Deploy to Preprod completes
- [ ] Terraform plan shows expected changes (PYTHONPATH env var update from PR #714)

🤖 Generated with [Claude Code](https://claude.com/claude-code)