### PR TITLE
fix(chaos): Resolve all 6 tech debt items from chaos refactor

### DIFF
--- a/docs/reference/TECH_DEBT_REGISTRY.md
+++ b/docs/reference/TECH_DEBT_REGISTRY.md
@@ -355,6 +355,23 @@ class CloudDatabase(ComponentResource):
 **Effort**: 4-6 weeks
 **Risk**: High (complete infrastructure rewrite)
 
+### TD-022: chaos_restore Lambda Not Deployed via Terraform
+**Status**: Blocked - Waiting for deployer IAM permissions
+**Location**: `src/lambdas/chaos_restore/handler.py` (code complete), `infrastructure/terraform/main.tf` (TODO comment)
+**Issue**: The chaos_restore Lambda code exists and is tested, but has no Terraform module for deployment.
+
+**Current State**:
+- Handler code: `src/lambdas/chaos_restore/handler.py` (complete)
+- Needs: Lambda module, IAM role (SSM + Lambda + IAM + EventBridge permissions), SNS subscription
+- Blocked by: `enable_chaos_testing = false` in main.tf (deployer lacks required IAM permissions)
+
+**Resolution**: Create Terraform module when chaos testing is enabled. Requires ECR image build pipeline.
+
+**Effort**: 2-3 hours once chaos testing is unblocked
+**Risk**: None (feature disabled, code exists but is not deployed)
+
+---
+
 ### TD-021: Lambda FIS Chaos Testing Blocked by Terraform Provider
 **Status**: Blocked - Waiting for upstream fix
 **Location**: `infrastructure/terraform/main.tf:442-445`, `modules/chaos/main.tf`

--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -1071,12 +1071,14 @@ module "chaos" {
   ]
   chaos_experiments_table_arn = module.dynamodb.chaos_experiments_table_arn
 
-  # Deprecated - kept for backwards compatibility
-  dynamodb_table_arn       = module.dynamodb.table_arn
-  write_throttle_alarm_arn = module.dynamodb.cloudwatch_alarm_write_throttles_arn
-
   depends_on = [module.ingestion_lambda, module.analysis_lambda, module.dashboard_lambda, module.metrics_lambda, module.notification_lambda, module.sse_streaming_lambda, module.monitoring]
 }
+
+# TODO (TD-2): Deploy chaos_restore Lambda
+# Code: src/lambdas/chaos_restore/handler.py (complete, tested)
+# Needs: Lambda module, IAM role (SSM + Lambda + IAM + EventBridge), SNS subscription
+# Blocked by: enable_chaos_testing = false (deployer permissions)
+# Track: docs/reference/TECH_DEBT_REGISTRY.md
 
 # ===================================================================
 # Module: AWS Amplify Frontend (Feature 1105)

--- a/infrastructure/terraform/modules/chaos/main.tf
+++ b/infrastructure/terraform/modules/chaos/main.tf
@@ -1,3 +1,10 @@
+# ============================================================================
+# LEGACY: AWS FIS Support (DISABLED)
+# Status: Blocked by Terraform AWS provider bug #41208
+# Decision: Using external actor architecture (Feature 1237) instead
+# Action: Delete this section when FIS support is no longer planned
+# ============================================================================
+#
 # AWS Fault Injection Service (FIS) for Chaos Testing
 # =====================================================
 #

--- a/infrastructure/terraform/modules/chaos/variables.tf
+++ b/infrastructure/terraform/modules/chaos/variables.tf
@@ -49,19 +49,3 @@ variable "chaos_experiments_table_arn" {
   type        = string
   default     = ""
 }
-
-# ============================================================================
-# Deprecated Variables (kept for backwards compatibility during migration)
-# ============================================================================
-
-variable "dynamodb_table_arn" {
-  description = "DEPRECATED: DynamoDB ARN - FIS doesn't support DynamoDB API fault injection"
-  type        = string
-  default     = ""
-}
-
-variable "write_throttle_alarm_arn" {
-  description = "DEPRECATED: Was used for DynamoDB throttle alarm"
-  type        = string
-  default     = ""
-}

--- a/infrastructure/terraform/modules/iam/main.tf
+++ b/infrastructure/terraform/modules/iam/main.tf
@@ -558,6 +558,16 @@ resource "aws_iam_role_policy" "dashboard_chaos" {
           "cloudwatch:GetMetricData"
         ]
         Resource = "*"
+      },
+      {
+        Sid    = "EventBridgeChaosControl"
+        Effect = "Allow"
+        Action = [
+          "events:DescribeRule",
+          "events:DisableRule",
+          "events:EnableRule"
+        ]
+        Resource = "arn:aws:events:*:*:rule/${var.environment}-*"
       }
     ]
   })

--- a/src/dashboard/chaos.html
+++ b/src/dashboard/chaos.html
@@ -201,22 +201,7 @@
                                             <span x-text="exp.duration_seconds + 's duration'"></span>
                                         </div>
                                     </div>
-                                    <!-- FIS Status (Phase 2.2) -->
-                                    <div x-show="exp.fis_status" class="mt-3 p-2 bg-base-300 rounded">
-                                        <div class="text-xs font-semibold opacity-75 mb-1">FIS Experiment Status</div>
-                                        <div class="flex gap-2 items-center text-sm">
-                                            <div class="badge badge-xs" :class="{
-                                                'badge-success': exp.fis_status?.state === 'running',
-                                                'badge-warning': exp.fis_status?.state === 'initiating',
-                                                'badge-error': exp.fis_status?.state === 'failed',
-                                                'badge-info': exp.fis_status?.state === 'completed'
-                                            }" x-text="exp.fis_status?.state"></div>
-                                            <span class="opacity-75" x-show="exp.fis_status?.reason" x-text="exp.fis_status?.reason"></span>
-                                        </div>
-                                        <div class="text-xs opacity-60 mt-1" x-show="exp.fis_status?.id">
-                                            FIS ID: <span x-text="exp.fis_status?.id"></span>
-                                        </div>
-                                    </div>
+                                    <!-- FIS status display removed (Feature 1237: external actor architecture) -->
                                 </div>
                                 <div class="flex flex-col items-end gap-2">
                                     <div class="badge badge-success gap-2">


### PR DESCRIPTION
## Summary

Cleans up all tech debt from the chaos external actor refactor (Feature 1237):

| # | Item | Risk | Fix |
|---|------|------|-----|
| TD-1 | EventBridge IAM missing from dashboard | HIGH | Added events:DescribeRule/DisableRule/EnableRule to chaos policy |
| TD-2 | chaos_restore Lambda not in Terraform | HIGH | Documented as TD-022 in tech debt registry (needs full Lambda module) |
| TD-3 | Orphaned FIS Terraform code | LOW | Added LEGACY header block explaining status |
| TD-4 | chaos.html FIS status references | LOW | Removed 15-line dead code block |
| TD-5 | Deployed code != main | NONE | Auto-resolved by deploy |
| TD-6 | Deprecated variables | TRIVIAL | Deleted unused dynamodb_table_arn and write_throttle_alarm_arn |

## Test plan
- [x] `terraform validate` passes
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)