### PR TITLE
feat(cache): CacheStats CloudWatch integration across all caches (1224)

### DIFF
--- a/src/lambdas/dashboard/configurations.py
+++ b/src/lambdas/dashboard/configurations.py
@@ -44,6 +44,7 @@ from src.lambdas.shared.models.configuration import (
 )
 from src.lambdas.shared.models.status_utils import ACTIVE, INACTIVE
 from src.lambdas.shared.retry import dynamodb_retry
+from src.lib.cache_utils import CacheStats, get_global_emitter
 
 logger = logging.getLogger(__name__)
 
@@ -65,6 +66,10 @@ _config_cache: dict[tuple[str, str], tuple[float, "ConfigurationResponse"]] = {}
 # Cache statistics
 _config_cache_stats = {"list_hits": 0, "list_misses": 0, "get_hits": 0, "get_misses": 0}
 
+# Feature 1224: CacheStats for CloudWatch metric emission
+_config_cw_stats = CacheStats(name="config")
+get_global_emitter().register(_config_cw_stats)
+
 
 def _get_cached_config_list(user_id: str) -> "ConfigurationListResponse | None":
     """Get user's configuration list from cache if not expired."""
@@ -74,10 +79,12 @@ def _get_cached_config_list(user_id: str) -> "ConfigurationListResponse | None":
         effective_ttl = entry[2] if len(entry) > 2 else CONFIG_CACHE_TTL
         if time.time() - timestamp < effective_ttl:
             _config_cache_stats["list_hits"] += 1
+            _config_cw_stats.record_hit()
             return response
         # Expired - remove
         del _config_list_cache[user_id]
     _config_cache_stats["list_misses"] += 1
+    _config_cw_stats.record_miss()
     return None
 
 
@@ -110,9 +117,11 @@ def _get_cached_config(user_id: str, config_id: str) -> "ConfigurationResponse |
         effective_ttl = entry[2] if len(entry) > 2 else CONFIG_CACHE_TTL
         if time.time() - timestamp < effective_ttl:
             _config_cache_stats["get_hits"] += 1
+            _config_cw_stats.record_hit()
             return response
         del _config_cache[key]
     _config_cache_stats["get_misses"] += 1
+    _config_cw_stats.record_miss()
     return None
 
 

--- a/src/lambdas/dashboard/handler.py
+++ b/src/lambdas/dashboard/handler.py
@@ -985,4 +985,14 @@ def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
         },
     )
 
-    return app.resolve(event, context)
+    response = app.resolve(event, context)
+
+    # Feature 1224: Flush cache metrics to CloudWatch if interval elapsed
+    try:
+        from src.lib.cache_utils import get_global_emitter
+
+        get_global_emitter().flush_to_cloudwatch()
+    except Exception:
+        logger.debug("Cache metrics flush failed", exc_info=True)
+
+    return response

--- a/src/lambdas/dashboard/metrics.py
+++ b/src/lambdas/dashboard/metrics.py
@@ -39,6 +39,7 @@ from typing import Any
 from boto3.dynamodb.conditions import Key
 
 from src.lambdas.shared.logging_utils import get_safe_error_info, sanitize_for_log
+from src.lib.cache_utils import CacheStats, get_global_emitter
 
 # Structured logging
 logger = logging.getLogger(__name__)
@@ -64,6 +65,10 @@ _metrics_cache: dict[str, tuple[float, Any, float]] = {}
 # Cache statistics
 _metrics_cache_stats = {"hits": 0, "misses": 0, "evictions": 0}
 
+# Feature 1224: CacheStats for CloudWatch metric emission
+_metrics_cw_stats = CacheStats(name="metrics")
+get_global_emitter().register(_metrics_cw_stats)
+
 
 def _get_cached_result(cache_key: str) -> Any | None:
     """Get cached result if not expired."""
@@ -73,10 +78,12 @@ def _get_cached_result(cache_key: str) -> Any | None:
         effective_ttl = entry[2] if len(entry) > 2 else METRICS_CACHE_TTL
         if time.time() - timestamp < effective_ttl:
             _metrics_cache_stats["hits"] += 1
+            _metrics_cw_stats.record_hit()
             return result
         # Expired - remove
         del _metrics_cache[cache_key]
     _metrics_cache_stats["misses"] += 1
+    _metrics_cw_stats.record_miss()
     return None
 
 

--- a/src/lambdas/dashboard/ohlc.py
+++ b/src/lambdas/dashboard/ohlc.py
@@ -45,6 +45,7 @@ from src.lambdas.shared.models import (
 from src.lambdas.shared.utils.event_helpers import get_query_params
 from src.lambdas.shared.utils.market import get_cache_expiration
 from src.lambdas.shared.utils.response_builder import error_response
+from src.lib.cache_utils import CacheStats, get_global_emitter
 
 logger = logging.getLogger(__name__)
 
@@ -70,6 +71,10 @@ OHLC_CACHE_MAX_ENTRIES = int(os.environ.get("OHLC_CACHE_MAX_ENTRIES", "256"))
 # Cache storage: {cache_key: (timestamp, response_dict)}
 _ohlc_cache: dict[str, tuple[float, dict]] = {}
 _ohlc_cache_stats: dict[str, int] = {"hits": 0, "misses": 0, "evictions": 0}
+
+# Feature 1224: CacheStats for CloudWatch metric emission
+_ohlc_cw_stats = CacheStats(name="ohlc_response")
+get_global_emitter().register(_ohlc_cw_stats)
 
 
 def _get_ohlc_cache_key(
@@ -129,10 +134,12 @@ def _get_cached_ohlc(cache_key: str, resolution: str) -> dict | None:
             effective_ttl = OHLC_CACHE_TTLS.get(resolution, OHLC_CACHE_DEFAULT_TTL)
         if time.time() - timestamp < effective_ttl:
             _ohlc_cache_stats["hits"] += 1
+            _ohlc_cw_stats.record_hit()
             return response
         # Expired, remove it
         del _ohlc_cache[cache_key]
     _ohlc_cache_stats["misses"] += 1
+    _ohlc_cw_stats.record_miss()
     return None
 
 

--- a/src/lambdas/dashboard/sentiment.py
+++ b/src/lambdas/dashboard/sentiment.py
@@ -31,6 +31,7 @@ from typing import Any, Literal
 from pydantic import BaseModel, Field
 
 from src.lambdas.shared.logging_utils import get_safe_error_info, sanitize_for_log
+from src.lib.cache_utils import CacheStats, get_global_emitter
 
 logger = logging.getLogger(__name__)
 
@@ -48,6 +49,10 @@ _sentiment_cache: dict[str, tuple[float, "SentimentResponse"]] = {}
 
 # Cache statistics
 _sentiment_cache_stats = {"hits": 0, "misses": 0}
+
+# Feature 1224: CacheStats for CloudWatch metric emission
+_sentiment_cw_stats = CacheStats(name="sentiment")
+get_global_emitter().register(_sentiment_cw_stats)
 
 
 def _get_sentiment_cache_key(config_id: str, tickers: list[str]) -> str:
@@ -75,10 +80,12 @@ def _get_cached_sentiment(cache_key: str) -> "SentimentResponse | None":
         effective_ttl = entry[2] if len(entry) > 2 else SENTIMENT_CACHE_TTL
         if time.time() - timestamp < effective_ttl:
             _sentiment_cache_stats["hits"] += 1
+            _sentiment_cw_stats.record_hit()
             return response
         # Expired - remove from cache
         del _sentiment_cache[cache_key]
     _sentiment_cache_stats["misses"] += 1
+    _sentiment_cw_stats.record_miss()
     return None
 
 

--- a/src/lambdas/shared/adapters/finnhub.py
+++ b/src/lambdas/shared/adapters/finnhub.py
@@ -19,6 +19,7 @@ from src.lambdas.shared.adapters.base import (
     SentimentData,
 )
 from src.lambdas.shared.logging_utils import sanitize_for_log
+from src.lib.cache_utils import CacheStats, get_global_emitter
 
 logger = logging.getLogger(__name__)
 
@@ -27,6 +28,10 @@ logger = logging.getLogger(__name__)
 # Feature 1224: Added jitter to TTL to prevent thundering herd
 # =============================================================================
 # Cache TTL in seconds (default 30 minutes for news/sentiment, 1 hour for OHLC)
+# Feature 1224: CacheStats for CloudWatch metric emission
+_finnhub_stats = CacheStats(name="finnhub")
+get_global_emitter().register(_finnhub_stats)
+
 API_CACHE_TTL_NEWS_SECONDS = int(os.environ.get("API_CACHE_TTL_NEWS_SECONDS", "1800"))
 API_CACHE_TTL_SENTIMENT_SECONDS = int(
     os.environ.get("API_CACHE_TTL_SENTIMENT_SECONDS", "1800")
@@ -56,9 +61,11 @@ def _get_from_cache(key: str, ttl: int) -> Any | None:
         # Feature 1224: Use stored jittered TTL if available, else base TTL
         effective_ttl = entry[2] if len(entry) > 2 else ttl
         if time.time() - timestamp < effective_ttl:
+            _finnhub_stats.record_hit()
             return value
         # Expired - remove from cache
         del _finnhub_cache[key]
+    _finnhub_stats.record_miss()
     return None
 
 

--- a/src/lambdas/shared/adapters/tiingo.py
+++ b/src/lambdas/shared/adapters/tiingo.py
@@ -19,6 +19,7 @@ from src.lambdas.shared.adapters.base import (
     SentimentData,
 )
 from src.lambdas.shared.logging_utils import sanitize_for_log
+from src.lib.cache_utils import CacheStats, get_global_emitter
 
 logger = logging.getLogger(__name__)
 
@@ -29,6 +30,10 @@ logger = logging.getLogger(__name__)
 # Cache TTL in seconds (default 30 minutes for news, 1 hour for OHLC)
 API_CACHE_TTL_NEWS_SECONDS = int(os.environ.get("API_CACHE_TTL_NEWS_SECONDS", "1800"))
 API_CACHE_TTL_OHLC_SECONDS = int(os.environ.get("API_CACHE_TTL_OHLC_SECONDS", "3600"))
+
+# Feature 1224: CacheStats for CloudWatch metric emission
+_tiingo_stats = CacheStats(name="tiingo")
+get_global_emitter().register(_tiingo_stats)
 
 # In-memory cache (survives Lambda warm invocations)
 # Feature 1224: tuple now (timestamp, value, effective_ttl) for jittered expiry
@@ -51,9 +56,11 @@ def _get_from_cache(key: str, ttl: int) -> Any | None:
         # Feature 1224: Use stored jittered TTL if available, else base TTL
         effective_ttl = entry[2] if len(entry) > 2 else ttl
         if time.time() - timestamp < effective_ttl:
+            _tiingo_stats.record_hit()
             return value
         # Expired - remove from cache
         del _tiingo_cache[key]
+    _tiingo_stats.record_miss()
     return None
 
 

--- a/src/lambdas/shared/circuit_breaker.py
+++ b/src/lambdas/shared/circuit_breaker.py
@@ -23,6 +23,7 @@ from typing import Any, Literal
 from aws_lambda_powertools import Tracer
 from pydantic import BaseModel
 
+from src.lib.cache_utils import CacheStats, get_global_emitter
 from src.lib.metrics import emit_metric
 
 logger = logging.getLogger(__name__)
@@ -39,6 +40,10 @@ _circuit_breaker_cache: dict[str, tuple[float, "CircuitBreakerState"]] = {}
 
 # Cache statistics for monitoring
 _cache_stats = {"hits": 0, "misses": 0}
+
+# Feature 1224: CacheStats for CloudWatch metric emission
+_cb_cache_stats = CacheStats(name="circuit_breaker")
+get_global_emitter().register(_cb_cache_stats)
 
 # Thread-safety lock for cache access (Feature 1010)
 _circuit_breaker_lock = threading.Lock()
@@ -68,10 +73,12 @@ def _get_cached_state(service: str) -> "CircuitBreakerState | None":
             effective_ttl = entry[2] if len(entry) > 2 else CIRCUIT_BREAKER_CACHE_TTL
             if time.time() - timestamp < effective_ttl:
                 _cache_stats["hits"] += 1
+                _cb_cache_stats.record_hit()
                 return state
             # Expired - remove from cache
             del _circuit_breaker_cache[service]
         _cache_stats["misses"] += 1
+        _cb_cache_stats.record_miss()
         return None
 
 

--- a/src/lambdas/shared/secrets.py
+++ b/src/lambdas/shared/secrets.py
@@ -35,6 +35,8 @@ import boto3
 from botocore.config import Config
 from botocore.exceptions import ClientError
 
+from src.lib.cache_utils import CacheStats, get_global_emitter
+
 # Structured logging for CloudWatch
 logger = logging.getLogger(__name__)
 
@@ -55,6 +57,10 @@ RETRY_CONFIG = Config(
 # In-memory cache
 # Structure: {secret_id: {"value": <parsed_value>, "expires_at": <timestamp>}}
 _secrets_cache: dict[str, dict[str, Any]] = {}
+
+# Feature 1224: CacheStats for CloudWatch metric emission
+_secrets_cw_stats = CacheStats(name="secrets")
+get_global_emitter().register(_secrets_cw_stats)
 
 
 def _sanitize_secret_id_for_log(secret_id: str) -> str:
@@ -293,14 +299,17 @@ def _get_from_cache(secret_id: str) -> dict[str, Any] | None:
         Cached secret value or None if not cached/expired
     """
     if secret_id not in _secrets_cache:
+        _secrets_cw_stats.record_miss()
         return None
 
     entry = _secrets_cache[secret_id]
     if time.time() > entry["expires_at"]:
         # Cache expired
         del _secrets_cache[secret_id]
+        _secrets_cw_stats.record_miss()
         return None
 
+    _secrets_cw_stats.record_hit()
     return entry["value"]
 
 


### PR DESCRIPTION
## Summary
- Register CacheStats instances with global CacheMetricEmitter for 8 caches: circuit_breaker, tiingo, finnhub, secrets, metrics, sentiment, config, ohlc_response
- Wire `flush_to_cloudwatch()` into Dashboard Lambda handler response path — batches cache hit/miss/eviction metrics into one CloudWatch API call every 60s
- ~$3.60/month estimated CloudWatch cost (12 metric/dimension combos)

## Context
Final phase of Feature 1224. Prior PRs: #735, #736, #737.

## Test plan
- [x] 3484 tests passing, zero regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)