### PR TITLE
fix(terraform): Shorten X-Ray names and add xray:TagResource for sampling rules

### DIFF
--- a/infrastructure/terraform/ci-user-policy.tf
+++ b/infrastructure/terraform/ci-user-policy.tf
@@ -759,7 +759,10 @@ data "aws_iam_policy_document" "ci_deploy_iam" {
     actions = [
       "xray:CreateSamplingRule",
       "xray:UpdateSamplingRule",
-      "xray:DeleteSamplingRule"
+      "xray:DeleteSamplingRule",
+      "xray:TagResource",
+      "xray:UntagResource",
+      "xray:ListTagsForResource"
     ]
     resources = [
       "arn:aws:xray:*:*:sampling-rule/*-sentiment-*"

--- a/infrastructure/terraform/modules/xray/main.tf
+++ b/infrastructure/terraform/modules/xray/main.tf
@@ -4,8 +4,8 @@
 # Creates X-Ray groups for trace filtering and environment-specific
 # sampling rules per contracts/xray-groups-sampling.md.
 #
-# Groups (5): sentiment-errors, production-traces, canary-traces,
-#             sentiment-sse, sse-reconnections
+# Groups (5): sentiment-errors, live-traces, canary-traces,
+#             sentiment-sse, sse-reconn
 #
 # Sampling: dev/preprod = 100%, prod = graduated (10%/5%/10%)
 
@@ -34,7 +34,7 @@ resource "aws_xray_group" "errors" {
 }
 
 resource "aws_xray_group" "production_traces" {
-  group_name        = "${var.environment}-sentiment-production-traces"
+  group_name        = "${var.environment}-sentiment-live-traces"
   filter_expression = "!annotation.synthetic"
 
   insights_configuration {
@@ -70,7 +70,7 @@ resource "aws_xray_group" "sse" {
 }
 
 resource "aws_xray_group" "sse_reconnections" {
-  group_name        = "${var.environment}-sentiment-sse-reconnections"
+  group_name        = "${var.environment}-sentiment-sse-reconn"
   filter_expression = "annotation.previous_trace_id BEGINSWITH \"1-\""
 
   insights_configuration {


### PR DESCRIPTION
## Summary
- Shorten X-Ray group names to fit AWS 32-char limit:
  - `{env}-sentiment-production-traces` (35 chars) → `{env}-sentiment-live-traces` (29 chars)
  - `{env}-sentiment-sse-reconnections` (35 chars) → `{env}-sentiment-sse-reconn` (28 chars)
- Add `xray:TagResource`, `xray:UntagResource`, `xray:ListTagsForResource` to sampling rules IAM statement

## Context
Deploy #7 failed because:
1. X-Ray group names exceeded AWS 32-character limit
2. `xray:TagResource` was only in the group statement, not sampling rules
3. `cloudwatch:PutCompositeAlarm` denied due to IAM propagation delay (will resolve on re-apply)

## Test plan
- [ ] Deploy pipeline passes (terraform apply succeeds)
- [ ] X-Ray groups created with shortened names
- [ ] Sampling rules created with tags
- [ ] Composite alarm created (IAM propagated from previous apply)

🤖 Generated with [Claude Code](https://claude.com/claude-code)