### PR TITLE
fix(deploy): Gate chaos_engineer_permissions — fixes Invalid index error

### DIFF
--- a/infrastructure/terraform/modules/chaos/main.tf
+++ b/infrastructure/terraform/modules/chaos/main.tf
@@ -211,7 +211,7 @@ resource "aws_iam_role" "chaos_engineer" {
 }
 
 resource "aws_iam_role_policy" "chaos_engineer_permissions" {
-  count = var.environment != "prod" ? 1 : 0
+  count = var.enable_chaos_testing && var.environment != "prod" ? 1 : 0
   name  = "${var.environment}-chaos-engineer-permissions"
   role  = aws_iam_role.chaos_engineer[0].id
 


### PR DESCRIPTION
The `chaos_engineer_permissions` resource still used `var.environment != "prod"` instead of `var.enable_chaos_testing` guard, causing Terraform "Invalid index" when the parent resources (chaos_engineer role, deny policy) are count=0.

One-line fix: add `var.enable_chaos_testing &&` to the count condition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)