### PR TITLE
fix(deploy): Gate chaos Terraform resources behind feature flag — unblocks 5 failed deploys

### DIFF
--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -1041,10 +1041,11 @@ module "chaos" {
   source = "./modules/chaos"
 
   environment = var.environment
-  # DISABLED: Terraform AWS provider doesn't support Lambda FIS target key "Functions" yet
-  # See: https://github.com/hashicorp/terraform-provider-aws/issues/41208
-  # Re-enable when provider version supports aws:lambda:invocation-add-delay targets
-  enable_chaos_testing = false # var.environment == "preprod"
+  # DISABLED: Deployer IAM user lacks ssm:PutParameter, iam:CreatePolicy, iam:CreateRole
+  # These permissions are needed for chaos infrastructure (kill switch, deny policy, engineer role)
+  # Also: Terraform AWS provider doesn't support Lambda FIS targets (#41208)
+  # Re-enable after granting deployer permissions or using TFC with admin role
+  enable_chaos_testing = false
 
   # Lambda targets for chaos experiments
   lambda_arns = [

--- a/infrastructure/terraform/modules/chaos/main.tf
+++ b/infrastructure/terraform/modules/chaos/main.tf
@@ -125,7 +125,7 @@ resource "aws_cloudwatch_log_group" "fis_experiments" {
 # Scripts manage the value at runtime; Terraform only creates the parameter.
 # checkov:skip=CKV2_AWS_34:Kill switch is a non-secret state flag (disarmed/armed/triggered), encryption unnecessary
 resource "aws_ssm_parameter" "chaos_kill_switch" {
-  count = var.environment != "prod" ? 1 : 0
+  count = var.enable_chaos_testing && var.environment != "prod" ? 1 : 0
   name  = "/chaos/${var.environment}/kill-switch"
   type  = "String"
   value = "disarmed"
@@ -145,7 +145,7 @@ resource "aws_ssm_parameter" "chaos_kill_switch" {
 # Pre-created deny-write policy for DynamoDB throttle chaos scenario.
 # This policy is always present but only attached to roles during chaos injection.
 resource "aws_iam_policy" "chaos_deny_dynamodb_write" {
-  count = var.environment != "prod" ? 1 : 0
+  count = var.enable_chaos_testing && var.environment != "prod" ? 1 : 0
   name  = "${var.environment}-chaos-deny-dynamodb-write"
 
   policy = jsonencode({
@@ -176,7 +176,7 @@ resource "aws_iam_policy" "chaos_deny_dynamodb_write" {
 # Chaos-engineer IAM role: least-privilege for external chaos operations.
 # Requires MFA and limited to 1-hour sessions.
 resource "aws_iam_role" "chaos_engineer" {
-  count = var.environment != "prod" ? 1 : 0
+  count = var.enable_chaos_testing && var.environment != "prod" ? 1 : 0
   name  = "${var.environment}-chaos-engineer"
 
   assume_role_policy = jsonencode({

--- a/infrastructure/terraform/modules/chaos/outputs.tf
+++ b/infrastructure/terraform/modules/chaos/outputs.tf
@@ -31,17 +31,17 @@ output "fis_log_group_name" {
 
 output "chaos_engineer_role_arn" {
   description = "ARN of the chaos-engineer IAM role"
-  value       = var.environment != "prod" ? aws_iam_role.chaos_engineer[0].arn : ""
+  value       = var.enable_chaos_testing && var.environment != "prod" ? aws_iam_role.chaos_engineer[0].arn : ""
 }
 
 output "kill_switch_parameter_name" {
   description = "Name of the SSM parameter for the chaos kill switch"
-  value       = var.environment != "prod" ? aws_ssm_parameter.chaos_kill_switch[0].name : ""
+  value       = var.enable_chaos_testing && var.environment != "prod" ? aws_ssm_parameter.chaos_kill_switch[0].name : ""
 }
 
 output "deny_dynamodb_write_policy_arn" {
   description = "ARN of the pre-created deny-DynamoDB-write policy"
-  value       = var.environment != "prod" ? aws_iam_policy.chaos_deny_dynamodb_write[0].arn : ""
+  value       = var.enable_chaos_testing && var.environment != "prod" ? aws_iam_policy.chaos_deny_dynamodb_write[0].arn : ""
 }
 
 # ============================================================================


### PR DESCRIPTION
## Summary

The chaos refactor (PR #774) added 3 Terraform resources that the deployer IAM user can't create:
- SSM parameter `/chaos/preprod/kill-switch` (needs ssm:PutParameter)
- IAM policy `preprod-chaos-deny-dynamodb-write` (needs iam:CreatePolicy)
- IAM role `preprod-chaos-engineer` (needs iam:CreateRole)

This caused **5 consecutive deploy failures**, blocking all code from reaching preprod since 2026-03-22 18:33 UTC.

**Fix**: Gate all 3 resources behind the existing `enable_chaos_testing` flag (currently `false`). The chaos scripts work without these pre-created resources — they create SSM parameters on first run with their own credentials.

**Tech debt registered**: 7 items documented (EventBridge IAM, chaos_restore Lambda deployment, FIS cleanup, etc.)

## Test plan
- [x] `terraform validate` passes
- [x] No functional resources changed (only count conditions)
- [x] Outputs correctly handle the false flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)