### PR TITLE
docs: Update diagrams for Function URL resolver change

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,7 +511,7 @@ Post-Phase 0 security hardening with httpOnly cookies:
 sequenceDiagram
     participant Browser
     participant Frontend as Next.js Frontend<br/>(Amplify)
-    participant Dashboard as Dashboard Lambda<br/>(API Gateway)
+    participant Dashboard as Dashboard Lambda<br/>(Function URL)
     participant Cognito as Cognito User Pool
     participant Users as sentiment-users
 
@@ -915,7 +915,7 @@ sentiment-analyzer-gsk/
 │   ├── lambdas/
 │   │   ├── ingestion/           # Ingestion Lambda
 │   │   ├── analysis/            # Analysis Lambda
-│   │   ├── dashboard/           # Dashboard Lambda (REST API)
+│   │   ├── dashboard/           # Dashboard Lambda (Function URL)
 │   │   ├── sse_streaming/       # SSE Lambda (real-time streaming)
 │   │   ├── metrics/             # Metrics Lambda (stuck item monitor)
 │   │   └── shared/              # Shared Lambda utilities

--- a/docs/diagrams/architecture.mmd
+++ b/docs/diagrams/architecture.mmd
@@ -29,7 +29,7 @@ flowchart TB
     subgraph Lambda["AWS Lambda Functions"]
         Ingestion["Ingestion Lambda<br/>512MB / 60s<br/>EventBridge trigger"]
         Analysis["Analysis Lambda<br/>1024MB / 30s<br/>SNS trigger"]
-        Dashboard["Dashboard Lambda<br/>512MB / 60s<br/>REST API + Auth<br/>/api/v2/* routes<br/>PKCE, CSRF, Sessions"]
+        Dashboard["Dashboard Lambda<br/>1024MB / 60s<br/>Function URL + Auth<br/>/api/v2/* routes<br/>PKCE, CSRF, Sessions"]
         SSE["SSE Lambda<br/>512MB / 60s<br/>RESPONSE_STREAM<br/>JWT validation"]
         Metrics["Metrics Lambda<br/>128MB / 30s<br/>EventBridge 1min<br/>StuckItems metric"]
         Notification["Notification Lambda<br/>256MB / 30s<br/>SNS + EventBridge<br/>SendGrid emails"]


### PR DESCRIPTION
## Summary
- architecture.mmd: Dashboard Lambda memory 512MB → 1024MB, description REST API → Function URL
- README.md: Sequence diagram participant label updated from API Gateway to Function URL
- README.md: Project tree description updated

Aligns diagram documentation with PR #724 (LambdaFunctionUrlResolver).

## Test plan
- [x] Docs-only change, no code impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)