### PR TITLE
fix(deploy): Add lambda:InvokeFunction to CI policy + fix payload format

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1023,6 +1023,7 @@ jobs:
             if aws lambda invoke \
               --function-name preprod-sentiment-dashboard \
               --payload "$PREWARM_EVENT" \
+              --cli-binary-format raw-in-base64-out \
               --cli-read-timeout 120 \
               /tmp/prewarm-response.json 2>&1; then
 

--- a/infrastructure/terraform/ci-user-policy.tf
+++ b/infrastructure/terraform/ci-user-policy.tf
@@ -83,7 +83,9 @@ data "aws_iam_policy_document" "ci_deploy_core" {
       # Lambda concurrency management (required for reserved_concurrency changes)
       "lambda:PutFunctionConcurrency",
       "lambda:DeleteFunctionConcurrency",
-      "lambda:GetFunctionConcurrency"
+      "lambda:GetFunctionConcurrency",
+      # Feature 1224: Pre-warm Lambda after image update (deploy smoke test)
+      "lambda:InvokeFunction"
     ]
     resources = [
       # Pattern: {env}-sentiment-* (preprod-sentiment-ingestion, prod-sentiment-dashboard, etc.)


### PR DESCRIPTION
## Summary
Root cause fix for deploy failures since PR #734 (deploys #13-#15):

1. **Missing IAM permission**: CI deploy user lacks `lambda:InvokeFunction` — pre-warm `aws lambda invoke` fails with AccessDeniedException
2. **Invalid payload format**: AWS CLI v2 requires `--cli-binary-format raw-in-base64-out` for raw JSON — without it, invoke fails with "Invalid base64"

Both caused the pre-warm step to fail silently, then smoke test hit persistent 404 on all 10 retries.

## Changes
- `ci-user-policy.tf`: Add `lambda:InvokeFunction` to `ci_deploy_core` policy
- `deploy.yml`: Add `--cli-binary-format raw-in-base64-out` to pre-warm invoke

## Test plan
- [x] Reproduced locally: `aws lambda invoke` returns AccessDeniedException for deployer user
- [x] With `--cli-binary-format raw-in-base64-out`, payload accepted correctly
- [ ] Deploy succeeds after merge (Terraform applies IAM change, then pre-warm works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)