### PR TITLE
test(cache): Metrics cache max_entries eviction test (1224.2)

### DIFF
--- a/specs/001-metrics-cache-bounds-test/spec.md
+++ b/specs/001-metrics-cache-bounds-test/spec.md
@@ -1,0 +1,41 @@
+# Feature Specification: Metrics Cache Max Entries Eviction Test
+
+**Feature Branch**: `001-metrics-cache-bounds-test`
+**Created**: 2026-03-17
+**Status**: Draft
+**Input**: Feature 1224.2 — Metrics Cache Max Entries Eviction Test
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Bounded Cache Regression Detection (Priority: P1)
+
+A developer modifies the metrics cache and accidentally removes the max_entries bound or LRU eviction logic. The test suite catches the regression — a dedicated test fills the cache beyond the limit and asserts that the oldest entry was evicted and the cache size never exceeds the configured maximum.
+
+**Why this priority**: The metrics cache was previously unbounded (FR-008 from Feature 1224). Without this test, the bound can be silently removed, re-introducing the unbounded growth bug.
+
+**Independent Test**: Fill the metrics cache with entries exceeding max_entries and verify eviction occurs.
+
+**Acceptance Scenarios**:
+
+1. **Given** the metrics cache is filled to its maximum capacity, **When** a new entry is added, **Then** the oldest entry is evicted and the cache size equals max_entries.
+2. **Given** the eviction counter exists, **When** eviction occurs, **Then** the eviction counter increments.
+
+### Edge Cases
+
+- What if max_entries is set to 1? The cache should still function (store 1, evict on 2nd).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Test MUST verify that adding entries beyond max_entries triggers LRU eviction.
+- **FR-002**: Test MUST verify cache size never exceeds max_entries after insertion.
+- **FR-003**: Test MUST verify eviction counter increments on eviction.
+- **FR-004**: Test MUST NOT modify production code — test-only change.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Test passes when LRU eviction is present and fails when eviction logic is removed.
+- **SC-002**: All existing tests continue to pass.

--- a/tests/unit/test_cache_bounds.py
+++ b/tests/unit/test_cache_bounds.py
@@ -1,0 +1,55 @@
+"""Test that the metrics cache is bounded and evicts oldest entries (Feature 1224.2).
+
+The metrics cache was previously unbounded. Feature 1224 added
+METRICS_CACHE_MAX_ENTRIES=100 with LRU eviction. This test verifies
+the bound is enforced — if someone removes the eviction logic, this fails.
+"""
+
+import src.lambdas.dashboard.metrics as metrics_mod
+
+
+class TestMetricsCacheBound:
+    def test_cache_evicts_oldest_when_full(self):
+        """Adding entries beyond max_entries triggers LRU eviction."""
+        metrics_mod.clear_metrics_cache()
+        max_entries = metrics_mod.METRICS_CACHE_MAX_ENTRIES
+
+        # Fill cache to capacity
+        for i in range(max_entries):
+            metrics_mod._set_cached_result(f"key-{i}", {"data": i})
+
+        assert len(metrics_mod._metrics_cache) == max_entries
+
+        # Add one more — should evict oldest (key-0)
+        metrics_mod._set_cached_result("overflow-key", {"data": "new"})
+
+        assert len(metrics_mod._metrics_cache) == max_entries
+        assert "overflow-key" in metrics_mod._metrics_cache
+        assert "key-0" not in metrics_mod._metrics_cache
+
+    def test_eviction_counter_increments(self):
+        """Eviction counter tracks number of LRU evictions."""
+        metrics_mod.clear_metrics_cache()
+        max_entries = metrics_mod.METRICS_CACHE_MAX_ENTRIES
+
+        # Fill cache
+        for i in range(max_entries):
+            metrics_mod._set_cached_result(f"key-{i}", {"data": i})
+
+        # Add 3 more — should trigger 3 evictions
+        for i in range(3):
+            metrics_mod._set_cached_result(f"extra-{i}", {"data": "extra"})
+
+        stats = metrics_mod.get_metrics_cache_stats()
+        assert stats["evictions"] == 3
+
+    def test_cache_size_never_exceeds_max(self):
+        """Cache size stays at max_entries even with many insertions."""
+        metrics_mod.clear_metrics_cache()
+        max_entries = metrics_mod.METRICS_CACHE_MAX_ENTRIES
+
+        # Insert 2x max_entries
+        for i in range(max_entries * 2):
+            metrics_mod._set_cached_result(f"key-{i}", {"data": i})
+
+        assert len(metrics_mod._metrics_cache) == max_entries


### PR DESCRIPTION
## Summary
3 tests verifying the metrics cache LRU eviction bound (was unbounded before Feature 1224). If eviction logic is removed, these tests fail.

## Test plan
- [x] 3 new tests, all passing
- [x] Pre-push hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)