### PR TITLE
feat(sse): Add stale connection sweeping for SIGKILL leak prevention

### DIFF
--- a/src/lambdas/sse_streaming/connection.py
+++ b/src/lambdas/sse_streaming/connection.py
@@ -2,6 +2,7 @@
 
 Provides thread-safe connection tracking with configurable limits.
 Per FR-008: Maximum 100 concurrent connections per Lambda instance.
+Feature 1235: Stale connection sweeping for SIGKILL leak prevention.
 """
 
 import logging
@@ -32,6 +33,7 @@ class SSEConnection:
         session_id: Session identifier for trace correlation (FR-008/T093)
         previous_trace_id: Previous trace ID for reconnection correlation (FR-008/T093)
         connection_sequence: Monotonic counter for this session (FR-008/T093)
+        last_activity: Timestamp of last heartbeat/event dispatch (Feature 1235)
     """
 
     connection_id: str = field(default_factory=lambda: str(uuid.uuid4()))
@@ -44,6 +46,7 @@ class SSEConnection:
     session_id: str | None = None
     previous_trace_id: str | None = None
     connection_sequence: int = 0
+    last_activity: float = field(default_factory=time.time)
 
     def matches_ticker(self, ticker: str) -> bool:
         """Check if this connection should receive events for a ticker.
@@ -85,6 +88,7 @@ class ConnectionManager:
     - Connection tracking by ID
     - Startup time tracking for uptime calculation
     - State validation with self-healing (Feature 1232)
+    - Stale connection sweeping (Feature 1235)
 
     Per research.md decision #4: In-memory connection tracking with thread-safe counter.
     """
@@ -127,6 +131,48 @@ class ConnectionManager:
         """Get Lambda uptime in seconds since manager creation."""
         return int(time.time() - self._start_time)
 
+    def update_activity(self, connection_id: str) -> None:
+        """Update last activity timestamp for a connection.
+
+        Called on every heartbeat/event dispatch to track liveness.
+        Feature 1235: SSE Connection Cleanup.
+
+        Args:
+            connection_id: ID of the connection to update
+        """
+        with self._lock:
+            conn = self._connections.get(connection_id)
+            if conn is not None:
+                conn.last_activity = time.time()
+
+    def sweep_stale(self, max_idle_seconds: float = 60.0) -> int:
+        """Remove connections that haven't had activity in max_idle_seconds.
+
+        Defends against leaked connections from SIGKILL'd Lambdas where
+        finally blocks don't execute and connections are never released.
+        Feature 1235: SSE Connection Cleanup.
+
+        Args:
+            max_idle_seconds: Maximum idle time (default: 2x heartbeat interval of 30s)
+
+        Returns:
+            Number of stale connections removed
+        """
+        now = time.time()
+        stale_ids: list[tuple[str, float]] = []
+        with self._lock:
+            for cid, conn in self._connections.items():
+                idle = now - conn.last_activity
+                if idle > max_idle_seconds:
+                    stale_ids.append((cid, idle))
+            for cid, idle in stale_ids:
+                self._connections.pop(cid, None)
+                logger.warning(
+                    "Removed stale SSE connection",
+                    extra={"connection_id": cid, "idle_seconds": idle},
+                )
+        return len(stale_ids)
+
     def acquire(
         self,
         user_id: str | None = None,
@@ -139,6 +185,10 @@ class ConnectionManager:
     ) -> SSEConnection | None:
         """Acquire a connection slot.
 
+        Sweeps stale connections before checking the limit, so leaked
+        connections from force-killed Lambdas don't permanently consume slots.
+        Feature 1235: SSE Connection Cleanup.
+
         Args:
             user_id: Optional user ID for authenticated streams
             config_id: Optional configuration ID for filtered streams
@@ -148,6 +198,9 @@ class ConnectionManager:
         Returns:
             SSEConnection if slot available, None if limit reached
         """
+        # Sweep stale connections before checking the limit
+        self.sweep_stale()
+
         with self._lock:
             if len(self._connections) >= self._max_connections:
                 logger.warning(

--- a/src/lambdas/sse_streaming/stream.py
+++ b/src/lambdas/sse_streaming/stream.py
@@ -395,6 +395,7 @@ class SSEStreamGenerator:
         heartbeat = self._create_heartbeat()
         self._event_buffer.add(heartbeat)
         self._conn_manager.update_last_event_id(connection.connection_id, heartbeat.id)
+        self._conn_manager.update_activity(connection.connection_id)
         yield self._inject_trace_id(heartbeat.to_sse_dict())
         self._trace_event_dispatch("heartbeat", dispatch_start)
         metrics_emitter.emit_events_sent(1, "heartbeat")
@@ -444,6 +445,7 @@ class SSEStreamGenerator:
                     self._conn_manager.update_last_event_id(
                         connection.connection_id, heartbeat.id
                     )
+                    self._conn_manager.update_activity(connection.connection_id)
                     yield self._inject_trace_id(heartbeat.to_sse_dict())
                     if not flush_fired:
                         self._trace_event_dispatch("heartbeat", dispatch_start)
@@ -611,6 +613,7 @@ class SSEStreamGenerator:
         heartbeat = self._create_heartbeat()
         self._event_buffer.add(heartbeat)
         self._conn_manager.update_last_event_id(connection.connection_id, heartbeat.id)
+        self._conn_manager.update_activity(connection.connection_id)
         yield heartbeat.to_sse_dict()
         metrics_emitter.emit_events_sent(1, "heartbeat")
 
@@ -634,6 +637,7 @@ class SSEStreamGenerator:
                     self._conn_manager.update_last_event_id(
                         connection.connection_id, heartbeat.id
                     )
+                    self._conn_manager.update_activity(connection.connection_id)
                     yield heartbeat.to_sse_dict()
                     metrics_emitter.emit_events_sent(1, "heartbeat")
                     last_heartbeat = current_time

--- a/tests/unit/sse_streaming/test_connection_cleanup.py
+++ b/tests/unit/sse_streaming/test_connection_cleanup.py
@@ -1,0 +1,200 @@
+"""Unit tests for SSE connection cleanup (Feature 1235).
+
+Tests stale connection sweeping to prevent connection leaks when Lambda
+is force-killed (SIGKILL) and finally blocks don't execute.
+"""
+
+import time
+
+from src.lambdas.sse_streaming.connection import ConnectionManager
+
+
+def _make_stale(manager: ConnectionManager, connection_id: str, age_seconds: float):
+    """Set a connection's last_activity to simulate staleness."""
+    conn = manager.get(connection_id)
+    if conn is not None:
+        conn.last_activity = time.time() - age_seconds
+
+
+class TestSweepRemovesStaleConnections:
+    """Test that sweep_stale removes connections past their TTL."""
+
+    def test_sweep_removes_stale_connections(self):
+        """Add connection, make it stale, sweep removes it."""
+        manager = ConnectionManager(max_connections=10)
+        conn = manager.acquire()
+        assert conn is not None
+        assert manager.count == 1
+
+        # Make it 70s stale (past 60s default TTL)
+        _make_stale(manager, conn.connection_id, 70.0)
+        removed = manager.sweep_stale()
+
+        assert removed == 1
+        assert manager.count == 0
+
+    def test_sweep_removes_multiple_stale(self):
+        """Multiple stale connections should all be removed."""
+        manager = ConnectionManager(max_connections=10)
+        conns = [manager.acquire() for _ in range(3)]
+        assert all(c is not None for c in conns)
+        assert manager.count == 3
+
+        for c in conns:
+            _make_stale(manager, c.connection_id, 70.0)
+
+        removed = manager.sweep_stale()
+        assert removed == 3
+        assert manager.count == 0
+
+
+class TestSweepKeepsActiveConnections:
+    """Test that sweep_stale preserves recently active connections."""
+
+    def test_sweep_keeps_active_connections(self):
+        """Connection with recent activity should not be swept."""
+        manager = ConnectionManager(max_connections=10)
+        conn = manager.acquire()
+        assert conn is not None
+
+        # Only 10s idle, well within 60s TTL
+        _make_stale(manager, conn.connection_id, 10.0)
+        removed = manager.sweep_stale()
+
+        assert removed == 0
+        assert manager.count == 1
+
+    def test_sweep_mixed_stale_and_active(self):
+        """Only stale connections should be removed, active ones preserved."""
+        manager = ConnectionManager(max_connections=10)
+        stale_conn = manager.acquire()
+        active_conn = manager.acquire()
+        assert stale_conn is not None
+        assert active_conn is not None
+
+        # stale_conn: 70s idle (stale), active_conn: 20s idle (fresh)
+        _make_stale(manager, stale_conn.connection_id, 70.0)
+        _make_stale(manager, active_conn.connection_id, 20.0)
+
+        removed = manager.sweep_stale()
+
+        assert removed == 1
+        assert manager.count == 1
+        assert manager.get(active_conn.connection_id) is not None
+        assert manager.get(stale_conn.connection_id) is None
+
+
+class TestAcquireTriggersSweep:
+    """Test that acquire() calls sweep_stale() before checking limits."""
+
+    def test_acquire_triggers_sweep(self):
+        """Stale connection at limit should be swept, allowing new acquire."""
+        manager = ConnectionManager(max_connections=1)
+
+        old_conn = manager.acquire()
+        assert old_conn is not None
+        assert manager.count == 1
+
+        # Make old connection stale, then try to acquire new one
+        _make_stale(manager, old_conn.connection_id, 70.0)
+        new_conn = manager.acquire()
+
+        assert new_conn is not None
+        assert manager.count == 1
+        assert manager.get(old_conn.connection_id) is None
+        assert manager.get(new_conn.connection_id) is not None
+
+
+class TestUpdateActivityRefreshesTimestamp:
+    """Test that update_activity prevents connections from being swept."""
+
+    def test_update_activity_refreshes_timestamp(self):
+        """Updated connection should not be swept even after creation TTL."""
+        manager = ConnectionManager(max_connections=10)
+        conn = manager.acquire()
+        assert conn is not None
+
+        # Make it look stale
+        _make_stale(manager, conn.connection_id, 70.0)
+
+        # Now refresh activity -- should set last_activity to now
+        manager.update_activity(conn.connection_id)
+
+        # Sweep should find nothing stale (last_activity is current)
+        removed = manager.sweep_stale()
+        assert removed == 0
+        assert manager.count == 1
+
+    def test_update_activity_nonexistent_connection(self):
+        """Updating activity for missing connection should not raise."""
+        manager = ConnectionManager(max_connections=10)
+        # Should not raise
+        manager.update_activity("nonexistent-id")
+
+
+class TestConnectionCountAccurateAfterSweep:
+    """Test that count property is accurate after sweep operations."""
+
+    def test_connection_count_accurate_after_sweep(self):
+        """count should match actual _connections length after sweep."""
+        manager = ConnectionManager(max_connections=10)
+        conn1 = manager.acquire()
+        conn2 = manager.acquire()
+        conn3 = manager.acquire()
+        assert conn1 is not None
+        assert conn2 is not None
+        assert conn3 is not None
+        assert manager.count == 3
+
+        # conn2 stays active, conn1 and conn3 go stale
+        _make_stale(manager, conn1.connection_id, 70.0)
+        _make_stale(manager, conn2.connection_id, 20.0)
+        _make_stale(manager, conn3.connection_id, 70.0)
+
+        removed = manager.sweep_stale()
+
+        assert removed == 2
+        assert manager.count == 1
+        # Verify count matches internal dict length
+        assert manager.count == len(manager._connections)
+
+    def test_count_accurate_after_sweep_and_acquire(self):
+        """Count should remain accurate through sweep + acquire cycles."""
+        manager = ConnectionManager(max_connections=5)
+        conns = [manager.acquire() for _ in range(5)]
+        assert all(c is not None for c in conns)
+        assert manager.count == 5
+
+        # All go stale, new acquire sweeps and adds
+        for c in conns:
+            _make_stale(manager, c.connection_id, 70.0)
+
+        new_conn = manager.acquire()
+        assert new_conn is not None
+        assert manager.count == 1
+        assert manager.count == len(manager._connections)
+
+
+class TestCustomMaxIdleSeconds:
+    """Test sweep_stale with custom max_idle_seconds parameter."""
+
+    def test_custom_ttl(self):
+        """Custom max_idle_seconds should be respected."""
+        manager = ConnectionManager(max_connections=10)
+        conn = manager.acquire()
+        assert conn is not None
+
+        # 15s idle with 10s TTL should be swept
+        _make_stale(manager, conn.connection_id, 15.0)
+        removed = manager.sweep_stale(max_idle_seconds=10.0)
+        assert removed == 1
+
+    def test_custom_ttl_not_exceeded(self):
+        """Connection within custom TTL should not be swept."""
+        manager = ConnectionManager(max_connections=10)
+        manager.acquire()
+
+        # 5s idle with 10s TTL should NOT be swept
+        # (connection was just created, last_activity is ~now, ~5s < 10s)
+        removed = manager.sweep_stale(max_idle_seconds=10.0)
+        assert removed == 0


### PR DESCRIPTION
## Summary
- Adds last_activity tracking to SSE connections
- sweep_stale() removes connections idle > 60s (2x heartbeat interval)
- Sweep runs on every acquire() before checking connection limit
- Heartbeat dispatch updates last_activity for liveness tracking

## Test plan
- [x] 34 connection tests passing (11 new cleanup + 23 existing)
🤖 Generated with [Claude Code](https://claude.com/claude-code)