### PR TITLE
feat(sse): Add connection manager state validation

### DIFF
--- a/src/lambdas/sse_streaming/connection.py
+++ b/src/lambdas/sse_streaming/connection.py
@@ -84,6 +84,7 @@ class ConnectionManager:
     - Thread-safe acquire/release operations
     - Connection tracking by ID
     - Startup time tracking for uptime calculation
+    - State validation with self-healing (Feature 1232)
 
     Per research.md decision #4: In-memory connection tracking with thread-safe counter.
     """
@@ -96,6 +97,7 @@ class ConnectionManager:
                             Defaults to SSE_MAX_CONNECTIONS env var or 100.
         """
         self._connections: dict[str, SSEConnection] = {}
+        self._active_count: int = 0
         self._lock = threading.Lock()
         self._start_time = time.time()
 
@@ -167,6 +169,7 @@ class ConnectionManager:
                 connection_sequence=connection_sequence,
             )
             self._connections[connection.connection_id] = connection
+            self._active_count += 1
 
             # T093: Add OTel annotations for connection tracing (FR-008)
             self._annotate_connection(connection)
@@ -226,6 +229,7 @@ class ConnectionManager:
         with self._lock:
             if connection_id in self._connections:
                 del self._connections[connection_id]
+                self._active_count -= 1
                 logger.info(
                     "Connection released",
                     extra={
@@ -268,6 +272,42 @@ class ConnectionManager:
                 self._connections[connection_id].last_event_id = event_id
                 return True
             return False
+
+    def validate_state(self) -> dict:
+        """Validate internal state consistency.
+
+        Checks that the _active_count counter matches the actual number of
+        connections in the dict. A mismatch indicates state drift from warm
+        Lambda invocations (e.g., exception paths skipping release, or
+        external manipulation of _connections).
+
+        Self-heals by correcting _active_count when drift is detected.
+
+        Feature 1232: SSE State Validation.
+
+        Returns:
+            dict with:
+                valid: bool - True if no issues found
+                issues: list[str] - descriptions of any issues detected
+                connection_count: int - actual number of connections
+                active_count_matches: bool - whether _active_count matched
+        """
+        issues: list[str] = []
+        with self._lock:
+            actual_count = len(self._connections)
+            if actual_count != self._active_count:
+                issues.append(
+                    f"Count mismatch: _active_count={self._active_count}, "
+                    f"actual={actual_count}"
+                )
+                self._active_count = actual_count  # Self-heal
+
+        return {
+            "valid": len(issues) == 0,
+            "issues": issues,
+            "connection_count": actual_count,
+            "active_count_matches": actual_count == self._active_count,
+        }
 
     def get_status(self) -> dict:
         """Get connection pool status.

--- a/src/lambdas/sse_streaming/handler.py
+++ b/src/lambdas/sse_streaming/handler.py
@@ -184,13 +184,45 @@ def _error_metadata_and_body(
 # =============================================================================
 
 
+def _validate_connection_state() -> None:
+    """Run state validation on the connection manager and log any issues.
+
+    Called at the start of each stream handler to detect and self-heal
+    state drift in the module-level ConnectionManager singleton across
+    warm Lambda invocations. Lightweight (dict length comparison).
+
+    Feature 1232: SSE State Validation.
+    """
+    validation = connection_manager.validate_state()
+    if not validation["valid"]:
+        logger.warning(
+            "Connection manager state drift detected (self-healed)",
+            extra={
+                "issues": validation["issues"],
+                "connection_count": validation["connection_count"],
+            },
+        )
+
+
 @tracer.capture_method
 def _handle_stream_status() -> Generator[bytes]:
     """Handle GET /api/v2/stream/status (non-streaming).
 
-    Yields a single complete response with connection pool status.
+    Yields a single complete response with connection pool status
+    and state validation result.
     """
+    validation = connection_manager.validate_state()
+    if not validation["valid"]:
+        logger.warning(
+            "Connection manager state drift detected (self-healed)",
+            extra={
+                "issues": validation["issues"],
+                "connection_count": validation["connection_count"],
+            },
+        )
+
     status = connection_manager.get_status()
+    status["state_valid"] = validation["valid"]
     logger.info("Stream status requested", extra=status)
 
     metadata = _streaming_metadata(
@@ -207,6 +239,9 @@ def _handle_global_stream(event: dict) -> Generator[bytes]:
     Streams real-time sentiment metrics to connected clients.
     Supports optional resolution and ticker filters via query params.
     """
+    # Feature 1232: Validate connection manager state on each stream connect
+    _validate_connection_state()
+
     last_event_id = _get_header(event, "Last-Event-ID")
     resolutions = _get_query_param(event, "resolutions")
     tickers = _get_query_param(event, "tickers")
@@ -318,6 +353,9 @@ def _handle_config_stream(event: dict, config_id: str) -> Generator[bytes]:
     Streams config-specific sentiment updates with authentication.
     Authentication precedence: Bearer token > X-User-ID header > user_token query param.
     """
+    # Feature 1232: Validate connection manager state on each stream connect
+    _validate_connection_state()
+
     authorization = _get_header(event, "Authorization")
     x_user_id = _get_header(event, "X-User-ID")
     user_token = _get_query_param(event, "user_token")

--- a/src/lambdas/sse_streaming/models.py
+++ b/src/lambdas/sse_streaming/models.py
@@ -30,6 +30,10 @@ class HeartbeatData(BaseModel):
     )
     connections: int = Field(description="Active connection count")
     uptime_seconds: int = Field(description="Lambda uptime in seconds")
+    state_valid: bool = Field(
+        default=True,
+        description="Whether connection manager state is consistent (Feature 1232)",
+    )
 
     @property
     def server_timestamp(self) -> datetime:
@@ -170,3 +174,7 @@ class StreamStatus(BaseModel):
     max_connections: int = Field(description="Maximum allowed connections")
     available: int = Field(description="Available connection slots")
     uptime_seconds: int = Field(description="Lambda uptime in seconds")
+    state_valid: bool = Field(
+        default=True,
+        description="Whether connection manager state is consistent (Feature 1232)",
+    )

--- a/tests/unit/sse_streaming/test_sse_state_validation.py
+++ b/tests/unit/sse_streaming/test_sse_state_validation.py
@@ -1,0 +1,230 @@
+"""Unit tests for SSE state validation (Feature 1232).
+
+Tests ConnectionManager.validate_state() for detecting and self-healing
+state drift in the module-level singleton across warm Lambda invocations.
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+from src.lambdas.sse_streaming.connection import ConnectionManager
+from src.lambdas.sse_streaming.handler import handler
+from tests.conftest import make_function_url_event, parse_streaming_response
+
+
+class TestValidateStateClean:
+    """Tests for validate_state on a fresh ConnectionManager."""
+
+    def test_validate_state_clean(self):
+        """Fresh ConnectionManager should report valid=True with no issues."""
+        manager = ConnectionManager(max_connections=10)
+        result = manager.validate_state()
+
+        assert result["valid"] is True
+        assert result["issues"] == []
+        assert result["connection_count"] == 0
+        assert result["active_count_matches"] is True
+
+    def test_validate_state_clean_with_connections(self):
+        """ConnectionManager with properly acquired connections should be valid."""
+        manager = ConnectionManager(max_connections=10)
+        manager.acquire()
+        manager.acquire()
+
+        result = manager.validate_state()
+
+        assert result["valid"] is True
+        assert result["issues"] == []
+        assert result["connection_count"] == 2
+        assert result["active_count_matches"] is True
+
+    def test_validate_state_clean_after_release(self):
+        """ConnectionManager after acquire+release should remain valid."""
+        manager = ConnectionManager(max_connections=10)
+        conn = manager.acquire()
+        manager.release(conn.connection_id)
+
+        result = manager.validate_state()
+
+        assert result["valid"] is True
+        assert result["issues"] == []
+        assert result["connection_count"] == 0
+        assert result["active_count_matches"] is True
+
+
+class TestValidateStateCountMismatch:
+    """Tests for validate_state detecting and self-healing _active_count drift."""
+
+    def test_validate_state_count_mismatch_high(self):
+        """Detect when _active_count is higher than actual connections."""
+        manager = ConnectionManager(max_connections=10)
+        manager.acquire()
+        # Simulate drift: _active_count is too high (e.g., release path missed)
+        manager._active_count = 5
+
+        result = manager.validate_state()
+
+        assert result["valid"] is False
+        assert len(result["issues"]) == 1
+        assert "_active_count=5" in result["issues"][0]
+        assert "actual=1" in result["issues"][0]
+        assert result["connection_count"] == 1
+
+    def test_validate_state_count_mismatch_low(self):
+        """Detect when _active_count is lower than actual connections."""
+        manager = ConnectionManager(max_connections=10)
+        manager.acquire()
+        manager.acquire()
+        # Simulate drift: _active_count is too low
+        manager._active_count = 0
+
+        result = manager.validate_state()
+
+        assert result["valid"] is False
+        assert len(result["issues"]) == 1
+        assert "_active_count=0" in result["issues"][0]
+        assert "actual=2" in result["issues"][0]
+
+    def test_validate_state_self_heals(self):
+        """After detecting mismatch, _active_count should be corrected."""
+        manager = ConnectionManager(max_connections=10)
+        manager.acquire()
+        manager._active_count = 99  # Wrong value
+
+        # First call detects and heals
+        result1 = manager.validate_state()
+        assert result1["valid"] is False
+
+        # Second call should be clean
+        result2 = manager.validate_state()
+        assert result2["valid"] is True
+        assert result2["issues"] == []
+        assert result2["active_count_matches"] is True
+
+    def test_validate_state_self_heals_to_correct_value(self):
+        """Self-heal should set _active_count to the actual dict length."""
+        manager = ConnectionManager(max_connections=10)
+        manager.acquire()
+        manager.acquire()
+        manager.acquire()
+        manager._active_count = 0
+
+        manager.validate_state()
+
+        # _active_count should now equal 3 (the actual count)
+        assert manager._active_count == 3
+
+
+class TestValidateCalledOnStreamConnect:
+    """Tests for validate_state being called when handler processes a stream request."""
+
+    def test_validate_called_on_global_stream(self):
+        """validate_state should be called when processing /api/v2/stream."""
+        mock_mgr = MagicMock()
+        mock_mgr.validate_state.return_value = {
+            "valid": True,
+            "issues": [],
+            "connection_count": 0,
+            "active_count_matches": True,
+        }
+        mock_mgr.acquire.return_value = None
+        mock_mgr.max_connections = 100
+
+        with (
+            patch("src.lambdas.sse_streaming.handler.connection_manager", mock_mgr),
+            patch("src.lambdas.sse_streaming.handler.metrics_emitter"),
+        ):
+            event = make_function_url_event(path="/api/v2/stream")
+            gen = handler(event, None)
+            list(gen)  # Consume generator
+
+            mock_mgr.validate_state.assert_called()
+
+    def test_validate_called_on_config_stream(self):
+        """validate_state should be called when processing config stream."""
+        mock_mgr = MagicMock()
+        mock_mgr.validate_state.return_value = {
+            "valid": True,
+            "issues": [],
+            "connection_count": 0,
+            "active_count_matches": True,
+        }
+        mock_mgr.acquire.return_value = None
+        mock_mgr.max_connections = 100
+
+        mock_lookup = MagicMock()
+        mock_lookup.validate_user_access.return_value = (True, ["AAPL"])
+
+        with (
+            patch("src.lambdas.sse_streaming.handler.connection_manager", mock_mgr),
+            patch(
+                "src.lambdas.sse_streaming.handler.config_lookup_service", mock_lookup
+            ),
+            patch("src.lambdas.sse_streaming.handler.metrics_emitter"),
+        ):
+            event = make_function_url_event(
+                path="/api/v2/configurations/test-config/stream",
+                headers={"X-User-ID": "user-123"},
+            )
+            gen = handler(event, None)
+            list(gen)  # Consume generator
+
+            mock_mgr.validate_state.assert_called()
+
+    def test_validate_called_on_stream_status(self):
+        """validate_state should be called when processing /api/v2/stream/status."""
+        mock_mgr = MagicMock()
+        mock_mgr.validate_state.return_value = {
+            "valid": True,
+            "issues": [],
+            "connection_count": 0,
+            "active_count_matches": True,
+        }
+        mock_mgr.get_status.return_value = {
+            "connections": 0,
+            "max_connections": 100,
+            "available": 100,
+            "uptime_seconds": 42,
+        }
+
+        with patch("src.lambdas.sse_streaming.handler.connection_manager", mock_mgr):
+            event = make_function_url_event(path="/api/v2/stream/status")
+            gen = handler(event, None)
+            list(gen)  # Consume generator
+
+            mock_mgr.validate_state.assert_called()
+
+    def test_stream_status_includes_state_valid(self):
+        """The /api/v2/stream/status response should include state_valid field."""
+        event = make_function_url_event(path="/api/v2/stream/status")
+        gen = handler(event, None)
+        metadata, body = parse_streaming_response(gen)
+
+        assert metadata["statusCode"] == 200
+        data = json.loads(body)
+        assert "state_valid" in data
+        assert data["state_valid"] is True
+
+    def test_stream_status_shows_invalid_state(self):
+        """The status response should show state_valid=False when drift exists."""
+        mock_mgr = MagicMock()
+        mock_mgr.validate_state.return_value = {
+            "valid": False,
+            "issues": ["Count mismatch: _active_count=5, actual=1"],
+            "connection_count": 1,
+            "active_count_matches": True,
+        }
+        mock_mgr.get_status.return_value = {
+            "connections": 1,
+            "max_connections": 100,
+            "available": 99,
+            "uptime_seconds": 42,
+        }
+
+        with patch("src.lambdas.sse_streaming.handler.connection_manager", mock_mgr):
+            event = make_function_url_event(path="/api/v2/stream/status")
+            gen = handler(event, None)
+            metadata, body = parse_streaming_response(gen)
+
+            data = json.loads(body)
+            assert data["state_valid"] is False


### PR DESCRIPTION
## Summary
- ConnectionManager.validate_state() detects and self-heals count drift
- Called on every stream connect (global, config, status)
- StreamStatus response includes state_valid field

## Test plan
- [x] 12 unit tests passing
🤖 Generated with [Claude Code](https://claude.com/claude-code)