### PR TITLE
fix(models): Add dedup and unknown to SentimentSourceType

### DIFF
--- a/src/lambdas/shared/models/sentiment_history.py
+++ b/src/lambdas/shared/models/sentiment_history.py
@@ -5,7 +5,9 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
-SentimentSourceType = Literal["tiingo", "finnhub", "our_model", "aggregated"]
+SentimentSourceType = Literal[
+    "tiingo", "finnhub", "our_model", "aggregated", "dedup", "unknown"
+]
 
 
 class SentimentPoint(BaseModel):


### PR DESCRIPTION
## Summary
- Real pipeline data uses source format `dedup:<hash>` which extracts to `"dedup"` — not in the `SentimentSourceType` Literal
- This caused pydantic `ValidationError` after the timeseries query fix in PR #782 unblocked the DynamoDB query
- Added `"dedup"` and `"unknown"` to the allowed source types

## Test plan
- [x] Verified locally: `SentimentPoint(source="dedup")` passes validation
- [x] 3394 unit tests passing
- [ ] Verify endpoint returns 200 after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)