### PR TITLE
fix(deploy): Complete v2 event format for pre-warm invoke

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1016,7 +1016,7 @@ jobs:
         run: |
           echo "🔥 Pre-warming Dashboard Lambda (forces container cold start)..."
 
-          PREWARM_EVENT='{"version":"2.0","requestContext":{"http":{"method":"GET","path":"/health"}},"rawPath":"/health","isBase64Encoded":false}'
+          PREWARM_EVENT='{"version":"2.0","routeKey":"$default","rawPath":"/health","rawQueryString":"","headers":{"content-type":"application/json"},"requestContext":{"accountId":"000000000000","apiId":"prewarm","domainName":"prewarm.lambda-url.us-east-1.on.aws","domainPrefix":"prewarm","http":{"method":"GET","path":"/health","protocol":"HTTP/1.1","sourceIp":"127.0.0.1","userAgent":"deploy-prewarm"},"requestId":"prewarm-health-check","routeKey":"$default","stage":"$default","time":"01/Jan/2024:00:00:00 +0000","timeEpoch":1704067200000},"isBase64Encoded":false}'
 
           for attempt in 1 2 3; do
             echo "  Attempt $attempt..."


### PR DESCRIPTION
## Summary
PR #742 fixed the IAM permission and CLI payload format — invoke now succeeds
but returns `FunctionError: "Unhandled"` because the event was missing required
Function URL v2 fields (`routeKey`, `rawQueryString`, `headers`, full
`requestContext`). LambdaFunctionUrlResolver can't parse the incomplete event.

This sends a complete v2 event matching the Function URL spec.

## Deploy failure progression
| Deploy | Issue | Fix |
|--------|-------|-----|
| #13 | Cold start 404, no retry | PR #733 (5x5s retry) |
| #14 | 404 persists past 25s | PR #734 (pre-warm + 10x10s) |
| #15 | Pre-warm: AccessDenied + Invalid base64 | PR #742 (IAM + CLI flag) |
| #16 | Pre-warm: FunctionError Unhandled | **This PR** (complete v2 event) |

## Test plan
- [ ] Deploy #17 pre-warm returns statusCode: 200 (not FunctionError)
- [ ] Smoke test passes on first attempt

🤖 Generated with [Claude Code](https://claude.com/claude-code)