### PR TITLE
test(cache): CacheStats wiring integration tests + flaky TTL fix (1224.3)

### DIFF
--- a/specs/001-cachestats-wiring-tests/spec.md
+++ b/specs/001-cachestats-wiring-tests/spec.md
@@ -1,0 +1,38 @@
+# Feature Specification: CacheStats Wiring Integration Tests
+
+**Feature Branch**: `001-cachestats-wiring-tests`
+**Created**: 2026-03-17
+**Status**: Draft
+**Input**: Feature 1224.3 — CacheStats Wiring Integration Tests
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - CacheStats Wiring Regression Detection (Priority: P1)
+
+A developer modifies a cache module and accidentally removes the `record_hit()` or `record_miss()` call. The test suite catches the regression — a dedicated test for each cache exercises the hit/miss path and asserts the module-level CacheStats instance incremented.
+
+**Why this priority**: Without these tests, CacheStats wiring removal is silent. CloudWatch metrics would stop flowing for that cache with no test failure.
+
+**Independent Test**: Exercise each cache's hit and miss paths, then inspect the CacheStats counter.
+
+**Acceptance Scenarios**:
+
+1. **Given** a cache hit occurs, **When** the test checks the CacheStats instance, **Then** the hits counter has incremented.
+2. **Given** a cache miss occurs, **When** the test checks the CacheStats instance, **Then** the misses counter has incremented.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Test suite MUST verify CacheStats.hits increments on cache hit for each wired cache.
+- **FR-002**: Test suite MUST verify CacheStats.misses increments on cache miss for each wired cache.
+- **FR-003**: Tests MUST cover all 8 caches with CacheStats wiring: circuit_breaker, tiingo, finnhub, secrets, metrics, sentiment, config, ohlc_response.
+- **FR-004**: Tests MUST NOT modify production code — test-only change.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: All 8 caches have CacheStats hit/miss wiring verified by tests.
+- **SC-002**: Removing a `record_hit()` or `record_miss()` call from any cache causes a test failure.
+- **SC-003**: All existing tests continue to pass.

--- a/tests/unit/test_cachestats_wiring.py
+++ b/tests/unit/test_cachestats_wiring.py
@@ -1,0 +1,195 @@
+"""Integration tests verifying CacheStats is wired into each cache module.
+
+Feature 1224.3: Each cache must increment its CacheStats instance on
+hit and miss. If someone removes a record_hit()/record_miss() call,
+exactly one test fails.
+"""
+
+from unittest.mock import MagicMock
+
+
+class TestCircuitBreakerCacheStats:
+    def test_hit_increments_stats(self):
+        import src.lambdas.shared.circuit_breaker as mod
+
+        mod.clear_cache()
+        mod._cb_cache_stats.hits = 0
+
+        state = mod.CircuitBreakerState.create_default("tiingo")
+        mod._set_cached_state("tiingo", state)
+        mod._get_cached_state("tiingo")  # Hit
+
+        assert mod._cb_cache_stats.hits >= 1
+
+    def test_miss_increments_stats(self):
+        import src.lambdas.shared.circuit_breaker as mod
+
+        mod.clear_cache()
+        mod._cb_cache_stats.misses = 0
+
+        mod._get_cached_state("nonexistent")  # Miss
+
+        assert mod._cb_cache_stats.misses >= 1
+
+
+class TestTiingoCacheStats:
+    def test_hit_increments_stats(self):
+        import src.lambdas.shared.adapters.tiingo as mod
+
+        mod.clear_cache()
+        mod._tiingo_stats.hits = 0
+
+        mod._put_in_cache("test", "value", 1800)
+        mod._get_from_cache("test", 1800)  # Hit
+
+        assert mod._tiingo_stats.hits >= 1
+
+    def test_miss_increments_stats(self):
+        import src.lambdas.shared.adapters.tiingo as mod
+
+        mod.clear_cache()
+        mod._tiingo_stats.misses = 0
+
+        mod._get_from_cache("nonexistent", 1800)  # Miss
+
+        assert mod._tiingo_stats.misses >= 1
+
+
+class TestFinnhubCacheStats:
+    def test_hit_increments_stats(self):
+        import src.lambdas.shared.adapters.finnhub as mod
+
+        mod.clear_cache()
+        mod._finnhub_stats.hits = 0
+
+        mod._put_in_cache("test", "value", 1800)
+        mod._get_from_cache("test", 1800)  # Hit
+
+        assert mod._finnhub_stats.hits >= 1
+
+    def test_miss_increments_stats(self):
+        import src.lambdas.shared.adapters.finnhub as mod
+
+        mod.clear_cache()
+        mod._finnhub_stats.misses = 0
+
+        mod._get_from_cache("nonexistent", 1800)  # Miss
+
+        assert mod._finnhub_stats.misses >= 1
+
+
+class TestSecretsCacheStats:
+    def test_hit_increments_stats(self):
+        import src.lambdas.shared.secrets as mod
+
+        mod.clear_cache()
+        mod._secrets_cw_stats.hits = 0
+
+        mod._set_in_cache("test-secret", {"key": "val"})
+        mod._get_from_cache("test-secret")  # Hit
+
+        assert mod._secrets_cw_stats.hits >= 1
+
+    def test_miss_increments_stats(self):
+        import src.lambdas.shared.secrets as mod
+
+        mod.clear_cache()
+        mod._secrets_cw_stats.misses = 0
+
+        mod._get_from_cache("nonexistent")  # Miss
+
+        assert mod._secrets_cw_stats.misses >= 1
+
+
+class TestMetricsCacheStats:
+    def test_hit_increments_stats(self):
+        import src.lambdas.dashboard.metrics as mod
+
+        mod.clear_metrics_cache()
+        mod._metrics_cw_stats.hits = 0
+
+        mod._set_cached_result("test-key", {"data": 1})
+        mod._get_cached_result("test-key")  # Hit
+
+        assert mod._metrics_cw_stats.hits >= 1
+
+    def test_miss_increments_stats(self):
+        import src.lambdas.dashboard.metrics as mod
+
+        mod.clear_metrics_cache()
+        mod._metrics_cw_stats.misses = 0
+
+        mod._get_cached_result("nonexistent")  # Miss
+
+        assert mod._metrics_cw_stats.misses >= 1
+
+
+class TestSentimentCacheStats:
+    def test_hit_increments_stats(self):
+        import src.lambdas.dashboard.sentiment as mod
+
+        mod.clear_sentiment_cache()
+        mod._sentiment_cw_stats.hits = 0
+
+        mock_response = MagicMock()
+        mod._set_cached_sentiment("test-key", mock_response)
+        mod._get_cached_sentiment("test-key")  # Hit
+
+        assert mod._sentiment_cw_stats.hits >= 1
+
+    def test_miss_increments_stats(self):
+        import src.lambdas.dashboard.sentiment as mod
+
+        mod.clear_sentiment_cache()
+        mod._sentiment_cw_stats.misses = 0
+
+        mod._get_cached_sentiment("nonexistent")  # Miss
+
+        assert mod._sentiment_cw_stats.misses >= 1
+
+
+class TestConfigCacheStats:
+    def test_list_hit_increments_stats(self):
+        import src.lambdas.dashboard.configurations as mod
+
+        mod.clear_config_cache()
+        mod._config_cw_stats.hits = 0
+
+        mock_response = MagicMock()
+        mod._set_cached_config_list("user-1", mock_response)
+        mod._get_cached_config_list("user-1")  # Hit
+
+        assert mod._config_cw_stats.hits >= 1
+
+    def test_list_miss_increments_stats(self):
+        import src.lambdas.dashboard.configurations as mod
+
+        mod.clear_config_cache()
+        mod._config_cw_stats.misses = 0
+
+        mod._get_cached_config_list("nonexistent")  # Miss
+
+        assert mod._config_cw_stats.misses >= 1
+
+
+class TestOHLCResponseCacheStats:
+    def test_hit_increments_stats(self):
+        import src.lambdas.dashboard.ohlc as mod
+
+        mod._ohlc_cache.clear()
+        mod._ohlc_cw_stats.hits = 0
+
+        mod._set_cached_ohlc("test-key", {"data": 1}, "D")
+        mod._get_cached_ohlc("test-key", "D")  # Hit
+
+        assert mod._ohlc_cw_stats.hits >= 1
+
+    def test_miss_increments_stats(self):
+        import src.lambdas.dashboard.ohlc as mod
+
+        mod._ohlc_cache.clear()
+        mod._ohlc_cw_stats.misses = 0
+
+        mod._get_cached_ohlc("nonexistent", "D")  # Miss
+
+        assert mod._ohlc_cw_stats.misses >= 1

--- a/tests/unit/test_timeseries_query.py
+++ b/tests/unit/test_timeseries_query.py
@@ -275,8 +275,8 @@ class TestTimeseriesQueryWithCache:
             response1 = service.query("AAPL", Resolution.ONE_MINUTE)
             assert response1.cache_hit is False
 
-        # After 60 seconds (1m TTL)
-        with freeze_time("2025-12-21T10:36:01Z"):
+        # Feature 1224: TTL has ±10% jitter, max 66s. Advance well past that.
+        with freeze_time("2025-12-21T10:37:10Z"):
             response2 = service.query("AAPL", Resolution.ONE_MINUTE)
             assert response2.cache_hit is False  # TTL expired
 


### PR DESCRIPTION
## Summary
- 16 tests verifying CacheStats.record_hit()/record_miss() wired into each cache module's hit/miss path
- Fix flaky `test_cache_miss_after_ttl` — advance time past max jittered TTL (66s → 130s)

Covers: circuit_breaker, tiingo, finnhub, secrets, metrics, sentiment, config, ohlc_response.

## Context
Coverage gap #3 from Feature 1224 audit. Test-only + flaky fix.

## Test plan
- [x] 16 new tests, all passing
- [x] Full suite passes (3224 tests, pre-push hooks green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)