### PR TITLE
fix(circuit-breaker): Reset failure count on any success

### DIFF
--- a/src/lambdas/shared/circuit_breaker.py
+++ b/src/lambdas/shared/circuit_breaker.py
@@ -174,11 +174,17 @@ class CircuitBreakerState(BaseModel):
         return "STATE"
 
     def record_success(self) -> None:
-        """Record successful API call."""
+        """Record successful API call.
+
+        Resets failure count on ANY success — a successful call proves
+        the service is reachable, so accumulated failures are stale.
+        Previously only reset on half_open→closed transition, which meant
+        4 failures + 1 success + 1 failure = tripped (non-consecutive).
+        """
         self.last_success_at = datetime.now(UTC)
+        self.failure_count = 0  # Feature 1227: Reset on any success, not just recovery
         if self.state == "half_open":
             self.state = "closed"
-            self.failure_count = 0
             self.total_recoveries += 1
 
     def record_failure(self) -> None:

--- a/tests/unit/shared/test_circuit_breaker.py
+++ b/tests/unit/shared/test_circuit_breaker.py
@@ -44,6 +44,29 @@ class TestCircuitBreakerState:
         assert cb.total_failures == 1
         assert cb.last_failure_at is not None
 
+    def test_success_resets_failure_count_in_closed_state(self):
+        """Test that success resets failure count even when circuit is closed.
+
+        Feature 1227: Previously, failures accumulated across successes
+        (4 failures + 1 success + 1 failure = tripped). Now, any success
+        resets the counter — only consecutive failures trip the breaker.
+        """
+        cb = CircuitBreakerState(service="tiingo", failure_threshold=5)
+
+        cb.record_failure()
+        cb.record_failure()
+        cb.record_failure()
+        cb.record_failure()
+        assert cb.failure_count == 4
+
+        cb.record_success()
+        assert cb.failure_count == 0  # Reset on success
+        assert cb.state == "closed"
+
+        cb.record_failure()
+        assert cb.failure_count == 1  # Starts from 0, not 5
+        assert cb.state == "closed"  # NOT tripped
+
     def test_circuit_trips_after_threshold(self):
         """Test circuit opens after reaching failure threshold."""
         cb = CircuitBreakerState(service="tiingo", failure_threshold=3)


### PR DESCRIPTION
## Summary

Circuit breaker `record_success()` only reset `failure_count` during half_open→closed recovery. In closed state, failures accumulated across successes: 4 failures + 1 success + 1 failure = tripped. Now any success resets the counter — only consecutive failures trip the breaker.

## Test plan

- [x] 26/26 circuit breaker tests pass (15 state + 10 thread safety + 1 new)
- [x] New test: `test_success_resets_failure_count_in_closed_state`

🤖 Generated with [Claude Code](https://claude.com/claude-code)