### PR TITLE
fix(ttl): Fix DynamoDB TTL attribute mismatch — records never expired

### DIFF
--- a/scripts/cleanup_orphaned_sessions.py
+++ b/scripts/cleanup_orphaned_sessions.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""One-time cleanup script for orphaned anonymous sessions.
+
+Root cause: DynamoDB TTL was configured on `ttl_timestamp` (Terraform), but
+anonymous session creation code wrote the TTL value to `ttl` instead. Result:
+DynamoDB TTL never fired and ~110K anonymous sessions accumulated.
+
+This script scans the users table for anonymous sessions and sets their
+`ttl_timestamp` to 0 (Unix epoch), causing DynamoDB TTL to delete them
+within 48 hours.
+
+Usage:
+    # Dry run (count only, no modifications)
+    python scripts/cleanup_orphaned_sessions.py --dry-run
+
+    # Execute cleanup on preprod
+    python scripts/cleanup_orphaned_sessions.py --table-name preprod-sentiment-users
+
+    # Execute cleanup on prod
+    python scripts/cleanup_orphaned_sessions.py --table-name prod-sentiment-users
+"""
+
+import argparse
+import logging
+import sys
+import time
+
+import boto3
+from boto3.dynamodb.conditions import Attr
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+)
+logger = logging.getLogger("cleanup_orphaned_sessions")
+
+DEFAULT_TABLE_NAME = "preprod-sentiment-users"
+
+
+def scan_anonymous_sessions(table, *, dry_run: bool) -> int:
+    """Scan for anonymous sessions and set ttl_timestamp to 0 for deletion.
+
+    Args:
+        table: boto3 DynamoDB Table resource.
+        dry_run: If True, count items without modifying.
+
+    Returns:
+        Total number of anonymous sessions found.
+    """
+    total_found = 0
+    total_updated = 0
+    last_evaluated_key = None
+
+    logger.info(
+        "Starting scan for auth_type='anonymous' items%s",
+        " (DRY RUN)" if dry_run else "",
+    )
+
+    while True:
+        scan_kwargs = {
+            "FilterExpression": Attr("auth_type").eq("anonymous"),
+            "ProjectionExpression": "PK, SK",
+        }
+        if last_evaluated_key:
+            scan_kwargs["ExclusiveStartKey"] = last_evaluated_key
+
+        response = table.scan(**scan_kwargs)
+        items = response.get("Items", [])
+        total_found += len(items)
+
+        if not dry_run and items:
+            for item in items:
+                try:
+                    table.update_item(
+                        Key={"PK": item["PK"], "SK": item["SK"]},
+                        UpdateExpression="SET #ttl = :zero",
+                        ExpressionAttributeNames={"#ttl": "ttl_timestamp"},
+                        ExpressionAttributeValues={":zero": 0},
+                    )
+                    total_updated += 1
+                except Exception:
+                    logger.exception(
+                        "Failed to update item PK=%s SK=%s",
+                        item["PK"],
+                        item["SK"],
+                    )
+
+        # Log progress every 1000 items
+        prev_milestone = (total_found - len(items)) // 1000
+        curr_milestone = total_found // 1000
+        if curr_milestone > prev_milestone:
+            if dry_run:
+                logger.info("Progress: %d anonymous sessions found so far", total_found)
+            else:
+                logger.info(
+                    "Progress: %d found, %d updated so far",
+                    total_found,
+                    total_updated,
+                )
+
+        last_evaluated_key = response.get("LastEvaluatedKey")
+        if not last_evaluated_key:
+            break
+
+    return total_found
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Clean up orphaned anonymous sessions by setting ttl_timestamp=0 for DynamoDB TTL deletion.",
+    )
+    parser.add_argument(
+        "--table-name",
+        default=DEFAULT_TABLE_NAME,
+        help=f"DynamoDB table name (default: {DEFAULT_TABLE_NAME})",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Count anonymous sessions without modifying them",
+    )
+    parser.add_argument(
+        "--region",
+        default="us-east-1",
+        help="AWS region (default: us-east-1)",
+    )
+
+    args = parser.parse_args()
+
+    dynamodb = boto3.resource("dynamodb", region_name=args.region)
+    table = dynamodb.Table(args.table_name)
+
+    logger.info("Table: %s (region: %s)", args.table_name, args.region)
+
+    start_time = time.monotonic()
+    total = scan_anonymous_sessions(table, dry_run=args.dry_run)
+    elapsed = time.monotonic() - start_time
+
+    if args.dry_run:
+        logger.info(
+            "DRY RUN complete: %d anonymous sessions found in %.1fs",
+            total,
+            elapsed,
+        )
+        logger.info(
+            "Run without --dry-run to set ttl_timestamp=0 on these items. "
+            "DynamoDB TTL will delete them within 48 hours.",
+        )
+    else:
+        logger.info(
+            "Cleanup complete: %d anonymous sessions marked for TTL deletion in %.1fs",
+            total,
+            elapsed,
+        )
+        logger.info(
+            "DynamoDB will delete these items within 48 hours.",
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/lambdas/dashboard/auth.py
+++ b/src/lambdas/dashboard/auth.py
@@ -168,8 +168,8 @@ def create_anonymous_session(
         # Store in DynamoDB
         item = user.to_dynamodb_item()
 
-        # Add TTL for automatic cleanup
-        item["ttl"] = int(expires_at.timestamp())
+        # Add TTL for automatic cleanup (must match Terraform ttl_timestamp attribute)
+        item["ttl_timestamp"] = int(expires_at.timestamp())
 
         table.put_item(Item=item)
 
@@ -370,7 +370,7 @@ def _extend_session_expiry_on_validation(table: Any, user: User) -> None:
         table.update_item(
             Key={"PK": user.pk, "SK": user.sk},
             UpdateExpression="SET session_expires_at = :expires, #ttl = :ttl",
-            ExpressionAttributeNames={"#ttl": "ttl"},
+            ExpressionAttributeNames={"#ttl": "ttl_timestamp"},
             ExpressionAttributeValues={
                 ":expires": new_expiry.isoformat(),
                 ":ttl": int(new_expiry.timestamp()) + (90 * 24 * 3600),
@@ -713,7 +713,9 @@ def create_user_with_email(
     )
 
     item = user.to_dynamodb_item()
-    item["ttl"] = int(expires_at.timestamp()) + (90 * 24 * 3600)  # 90 days for auth
+    item["ttl_timestamp"] = int(expires_at.timestamp()) + (
+        90 * 24 * 3600
+    )  # 90 days for auth
 
     try:
         # Conditional write to prevent race condition
@@ -844,7 +846,7 @@ def extend_session(table: Any, user_id: str) -> User | None:
             },
             UpdateExpression="SET session_expires_at = :expires, last_active_at = :now, #ttl = :ttl",
             ExpressionAttributeNames={
-                "#ttl": "ttl",
+                "#ttl": "ttl_timestamp",
             },
             ExpressionAttributeValues={
                 ":expires": new_expiry.isoformat(),
@@ -941,7 +943,7 @@ def extend_session_expiry(table: Any, user_id: str) -> User | None:
         table.update_item(
             Key={"PK": user.pk, "SK": user.sk},
             UpdateExpression="SET session_expires_at = :expires, last_active_at = :last_active, #ttl = :ttl",
-            ExpressionAttributeNames={"#ttl": "ttl"},
+            ExpressionAttributeNames={"#ttl": "ttl_timestamp"},
             ExpressionAttributeValues={
                 ":expires": new_expiry.isoformat(),
                 ":last_active": now.isoformat(),
@@ -1109,7 +1111,7 @@ def evict_oldest_session_atomic(
                 "Item": {
                     "PK": {"S": f"BLOCK#refresh#{refresh_token_hash}"},
                     "SK": {"S": "BLOCK"},
-                    "ttl": {"N": str(blocklist_ttl)},
+                    "ttl_timestamp": {"N": str(blocklist_ttl)},
                     "evicted_at": {"S": now.isoformat()},
                     "user_id": {"S": user_id},
                     "reason": {"S": "session_limit_eviction"},
@@ -1941,7 +1943,7 @@ def _create_authenticated_user(
     )
 
     item = user.to_dynamodb_item()
-    item["ttl"] = int(expires_at.timestamp()) + (
+    item["ttl_timestamp"] = int(expires_at.timestamp()) + (
         90 * 24 * 3600
     )  # 90 days for auth users
     table.put_item(Item=item)
@@ -3080,7 +3082,7 @@ def link_email_to_oauth_user(
         "created_at": now.isoformat(),
         "expires_at": expires_at.isoformat(),
         "used": False,
-        "ttl": int(expires_at.timestamp()) + 3600,  # 1 hour buffer
+        "ttl_timestamp": int(expires_at.timestamp()) + 3600,  # 1 hour buffer
     }
 
     try:

--- a/src/lambdas/dashboard/metrics.py
+++ b/src/lambdas/dashboard/metrics.py
@@ -563,7 +563,7 @@ def sanitize_item_for_response(item: dict[str, Any]) -> dict[str, Any]:
         We flatten these for backward compatibility.
     """
     # Fields to exclude from API responses
-    hidden_fields = {"ttl", "content_hash"}
+    hidden_fields = {"ttl", "ttl_timestamp", "content_hash"}
 
     sanitized = {}
     for key, value in item.items():

--- a/src/lambdas/shared/auth/oauth_state.py
+++ b/src/lambdas/shared/auth/oauth_state.py
@@ -88,7 +88,7 @@ def store_oauth_state(
         "redirect_uri": redirect_uri,
         "created_at": now.isoformat(),
         "used": False,
-        "ttl": ttl,
+        "ttl_timestamp": ttl,
         "code_verifier": code_verifier,
     }
     if user_id:

--- a/src/lambdas/shared/middleware/hcaptcha.py
+++ b/src/lambdas/shared/middleware/hcaptcha.py
@@ -257,7 +257,7 @@ def record_action_for_rate_limit(
                 "action": action,
                 "client_ip": client_ip,
                 "created_at": now.isoformat(),
-                "ttl": ttl,
+                "ttl_timestamp": ttl,
                 "entity_type": "RATE_LIMIT_RECORD",
             }
         )

--- a/src/lambdas/shared/middleware/rate_limit.py
+++ b/src/lambdas/shared/middleware/rate_limit.py
@@ -236,7 +236,7 @@ def _record_request(
                 "action": action,
                 "rate_key": rate_key,
                 "created_at": timestamp.isoformat(),
-                "ttl": ttl,
+                "ttl_timestamp": ttl,
                 "entity_type": "RATE_LIMIT",
             }
         )

--- a/src/lambdas/shared/models/magic_link_token.py
+++ b/src/lambdas/shared/models/magic_link_token.py
@@ -51,7 +51,7 @@ class MagicLinkToken(BaseModel):
             "created_at": self.created_at.isoformat(),
             "expires_at": self.expires_at.isoformat(),
             "used": self.used,
-            "ttl": ttl,
+            "ttl_timestamp": ttl,
             "entity_type": "MAGIC_LINK_TOKEN",
         }
         # Feature 1166: Only include signature if present (backwards compat)

--- a/src/lambdas/shared/models/webhook_event.py
+++ b/src/lambdas/shared/models/webhook_event.py
@@ -45,7 +45,7 @@ class WebhookEvent(BaseModel):
         if self.subscription_id:
             item["subscription_id"] = self.subscription_id
         if self.ttl:
-            item["ttl"] = self.ttl
+            item["ttl_timestamp"] = self.ttl
         return item
 
     @classmethod
@@ -57,5 +57,5 @@ class WebhookEvent(BaseModel):
             user_id=item["user_id"],
             subscription_id=item.get("subscription_id"),
             processed_at=datetime.fromisoformat(item["processed_at"]),
-            ttl=item.get("ttl"),
+            ttl=item.get("ttl_timestamp", item.get("ttl")),
         )

--- a/src/lambdas/shared/quota_tracker.py
+++ b/src/lambdas/shared/quota_tracker.py
@@ -297,7 +297,7 @@ class QuotaTracker(BaseModel):
             "sendgrid": serialize_quota(self.sendgrid),
             "total_api_calls_today": self.total_api_calls_today,
             "estimated_daily_cost": str(self.estimated_daily_cost),
-            "ttl": ttl,
+            "ttl_timestamp": ttl,
             "entity_type": "QUOTA_TRACKER",
         }
 
@@ -497,7 +497,7 @@ class QuotaTrackerManager:
                 "#used": f"{service}_used",
                 "#total": "total_api_calls_today",
                 "#updated": "updated_at",
-                "#ttl": "ttl",
+                "#ttl": "ttl_timestamp",
                 "#entity": "entity_type",
             },
             ExpressionAttributeValues={

--- a/tests/e2e/test_full_pipeline.py
+++ b/tests/e2e/test_full_pipeline.py
@@ -222,7 +222,7 @@ class TestFullPipeline:
                 "source_name": article["source"]["name"],
                 "tag": ["AI", "climate", "economy"][i],
                 "status": "pending",
-                "ttl": int(datetime.now(UTC).timestamp()) + 86400 * 30,
+                "ttl_timestamp": int(datetime.now(UTC).timestamp()) + 86400 * 30,
                 "content_hash": hashlib.sha256(article["url"].encode()).hexdigest()[
                     :16
                 ],

--- a/tests/integration/test_us2_magic_link.py
+++ b/tests/integration/test_us2_magic_link.py
@@ -446,7 +446,7 @@ def _store_magic_link_token(
         "used": False,
         "invalidated": False,
         "entity_type": "MAGIC_LINK_TOKEN",
-        "ttl": int(expires_at.timestamp()) + 86400,  # TTL 1 day after expiry
+        "ttl_timestamp": int(expires_at.timestamp()) + 86400,  # TTL 1 day after expiry
     }
 
     if anonymous_user_id:

--- a/tests/unit/dashboard/test_auth.py
+++ b/tests/unit/dashboard/test_auth.py
@@ -76,7 +76,7 @@ class TestCreateAnonymousSession:
         assert item["SK"] == "PROFILE"
         assert item["auth_type"] == "anonymous"
         assert item["timezone"] == "Europe/London"
-        assert "ttl" in item
+        assert "ttl_timestamp" in item
 
     def test_handles_dynamodb_error(self):
         """Should raise on DynamoDB error."""

--- a/tests/unit/dashboard/test_stripe_webhook.py
+++ b/tests/unit/dashboard/test_stripe_webhook.py
@@ -53,7 +53,7 @@ class TestWebhookEvent:
         assert item["event_type"] == "customer.subscription.created"
         assert item["user_id"] == "user_456"
         assert item["subscription_id"] == "sub_789"
-        assert item["ttl"] == 1234567890
+        assert item["ttl_timestamp"] == 1234567890
         assert item["entity_type"] == "webhook_event"
 
     def test_to_dynamodb_item_without_optional_fields(self):
@@ -67,7 +67,7 @@ class TestWebhookEvent:
         item = event.to_dynamodb_item()
 
         assert "subscription_id" not in item
-        assert "ttl" not in item
+        assert "ttl_timestamp" not in item
 
     def test_from_dynamodb_item(self):
         """Test parsing DynamoDB item to model."""

--- a/tests/unit/shared/middleware/test_hcaptcha.py
+++ b/tests/unit/shared/middleware/test_hcaptcha.py
@@ -206,7 +206,7 @@ class TestRecordActionForRateLimit:
         assert item["PK"] == "RATE#1.2.3.4"
         assert item["action"] == "config_create"
         assert item["entity_type"] == "RATE_LIMIT_RECORD"
-        assert "ttl" in item
+        assert "ttl_timestamp" in item
 
     def test_handles_error_gracefully(self, mock_table):
         """Handles errors gracefully."""

--- a/tests/unit/shared/test_quota_tracker.py
+++ b/tests/unit/shared/test_quota_tracker.py
@@ -167,7 +167,7 @@ class TestQuotaTracker:
 
         assert item["PK"] == "SYSTEM#QUOTA"
         assert item["entity_type"] == "QUOTA_TRACKER"
-        assert "ttl" in item
+        assert "ttl_timestamp" in item
         assert item["tiingo"]["used"] == 10
         assert item["total_api_calls_today"] == 10
 


### PR DESCRIPTION
## Summary

- Fix TTL attribute name mismatch: code wrote `ttl` but DynamoDB TTL configured on `ttl_timestamp`
- **All** user table entity types affected: anonymous sessions, auth users, magic links, OAuth state, webhooks, rate limits, quota tracker, blocklist
- 110K+ orphaned records in preprod, growing at ~31K/day from CI
- Cleanup script included to expire existing orphaned anonymous sessions

## Changes

- 8 source files: `ttl` → `ttl_timestamp` (15 occurrences)
- 6 test files updated to match
- New `scripts/cleanup_orphaned_sessions.py` (--dry-run, --table-name)

## Test plan

- [x] 74 affected unit tests pass
- [x] Lint + format + security pass
- [ ] After merge: run `python scripts/cleanup_orphaned_sessions.py --dry-run` then without flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)