### PR TITLE
fix(deploy): Stop Terraform/CI double image update causing Function URL 404

### DIFF
--- a/infrastructure/terraform/modules/lambda/main.tf
+++ b/infrastructure/terraform/modules/lambda/main.tf
@@ -100,10 +100,14 @@ resource "aws_lambda_function" "this" {
     Name = var.function_name
   })
 
-  # Note: ignore_source_code_changes variable is available but not used here
-  # because Terraform requires static lists in lifecycle blocks.
-  # For deployments that need to ignore source changes, use a separate resource
-  # or manage deployments via Lambda aliases instead.
+  # Feature 1224: Ignore image_uri changes made by CI/CD force-update step.
+  # Without this, Terraform apply reverts image_uri to :latest, then the
+  # Force Image Update step changes it to :sha — causing a double function
+  # update that breaks the Function URL routing (persistent 404).
+  # CI manages image_uri via aws lambda update-function-code.
+  lifecycle {
+    ignore_changes = [image_uri]
+  }
 }
 
 # Lambda Function URL (optional)


### PR DESCRIPTION
## Summary
**Root cause** of all deploy failures since #13 (6 consecutive failures):

Terraform apply reverts `image_uri` to `:latest`, then Force Image Update changes it to `:sha`. This **double function update** breaks Function URL routing — returns 404 until internal routing re-propagates (longer than our 100s retry budget).

Evidence: Deploy #17 pre-warm via direct `aws lambda invoke` returns 200 (function works), but Function URL returns 404 for 100+ seconds (routing broken by double update).

**Fix**: `lifecycle { ignore_changes = [image_uri] }` — Terraform no longer touches `image_uri`. CI manages it exclusively via `aws lambda update-function-code`. Single update, no race condition.

## Deploy failure archaeology
| Deploy | Layer | Fix |
|--------|-------|-----|
| #13 | No retry | PR #733 |
| #14 | Not enough retry | PR #734 |
| #15 | IAM + base64 | PR #742 |
| #16 | Incomplete event | PR #743 |
| #17 | **Double update race** | **This PR** |

## Test plan
- [x] Terraform fmt + validate pass
- [x] Checkov/Trivy IaC scan pass
- [ ] Deploy #18 smoke test passes (single update, no 404)

🤖 Generated with [Claude Code](https://claude.com/claude-code)