### PR TITLE
fix(auth): Add missing ErrorResponse class causing 502 on auth endpoints

### DIFF
--- a/src/lambdas/dashboard/auth.py
+++ b/src/lambdas/dashboard/auth.py
@@ -1493,6 +1493,23 @@ class RefreshTokenResponse(BaseModel):
     message: str | None = None
 
 
+class ErrorDetail(BaseModel):
+    """Error detail for auth error responses."""
+
+    code: str
+    message: str
+    details: dict[str, Any] | None = None
+
+
+class ErrorResponse(BaseModel):
+    """Standard error response for auth service functions.
+
+    Used by router_v2.py: isinstance(result, auth_service.ErrorResponse)
+    """
+
+    error: ErrorDetail
+
+
 class SignOutResponse(BaseModel):
     """Response for POST /api/v2/auth/signout."""
 


### PR DESCRIPTION
## Summary
`router_v2.py` references `auth_service.ErrorResponse` in 5 places but `auth.py` never defined it. Any auth endpoint returning an error path (refresh, callback, session) crashes with:
```
AttributeError: module 'src.lambdas.dashboard.auth' has no attribute 'ErrorResponse'
```

This caused the `/api/v2/auth/refresh` 502 in integration tests and affects all 5 auth error paths.

## Changes
Add `ErrorDetail` and `ErrorResponse` classes to `auth.py`, matching the pattern used in `configurations.py`, `alerts.py`, `notifications.py`, and `sentiment.py`.

## Test plan
- [x] 436 auth unit tests pass
- [x] `from src.lambdas.dashboard.auth import ErrorResponse` succeeds
- [ ] Integration test `test_token_refresh` returns 401 instead of 502

🤖 Generated with [Claude Code](https://claude.com/claude-code)