### PR TITLE
fix(terraform): Align X-Ray names with IAM policy and add PutCompositeAlarm

### DIFF
--- a/infrastructure/terraform/ci-user-policy.tf
+++ b/infrastructure/terraform/ci-user-policy.tf
@@ -395,6 +395,7 @@ data "aws_iam_policy_document" "ci_deploy_monitoring" {
     effect = "Allow"
     actions = [
       "cloudwatch:PutMetricAlarm",
+      "cloudwatch:PutCompositeAlarm",
       "cloudwatch:DeleteAlarms",
       "cloudwatch:DescribeAlarms",
       "cloudwatch:TagResource",

--- a/infrastructure/terraform/modules/xray/main.tf
+++ b/infrastructure/terraform/modules/xray/main.tf
@@ -34,7 +34,7 @@ resource "aws_xray_group" "errors" {
 }
 
 resource "aws_xray_group" "production_traces" {
-  group_name        = "${var.environment}-production-traces"
+  group_name        = "${var.environment}-sentiment-production-traces"
   filter_expression = "!annotation.synthetic"
 
   insights_configuration {
@@ -46,7 +46,7 @@ resource "aws_xray_group" "production_traces" {
 }
 
 resource "aws_xray_group" "canary_traces" {
-  group_name        = "${var.environment}-canary-traces"
+  group_name        = "${var.environment}-sentiment-canary-traces"
   filter_expression = "annotation.synthetic = true"
 
   insights_configuration {
@@ -70,7 +70,7 @@ resource "aws_xray_group" "sse" {
 }
 
 resource "aws_xray_group" "sse_reconnections" {
-  group_name        = "${var.environment}-sse-reconnections"
+  group_name        = "${var.environment}-sentiment-sse-reconnections"
   filter_expression = "annotation.previous_trace_id BEGINSWITH \"1-\""
 
   insights_configuration {
@@ -91,7 +91,7 @@ resource "aws_xray_group" "sse_reconnections" {
 resource "aws_xray_sampling_rule" "non_prod" {
   count = local.is_prod ? 0 : 1
 
-  rule_name      = "sentiment-${var.environment}-all"
+  rule_name      = "${var.environment}-sentiment-all"
   priority       = 1000
   reservoir_size = var.reservoir_size
   fixed_rate     = var.fixed_rate
@@ -110,7 +110,7 @@ resource "aws_xray_sampling_rule" "non_prod" {
 resource "aws_xray_sampling_rule" "prod_apigw" {
   count = local.is_prod ? 1 : 0
 
-  rule_name      = "sentiment-prod-apigw"
+  rule_name      = "prod-sentiment-apigw"
   priority       = 100
   reservoir_size = var.prod_apigw_reservoir_size
   fixed_rate     = var.prod_apigw_fixed_rate
@@ -129,7 +129,7 @@ resource "aws_xray_sampling_rule" "prod_apigw" {
 resource "aws_xray_sampling_rule" "prod_fnurl" {
   count = local.is_prod ? 1 : 0
 
-  rule_name      = "sentiment-prod-fnurl"
+  rule_name      = "prod-sentiment-fnurl"
   priority       = 200
   reservoir_size = var.prod_fnurl_reservoir_size
   fixed_rate     = var.prod_fnurl_fixed_rate
@@ -148,7 +148,7 @@ resource "aws_xray_sampling_rule" "prod_fnurl" {
 resource "aws_xray_sampling_rule" "prod_default" {
   count = local.is_prod ? 1 : 0
 
-  rule_name      = "sentiment-prod-default"
+  rule_name      = "prod-sentiment-default"
   priority       = 9000
   reservoir_size = var.prod_default_reservoir_size
   fixed_rate     = var.prod_default_fixed_rate


### PR DESCRIPTION
## Summary
- Rename 3 X-Ray groups to include `sentiment` prefix (e.g. `{env}-production-traces` → `{env}-sentiment-production-traces`) so they match deployer IAM policy pattern `*-sentiment-*`
- Rename 4 sampling rules from `sentiment-{env}-*` → `{env}-sentiment-*` for consistency
- Add `cloudwatch:PutCompositeAlarm` to deployer IAM policy (deploy #6 failed on this)

## Context
Deploy run #6 failed with AccessDenied because X-Ray group/sampling rule names didn't match the deployer IAM policy's `*-sentiment-*` resource pattern. This PR aligns the names and adds the missing CloudWatch permission.

## Test plan
- [ ] Deploy pipeline passes (terraform apply succeeds)
- [ ] X-Ray groups created with correct `sentiment` prefix
- [ ] Sampling rules applied successfully
- [ ] Composite alarm created without AccessDenied

🤖 Generated with [Claude Code](https://claude.com/claude-code)