### PR TITLE
feat(reliability): Pre-chaos stability hardening

### DIFF
--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -278,6 +278,9 @@ module "ingestion_lambda" {
     TIMESERIES_TABLE = module.dynamodb.timeseries_table_name
   }
 
+  # Dead letter queue (chaos-readiness: data loss prevention on async failure)
+  dlq_arn = module.sns.dlq_arn
+
   # Logging
   log_retention_days = var.environment == "prod" ? 90 : 30
 
@@ -552,6 +555,9 @@ module "notification_lambda" {
 
   # No Function URL needed - triggered by SNS and EventBridge
   create_function_url = false
+
+  # Dead letter queue (chaos-readiness: failed emails can be retried)
+  dlq_arn = module.sns.dlq_arn
 
   # Logging
   log_retention_days = var.environment == "prod" ? 90 : 30

--- a/infrastructure/terraform/modules/cloudwatch-alarms/main.tf
+++ b/infrastructure/terraform/modules/cloudwatch-alarms/main.tf
@@ -7,12 +7,14 @@
 # Categories:
 # 1. Lambda Errors (6)
 # 2. Lambda Latency P95 (6)
-# 3. Silent Failure composite (1)
-# 4. Canary heartbeat + completeness (2)
-# 5. API Gateway + Function URL (3)
-# 6. Composite (1)
+# 3. Lambda Throttles (6) -- chaos-readiness
+# 4. Silent Failure composite (1)
+# 5. Canary heartbeat + completeness (2)
+# 6. API Gateway + Function URL (3)
+# 7. SSE Connection Count (1) -- chaos-readiness
+# 8. Composite (1)
 #
-# Total Phase 1: ~19 alarms
+# Total Phase 1: ~26 alarms
 
 locals {
   common_tags = merge(var.tags, {
@@ -96,6 +98,34 @@ resource "aws_cloudwatch_metric_alarm" "lambda_latency" {
   threshold           = local.latency_threshold_map[each.key]
   alarm_description   = "${each.key} Lambda P95 latency exceeded ${local.latency_threshold_map[each.key]}ms"
   treat_missing_data  = "missing"
+
+  dimensions = {
+    FunctionName = local.lambda_function_name_map[each.key]
+  }
+
+  alarm_actions = var.alarm_actions
+  ok_actions    = var.ok_actions
+
+  tags = local.common_tags
+}
+
+# ===================================================================
+# Category 3: Lambda Throttle Alarms (chaos-readiness)
+# ===================================================================
+
+resource "aws_cloudwatch_metric_alarm" "lambda_throttles" {
+  for_each = toset(local.lambda_services)
+
+  alarm_name          = "${var.environment}-${each.key}-lambda-throttles"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "Throttles"
+  namespace           = "AWS/Lambda"
+  period              = 60
+  statistic           = "Sum"
+  threshold           = 0
+  alarm_description   = "Lambda ${each.key} is being throttled (reserved concurrency exceeded)"
+  treat_missing_data  = "notBreaching"
 
   dimensions = {
     FunctionName = local.lambda_function_name_map[each.key]
@@ -250,6 +280,28 @@ resource "aws_cloudwatch_metric_alarm" "fnurl_5xx" {
 }
 
 # ===================================================================
+# Category 9: SSE Connection Count Alarm (chaos-readiness)
+# ===================================================================
+
+resource "aws_cloudwatch_metric_alarm" "sse_connection_count" {
+  alarm_name          = "${var.environment}-sse-high-connection-count"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "ActiveConnections"
+  namespace           = "SentimentAnalyzer/SSE"
+  period              = 60
+  statistic           = "Maximum"
+  threshold           = var.sse_max_connections * 0.8
+  alarm_description   = "SSE active connections exceeded 80% of ${var.sse_max_connections} max"
+  treat_missing_data  = "notBreaching"
+
+  alarm_actions = var.alarm_actions
+  ok_actions    = var.ok_actions
+
+  tags = local.common_tags
+}
+
+# ===================================================================
 # Composite Alarm -- All Critical Tier (FR-129)
 # ===================================================================
 
@@ -260,6 +312,9 @@ resource "aws_cloudwatch_composite_alarm" "critical" {
   alarm_rule = join(" OR ", concat(
     [for svc in local.lambda_services :
       "ALARM(${aws_cloudwatch_metric_alarm.lambda_errors[svc].alarm_name})"
+    ],
+    [for svc in local.lambda_services :
+      "ALARM(${aws_cloudwatch_metric_alarm.lambda_throttles[svc].alarm_name})"
     ],
     [
       "ALARM(${aws_cloudwatch_metric_alarm.silent_failure_composite.alarm_name})",

--- a/infrastructure/terraform/modules/cloudwatch-alarms/variables.tf
+++ b/infrastructure/terraform/modules/cloudwatch-alarms/variables.tf
@@ -114,6 +114,16 @@ variable "api_gateway_latency_threshold" {
 }
 
 # ===================================================================
+# Category 9: SSE Connection Count (chaos-readiness)
+# ===================================================================
+
+variable "sse_max_connections" {
+  description = "Maximum SSE connections before alarm fires (alarm at 80% of this value)"
+  type        = number
+  default     = 100
+}
+
+# ===================================================================
 # Silent Failure Alarm Toggle
 # ===================================================================
 

--- a/infrastructure/terraform/modules/iam/main.tf
+++ b/infrastructure/terraform/modules/iam/main.tf
@@ -196,6 +196,25 @@ resource "aws_iam_role_policy" "ingestion_feature_006_users" {
   })
 }
 
+# Ingestion Lambda: SQS Dead Letter Queue (chaos-readiness)
+resource "aws_iam_role_policy" "ingestion_dlq" {
+  name = "${var.environment}-ingestion-dlq-policy"
+  role = aws_iam_role.ingestion_lambda.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "sqs:SendMessage"
+        ]
+        Resource = var.dlq_arn
+      }
+    ]
+  })
+}
+
 # ===================================================================
 # Analysis Lambda IAM Role
 # ===================================================================
@@ -805,6 +824,25 @@ resource "aws_iam_role_policy" "notification_metrics" {
             "cloudwatch:namespace" = "SentimentAnalyzer"
           }
         }
+      }
+    ]
+  })
+}
+
+# Notification Lambda: SQS Dead Letter Queue (chaos-readiness)
+resource "aws_iam_role_policy" "notification_dlq" {
+  name = "${var.environment}-notification-dlq-policy"
+  role = aws_iam_role.notification_lambda.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "sqs:SendMessage"
+        ]
+        Resource = var.dlq_arn
       }
     ]
   })

--- a/infrastructure/terraform/modules/iam/variables.tf
+++ b/infrastructure/terraform/modules/iam/variables.tf
@@ -21,7 +21,7 @@ variable "analysis_topic_arn" {
 }
 
 variable "dlq_arn" {
-  description = "ARN of the SQS dead letter queue for analysis Lambda"
+  description = "ARN of the SQS dead letter queue for Lambda functions (analysis, ingestion, notification)"
   type        = string
 }
 

--- a/src/lambdas/dashboard/handler.py
+++ b/src/lambdas/dashboard/handler.py
@@ -993,6 +993,6 @@ def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
 
         get_global_emitter().flush_to_cloudwatch()
     except Exception:
-        logger.debug("Cache metrics flush failed", exc_info=True)
+        logger.warning("Cache metrics flush failed", exc_info=True)
 
     return response

--- a/src/lambdas/notification/handler.py
+++ b/src/lambdas/notification/handler.py
@@ -35,8 +35,8 @@ SENDGRID_SECRET_ARN = os.environ.get("SENDGRID_SECRET_ARN", "")
 DYNAMODB_TABLE = os.environ["DATABASE_TABLE"]
 ENVIRONMENT = os.environ.get("ENVIRONMENT", "dev")
 FROM_EMAIL = os.environ.get("FROM_EMAIL", "noreply@sentiment-analyzer.com")
-# Blind spot fix: Use localhost as fallback (matches Terraform dev default, not hardcoded prod URL)
-DASHBOARD_URL = os.environ.get("DASHBOARD_URL", "http://localhost:3000")
+# Pre-chaos stability: No localhost fallback — must be set explicitly per environment
+DASHBOARD_URL = os.environ.get("DASHBOARD_URL", "")
 
 
 @tracer.capture_lambda_handler

--- a/src/lambdas/shared/circuit_breaker.py
+++ b/src/lambdas/shared/circuit_breaker.py
@@ -365,14 +365,15 @@ class CircuitBreakerManager:
             logger.warning(
                 "Failed to load circuit breaker, using default (fail-open: closed state)",
                 extra={"service": service, "error": str(e)},
+                exc_info=True,
             )
             # X-Ray error subsegment for silent failure visibility
             try:
                 with tracer.provider.in_subsegment("circuit_breaker_load") as subseg:
                     subseg.put_annotation("error", True)
                     subseg.add_exception(e)
-            except Exception:  # noqa: S110
-                pass  # Best-effort: don't fail if X-Ray unavailable
+            except Exception:
+                logger.debug("X-Ray subsegment failed", exc_info=True)
             # CloudWatch metric for silent failure alerting (SC-019)
             emit_metric(
                 name="SilentFailure/Count",
@@ -412,17 +413,19 @@ class CircuitBreakerManager:
             )
             return True
         except Exception as e:
-            logger.error(
-                "Failed to save circuit breaker",
+            logger.warning(
+                "Failed to save circuit breaker state to DynamoDB, "
+                "in-memory state preserved (fail-open)",
                 extra={"service": state.service, "error": str(e)},
+                exc_info=True,
             )
             # X-Ray error subsegment for silent failure visibility
             try:
                 with tracer.provider.in_subsegment("circuit_breaker_save") as subseg:
                     subseg.put_annotation("error", True)
                     subseg.add_exception(e)
-            except Exception:  # noqa: S110
-                pass  # Best-effort: don't fail if X-Ray unavailable
+            except Exception:
+                logger.debug("X-Ray subsegment failed", exc_info=True)
             # CloudWatch metric for silent failure alerting (SC-019)
             emit_metric(
                 name="SilentFailure/Count",

--- a/src/lambdas/shared/middleware/security_headers.py
+++ b/src/lambdas/shared/middleware/security_headers.py
@@ -30,8 +30,8 @@ from typing import Any
 
 # Environment
 ENVIRONMENT = os.environ.get("ENVIRONMENT", "dev")
-# Blind spot fix: Use localhost as fallback (matches Terraform dev default, not hardcoded prod URL)
-DASHBOARD_URL = os.environ.get("DASHBOARD_URL", "http://localhost:3000")
+# Pre-chaos stability: No localhost fallback — must be set explicitly per environment
+DASHBOARD_URL = os.environ.get("DASHBOARD_URL", "")
 
 # Security headers configuration
 SECURITY_HEADERS = {

--- a/src/lambdas/sse_streaming/polling.py
+++ b/src/lambdas/sse_streaming/polling.py
@@ -350,8 +350,8 @@ class PollingService:
                         hit_rate = stats["hits"] / total_requests
                         span.set_attribute("cache_hit_rate", round(hit_rate, 4))
                     span.set_attribute("cache_hit", not changed)
-                except Exception:  # noqa: S110
-                    pass  # Best-effort cache metrics
+                except Exception:
+                    logger.debug("Cache metrics annotation failed", exc_info=True)
 
             logger.debug(
                 "DynamoDB poll complete",

--- a/src/lib/timeseries/fanout.py
+++ b/src/lib/timeseries/fanout.py
@@ -200,8 +200,8 @@ def write_fanout(
             with tracer.provider.in_subsegment("fanout_batch_write") as subseg:
                 subseg.put_annotation("error", True)
                 subseg.add_exception(e)
-        except Exception:  # noqa: S110
-            pass  # Best-effort: don't fail if X-Ray unavailable
+        except Exception:
+            logger.debug("X-Ray subsegment failed", exc_info=True)
         try:
             emit_metric(
                 name="SilentFailure/Count",
@@ -210,8 +210,8 @@ def write_fanout(
                 dimensions={"FailurePath": "fanout_batch_write"},
                 namespace="SentimentAnalyzer/Reliability",
             )
-        except Exception:  # noqa: S110
-            pass  # Best-effort: don't block on metric failure
+        except Exception:
+            logger.debug("Metric emission failed", exc_info=True)
         raise
 
 
@@ -310,8 +310,8 @@ def write_fanout_with_update(
                 with tracer.provider.in_subsegment("fanout_base_update") as subseg:
                     subseg.put_annotation("error", True)
                     subseg.add_exception(e)
-            except Exception:  # noqa: S110
-                pass
+            except Exception:
+                logger.debug("X-Ray subsegment failed", exc_info=True)
             try:
                 emit_metric(
                     name="SilentFailure/Count",
@@ -320,8 +320,8 @@ def write_fanout_with_update(
                     dimensions={"FailurePath": "fanout_base_update"},
                     namespace="SentimentAnalyzer/Reliability",
                 )
-            except Exception:  # noqa: S110
-                pass
+            except Exception:
+                logger.debug("Metric emission failed", exc_info=True)
             raise
 
         # Second update: Update label count (now that label_counts exists)
@@ -348,8 +348,8 @@ def write_fanout_with_update(
                     with tracer.provider.in_subsegment("fanout_label_update") as subseg:
                         subseg.put_annotation("error", True)
                         subseg.add_exception(e)
-                except Exception:  # noqa: S110
-                    pass
+                except Exception:
+                    logger.debug("X-Ray subsegment failed", exc_info=True)
                 try:
                     emit_metric(
                         name="SilentFailure/Count",
@@ -358,8 +358,8 @@ def write_fanout_with_update(
                         dimensions={"FailurePath": "fanout_label_update"},
                         namespace="SentimentAnalyzer/Reliability",
                     )
-                except Exception:  # noqa: S110
-                    pass
+                except Exception:
+                    logger.debug("Metric emission failed", exc_info=True)
                 raise
 
         # Third update: Conditional update for high (if new value is higher)
@@ -383,8 +383,8 @@ def write_fanout_with_update(
                         dimensions={"FailurePath": "fanout_conditional"},
                         namespace="SentimentAnalyzer/Reliability",
                     )
-                except Exception:  # noqa: S110
-                    pass
+                except Exception:
+                    logger.debug("Metric emission failed", exc_info=True)
             else:
                 try:
                     with tracer.provider.in_subsegment(
@@ -392,8 +392,8 @@ def write_fanout_with_update(
                     ) as subseg:
                         subseg.put_annotation("error", True)
                         subseg.add_exception(e)
-                except Exception:  # noqa: S110
-                    pass
+                except Exception:
+                    logger.debug("X-Ray subsegment failed", exc_info=True)
                 try:
                     emit_metric(
                         name="SilentFailure/Count",
@@ -402,8 +402,8 @@ def write_fanout_with_update(
                         dimensions={"FailurePath": "fanout_conditional_unexpected"},
                         namespace="SentimentAnalyzer/Reliability",
                     )
-                except Exception:  # noqa: S110
-                    pass
+                except Exception:
+                    logger.debug("Metric emission failed", exc_info=True)
                 raise
 
         # Fourth update: Conditional update for low (if new value is lower)
@@ -427,8 +427,8 @@ def write_fanout_with_update(
                         dimensions={"FailurePath": "fanout_conditional"},
                         namespace="SentimentAnalyzer/Reliability",
                     )
-                except Exception:  # noqa: S110
-                    pass
+                except Exception:
+                    logger.debug("Metric emission failed", exc_info=True)
             else:
                 try:
                     with tracer.provider.in_subsegment(
@@ -436,8 +436,8 @@ def write_fanout_with_update(
                     ) as subseg:
                         subseg.put_annotation("error", True)
                         subseg.add_exception(e)
-                except Exception:  # noqa: S110
-                    pass
+                except Exception:
+                    logger.debug("X-Ray subsegment failed", exc_info=True)
                 try:
                     emit_metric(
                         name="SilentFailure/Count",
@@ -446,6 +446,6 @@ def write_fanout_with_update(
                         dimensions={"FailurePath": "fanout_conditional_unexpected"},
                         namespace="SentimentAnalyzer/Reliability",
                     )
-                except Exception:  # noqa: S110
-                    pass
+                except Exception:
+                    logger.debug("Metric emission failed", exc_info=True)
                 raise


### PR DESCRIPTION
## Summary

Prepare system for chaos injection testing by closing 6 stability gaps:

- **Lambda throttle alarms**: 6 new alarms (one per function) fire on any throttle event
- **SSE connection count alarm**: fires at 80% of max connections (configurable threshold)
- **DLQs for ingestion + notification**: failed async invocations now queued instead of silently discarded
- **Silent exception handlers upgraded**: `pass` → `logger.warning`/`logger.debug` with `exc_info=True` across 15+ sites
- **Circuit breaker logging improved**: `exc_info=True` on persistence failures for full tracebacks
- **DASHBOARD_URL localhost fallback removed**: empty string default instead of plausible-but-wrong `http://localhost:3000`

## Test plan

- [x] All pre-commit hooks pass (lint, format, security, Terraform, bandit, trivy, checkov)
- [x] Terraform fmt clean
- [ ] CI tests pass
- [ ] Terraform plan shows only new alarm + DLQ resources (no destructive changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)