### PR TITLE
feat(chaos): Wire all 3 scenarios end-to-end with auto-stop

### DIFF
--- a/src/lambdas/analysis/handler.py
+++ b/src/lambdas/analysis/handler.py
@@ -65,7 +65,11 @@ from src.lambdas.analysis.sentiment import (
     get_model_load_time_ms,
     load_model,
 )
-from src.lambdas.shared.chaos_injection import get_chaos_delay_ms
+from src.lambdas.shared.chaos_injection import (
+    auto_stop_expired,
+    get_chaos_delay_ms,
+    is_chaos_active,
+)
 from src.lambdas.shared.dynamodb import get_table
 from src.lib.metrics import (
     emit_metric,
@@ -117,6 +121,11 @@ def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
     delay_ms = get_chaos_delay_ms("lambda_cold_start")
     if delay_ms > 0:
         time.sleep(delay_ms / 1000.0)  # Convert ms to seconds
+        emit_metric(
+            "ChaosInjectionActive",
+            1,
+            dimensions={"Scenario": "lambda_cold_start"},
+        )
         log_structured(
             "WARNING",
             f"Chaos experiment active: injected {delay_ms}ms delay",
@@ -124,6 +133,21 @@ def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
             delay_ms=delay_ms,
             lambda_function="analysis",
         )
+
+    # Feature 1236: DynamoDB throttle chaos check (before DynamoDB writes)
+    if is_chaos_active("dynamodb_throttle"):
+        throttle_delay = get_chaos_delay_ms("dynamodb_throttle")
+        if throttle_delay > 0:
+            time.sleep(throttle_delay / 1000.0)
+            emit_metric(
+                "ChaosInjectionActive",
+                1,
+                dimensions={"Scenario": "dynamodb_throttle"},
+            )
+
+    # Feature 1236: Auto-stop expired chaos experiments
+    auto_stop_expired("lambda_cold_start")
+    auto_stop_expired("dynamodb_throttle")
 
     try:
         # Parse SNS message

--- a/src/lambdas/dashboard/chaos.py
+++ b/src/lambdas/dashboard/chaos.py
@@ -573,21 +573,17 @@ def start_experiment(experiment_id: str) -> dict[str, Any]:
         )
 
     scenario_type = experiment["scenario_type"]
-    blast_radius = experiment["blast_radius"]
-    duration_seconds = experiment["duration_seconds"]
 
     try:
         # Route to appropriate chaos implementation
         if scenario_type == "dynamodb_throttle":
-            # AWS FIS integration (Phase 2)
-            fis_experiment_id = start_fis_experiment(
-                experiment_id, blast_radius, duration_seconds
-            )
-
-            # Update experiment with FIS experiment ID
+            # App-level throttle injection (FIS provider bug workaround)
+            delay_ms = int(experiment.get("parameters", {}).get("delay_ms", 500))
             results = {
-                "fis_experiment_id": fis_experiment_id,
                 "started_at": datetime.now(UTC).isoformat() + "Z",
+                "injection_method": "dynamodb_flag",
+                "delay_ms": delay_ms,
+                "note": "Lambdas will inject delay_ms before DynamoDB writes while experiment is running",
             }
             update_experiment_status(experiment_id, "running", results)
 
@@ -603,8 +599,15 @@ def start_experiment(experiment_id: str) -> dict[str, Any]:
             update_experiment_status(experiment_id, "running", results)
 
         elif scenario_type == "lambda_cold_start":
-            # Phase 4: Lambda delay injection
-            raise ChaosError("lambda_cold_start scenario not yet implemented (Phase 4)")
+            # Phase 4: Lambda delay injection via DynamoDB flag
+            delay_ms = int(experiment.get("parameters", {}).get("delay_ms", 3000))
+            results = {
+                "started_at": datetime.now(UTC).isoformat() + "Z",
+                "injection_method": "dynamodb_flag",
+                "delay_ms": delay_ms,
+                "note": "Analysis Lambda will inject delay_ms before processing while experiment is running",
+            }
+            update_experiment_status(experiment_id, "running", results)
 
         else:
             raise ValueError(f"Unknown scenario_type: {scenario_type}")
@@ -652,14 +655,7 @@ def stop_experiment(experiment_id: str) -> dict[str, Any]:
     try:
         # Route to appropriate stop implementation
         if scenario_type == "dynamodb_throttle":
-            # AWS FIS integration (Phase 2)
-            fis_experiment_id = experiment.get("results", {}).get("fis_experiment_id")
-            if not fis_experiment_id:
-                raise ChaosError("FIS experiment ID not found in experiment results")
-
-            stop_fis_experiment(fis_experiment_id)
-
-            # Update experiment status
+            # App-level throttle stop (FIS provider bug workaround)
             results = experiment.get("results", {})
             results["stopped_at"] = datetime.now(UTC).isoformat() + "Z"
             update_experiment_status(experiment_id, "stopped", results)
@@ -673,7 +669,9 @@ def stop_experiment(experiment_id: str) -> dict[str, Any]:
 
         elif scenario_type == "lambda_cold_start":
             # Phase 4: Stop Lambda delay injection
-            raise ChaosError("lambda_cold_start scenario not yet implemented (Phase 4)")
+            results = experiment.get("results", {})
+            results["stopped_at"] = datetime.now(UTC).isoformat() + "Z"
+            update_experiment_status(experiment_id, "stopped", results)
 
         else:
             raise ValueError(f"Unknown scenario_type: {scenario_type}")

--- a/src/lambdas/ingestion/handler.py
+++ b/src/lambdas/ingestion/handler.py
@@ -100,6 +100,11 @@ from src.lambdas.shared.adapters.base import (
 )
 from src.lambdas.shared.adapters.finnhub import FinnhubAdapter
 from src.lambdas.shared.adapters.tiingo import TiingoAdapter
+from src.lambdas.shared.chaos_injection import (
+    auto_stop_expired,
+    get_chaos_delay_ms,
+    is_chaos_active,
+)
 from src.lambdas.shared.circuit_breaker import CircuitBreakerState
 from src.lambdas.shared.dynamodb import get_table
 from src.lambdas.shared.failure_tracker import ConsecutiveFailureTracker
@@ -185,6 +190,22 @@ def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
             ),
         }
 
+    # Feature 1236: Chaos injection gate - ingestion_failure
+    if is_chaos_active("ingestion_failure"):
+        logger.warning(
+            "Chaos: skipping ingestion",
+            extra={"scenario": "ingestion_failure", "experiment_active": True},
+        )
+        emit_metric(
+            "ChaosInjectionActive", 1, dimensions={"Scenario": "ingestion_failure"}
+        )
+        return {
+            "statusCode": 200,
+            "body": json.dumps(
+                {"status": "chaos_active", "scenario": "ingestion_failure"}
+            ),
+        }
+
     start_time = time.perf_counter()
     request_id = getattr(context, "aws_request_id", "unknown")
 
@@ -195,6 +216,21 @@ def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
             "event_source": event.get("source", "unknown"),
         },
     )
+
+    # Feature 1236: Auto-stop expired chaos experiments
+    auto_stop_expired("ingestion_failure")
+    auto_stop_expired("dynamodb_throttle")
+
+    # Feature 1236: DynamoDB throttle chaos check (before DynamoDB writes)
+    if is_chaos_active("dynamodb_throttle"):
+        throttle_delay = get_chaos_delay_ms("dynamodb_throttle")
+        if throttle_delay > 0:
+            time.sleep(throttle_delay / 1000.0)
+            emit_metric(
+                "ChaosInjectionActive",
+                1,
+                dimensions={"Scenario": "dynamodb_throttle"},
+            )
 
     # Initialize counters
     summary = {

--- a/src/lambdas/shared/chaos_injection.py
+++ b/src/lambdas/shared/chaos_injection.py
@@ -15,15 +15,21 @@ Phase 4: Lambda Cold Start Delays
 Allows any Lambda to inject configurable delays at handler entry to simulate
 cold start performance degradation.
 
+Phase 5: Auto-Stop Expired Experiments
+---------------------------------------
+Automatically stops experiments that have exceeded their duration_seconds,
+preventing runaway chaos experiments.
+
 Safety Design:
 --------------
 - Fail-safe: Returns False/0 on any errors (never blocks normal operation)
 - Environment-aware: Only checks chaos state in preprod/dev/test
-- Read-only: Only queries DynamoDB, never modifies state
+- Auto-stop: Expired experiments are cleaned up automatically
 """
 
 import logging
 import os
+from datetime import UTC, datetime
 from typing import Any
 
 import boto3
@@ -202,3 +208,110 @@ def get_chaos_delay_ms(scenario_type: str) -> int:
             extra={"scenario_type": scenario_type, "error": str(e)},
         )
         return 0
+
+
+def auto_stop_expired(scenario_type: str) -> bool:
+    """
+    Auto-stop experiments that have exceeded their duration_seconds.
+
+    Returns True if an experiment was auto-stopped.
+    Fails safe: returns False on any error.
+
+    Args:
+        scenario_type: Type of chaos scenario (e.g., "ingestion_failure", "lambda_cold_start")
+
+    Returns:
+        True if an experiment was auto-stopped, False otherwise
+
+    Safety:
+        - Returns False if not in preprod/dev/test environment
+        - Returns False if chaos table not configured
+        - Returns False on any errors (fail-safe)
+        - Only modifies expired experiments (completed status)
+    """
+    # Read environment variables at call time for testability
+    environment = os.environ.get("ENVIRONMENT", "dev")
+    chaos_table = os.environ.get("CHAOS_EXPERIMENTS_TABLE", "")
+
+    # Production safety: Never auto-stop in prod
+    if environment not in ["preprod", "dev", "test"]:
+        return False
+
+    # If chaos table not configured, no chaos testing available
+    if not chaos_table:
+        return False
+
+    try:
+        table = _get_dynamodb().Table(chaos_table)
+
+        # Query by_status GSI for running experiments of this type
+        response = table.query(
+            IndexName="by_status",
+            KeyConditionExpression="status = :status",
+            FilterExpression="scenario_type = :scenario_type",
+            ExpressionAttributeValues={
+                ":status": "running",
+                ":scenario_type": scenario_type,
+            },
+            Limit=5,
+        )
+
+        now = datetime.now(UTC)
+        for item in response.get("Items", []):
+            results = item.get("results", {})
+            started_at_str = results.get("started_at", "")
+            duration = int(item.get("duration_seconds", 300))
+
+            if started_at_str:
+                # Handle multiple timestamp formats:
+                # - "2025-01-01T00:00:00Z" (trailing Z only)
+                # - "2025-01-01T00:00:00+00:00Z" (offset + trailing Z)
+                # - "2025-01-01T00:00:00+00:00" (offset only)
+                ts = started_at_str.rstrip("Z")
+                if not ts.endswith("+00:00") and "+" not in ts[-6:]:
+                    ts += "+00:00"
+                started_at = datetime.fromisoformat(ts)
+                if (now - started_at).total_seconds() > duration:
+                    exp_id = item["experiment_id"]
+
+                    # Update to completed with auto-stop metadata
+                    results["stopped_at"] = now.isoformat() + "Z"
+                    results["auto_stopped"] = True
+                    table.update_item(
+                        Key={"experiment_id": exp_id},
+                        UpdateExpression="SET #s = :completed, results = :results, updated_at = :now",
+                        ExpressionAttributeNames={"#s": "status"},
+                        ExpressionAttributeValues={
+                            ":completed": "completed",
+                            ":results": results,
+                            ":now": now.isoformat() + "Z",
+                        },
+                    )
+
+                    logger.info(
+                        "Auto-stopped expired chaos experiment",
+                        extra={
+                            "experiment_id": exp_id,
+                            "scenario": scenario_type,
+                            "duration_seconds": duration,
+                        },
+                    )
+                    return True
+
+        return False
+
+    except ClientError as e:
+        # Fail-safe: On DynamoDB errors, skip auto-stop
+        logger.debug(
+            "Auto-stop check failed (safe)",
+            extra={"scenario_type": scenario_type, "error": str(e)},
+        )
+        return False
+
+    except Exception as e:
+        # Fail-safe: On any unexpected errors, skip auto-stop
+        logger.debug(
+            "Auto-stop check failed (safe)",
+            extra={"scenario_type": scenario_type, "error": str(e)},
+        )
+        return False

--- a/tests/unit/test_chaos_auto_stop.py
+++ b/tests/unit/test_chaos_auto_stop.py
@@ -1,0 +1,335 @@
+"""
+Unit Tests for Chaos Auto-Stop Expired Experiments
+===================================================
+
+Feature 1236: Tests that expired chaos experiments are automatically
+stopped to prevent runaway chaos.
+
+Tests:
+- auto_stop_expired returns True when experiment exceeded duration
+- auto_stop_expired returns False when experiment still within duration
+- auto_stop_expired returns False in production environment
+- auto_stop_expired returns False when no chaos table configured
+- auto_stop_expired handles DynamoDB errors gracefully
+"""
+
+import os
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+import pytest
+from botocore.exceptions import ClientError
+
+import src.lambdas.shared.chaos_injection as chaos_injection_module
+from src.lambdas.shared.chaos_injection import auto_stop_expired
+
+
+class TestAutoStopExpired:
+    """Tests for auto_stop_expired() function."""
+
+    @pytest.fixture(autouse=True)
+    def reset_dynamodb_client(self, monkeypatch):
+        """Reset the global DynamoDB client before and after each test."""
+        monkeypatch.setattr(chaos_injection_module, "_dynamodb_client", None)
+        yield
+        chaos_injection_module._dynamodb_client = None
+
+    @patch.dict(
+        os.environ,
+        {
+            "ENVIRONMENT": "preprod",
+            "CHAOS_EXPERIMENTS_TABLE": "preprod-chaos-experiments",
+        },
+    )
+    @patch("src.lambdas.shared.chaos_injection.boto3.resource")
+    def test_auto_stops_expired_experiment(self, mock_boto3_resource):
+        """Test auto-stops experiment that has exceeded its duration."""
+        # Experiment started 10 minutes ago with 60 second duration
+        started_at = (datetime.now(UTC) - timedelta(minutes=10)).isoformat() + "Z"
+
+        mock_table = MagicMock()
+        mock_table.query.return_value = {
+            "Items": [
+                {
+                    "experiment_id": "exp-123",
+                    "scenario_type": "ingestion_failure",
+                    "status": "running",
+                    "duration_seconds": 60,
+                    "results": {
+                        "started_at": started_at,
+                        "injection_method": "dynamodb_flag",
+                    },
+                }
+            ]
+        }
+        mock_dynamodb = MagicMock()
+        mock_dynamodb.Table.return_value = mock_table
+        mock_boto3_resource.return_value = mock_dynamodb
+
+        result = auto_stop_expired("ingestion_failure")
+
+        assert result is True
+        mock_table.update_item.assert_called_once()
+        update_call = mock_table.update_item.call_args[1]
+        assert update_call["Key"]["experiment_id"] == "exp-123"
+        assert update_call["ExpressionAttributeValues"][":completed"] == "completed"
+
+    @patch.dict(
+        os.environ,
+        {
+            "ENVIRONMENT": "preprod",
+            "CHAOS_EXPERIMENTS_TABLE": "preprod-chaos-experiments",
+        },
+    )
+    @patch("src.lambdas.shared.chaos_injection.boto3.resource")
+    def test_does_not_stop_active_experiment(self, mock_boto3_resource):
+        """Test does not stop experiment still within its duration."""
+        # Experiment started 10 seconds ago with 300 second duration
+        started_at = (datetime.now(UTC) - timedelta(seconds=10)).isoformat() + "Z"
+
+        mock_table = MagicMock()
+        mock_table.query.return_value = {
+            "Items": [
+                {
+                    "experiment_id": "exp-456",
+                    "scenario_type": "ingestion_failure",
+                    "status": "running",
+                    "duration_seconds": 300,
+                    "results": {
+                        "started_at": started_at,
+                        "injection_method": "dynamodb_flag",
+                    },
+                }
+            ]
+        }
+        mock_dynamodb = MagicMock()
+        mock_dynamodb.Table.return_value = mock_table
+        mock_boto3_resource.return_value = mock_dynamodb
+
+        result = auto_stop_expired("ingestion_failure")
+
+        assert result is False
+        mock_table.update_item.assert_not_called()
+
+    @patch.dict(
+        os.environ,
+        {
+            "ENVIRONMENT": "preprod",
+            "CHAOS_EXPERIMENTS_TABLE": "preprod-chaos-experiments",
+        },
+    )
+    @patch("src.lambdas.shared.chaos_injection.boto3.resource")
+    def test_returns_false_when_no_experiments(self, mock_boto3_resource):
+        """Test returns False when no running experiments found."""
+        mock_table = MagicMock()
+        mock_table.query.return_value = {"Items": []}
+        mock_dynamodb = MagicMock()
+        mock_dynamodb.Table.return_value = mock_table
+        mock_boto3_resource.return_value = mock_dynamodb
+
+        result = auto_stop_expired("ingestion_failure")
+
+        assert result is False
+
+    @patch.dict(
+        os.environ,
+        {
+            "ENVIRONMENT": "production",
+            "CHAOS_EXPERIMENTS_TABLE": "prod-chaos-experiments",
+        },
+    )
+    def test_production_environment_returns_false(self):
+        """Test returns False in production (safety check)."""
+        result = auto_stop_expired("ingestion_failure")
+
+        assert result is False
+
+    @patch.dict(
+        os.environ,
+        {"ENVIRONMENT": "preprod", "CHAOS_EXPERIMENTS_TABLE": ""},
+    )
+    def test_no_chaos_table_returns_false(self):
+        """Test returns False when chaos table not configured."""
+        result = auto_stop_expired("ingestion_failure")
+
+        assert result is False
+
+    @patch.dict(
+        os.environ,
+        {
+            "ENVIRONMENT": "preprod",
+            "CHAOS_EXPERIMENTS_TABLE": "preprod-chaos-experiments",
+        },
+    )
+    @patch("src.lambdas.shared.chaos_injection.boto3.resource")
+    def test_dynamodb_error_returns_false(self, mock_boto3_resource):
+        """Test returns False on DynamoDB errors (fail-safe)."""
+        mock_table = MagicMock()
+        mock_table.query.side_effect = ClientError(
+            {
+                "Error": {
+                    "Code": "ResourceNotFoundException",
+                    "Message": "Table not found",
+                }
+            },
+            "Query",
+        )
+        mock_dynamodb = MagicMock()
+        mock_dynamodb.Table.return_value = mock_table
+        mock_boto3_resource.return_value = mock_dynamodb
+
+        result = auto_stop_expired("ingestion_failure")
+
+        assert result is False
+
+    @patch.dict(
+        os.environ,
+        {
+            "ENVIRONMENT": "preprod",
+            "CHAOS_EXPERIMENTS_TABLE": "preprod-chaos-experiments",
+        },
+    )
+    @patch("src.lambdas.shared.chaos_injection.boto3.resource")
+    def test_unexpected_error_returns_false(self, mock_boto3_resource):
+        """Test returns False on unexpected errors (fail-safe)."""
+        mock_boto3_resource.side_effect = Exception("Unexpected error")
+
+        result = auto_stop_expired("ingestion_failure")
+
+        assert result is False
+
+    @patch.dict(
+        os.environ,
+        {
+            "ENVIRONMENT": "preprod",
+            "CHAOS_EXPERIMENTS_TABLE": "preprod-chaos-experiments",
+        },
+    )
+    @patch("src.lambdas.shared.chaos_injection.boto3.resource")
+    def test_experiment_without_started_at_skipped(self, mock_boto3_resource):
+        """Test experiments without started_at are skipped."""
+        mock_table = MagicMock()
+        mock_table.query.return_value = {
+            "Items": [
+                {
+                    "experiment_id": "exp-789",
+                    "scenario_type": "ingestion_failure",
+                    "status": "running",
+                    "duration_seconds": 60,
+                    "results": {},  # No started_at
+                }
+            ]
+        }
+        mock_dynamodb = MagicMock()
+        mock_dynamodb.Table.return_value = mock_table
+        mock_boto3_resource.return_value = mock_dynamodb
+
+        result = auto_stop_expired("ingestion_failure")
+
+        assert result is False
+        mock_table.update_item.assert_not_called()
+
+    @patch.dict(
+        os.environ,
+        {
+            "ENVIRONMENT": "dev",
+            "CHAOS_EXPERIMENTS_TABLE": "dev-chaos-experiments",
+        },
+    )
+    @patch("src.lambdas.shared.chaos_injection.boto3.resource")
+    def test_dev_environment_allowed(self, mock_boto3_resource):
+        """Test auto-stop works in dev environment."""
+        started_at = (datetime.now(UTC) - timedelta(minutes=10)).isoformat() + "Z"
+
+        mock_table = MagicMock()
+        mock_table.query.return_value = {
+            "Items": [
+                {
+                    "experiment_id": "exp-dev-1",
+                    "scenario_type": "lambda_cold_start",
+                    "status": "running",
+                    "duration_seconds": 60,
+                    "results": {"started_at": started_at, "delay_ms": 3000},
+                }
+            ]
+        }
+        mock_dynamodb = MagicMock()
+        mock_dynamodb.Table.return_value = mock_table
+        mock_boto3_resource.return_value = mock_dynamodb
+
+        result = auto_stop_expired("lambda_cold_start")
+
+        assert result is True
+
+    @patch.dict(
+        os.environ,
+        {
+            "ENVIRONMENT": "preprod",
+            "CHAOS_EXPERIMENTS_TABLE": "preprod-chaos-experiments",
+        },
+    )
+    @patch("src.lambdas.shared.chaos_injection.boto3.resource")
+    def test_defaults_to_300_second_duration(self, mock_boto3_resource):
+        """Test defaults to 300 second duration when not specified."""
+        # Started 4 minutes ago -- should NOT be stopped (default duration is 300s)
+        started_at = (datetime.now(UTC) - timedelta(minutes=4)).isoformat() + "Z"
+
+        mock_table = MagicMock()
+        mock_table.query.return_value = {
+            "Items": [
+                {
+                    "experiment_id": "exp-no-dur",
+                    "scenario_type": "dynamodb_throttle",
+                    "status": "running",
+                    # No duration_seconds -- defaults to 300
+                    "results": {"started_at": started_at},
+                }
+            ]
+        }
+        mock_dynamodb = MagicMock()
+        mock_dynamodb.Table.return_value = mock_table
+        mock_boto3_resource.return_value = mock_dynamodb
+
+        result = auto_stop_expired("dynamodb_throttle")
+
+        assert result is False
+        mock_table.update_item.assert_not_called()
+
+    @patch.dict(
+        os.environ,
+        {
+            "ENVIRONMENT": "preprod",
+            "CHAOS_EXPERIMENTS_TABLE": "preprod-chaos-experiments",
+        },
+    )
+    @patch("src.lambdas.shared.chaos_injection.boto3.resource")
+    def test_auto_stop_sets_results_metadata(self, mock_boto3_resource):
+        """Test that auto-stop sets correct metadata in results."""
+        started_at = (datetime.now(UTC) - timedelta(minutes=10)).isoformat() + "Z"
+
+        mock_table = MagicMock()
+        mock_table.query.return_value = {
+            "Items": [
+                {
+                    "experiment_id": "exp-meta",
+                    "scenario_type": "ingestion_failure",
+                    "status": "running",
+                    "duration_seconds": 60,
+                    "results": {
+                        "started_at": started_at,
+                        "injection_method": "dynamodb_flag",
+                    },
+                }
+            ]
+        }
+        mock_dynamodb = MagicMock()
+        mock_dynamodb.Table.return_value = mock_table
+        mock_boto3_resource.return_value = mock_dynamodb
+
+        auto_stop_expired("ingestion_failure")
+
+        update_call = mock_table.update_item.call_args[1]
+        results = update_call["ExpressionAttributeValues"][":results"]
+        assert results["auto_stopped"] is True
+        assert "stopped_at" in results
+        assert results["injection_method"] == "dynamodb_flag"  # Preserved original

--- a/tests/unit/test_chaos_fis.py
+++ b/tests/unit/test_chaos_fis.py
@@ -322,33 +322,35 @@ class TestStartExperimentWithFIS:
         mock_dynamodb_table,
         sample_experiment,
     ):
-        """Test starting DynamoDB throttle experiment with FIS."""
+        """Test starting DynamoDB throttle experiment with DynamoDB-flag pattern."""
         # Mock get_experiment to return pending experiment
         mock_dynamodb_table.get_item.return_value = {"Item": sample_experiment}
 
-        # Mock FIS start
-        mock_fis_client.start_experiment.return_value = {
-            "experiment": {"id": "EXP123456789"}
+        # Mock update_item and second get_item for updated experiment
+        updated_experiment = sample_experiment.copy()
+        updated_experiment["status"] = "running"
+        updated_experiment["results"] = {
+            "started_at": "2025-01-01T00:00:00Z",
+            "injection_method": "dynamodb_flag",
+            "delay_ms": 500,
         }
+        mock_dynamodb_table.get_item.side_effect = [
+            {"Item": sample_experiment},
+            {"Item": updated_experiment},
+        ]
 
-        # Mock update_experiment_status
-        with patch(
-            "src.lambdas.dashboard.chaos.update_experiment_status"
-        ) as mock_update:
-            mock_update.return_value = True
+        start_experiment(sample_experiment["experiment_id"])
 
-            start_experiment(sample_experiment["experiment_id"])
+        # FIS should NOT be called (replaced with DynamoDB-flag pattern)
+        mock_fis_client.start_experiment.assert_not_called()
 
-            # Verify FIS experiment was started
-            mock_fis_client.start_experiment.assert_called_once()
-
-            # Verify experiment status was updated
-            mock_update.assert_called_once()
-            call_args = mock_update.call_args
-            assert call_args[0][0] == sample_experiment["experiment_id"]
-            assert call_args[0][1] == "running"
-            assert "fis_experiment_id" in call_args[0][2]
-            assert call_args[0][2]["fis_experiment_id"] == "EXP123456789"
+        # Verify experiment status was updated via DynamoDB
+        mock_dynamodb_table.update_item.assert_called_once()
+        update_call = mock_dynamodb_table.update_item.call_args
+        assert update_call[1]["ExpressionAttributeValues"][":status"] == "running"
+        results = update_call[1]["ExpressionAttributeValues"][":results"]
+        assert results["injection_method"] == "dynamodb_flag"
+        assert results["delay_ms"] == 500
 
     def test_start_experiment_not_found(
         self, mock_environment_preprod, mock_dynamodb_table
@@ -426,10 +428,14 @@ class TestStopExperimentWithFIS:
         mock_dynamodb_table,
         sample_experiment,
     ):
-        """Test stopping DynamoDB throttle experiment with FIS."""
-        # Mock running experiment with FIS experiment ID
+        """Test stopping DynamoDB throttle experiment with DynamoDB-flag pattern."""
+        # Mock running experiment with DynamoDB-flag results
         sample_experiment["status"] = "running"
-        sample_experiment["results"] = {"fis_experiment_id": "EXP123456789"}
+        sample_experiment["results"] = {
+            "started_at": "2025-01-01T00:00:00Z",
+            "injection_method": "dynamodb_flag",
+            "delay_ms": 500,
+        }
         mock_dynamodb_table.get_item.return_value = {"Item": sample_experiment}
 
         # Mock update_experiment_status
@@ -440,8 +446,8 @@ class TestStopExperimentWithFIS:
 
             stop_experiment(sample_experiment["experiment_id"])
 
-            # Verify FIS experiment was stopped
-            mock_fis_client.stop_experiment.assert_called_once_with(id="EXP123456789")
+            # FIS should NOT be called (replaced with DynamoDB-flag pattern)
+            mock_fis_client.stop_experiment.assert_not_called()
 
             # Verify experiment status was updated
             mock_update.assert_called_once()
@@ -449,19 +455,6 @@ class TestStopExperimentWithFIS:
             assert call_args[0][0] == sample_experiment["experiment_id"]
             assert call_args[0][1] == "stopped"
             assert "stopped_at" in call_args[0][2]
-
-    def test_stop_experiment_missing_fis_id(
-        self, mock_environment_preprod, mock_dynamodb_table, sample_experiment
-    ):
-        """Test stopping experiment fails when FIS experiment ID missing."""
-        sample_experiment["status"] = "running"
-        sample_experiment["results"] = {}  # No FIS experiment ID
-        mock_dynamodb_table.get_item.return_value = {"Item": sample_experiment}
-
-        with pytest.raises(ChaosError) as exc_info:
-            stop_experiment(sample_experiment["experiment_id"])
-
-        assert "FIS experiment ID not found" in str(exc_info.value)
 
     def test_stop_experiment_invalid_status(
         self, mock_environment_preprod, mock_dynamodb_table, sample_experiment
@@ -759,3 +752,202 @@ class TestCreateExperiment:
 
             assert result["scenario_type"] == scenario
             mock_dynamodb_table.put_item.assert_called_once()
+
+
+# ===================================================================
+# Tests for lambda_cold_start scenario (Phase 4 - Feature 1236)
+# ===================================================================
+
+
+class TestLambdaColdStartExperiment:
+    """Tests for lambda_cold_start start/stop in chaos.py."""
+
+    def test_start_cold_start_default_delay(
+        self,
+        mock_environment_preprod,
+        mock_dynamodb_table,
+        sample_experiment,
+    ):
+        """Test starting lambda_cold_start with default 3000ms delay."""
+        sample_experiment["scenario_type"] = "lambda_cold_start"
+        sample_experiment["parameters"] = {}
+        mock_dynamodb_table.get_item.return_value = {"Item": sample_experiment}
+
+        # Mock the update_item and second get_item
+        updated_experiment = sample_experiment.copy()
+        updated_experiment["status"] = "running"
+        updated_experiment["results"] = {
+            "started_at": "2025-01-01T00:00:00Z",
+            "injection_method": "dynamodb_flag",
+            "delay_ms": 3000,
+        }
+        mock_dynamodb_table.get_item.side_effect = [
+            {"Item": sample_experiment},
+            {"Item": updated_experiment},
+        ]
+
+        start_experiment(sample_experiment["experiment_id"])
+
+        mock_dynamodb_table.update_item.assert_called_once()
+        update_call = mock_dynamodb_table.update_item.call_args
+        assert update_call[1]["ExpressionAttributeValues"][":status"] == "running"
+        # Verify results include delay_ms
+        results = update_call[1]["ExpressionAttributeValues"][":results"]
+        assert results["delay_ms"] == 3000
+        assert results["injection_method"] == "dynamodb_flag"
+
+    def test_start_cold_start_custom_delay(
+        self,
+        mock_environment_preprod,
+        mock_dynamodb_table,
+        sample_experiment,
+    ):
+        """Test starting lambda_cold_start with custom delay_ms parameter."""
+        sample_experiment["scenario_type"] = "lambda_cold_start"
+        sample_experiment["parameters"] = {"delay_ms": 5000}
+        mock_dynamodb_table.get_item.return_value = {"Item": sample_experiment}
+
+        updated_experiment = sample_experiment.copy()
+        updated_experiment["status"] = "running"
+        updated_experiment["results"] = {
+            "started_at": "2025-01-01T00:00:00Z",
+            "injection_method": "dynamodb_flag",
+            "delay_ms": 5000,
+        }
+        mock_dynamodb_table.get_item.side_effect = [
+            {"Item": sample_experiment},
+            {"Item": updated_experiment},
+        ]
+
+        start_experiment(sample_experiment["experiment_id"])
+
+        update_call = mock_dynamodb_table.update_item.call_args
+        results = update_call[1]["ExpressionAttributeValues"][":results"]
+        assert results["delay_ms"] == 5000
+
+    def test_stop_cold_start(
+        self,
+        mock_environment_preprod,
+        mock_dynamodb_table,
+        sample_experiment,
+    ):
+        """Test stopping lambda_cold_start experiment."""
+        sample_experiment["scenario_type"] = "lambda_cold_start"
+        sample_experiment["status"] = "running"
+        sample_experiment["results"] = {
+            "started_at": "2025-01-01T00:00:00Z",
+            "injection_method": "dynamodb_flag",
+            "delay_ms": 3000,
+        }
+        mock_dynamodb_table.get_item.return_value = {"Item": sample_experiment}
+
+        with patch(
+            "src.lambdas.dashboard.chaos.update_experiment_status"
+        ) as mock_update:
+            mock_update.return_value = True
+
+            stop_experiment(sample_experiment["experiment_id"])
+
+            mock_update.assert_called_once()
+            call_args = mock_update.call_args
+            assert call_args[0][0] == sample_experiment["experiment_id"]
+            assert call_args[0][1] == "stopped"
+            results = call_args[0][2]
+            assert "stopped_at" in results
+            assert results["delay_ms"] == 3000  # Preserved
+
+
+# ===================================================================
+# Tests for dynamodb_throttle DynamoDB-flag pattern (Phase 5 - Feature 1236)
+# ===================================================================
+
+
+class TestDynamoDBThrottleFlagPattern:
+    """Tests for dynamodb_throttle using DynamoDB-flag pattern (FIS workaround)."""
+
+    def test_start_dynamodb_throttle_flag_pattern(
+        self,
+        mock_environment_preprod,
+        mock_dynamodb_table,
+        sample_experiment,
+    ):
+        """Test starting dynamodb_throttle uses DynamoDB-flag, not FIS."""
+        sample_experiment["scenario_type"] = "dynamodb_throttle"
+        sample_experiment["parameters"] = {}
+        mock_dynamodb_table.get_item.return_value = {"Item": sample_experiment}
+
+        updated_experiment = sample_experiment.copy()
+        updated_experiment["status"] = "running"
+        updated_experiment["results"] = {
+            "started_at": "2025-01-01T00:00:00Z",
+            "injection_method": "dynamodb_flag",
+            "delay_ms": 500,
+        }
+        mock_dynamodb_table.get_item.side_effect = [
+            {"Item": sample_experiment},
+            {"Item": updated_experiment},
+        ]
+
+        start_experiment(sample_experiment["experiment_id"])
+
+        update_call = mock_dynamodb_table.update_item.call_args
+        results = update_call[1]["ExpressionAttributeValues"][":results"]
+        assert results["injection_method"] == "dynamodb_flag"
+        assert results["delay_ms"] == 500
+
+    def test_start_dynamodb_throttle_custom_delay(
+        self,
+        mock_environment_preprod,
+        mock_dynamodb_table,
+        sample_experiment,
+    ):
+        """Test dynamodb_throttle with custom delay_ms."""
+        sample_experiment["scenario_type"] = "dynamodb_throttle"
+        sample_experiment["parameters"] = {"delay_ms": 1000}
+        mock_dynamodb_table.get_item.return_value = {"Item": sample_experiment}
+
+        updated_experiment = sample_experiment.copy()
+        updated_experiment["status"] = "running"
+        mock_dynamodb_table.get_item.side_effect = [
+            {"Item": sample_experiment},
+            {"Item": updated_experiment},
+        ]
+
+        start_experiment(sample_experiment["experiment_id"])
+
+        update_call = mock_dynamodb_table.update_item.call_args
+        results = update_call[1]["ExpressionAttributeValues"][":results"]
+        assert results["delay_ms"] == 1000
+
+    def test_stop_dynamodb_throttle_flag_pattern(
+        self,
+        mock_environment_preprod,
+        mock_dynamodb_table,
+        mock_fis_client,
+        sample_experiment,
+    ):
+        """Test stopping dynamodb_throttle does NOT call FIS."""
+        sample_experiment["scenario_type"] = "dynamodb_throttle"
+        sample_experiment["status"] = "running"
+        sample_experiment["results"] = {
+            "started_at": "2025-01-01T00:00:00Z",
+            "injection_method": "dynamodb_flag",
+            "delay_ms": 500,
+        }
+        mock_dynamodb_table.get_item.return_value = {"Item": sample_experiment}
+
+        with patch(
+            "src.lambdas.dashboard.chaos.update_experiment_status"
+        ) as mock_update:
+            mock_update.return_value = True
+
+            stop_experiment(sample_experiment["experiment_id"])
+
+            # FIS should NOT be called
+            mock_fis_client.stop_experiment.assert_not_called()
+
+            # Status should be updated to stopped
+            mock_update.assert_called_once()
+            call_args = mock_update.call_args
+            assert call_args[0][1] == "stopped"
+            assert "stopped_at" in call_args[0][2]

--- a/tests/unit/test_chaos_ingestion_wiring.py
+++ b/tests/unit/test_chaos_ingestion_wiring.py
@@ -1,0 +1,200 @@
+"""
+Unit Tests for Chaos Injection Wiring in Ingestion Handler
+==========================================================
+
+Feature 1236: Tests that the ingestion Lambda correctly gates on
+chaos experiments and emits metrics.
+
+Tests:
+- test_chaos_active_returns_early: Handler short-circuits when ingestion_failure is active
+- test_chaos_inactive_proceeds: Handler proceeds normally when no chaos active
+- test_chaos_emits_metric: ChaosInjectionActive metric is emitted
+- test_production_env_skips_chaos: Chaos is never checked in production
+"""
+
+import json
+import os
+from unittest.mock import MagicMock, patch
+
+
+class TestChaosIngestionWiring:
+    """Tests for ingestion_failure chaos wiring in the ingestion handler."""
+
+    @patch.dict(
+        os.environ,
+        {
+            "ENVIRONMENT": "preprod",
+            "CHAOS_EXPERIMENTS_TABLE": "preprod-chaos-experiments",
+            "DATABASE_TABLE": "test-table",
+            "USERS_TABLE": "test-users",
+            "TIINGO_SECRET_ARN": "arn:aws:secretsmanager:us-east-1:123:secret:tiingo",
+            "FINNHUB_SECRET_ARN": "arn:aws:secretsmanager:us-east-1:123:secret:finnhub",
+            "SNS_TOPIC_ARN": "arn:aws:sns:us-east-1:123:test-topic",
+            "ALERT_TOPIC_ARN": "arn:aws:sns:us-east-1:123:alert-topic",
+            "AWS_REGION": "us-east-1",
+            "CLOUD_REGION": "us-east-1",
+        },
+    )
+    @patch("src.lambdas.ingestion.handler.is_chaos_active", return_value=True)
+    @patch("src.lambdas.ingestion.handler.emit_metric")
+    def test_chaos_active_returns_early(self, mock_emit_metric, mock_is_chaos):
+        """Test handler returns early when ingestion_failure chaos is active."""
+        from src.lambdas.ingestion.handler import lambda_handler
+
+        event = {"source": "aws.events"}
+        context = MagicMock()
+        context.aws_request_id = "test-request-id"
+
+        result = lambda_handler(event, context)
+
+        assert result["statusCode"] == 200
+        body = json.loads(result["body"])
+        assert body["status"] == "chaos_active"
+        assert body["scenario"] == "ingestion_failure"
+
+        # Verify chaos check was called
+        mock_is_chaos.assert_called_once_with("ingestion_failure")
+
+    @patch.dict(
+        os.environ,
+        {
+            "ENVIRONMENT": "preprod",
+            "CHAOS_EXPERIMENTS_TABLE": "preprod-chaos-experiments",
+            "DATABASE_TABLE": "test-table",
+            "USERS_TABLE": "test-users",
+            "TIINGO_SECRET_ARN": "arn:aws:secretsmanager:us-east-1:123:secret:tiingo",
+            "FINNHUB_SECRET_ARN": "arn:aws:secretsmanager:us-east-1:123:secret:finnhub",
+            "SNS_TOPIC_ARN": "arn:aws:sns:us-east-1:123:test-topic",
+            "ALERT_TOPIC_ARN": "arn:aws:sns:us-east-1:123:alert-topic",
+            "AWS_REGION": "us-east-1",
+            "CLOUD_REGION": "us-east-1",
+        },
+    )
+    @patch("src.lambdas.ingestion.handler.is_chaos_active", return_value=False)
+    @patch("src.lambdas.ingestion.handler.auto_stop_expired", return_value=False)
+    @patch("src.lambdas.ingestion.handler.get_chaos_delay_ms", return_value=0)
+    @patch("src.lambdas.ingestion.handler._get_active_tickers", return_value=[])
+    @patch("src.lambdas.ingestion.handler.get_table")
+    @patch("src.lambdas.ingestion.handler._get_config")
+    def test_chaos_inactive_proceeds(
+        self,
+        mock_config,
+        mock_get_table,
+        mock_get_tickers,
+        mock_delay,
+        mock_auto_stop,
+        mock_is_chaos,
+    ):
+        """Test handler proceeds normally when chaos is not active."""
+        from src.lambdas.ingestion.handler import lambda_handler
+
+        mock_config.return_value = {
+            "dynamodb_table": "test-table",
+            "users_table": "test-users",
+            "tiingo_secret_arn": "arn:aws:secretsmanager:us-east-1:123:secret:tiingo",
+            "finnhub_secret_arn": "arn:aws:secretsmanager:us-east-1:123:secret:finnhub",
+            "sns_topic_arn": "arn:aws:sns:us-east-1:123:test-topic",
+            "alert_topic_arn": "arn:aws:sns:us-east-1:123:alert-topic",
+            "aws_region": "us-east-1",
+        }
+        mock_get_table.return_value = MagicMock()
+
+        event = {"source": "aws.events"}
+        context = MagicMock()
+        context.aws_request_id = "test-request-id"
+
+        result = lambda_handler(event, context)
+
+        # Handler should proceed past chaos check
+        assert result["statusCode"] == 200
+        body = result["body"]
+        assert body["message"] == "No active tickers"
+
+    @patch.dict(
+        os.environ,
+        {
+            "ENVIRONMENT": "preprod",
+            "CHAOS_EXPERIMENTS_TABLE": "preprod-chaos-experiments",
+            "DATABASE_TABLE": "test-table",
+            "USERS_TABLE": "test-users",
+            "TIINGO_SECRET_ARN": "arn:aws:secretsmanager:us-east-1:123:secret:tiingo",
+            "FINNHUB_SECRET_ARN": "arn:aws:secretsmanager:us-east-1:123:secret:finnhub",
+            "SNS_TOPIC_ARN": "arn:aws:sns:us-east-1:123:test-topic",
+            "ALERT_TOPIC_ARN": "arn:aws:sns:us-east-1:123:alert-topic",
+            "AWS_REGION": "us-east-1",
+            "CLOUD_REGION": "us-east-1",
+        },
+    )
+    @patch("src.lambdas.ingestion.handler.is_chaos_active", return_value=True)
+    @patch("src.lambdas.ingestion.handler.emit_metric")
+    def test_chaos_emits_metric(self, mock_emit_metric, mock_is_chaos):
+        """Test ChaosInjectionActive metric is emitted when chaos is active."""
+        from src.lambdas.ingestion.handler import lambda_handler
+
+        event = {"source": "aws.events"}
+        context = MagicMock()
+        context.aws_request_id = "test-request-id"
+
+        lambda_handler(event, context)
+
+        # Verify ChaosInjectionActive metric was emitted
+        mock_emit_metric.assert_called_once_with(
+            "ChaosInjectionActive",
+            1,
+            dimensions={"Scenario": "ingestion_failure"},
+        )
+
+    @patch.dict(
+        os.environ,
+        {
+            "ENVIRONMENT": "prod",
+            "CHAOS_EXPERIMENTS_TABLE": "",
+            "DATABASE_TABLE": "prod-table",
+            "USERS_TABLE": "prod-users",
+            "TIINGO_SECRET_ARN": "arn:aws:secretsmanager:us-east-1:123:secret:tiingo",
+            "FINNHUB_SECRET_ARN": "arn:aws:secretsmanager:us-east-1:123:secret:finnhub",
+            "SNS_TOPIC_ARN": "arn:aws:sns:us-east-1:123:test-topic",
+            "ALERT_TOPIC_ARN": "arn:aws:sns:us-east-1:123:alert-topic",
+            "AWS_REGION": "us-east-1",
+            "CLOUD_REGION": "us-east-1",
+        },
+    )
+    @patch("src.lambdas.ingestion.handler.is_chaos_active", return_value=False)
+    @patch("src.lambdas.ingestion.handler.auto_stop_expired", return_value=False)
+    @patch("src.lambdas.ingestion.handler.get_chaos_delay_ms", return_value=0)
+    @patch("src.lambdas.ingestion.handler._get_active_tickers", return_value=[])
+    @patch("src.lambdas.ingestion.handler.get_table")
+    @patch("src.lambdas.ingestion.handler._get_config")
+    def test_production_env_skips_chaos(
+        self,
+        mock_config,
+        mock_get_table,
+        mock_get_tickers,
+        mock_delay,
+        mock_auto_stop,
+        mock_is_chaos,
+    ):
+        """Test that production environment never activates chaos."""
+        from src.lambdas.ingestion.handler import lambda_handler
+
+        mock_config.return_value = {
+            "dynamodb_table": "prod-table",
+            "users_table": "prod-users",
+            "tiingo_secret_arn": "arn:aws:secretsmanager:us-east-1:123:secret:tiingo",
+            "finnhub_secret_arn": "arn:aws:secretsmanager:us-east-1:123:secret:finnhub",
+            "sns_topic_arn": "arn:aws:sns:us-east-1:123:test-topic",
+            "alert_topic_arn": "arn:aws:sns:us-east-1:123:alert-topic",
+            "aws_region": "us-east-1",
+        }
+        mock_get_table.return_value = MagicMock()
+
+        event = {"source": "aws.events"}
+        context = MagicMock()
+        context.aws_request_id = "test-request-id"
+
+        result = lambda_handler(event, context)
+
+        # is_chaos_active should return False for prod
+        # Handler should have proceeded to normal flow
+        mock_is_chaos.assert_called()
+        assert result["statusCode"] == 200


### PR DESCRIPTION
## Summary

Completes the chaos injection infrastructure by wiring all 3 scenarios end-to-end:

- **ingestion_failure**: Ingestion Lambda now checks `is_chaos_active()` and skips article fetching when active
- **lambda_cold_start**: Removed `NotImplementedError` — experiments can now start/stop, analysis Lambda injects configurable delay (default 3000ms)
- **dynamodb_throttle**: Replaced blocked FIS approach with app-level delay injection before DynamoDB writes (default 500ms)

Additional features:
- **Auto-stop**: Experiments exceeding `duration_seconds` are automatically marked "completed" on next Lambda invocation
- **CloudWatch metrics**: `ChaosInjectionActive` metric emitted for all 3 scenarios with `Scenario` dimension
- **Production safety**: Triple-gated (environment check in API + detection helper + empty table fallback)

## Test plan

- [x] 80 chaos-specific tests passing (15 new ingestion + auto-stop, 6 new scenario tests, 59 existing)
- [x] Lint clean
- [x] All pre-commit hooks passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)