### PR TITLE
fix(terraform): Rename EventBridge X-Ray canary rule to match IAM pattern

### DIFF
--- a/infrastructure/terraform/modules/eventbridge/main.tf
+++ b/infrastructure/terraform/modules/eventbridge/main.tf
@@ -119,7 +119,7 @@ resource "aws_lambda_permission" "eventbridge_invoke_digest" {
 resource "aws_cloudwatch_event_rule" "canary_schedule" {
   count = var.create_canary_schedule ? 1 : 0
 
-  name                = "${var.environment}-xray-canary-schedule"
+  name                = "${var.environment}-sentiment-xray-canary"
   description         = "Trigger X-Ray canary health validation every 5 minutes"
   schedule_expression = "rate(5 minutes)"
 


### PR DESCRIPTION
## Summary

- Rename `${env}-xray-canary-schedule` to `${env}-sentiment-xray-canary`
- Fixes AccessDeniedException on `events:TagResource` during terraform apply
- IAM policy scopes EventBridge to `*-sentiment-*` pattern

## Root Cause

The EventBridge rule for the X-Ray canary used `${env}-xray-canary-schedule` which doesn't match the IAM ARN pattern `arn:aws:events:*:*:rule/*-sentiment-*`. Detected by new `/xray-naming-validate` methodology (XRAY-003).

## Test plan

- [ ] Terraform plan shows rename (destroy + create for EventBridge rule)
- [ ] Deploy pipeline passes terraform apply without AccessDeniedException
- [ ] X-Ray canary Lambda continues to be triggered every 5 minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)