### PR TITLE
fix(ingestion): Fix runtime bugs — wrong DDB table + missing UpdateItem IAM

### DIFF
--- a/infrastructure/terraform/ci-user-policy.tf
+++ b/infrastructure/terraform/ci-user-policy.tf
@@ -394,7 +394,10 @@ data "aws_iam_policy_document" "ci_deploy_monitoring" {
       # CloudWatch Logs Insights queries (for E2E observability tests)
       "logs:StartQuery",
       "logs:GetQueryResults",
-      "logs:StopQuery"
+      "logs:StopQuery",
+      # Feature 1227: Read log events for pipeline debugging
+      "logs:GetLogEvents",
+      "logs:FilterLogEvents"
     ]
     resources = [
       # Pattern: {env}-sentiment-* (preprod-sentiment-dashboard, prod-sentiment-ingestion, etc.)

--- a/infrastructure/terraform/modules/iam/main.tf
+++ b/infrastructure/terraform/modules/iam/main.tf
@@ -40,7 +40,8 @@ resource "aws_iam_role_policy" "ingestion_dynamodb" {
         Effect = "Allow"
         Action = [
           "dynamodb:PutItem",
-          "dynamodb:GetItem"
+          "dynamodb:GetItem",
+          "dynamodb:UpdateItem" # Feature 1227: Required for Feature 1010 dedup upsert
         ]
         Resource = var.dynamodb_table_arn
       },

--- a/src/lambdas/ingestion/handler.py
+++ b/src/lambdas/ingestion/handler.py
@@ -233,11 +233,13 @@ def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
         )
 
         # Initialize circuit breakers (load from DynamoDB or create default)
-        tiingo_breaker = _get_or_create_circuit_breaker(table, "tiingo")
-        finnhub_breaker = _get_or_create_circuit_breaker(table, "finnhub")
+        # Feature 1227: Circuit breakers use PK/SK schema → must use users_table, not items table
+        tiingo_breaker = _get_or_create_circuit_breaker(users_table, "tiingo")
+        finnhub_breaker = _get_or_create_circuit_breaker(users_table, "finnhub")
 
         # Get quota tracker (load from DynamoDB or create default)
-        quota_tracker = _get_or_create_quota_tracker(table)
+        # Feature 1227: Quota tracker uses PK/SK schema → must use users_table
+        quota_tracker = _get_or_create_quota_tracker(users_table)
 
         # Get API keys from Secrets Manager
         tiingo_key = get_api_key(config["tiingo_secret_arn"])
@@ -498,9 +500,9 @@ def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
 
         finally:
             # Save state to DynamoDB
-            _save_circuit_breaker(table, tiingo_breaker)
-            _save_circuit_breaker(table, finnhub_breaker)
-            _save_quota_tracker(table, quota_tracker)
+            _save_circuit_breaker(users_table, tiingo_breaker)
+            _save_circuit_breaker(users_table, finnhub_breaker)
+            _save_quota_tracker(users_table, quota_tracker)
 
             # Clean up adapters
             if tiingo_adapter:


### PR DESCRIPTION
## Summary

Follow-up to PR #756. The ingestion Lambda starts (import fixed) but crashes at runtime due to two bugs:

1. **Wrong DynamoDB table**: Circuit breaker and quota tracker use `PK`/`SK` keys but were passed the items table (`source_id`/`timestamp` schema). Every operation failed with `ValidationException: key element does not match schema`. Fix: 6 calls changed from `table` to `users_table`.

2. **Missing IAM permission**: Feature 1010 dedup uses `UpdateItem` but IAM only had `PutItem`+`GetItem`. Every article upsert failed with `AccessDeniedException`. Fix: add `dynamodb:UpdateItem`.

Also adds `logs:GetLogEvents`/`FilterLogEvents` to CI deployer for debugging.

**Already verified live**: Deployed debug ZIP directly, invoked Lambda — 662 articles fetched, 547 stored, 515 timeseries records created. Pipeline is alive.

## Test plan

- [x] Pre-existing unit tests pass (3563)
- [x] Direct Lambda invoke: 662 articles, 0 errors, 515 timeseries records
- [ ] Deploy pipeline applies Terraform IAM change
- [ ] Next scheduled ingestion cycle succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)