### PR TITLE
fix(frontend): Fix Amplify build — restore customer dashboard

### DIFF
--- a/frontend/src/lib/api/sse-parser.ts
+++ b/frontend/src/lib/api/sse-parser.ts
@@ -33,7 +33,7 @@ export interface SSEEvent {
  * - BOM stripping on first chunk
  */
 export class SSEParser {
-  private decoder = new TextDecoder('utf-8', { stream: true });
+  private decoder = new TextDecoder('utf-8');
   private buffer = '';
   private eventType = '';
   private dataLines: string[] = [];
@@ -84,7 +84,7 @@ export class SSEParser {
 
   /** Reset parser state for a new connection. */
   reset(): void {
-    this.decoder = new TextDecoder('utf-8', { stream: true });
+    this.decoder = new TextDecoder('utf-8');
     this.buffer = '';
     this.eventType = '';
     this.dataLines = [];

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -22,5 +22,5 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "tests"]
 }


### PR DESCRIPTION
## Summary

- **`sse-parser.ts`**: Remove `{ stream: true }` from `TextDecoder` constructor (only valid on `.decode()`, not constructor)
- **`tsconfig.json`**: Exclude `tests/` from compilation — test helpers import `@aws-sdk/client-dynamodb` which isn't a frontend dependency

Amplify builds have been failing since job #207 (3 days). The correct `NEXT_PUBLIC_API_URL` is already in Amplify's config (Terraform updated it), but no successful build has deployed it. Once this merges, Amplify auto-builds and the frontend gets the correct Lambda URL.

**Discovery**: Found via trace inspection diagnostic — Playwright screenshots showed "No tickers found" for all tickers. Network capture revealed the frontend was calling the old destroyed Function URL.

## Test plan

- [x] `npx tsc --noEmit` passes (source files, excluding tests)
- [x] `npx next build` succeeds with correct API URL
- [ ] Amplify build #210 succeeds after merge
- [ ] Dashboard search returns results for AAPL, LCID

🤖 Generated with [Claude Code](https://claude.com/claude-code)