### PR TITLE
feat(quota): Add hysteresis to rate mode transitions

### DIFF
--- a/src/lambdas/shared/quota_tracker.py
+++ b/src/lambdas/shared/quota_tracker.py
@@ -13,6 +13,11 @@ Feature 1224 (Cache Architecture Audit):
 - 25% rate reduction + alert on DynamoDB disconnection
 - Flat atomic counter fields (tiingo_used, finnhub_used, sendgrid_used)
 
+Feature 1233 (Quota Rate Hysteresis):
+- Asymmetric thresholds prevent oscillation during DynamoDB flapping
+- 3 consecutive failures to enter reduced-rate mode
+- 5 consecutive successes to exit reduced-rate mode
+
 Thread-safety (Feature 1010):
 - Module-level lock protects cache access during parallel ingestion
 - record_call() and check_quota() are thread-safe
@@ -62,6 +67,13 @@ _reduced_rate_since: float | None = None
 _last_disconnected_alert: float = 0.0
 REDUCED_RATE_FRACTION = 0.25  # 25% of normal rate
 DISCONNECTED_ALERT_INTERVAL = 300  # Max one alert per 5 minutes
+
+# Feature 1233: Hysteresis counters for rate mode transitions
+# Asymmetric thresholds prevent oscillation during DynamoDB flapping
+QUOTA_RATE_ENTRY_THRESHOLD = int(os.environ.get("QUOTA_RATE_ENTRY_THRESHOLD", "3"))
+QUOTA_RATE_EXIT_THRESHOLD = int(os.environ.get("QUOTA_RATE_EXIT_THRESHOLD", "5"))
+_consecutive_failures = 0
+_consecutive_successes = 0
 
 
 def _get_cached_tracker() -> "QuotaTracker | None":
@@ -165,6 +177,41 @@ def _exit_reduced_rate_mode() -> None:
             _reduced_rate_since = None
 
 
+def _record_dynamo_success() -> None:
+    """Record a successful DynamoDB operation for hysteresis tracking (Feature 1233).
+
+    Resets failure counter and increments success counter. Only exits
+    reduced-rate mode after QUOTA_RATE_EXIT_THRESHOLD consecutive successes
+    to prevent oscillation during DynamoDB flapping.
+    """
+    global _consecutive_failures, _consecutive_successes
+    with _quota_cache_lock:
+        _consecutive_failures = 0
+        _consecutive_successes += 1
+        if _reduced_rate_mode and _consecutive_successes >= QUOTA_RATE_EXIT_THRESHOLD:
+            _exit_reduced_rate_mode()
+            _consecutive_successes = 0
+
+
+def _record_dynamo_failure() -> None:
+    """Record a failed DynamoDB operation for hysteresis tracking (Feature 1233).
+
+    Resets success counter and increments failure counter. Only enters
+    reduced-rate mode after QUOTA_RATE_ENTRY_THRESHOLD consecutive failures
+    to prevent oscillation during DynamoDB flapping.
+    """
+    global _consecutive_failures, _consecutive_successes
+    with _quota_cache_lock:
+        _consecutive_successes = 0
+        _consecutive_failures += 1
+        if (
+            not _reduced_rate_mode
+            and _consecutive_failures >= QUOTA_RATE_ENTRY_THRESHOLD
+        ):
+            _enter_reduced_rate_mode()
+            _consecutive_failures = 0
+
+
 def clear_quota_cache() -> None:
     """Clear cache and reset stats. Used in tests.
 
@@ -172,12 +219,15 @@ def clear_quota_cache() -> None:
     """
     global _quota_tracker_cache, _quota_cache_stats
     global _reduced_rate_mode, _reduced_rate_since, _last_disconnected_alert
+    global _consecutive_failures, _consecutive_successes
     with _quota_cache_lock:
         _quota_tracker_cache = None
         _quota_cache_stats = {"hits": 0, "misses": 0, "syncs": 0, "atomic_writes": 0}
         _reduced_rate_mode = False
         _reduced_rate_since = None
         _last_disconnected_alert = 0.0
+        _consecutive_failures = 0
+        _consecutive_successes = 0
 
 
 class APIQuotaUsage(BaseModel):
@@ -467,8 +517,8 @@ class QuotaTrackerManager:
                 tracker = QuotaTracker.create_default()
                 logger.debug("Quota tracker created default", extra={"date": today})
 
-            # DynamoDB is reachable — exit reduced-rate mode if active
-            _exit_reduced_rate_mode()
+            # DynamoDB is reachable — record success for hysteresis (Feature 1233)
+            _record_dynamo_success()
 
         except Exception as e:
             logger.warning(
@@ -589,6 +639,9 @@ class QuotaTrackerManager:
         counter for immediate cross-instance visibility. Falls back to 25%
         rate reduction if DynamoDB is unreachable.
 
+        Feature 1233: Uses hysteresis for mode transitions — 3 consecutive
+        failures to enter reduced-rate, 5 consecutive successes to exit.
+
         Thread-safe: Uses _quota_cache_lock to protect the local cache
         read-modify-write cycle (Feature 1179).
 
@@ -602,13 +655,13 @@ class QuotaTrackerManager:
         # Step 1: Atomic DynamoDB increment (immediate cross-instance visibility)
         try:
             self._atomic_increment_usage(service, count)
-            _exit_reduced_rate_mode()
+            _record_dynamo_success()
         except Exception as e:
             logger.error(
-                "Atomic quota increment failed — entering reduced-rate mode",
+                "Atomic quota increment failed — recording failure for hysteresis",
                 extra={"service": service, "error": str(e)},
             )
-            _enter_reduced_rate_mode()
+            _record_dynamo_failure()
 
         # Step 2: Update local cache
         with _quota_cache_lock:

--- a/tests/unit/test_quota_tracker_atomic.py
+++ b/tests/unit/test_quota_tracker_atomic.py
@@ -1,6 +1,8 @@
 """Unit tests for Feature 1224: Quota tracker atomic DynamoDB counters.
 
 Tests atomic increment, 25% fallback, disconnected alert, and threshold warning.
+Updated for Feature 1233: Hysteresis requires 3 consecutive failures to enter
+reduced-rate mode and 5 consecutive successes to exit.
 """
 
 import threading
@@ -102,7 +104,7 @@ class TestReducedRateFallback:
 
     @freeze_time("2024-01-02 10:00:00")
     def test_enters_reduced_rate_on_dynamodb_failure(self):
-        """DynamoDB write failure triggers 25% rate mode."""
+        """DynamoDB write failure triggers 25% rate mode after 3 consecutive failures (Feature 1233)."""
         table = _make_mock_table()
         dynamo_error = ClientError(
             {"Error": {"Code": "ServiceUnavailable", "Message": "down"}},
@@ -119,6 +121,9 @@ class TestReducedRateFallback:
         _set_cached_tracker(tracker)
 
         manager = QuotaTrackerManager(table)
+        # Feature 1233: Need 3 consecutive failures to enter reduced-rate mode
+        manager.record_call("tiingo")
+        manager.record_call("tiingo")
         manager.record_call("tiingo")
 
         assert manager.is_reduced_rate() is True
@@ -152,7 +157,7 @@ class TestReducedRateFallback:
 
     @freeze_time("2024-01-02 10:00:00")
     def test_exits_reduced_rate_on_successful_write(self):
-        """Successful DynamoDB write exits reduced-rate mode."""
+        """Successful DynamoDB writes exit reduced-rate mode after 5 consecutive successes (Feature 1233)."""
         table = _make_mock_table()
         manager = QuotaTrackerManager(table)
 
@@ -167,8 +172,9 @@ class TestReducedRateFallback:
         _enter_reduced_rate_mode()
         assert manager.is_reduced_rate()
 
-        # Successful record_call exits reduced-rate mode
-        manager.record_call("tiingo")
+        # Feature 1233: Need 5 consecutive successes to exit reduced-rate mode
+        for _ in range(5):
+            manager.record_call("tiingo")
         assert manager.is_reduced_rate() is False
 
 
@@ -178,14 +184,25 @@ class TestDisconnectedAlert:
     @freeze_time("2024-01-02 10:00:00")
     @patch("src.lib.metrics.emit_metric")
     def test_emits_disconnected_metric_on_failure(self, mock_emit):
-        """QuotaTracker/Disconnected metric emitted on DynamoDB failure."""
+        """QuotaTracker/Disconnected metric emitted after 3 consecutive failures (Feature 1233)."""
         table = _make_mock_table()
-        table.update_item.side_effect = ClientError(
+        dynamo_error = ClientError(
             {"Error": {"Code": "ServiceUnavailable", "Message": "down"}},
             "UpdateItem",
         )
+        table.update_item.side_effect = dynamo_error
+
+        # Pre-load cache so get_tracker doesn't hit DynamoDB and record a success
+        from src.lambdas.shared.quota_tracker import _set_cached_tracker
+
+        tracker = QuotaTracker.create_default()
+        _set_cached_tracker(tracker)
+
         manager = QuotaTrackerManager(table)
 
+        # Feature 1233: Need 3 consecutive failures to enter reduced-rate mode and emit metric
+        manager.record_call("tiingo")
+        manager.record_call("tiingo")
         manager.record_call("tiingo")
 
         mock_emit.assert_called_with("QuotaTracker/Disconnected", 1.0)
@@ -193,19 +210,30 @@ class TestDisconnectedAlert:
     @freeze_time("2024-01-02 10:00:00")
     @patch("src.lib.metrics.emit_metric")
     def test_alert_spam_protection(self, mock_emit):
-        """Disconnected alert emitted at most once per 5 minutes."""
+        """Disconnected alert emitted at most once per 5 minutes (Feature 1233: after hysteresis)."""
         table = _make_mock_table()
         table.update_item.side_effect = ClientError(
             {"Error": {"Code": "ServiceUnavailable", "Message": "down"}},
             "UpdateItem",
         )
+
+        # Pre-load cache so get_tracker doesn't hit DynamoDB and record a success
+        from src.lambdas.shared.quota_tracker import _set_cached_tracker
+
+        tracker = QuotaTracker.create_default()
+        _set_cached_tracker(tracker)
+
         manager = QuotaTrackerManager(table)
 
-        # First call emits alert
+        # Feature 1233: 3 consecutive failures to enter reduced-rate mode and emit first alert
+        manager.record_call("tiingo")
+        manager.record_call("tiingo")
         manager.record_call("tiingo")
         assert mock_emit.call_count == 1
 
-        # Second call within 5 minutes — no new alert
+        # Additional failures within 5 minutes — no new alert (spam protection)
+        manager.record_call("tiingo")
+        manager.record_call("tiingo")
         manager.record_call("tiingo")
         assert mock_emit.call_count == 1  # Still 1
 

--- a/tests/unit/test_quota_tracker_hysteresis.py
+++ b/tests/unit/test_quota_tracker_hysteresis.py
@@ -1,0 +1,210 @@
+"""Unit tests for Feature 1233: Quota rate hysteresis.
+
+Tests asymmetric thresholds that prevent oscillation between normal and
+reduced-rate mode during DynamoDB flapping. Entry requires 3 consecutive
+failures; exit requires 5 consecutive successes.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.lambdas.shared.quota_tracker import (
+    QuotaTracker,
+    QuotaTrackerManager,
+    _enter_reduced_rate_mode,
+    _record_dynamo_failure,
+    _record_dynamo_success,
+    _set_cached_tracker,
+    clear_quota_cache,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_quota_state():
+    """Reset quota cache and hysteresis counters between tests."""
+    clear_quota_cache()
+    yield
+    clear_quota_cache()
+
+
+def _make_mock_table():
+    """Create a mock DynamoDB table."""
+    table = MagicMock()
+    table.get_item.return_value = {}
+    table.update_item.return_value = {}
+    table.put_item.return_value = {}
+    return table
+
+
+def _preload_cache():
+    """Pre-load cache with a default tracker so DynamoDB isn't hit."""
+    tracker = QuotaTracker.create_default()
+    _set_cached_tracker(tracker)
+    return tracker
+
+
+class TestHysteresisEntry:
+    """Tests for entering reduced-rate mode with hysteresis."""
+
+    def test_does_not_enter_reduced_on_single_failure(self):
+        """A single DynamoDB failure should NOT trigger reduced-rate mode."""
+        table = _make_mock_table()
+        manager = QuotaTrackerManager(table)
+
+        _record_dynamo_failure()
+
+        assert manager.is_reduced_rate() is False
+
+    def test_does_not_enter_reduced_on_two_failures(self):
+        """Two consecutive failures should NOT trigger reduced-rate mode."""
+        table = _make_mock_table()
+        manager = QuotaTrackerManager(table)
+
+        _record_dynamo_failure()
+        _record_dynamo_failure()
+
+        assert manager.is_reduced_rate() is False
+
+    def test_enters_reduced_after_3_consecutive_failures(self):
+        """Three consecutive failures should trigger reduced-rate mode."""
+        table = _make_mock_table()
+        manager = QuotaTrackerManager(table)
+
+        _record_dynamo_failure()
+        _record_dynamo_failure()
+        _record_dynamo_failure()
+
+        assert manager.is_reduced_rate() is True
+
+
+class TestHysteresisExit:
+    """Tests for exiting reduced-rate mode with hysteresis."""
+
+    def test_does_not_exit_on_single_success(self):
+        """A single success while in reduced mode should NOT exit."""
+        table = _make_mock_table()
+        manager = QuotaTrackerManager(table)
+
+        # Enter reduced mode directly (bypass hysteresis for setup)
+        _enter_reduced_rate_mode()
+        assert manager.is_reduced_rate() is True
+
+        _record_dynamo_success()
+
+        assert manager.is_reduced_rate() is True
+
+    def test_does_not_exit_on_four_successes(self):
+        """Four consecutive successes should NOT exit reduced-rate mode."""
+        table = _make_mock_table()
+        manager = QuotaTrackerManager(table)
+
+        _enter_reduced_rate_mode()
+
+        for _ in range(4):
+            _record_dynamo_success()
+
+        assert manager.is_reduced_rate() is True
+
+    def test_exits_reduced_after_5_consecutive_successes(self):
+        """Five consecutive successes should exit reduced-rate mode."""
+        table = _make_mock_table()
+        manager = QuotaTrackerManager(table)
+
+        _enter_reduced_rate_mode()
+        assert manager.is_reduced_rate() is True
+
+        for _ in range(5):
+            _record_dynamo_success()
+
+        assert manager.is_reduced_rate() is False
+
+
+class TestCounterResets:
+    """Tests for counter reset behavior on alternating outcomes."""
+
+    def test_failure_resets_success_counter(self):
+        """A failure after 4 successes should reset progress toward exit."""
+        table = _make_mock_table()
+        manager = QuotaTrackerManager(table)
+
+        _enter_reduced_rate_mode()
+
+        # 4 successes (not enough to exit, need 5)
+        for _ in range(4):
+            _record_dynamo_success()
+        assert manager.is_reduced_rate() is True
+
+        # 1 failure resets success counter
+        _record_dynamo_failure()
+
+        # 4 more successes (would be 8 total without reset, but counter was reset)
+        for _ in range(4):
+            _record_dynamo_success()
+
+        # Still in reduced mode because we only have 4 consecutive successes
+        assert manager.is_reduced_rate() is True
+
+        # 1 more success (5 consecutive) exits
+        _record_dynamo_success()
+        assert manager.is_reduced_rate() is False
+
+    def test_success_resets_failure_counter(self):
+        """A success after 2 failures should reset progress toward entry."""
+        table = _make_mock_table()
+        manager = QuotaTrackerManager(table)
+
+        # 2 failures (not enough to enter, need 3)
+        _record_dynamo_failure()
+        _record_dynamo_failure()
+        assert manager.is_reduced_rate() is False
+
+        # 1 success resets failure counter
+        _record_dynamo_success()
+
+        # 2 more failures (would be 4 total without reset, but counter was reset)
+        _record_dynamo_failure()
+        _record_dynamo_failure()
+
+        # Still normal mode because we only have 2 consecutive failures
+        assert manager.is_reduced_rate() is False
+
+        # 1 more failure (3 consecutive) enters reduced
+        _record_dynamo_failure()
+        assert manager.is_reduced_rate() is True
+
+
+class TestRapidFlapping:
+    """Tests for stability under rapid alternation."""
+
+    def test_rapid_flapping_stays_stable(self):
+        """Alternating success/failure 20 times should never enter reduced mode.
+
+        Because alternation resets the counter each time, we never reach
+        3 consecutive failures.
+        """
+        table = _make_mock_table()
+        manager = QuotaTrackerManager(table)
+
+        for _ in range(20):
+            _record_dynamo_success()
+            assert manager.is_reduced_rate() is False
+            _record_dynamo_failure()
+            assert manager.is_reduced_rate() is False
+
+    def test_flapping_after_entering_reduced_stays_reduced(self):
+        """Once in reduced mode, alternating should not exit (need 5 consecutive)."""
+        table = _make_mock_table()
+        manager = QuotaTrackerManager(table)
+
+        # Enter reduced mode
+        for _ in range(3):
+            _record_dynamo_failure()
+        assert manager.is_reduced_rate() is True
+
+        # Rapid flapping — should stay reduced
+        for _ in range(20):
+            _record_dynamo_success()
+            assert manager.is_reduced_rate() is True
+            _record_dynamo_failure()
+            assert manager.is_reduced_rate() is True


### PR DESCRIPTION
## Summary
- Fixes oscillation between 25% and 100% rate during DynamoDB flapping
- Asymmetric thresholds: 3 consecutive failures to enter reduced mode, 5 consecutive successes to exit
- Configurable via QUOTA_RATE_ENTRY_THRESHOLD and QUOTA_RATE_EXIT_THRESHOLD env vars

## Test plan
- [x] 23 quota tests passing (10 new hysteresis + 13 existing)
🤖 Generated with [Claude Code](https://claude.com/claude-code)