### PR TITLE
feat(1244): Fix sign-in bug + customer dashboard E2E coverage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,35 @@
 
 Auto-generated from all feature plans. Last updated: 2025-11-26
 
+## CRITICAL: Two Dashboards — Know Which One You're Touching
+
+This repo has TWO completely separate dashboards. Confusing them has caused 4 separate incidents. **STOP and verify which one you mean before writing code, tests, or fixes.**
+
+| | Customer Dashboard (what users see) | Admin/Debug Dashboard (internal) |
+|---|---|---|
+| **Tech** | Next.js 14 + React 18 + TypeScript | Vanilla JS + HTMX + Chart.js |
+| **Source** | `frontend/` | `src/dashboard/` |
+| **URL** | `https://main.d29tlmksqcx494.amplifyapp.com/` | Lambda Function URL (direct) |
+| **Hosted on** | AWS Amplify | Lambda Function URL response |
+| **Auth** | "Guest" button → anonymous session | None (direct Lambda access) |
+| **API routes** | `/api/v2/configurations/{id}/sentiment` | `/api/v2/tickers/{ticker}/sentiment/history` |
+| **Data hook** | `useSentiment(configId)` in React | `fetch()` in vanilla JS |
+| **Env var** | `PREPROD_FRONTEND_URL` | `DASHBOARD_URL` |
+| **Test suite** | `frontend/tests/e2e/*.spec.ts` | `tests/e2e/test_*.py` |
+| **Test runner** | `cd frontend && npx playwright test` | `pytest tests/e2e/` |
+| **Header comment** | `// Target: Customer Dashboard (Next.js/Amplify)` | `# Target: Admin Dashboard (Lambda HTMX)` |
+
+### Rules
+
+1. **"Dashboard" always means the customer dashboard** unless explicitly qualified as "admin dashboard" or "HTMX dashboard".
+2. **E2E/Playwright tests MUST target the Amplify URL** for customer-facing features. Testing the Lambda Function URL tests an internal tool, NOT what users see.
+3. **When fixing a bug visible to users**, verify the fix on `https://main.d29tlmksqcx494.amplifyapp.com/`, not on the Lambda Function URL.
+4. **The two dashboards use different API routes.** A fix to one endpoint may not fix the other. Always check which route the customer dashboard calls.
+
+### Why This Keeps Happening
+
+The Lambda is named `dashboard Lambda`, the handler is `src/lambdas/dashboard/`, and it serves `src/dashboard/index.html`. When following code paths, you naturally land on the HTMX dashboard. The Next.js app is in a completely separate `frontend/` directory. All existing Playwright tests already target `DASHBOARD_URL` → Lambda. The pattern is self-reinforcing. **Break the pattern by checking this table.**
+
 ## Active Technologies
 - TypeScript 5.x, Node.js 20 LTS (007-sentiment-dashboard-frontend)
 - Python 3.13 + pytest, pytest-asyncio, httpx, boto3, moto (for local unit tests only), aws-xray-sdk (008-e2e-validation-suite)
@@ -102,6 +131,7 @@ Auto-generated from all feature plans. Last updated: 2025-11-26
 - N/A (client-side state only, no persistence) (1226-frontend-error-visibility)
 - Python 3.13 (existing project standard) + aws_lambda_powertools 3.7.0 (missing from ingestion ZIP), boto3 (existing), pydantic (existing) (1227-real-sentiment-pipeline)
 - DynamoDB `{env}-sentiment-timeseries` table (existing, 678 records, PK=`{ticker}#{resolution}`, SK=ISO timestamp) (1227-real-sentiment-pipeline)
+- TypeScript 5.x (frontend), Python 3.13 (backend test relabeling) + Next.js 14, React 18, Radix UI (existing: dialog, tooltip, switch; add: dropdown-menu), Playwright 1.57, TradingView Lightweight Charts (1244-customer-e2e-coverage)
 
 - **Python 3.13** with aws-lambda-powertools, boto3, pydantic, httpx, orjson
 - **AWS Services**: DynamoDB (single-table design), S3, Lambda, SNS, EventBridge, Cognito, Amplify
@@ -899,9 +929,9 @@ aws cloudwatch get-metric-data --metric-data-queries '[...]' --start-time ... --
 ```
 
 ## Recent Changes
+- 1244-customer-e2e-coverage: Added TypeScript 5.x (frontend), Python 3.13 (backend test relabeling) + Next.js 14, React 18, Radix UI (existing: dialog, tooltip, switch; add: dropdown-menu), Playwright 1.57, TradingView Lightweight Charts
 - 1227-real-sentiment-pipeline: Added Python 3.13 (existing project standard) + aws_lambda_powertools 3.7.0 (missing from ingestion ZIP), boto3 (existing), pydantic (existing)
 - 1226-frontend-error-visibility: Added TypeScript ^5 / Next.js 14.2.21 / React ^18 + @tanstack/react-query ^5.90.11, zustand ^5.0.8, sonner ^2.0.7
-- 001-cache-architecture-audit: Added Python 3.13 + boto3 (AWS SDK), pydantic (validation), functools (current caching)
 
 <!-- MANUAL ADDITIONS START -->
 

--- a/Makefile
+++ b/Makefile
@@ -39,8 +39,19 @@ install-tools: ## Install CLI tools via aqua
 # Validation (Zero AWS Cost)
 # ============================================================================
 
-validate: fmt lint security sast check-banned-terms ## Run all validation (fmt + lint + security + sast + banned terms)
+validate: fmt lint security sast check-banned-terms check-test-target-headers ## Run all validation (fmt + lint + security + sast + banned terms + test headers)
 	@echo "$(GREEN)✓ All validation passed$(NC)"
+
+check-test-target-headers: ## Verify all Playwright test files have Target: dashboard headers
+	@echo "Checking test target headers..."
+	@MISSING=$$(cd $(CURDIR) && grep -rL "Target:.*Dashboard" frontend/tests/e2e/*.spec.ts tests/e2e/test_*.py 2>/dev/null); \
+	if [ -n "$$MISSING" ]; then \
+		echo "$(RED)✗ Files missing Target: header:$(NC)"; \
+		echo "$$MISSING"; \
+		echo "Add '// Target: Customer Dashboard (Next.js/Amplify)' or '# Target: Admin Dashboard (Lambda HTMX)' as the first line"; \
+		exit 1; \
+	fi
+	@echo "$(GREEN)✓ All Playwright test files have target headers$(NC)"
 
 fmt: ## Format Python code (Ruff only - Black removed in feat(057))
 	ruff format src tests

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.15",
+        "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@radix-ui/react-label": "^2.1.8",
         "@radix-ui/react-slider": "^1.3.6",
         "@radix-ui/react-slot": "^1.2.4",
@@ -1758,6 +1759,35 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-dropdown-menu": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.16.tgz",
+      "integrity": "sha512-1PLGQEynI/3OX/ftV54COn+3Sud/Mn8vALg2rWnBLnRaGtJDduNW/22XjlGgPdpcIbiQxjKtb7BkcjP00nqfJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-menu": "2.1.16",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-focus-guards": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
@@ -1858,6 +1888,64 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.16.tgz",
+      "integrity": "sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -1979,6 +2067,37 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz",
+      "integrity": "sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.15",
+    "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-slider": "^1.3.6",
     "@radix-ui/react-slot": "^1.2.4",

--- a/frontend/src/components/auth/user-menu.tsx
+++ b/frontend/src/components/auth/user-menu.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { motion, AnimatePresence } from 'framer-motion';
+import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import {
   User,
   Settings,
@@ -67,150 +67,103 @@ export function UserMenu({ className }: UserMenuProps) {
   const authTypeLabel = authTypeLabels[user?.authType || 'anonymous'];
 
   return (
-    <div className={cn('relative', className)}>
-      <Button
-        variant="ghost"
-        size="sm"
-        onClick={() => setIsOpen(!isOpen)}
-        className="gap-2"
-      >
-        <div className="w-8 h-8 rounded-full bg-accent/20 flex items-center justify-center">
-          <User className="w-4 h-4 text-accent" />
-        </div>
-        <span className="hidden sm:inline text-sm font-medium truncate max-w-[100px]">
-          {displayName}
-        </span>
-        <ChevronDown
-          className={cn(
-            'w-4 h-4 transition-transform',
-            isOpen && 'rotate-180'
-          )}
-        />
-      </Button>
+    <DropdownMenu.Root open={isOpen} onOpenChange={setIsOpen}>
+      <DropdownMenu.Trigger asChild>
+        <Button
+          variant="ghost"
+          size="sm"
+          data-testid="user-menu-trigger"
+          className={cn('gap-2', className)}
+        >
+          <div className="w-8 h-8 rounded-full bg-accent/20 flex items-center justify-center">
+            <User className="w-4 h-4 text-accent" />
+          </div>
+          <span className="hidden sm:inline text-sm font-medium truncate max-w-[100px]">
+            {displayName}
+          </span>
+          <ChevronDown
+            className={cn(
+              'w-4 h-4 transition-transform',
+              isOpen && 'rotate-180'
+            )}
+          />
+        </Button>
+      </DropdownMenu.Trigger>
 
-      <AnimatePresence>
-        {isOpen && (
-          <>
-            {/* Backdrop */}
-            <motion.div
-              className="fixed inset-0 z-40"
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
-              onClick={() => setIsOpen(false)}
-            />
-
-            {/* Menu */}
-            <motion.div
-              className="absolute right-0 top-full mt-2 w-64 z-50 rounded-lg border border-border bg-background/95 backdrop-blur-lg shadow-lg overflow-hidden"
-              initial={{ opacity: 0, y: -10, scale: 0.95 }}
-              animate={{ opacity: 1, y: 0, scale: 1 }}
-              exit={{ opacity: 0, y: -10, scale: 0.95 }}
-              transition={{ duration: 0.15 }}
-            >
-              {/* User info section */}
-              <div className="p-4 border-b border-border">
-                <div className="flex items-center gap-3">
-                  <div className="w-10 h-10 rounded-full bg-accent/20 flex items-center justify-center">
-                    <User className="w-5 h-5 text-accent" />
-                  </div>
-                  <div className="flex-1 min-w-0">
-                    <p className="font-medium text-foreground truncate">
-                      {displayName}
-                    </p>
-                    {user?.email && (
-                      <p className="text-xs text-muted-foreground truncate">
-                        {user.email}
-                      </p>
-                    )}
-                  </div>
-                </div>
-
-                {/* Auth type badge */}
-                <div className="mt-3 flex items-center gap-2 text-xs text-muted-foreground">
-                  <Shield className="w-3 h-3" />
-                  <span>Signed in via {authTypeLabel}</span>
-                </div>
+      <DropdownMenu.Portal>
+        <DropdownMenu.Content
+          className="w-64 z-50 rounded-lg border border-border bg-background/95 backdrop-blur-lg shadow-lg overflow-hidden data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=top]:slide-in-from-bottom-2 data-[side=bottom]:slide-in-from-top-2"
+          side="top"
+          align="start"
+          sideOffset={8}
+        >
+          {/* User info section */}
+          <div className="p-4 border-b border-border">
+            <div className="flex items-center gap-3">
+              <div className="w-10 h-10 rounded-full bg-accent/20 flex items-center justify-center">
+                <User className="w-5 h-5 text-accent" />
               </div>
-
-              {/* Menu items */}
-              <div className="p-2">
-                {isAnonymous && (
-                  <MenuButton
-                    icon={Mail}
-                    label="Sign in with email"
-                    onClick={() => {
-                      setIsOpen(false);
-                      window.location.href = '/auth/signin';
-                    }}
-                    highlight
-                  />
+              <div className="flex-1 min-w-0">
+                <p className="font-medium text-foreground truncate">
+                  {displayName}
+                </p>
+                {user?.email && (
+                  <p className="text-xs text-muted-foreground truncate">
+                    {user.email}
+                  </p>
                 )}
-
-                <MenuButton
-                  icon={Settings}
-                  label="Settings"
-                  onClick={() => {
-                    setIsOpen(false);
-                    window.location.href = '/settings';
-                  }}
-                />
-
-                <MenuButton
-                  icon={LogOut}
-                  label="Sign out"
-                  onClick={() => {
-                    setIsOpen(false);
-                    signOut();
-                  }}
-                  disabled={isLoading}
-                  danger
-                />
               </div>
-            </motion.div>
-          </>
-        )}
-      </AnimatePresence>
-    </div>
+            </div>
+
+            {/* Auth type badge */}
+            <div className="mt-3 flex items-center gap-2 text-xs text-muted-foreground">
+              <Shield className="w-3 h-3" />
+              <span>Signed in via {authTypeLabel}</span>
+            </div>
+          </div>
+
+          {/* Menu items */}
+          <div className="p-2">
+            {isAnonymous && (
+              <DropdownMenu.Item
+                className="flex items-center gap-3 px-3 py-2 rounded-md text-sm transition-colors text-accent hover:bg-accent/10 cursor-pointer outline-none data-[highlighted]:bg-accent/10"
+                onSelect={() => {
+                  window.location.href = '/auth/signin';
+                }}
+              >
+                <Mail className="w-4 h-4" />
+                <span>Sign in with email</span>
+              </DropdownMenu.Item>
+            )}
+
+            <DropdownMenu.Item
+              className="flex items-center gap-3 px-3 py-2 rounded-md text-sm transition-colors hover:bg-muted/50 cursor-pointer outline-none data-[highlighted]:bg-muted/50"
+              onSelect={() => {
+                window.location.href = '/settings';
+              }}
+            >
+              <Settings className="w-4 h-4" />
+              <span>Settings</span>
+            </DropdownMenu.Item>
+
+            <DropdownMenu.Item
+              className="flex items-center gap-3 px-3 py-2 rounded-md text-sm transition-colors text-red-500 hover:bg-red-500/10 cursor-pointer outline-none data-[highlighted]:bg-red-500/10 data-[disabled]:opacity-50 data-[disabled]:cursor-not-allowed"
+              onSelect={() => {
+                signOut();
+              }}
+              disabled={isLoading}
+            >
+              <LogOut className="w-4 h-4" />
+              <span>Sign out</span>
+            </DropdownMenu.Item>
+          </div>
+        </DropdownMenu.Content>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
   );
 }
 
-interface MenuButtonProps {
-  icon: React.ComponentType<{ className?: string }>;
-  label: string;
-  onClick: () => void;
-  disabled?: boolean;
-  highlight?: boolean;
-  danger?: boolean;
-}
-
-function MenuButton({
-  icon: Icon,
-  label,
-  onClick,
-  disabled,
-  highlight,
-  danger,
-}: MenuButtonProps) {
-  return (
-    <button
-      onClick={onClick}
-      disabled={disabled}
-      className={cn(
-        'w-full flex items-center gap-3 px-3 py-2 rounded-md text-sm transition-colors',
-        'hover:bg-muted/50',
-        'disabled:opacity-50 disabled:cursor-not-allowed',
-        highlight && 'text-accent hover:bg-accent/10',
-        danger && 'text-red-500 hover:bg-red-500/10'
-      )}
-    >
-      <Icon className="w-4 h-4" />
-      <span>{label}</span>
-    </button>
-  );
-}
-
-// Session timer component
+// Session timer component (separate export — NOT inside DropdownMenu)
 interface SessionTimerProps {
   className?: string;
 }

--- a/frontend/tests/e2e/README.md
+++ b/frontend/tests/e2e/README.md
@@ -1,0 +1,42 @@
+# Customer Dashboard E2E Tests
+
+This directory contains Playwright E2E tests for the **customer-facing Next.js dashboard** hosted on AWS Amplify.
+
+## Target Dashboard
+
+All tests in this directory target the **Customer Dashboard (Next.js/Amplify)** — the app at `https://main.d29tlmksqcx494.amplifyapp.com/`.
+
+For admin dashboard (Lambda HTMX) tests, see `tests/e2e/` at the repository root.
+
+## Running Tests
+
+```bash
+# Against local dev server (default)
+cd frontend && npx playwright test
+
+# Against deployed Amplify app
+PREPROD_FRONTEND_URL=https://main.d29tlmksqcx494.amplifyapp.com/ npx playwright test
+
+# Run a specific test file
+npx playwright test sentiment-visibility
+npx playwright test signin-interaction
+```
+
+## Adding New Tests
+
+1. Create a new `.spec.ts` file in this directory
+2. **Required**: Add this as the first line:
+   ```typescript
+   // Target: Customer Dashboard (Next.js/Amplify)
+   ```
+3. Use `page.getByRole()`, `page.getByLabel()`, `page.getByPlaceholder()` selectors (accessibility-first)
+4. Tests must work against both `localhost:3000` and `PREPROD_FRONTEND_URL`
+
+## Two-Dashboard Architecture
+
+| Dashboard | Directory | URL | Tech |
+|-----------|-----------|-----|------|
+| Customer (this dir) | `frontend/tests/e2e/` | Amplify or localhost:3000 | Next.js/React |
+| Admin | `tests/e2e/` (repo root) | Lambda Function URL | HTMX/Chart.js |
+
+The `make check-test-target-headers` target enforces that all Playwright test files have a `Target:` header comment.

--- a/frontend/tests/e2e/account-linking.spec.ts
+++ b/frontend/tests/e2e/account-linking.spec.ts
@@ -1,3 +1,4 @@
+// Target: Customer Dashboard (Next.js/Amplify)
 /**
  * E2E tests for account linking flows (Feature 1223, US5).
  *

--- a/frontend/tests/e2e/alerts-crud.spec.ts
+++ b/frontend/tests/e2e/alerts-crud.spec.ts
@@ -1,3 +1,4 @@
+// Target: Customer Dashboard (Next.js/Amplify)
 /**
  * E2E tests for alert management CRUD (Feature 1223, US3).
  *

--- a/frontend/tests/e2e/auth.spec.ts
+++ b/frontend/tests/e2e/auth.spec.ts
@@ -1,3 +1,4 @@
+// Target: Customer Dashboard (Next.js/Amplify)
 import { test, expect } from '@playwright/test';
 
 test.describe('Authentication Flow', () => {

--- a/frontend/tests/e2e/chaos.spec.ts
+++ b/frontend/tests/e2e/chaos.spec.ts
@@ -1,3 +1,4 @@
+// Target: Customer Dashboard (Next.js/Amplify)
 import { test, expect } from '@playwright/test';
 
 // Chaos tests run against the API directly since the chaos dashboard

--- a/frontend/tests/e2e/error-visibility-auth.spec.ts
+++ b/frontend/tests/e2e/error-visibility-auth.spec.ts
@@ -1,3 +1,4 @@
+// Target: Customer Dashboard (Next.js/Amplify)
 import { test, expect, type ConsoleMessage } from '@playwright/test';
 
 /**

--- a/frontend/tests/e2e/error-visibility-banner.spec.ts
+++ b/frontend/tests/e2e/error-visibility-banner.spec.ts
@@ -1,3 +1,4 @@
+// Target: Customer Dashboard (Next.js/Amplify)
 import { test, expect, type ConsoleMessage } from '@playwright/test';
 
 /**

--- a/frontend/tests/e2e/error-visibility-search.spec.ts
+++ b/frontend/tests/e2e/error-visibility-search.spec.ts
@@ -1,3 +1,4 @@
+// Target: Customer Dashboard (Next.js/Amplify)
 import { test, expect, type ConsoleMessage } from '@playwright/test';
 
 /**

--- a/frontend/tests/e2e/first-impression.spec.ts
+++ b/frontend/tests/e2e/first-impression.spec.ts
@@ -1,3 +1,4 @@
+// Target: Customer Dashboard (Next.js/Amplify)
 import { test, expect } from '@playwright/test';
 
 test.describe('First Impression Flow', () => {

--- a/frontend/tests/e2e/magic-link.spec.ts
+++ b/frontend/tests/e2e/magic-link.spec.ts
@@ -1,3 +1,4 @@
+// Target: Customer Dashboard (Next.js/Amplify)
 /**
  * E2E tests for magic link authentication flow (Feature 1223, US2).
  *

--- a/frontend/tests/e2e/navigation.spec.ts
+++ b/frontend/tests/e2e/navigation.spec.ts
@@ -1,3 +1,4 @@
+// Target: Customer Dashboard (Next.js/Amplify)
 import { test, expect } from '@playwright/test';
 
 test.describe('Navigation Flow', () => {

--- a/frontend/tests/e2e/oauth-flow.spec.ts
+++ b/frontend/tests/e2e/oauth-flow.spec.ts
@@ -1,3 +1,4 @@
+// Target: Customer Dashboard (Next.js/Amplify)
 /**
  * E2E tests for OAuth login flow (Feature 1223, US1).
  *

--- a/frontend/tests/e2e/sanity.spec.ts
+++ b/frontend/tests/e2e/sanity.spec.ts
@@ -1,3 +1,4 @@
+// Target: Customer Dashboard (Next.js/Amplify)
 import { test, expect } from '@playwright/test';
 
 test.describe('Critical User Path - Sanity Tests', () => {

--- a/frontend/tests/e2e/sentiment-visibility.spec.ts
+++ b/frontend/tests/e2e/sentiment-visibility.spec.ts
@@ -1,0 +1,104 @@
+// Target: Customer Dashboard (Next.js/Amplify)
+import { test, expect } from '@playwright/test';
+
+test.describe('Sentiment Data Visibility', () => {
+  test.setTimeout(30000);
+
+  async function searchAndSelectTicker(page: import('@playwright/test').Page, ticker: string) {
+    const searchInput = page.getByPlaceholder(/search tickers/i);
+    await searchInput.clear();
+    await searchInput.fill(ticker);
+
+    // Handle 429 rate limiting on search endpoint
+    let retries = 0;
+    const maxRetries = 3;
+    let rateLimited = false;
+
+    page.on('response', (response) => {
+      if (response.url().includes('search') && response.status() === 429) {
+        rateLimited = true;
+      }
+    });
+
+    // Wait for suggestions to appear
+    const suggestion = page.getByRole('option', { name: new RegExp(ticker, 'i') });
+    while (retries < maxRetries) {
+      try {
+        await suggestion.waitFor({ timeout: 5000 });
+        rateLimited = false;
+        break;
+      } catch {
+        if (rateLimited) {
+          retries++;
+          rateLimited = false;
+          if (retries >= maxRetries) {
+            test.skip(true, `Rate limited (429) after ${maxRetries} retries on search endpoint`);
+          }
+          await page.waitForTimeout(2000);
+          await searchInput.clear();
+          await searchInput.fill(ticker);
+        } else {
+          throw new Error(`Suggestion for ${ticker} did not appear`);
+        }
+      }
+    }
+
+    await suggestion.click();
+  }
+
+  test('AAPL chart displays sentiment data points', async ({ page }) => {
+    await page.goto('/');
+
+    await searchAndSelectTicker(page, 'AAPL');
+
+    // Wait for chart to render
+    const chart = page.getByRole('img', { name: /price and sentiment/i });
+    await chart.waitFor({ timeout: 15000 });
+
+    // Assert chart contains sentiment data
+    const ariaLabel = await chart.getAttribute('aria-label');
+    expect(ariaLabel).toBeDefined();
+    expect(ariaLabel!.toLowerCase()).toContain('sentiment');
+  });
+
+  test('chart updates on time range change', async ({ page }) => {
+    await page.goto('/');
+
+    await searchAndSelectTicker(page, 'AAPL');
+
+    // Wait for initial chart
+    const chart = page.getByRole('img', { name: /price and sentiment/i });
+    await chart.waitFor({ timeout: 15000 });
+
+    // Click 1M time range button
+    await page.getByRole('button', { name: /^1M$/i }).click();
+
+    // Wait for chart to update
+    await page.waitForTimeout(2000);
+
+    // Assert no error messages are visible
+    const errorText = page.getByText(/error/i);
+    const failedText = page.getByText(/failed/i);
+    await expect(errorText).toBeHidden();
+    await expect(failedText).toBeHidden();
+  });
+
+  test('multiple tickers show sentiment data', async ({ page }) => {
+    await page.goto('/');
+
+    // Load AAPL chart first
+    await searchAndSelectTicker(page, 'AAPL');
+
+    const chart = page.getByRole('img', { name: /price and sentiment/i });
+    await chart.waitFor({ timeout: 15000 });
+
+    // Switch to MSFT
+    await searchAndSelectTicker(page, 'MSFT');
+
+    // Wait for chart to update with MSFT data
+    await chart.waitFor({ timeout: 15000 });
+
+    // Assert chart is still visible after ticker switch
+    await expect(chart).toBeVisible();
+  });
+});

--- a/frontend/tests/e2e/session-lifecycle.spec.ts
+++ b/frontend/tests/e2e/session-lifecycle.spec.ts
@@ -1,3 +1,4 @@
+// Target: Customer Dashboard (Next.js/Amplify)
 /**
  * E2E tests for session lifecycle (Feature 1223, US4).
  *

--- a/frontend/tests/e2e/settings.spec.ts
+++ b/frontend/tests/e2e/settings.spec.ts
@@ -1,3 +1,4 @@
+// Target: Customer Dashboard (Next.js/Amplify)
 import { test, expect } from '@playwright/test';
 
 /**

--- a/frontend/tests/e2e/signin-interaction.spec.ts
+++ b/frontend/tests/e2e/signin-interaction.spec.ts
@@ -1,0 +1,61 @@
+// Target: Customer Dashboard (Next.js/Amplify)
+//
+// Regression tests for the sign-in interaction (Feature 1244).
+// Verifies the Guest button produces a visible menu on both desktop
+// and mobile viewports. Covers the bug where the dropdown was hidden
+// by CSS stacking context + self-occluding backdrop (PRs #782-783 era).
+
+import { test, expect } from '@playwright/test';
+
+test.describe('Sign-In Interaction', () => {
+  test.setTimeout(30_000);
+
+  test('Guest button opens user menu on desktop', async ({ page }) => {
+    await page.goto('/');
+
+    // Wait for auth initialization (skeleton → button)
+    const guestButton = page.getByRole('button', { name: /guest/i });
+    await expect(guestButton).toBeVisible({ timeout: 10_000 });
+
+    // Click the Guest button
+    await guestButton.click();
+
+    // Radix DropdownMenu renders items with role="menuitem"
+    const menuItem = page.getByRole('menuitem').first();
+    await expect(menuItem).toBeVisible({ timeout: 5_000 });
+  });
+
+  test('Guest button opens user menu on mobile', async ({ page }) => {
+    // Set mobile viewport (Pixel 5)
+    await page.setViewportSize({ width: 393, height: 851 });
+    await page.goto('/');
+
+    // On mobile, the "Guest" text is hidden (sm:inline). Use data-testid.
+    const trigger = page.locator('[data-testid="user-menu-trigger"]');
+    await expect(trigger).toBeVisible({ timeout: 10_000 });
+
+    await trigger.click();
+
+    // Menu should appear with at least one item
+    const menuItem = page.getByRole('menuitem').first();
+    await expect(menuItem).toBeVisible({ timeout: 5_000 });
+  });
+
+  test('menu closes on Escape key', async ({ page }) => {
+    await page.goto('/');
+
+    const guestButton = page.getByRole('button', { name: /guest/i });
+    await expect(guestButton).toBeVisible({ timeout: 10_000 });
+
+    // Open menu
+    await guestButton.click();
+    const menuItem = page.getByRole('menuitem').first();
+    await expect(menuItem).toBeVisible({ timeout: 5_000 });
+
+    // Press Escape — Radix handles this automatically
+    await page.keyboard.press('Escape');
+
+    // Menu should be gone
+    await expect(menuItem).not.toBeVisible({ timeout: 3_000 });
+  });
+});

--- a/frontend/tests/e2e/xray-trace-propagation.spec.ts
+++ b/frontend/tests/e2e/xray-trace-propagation.spec.ts
@@ -1,3 +1,4 @@
+// Target: Customer Dashboard (Next.js/Amplify)
 /**
  * X-Ray Trace Propagation E2E Test (T068, SC-085)
  *

--- a/tests/e2e/test_alerts.py
+++ b/tests/e2e/test_alerts.py
@@ -1,3 +1,4 @@
+# Target: Admin Dashboard (Lambda HTMX)
 # E2E Tests: Alert Rule Lifecycle (User Story 5)
 #
 # Tests alert rule CRUD and management:

--- a/tests/e2e/test_anonymous_restrictions.py
+++ b/tests/e2e/test_anonymous_restrictions.py
@@ -1,3 +1,4 @@
+# Target: Admin Dashboard (Lambda HTMX)
 # E2E Tests: Anonymous User Restrictions (403 Forbidden Scenarios)
 #
 # Tests operations that anonymous users are NOT allowed to perform.

--- a/tests/e2e/test_auth_anonymous.py
+++ b/tests/e2e/test_auth_anonymous.py
@@ -1,3 +1,4 @@
+# Target: Admin Dashboard (Lambda HTMX)
 # E2E Tests: Anonymous Session (User Story 1)
 #
 # Tests anonymous user flows:

--- a/tests/e2e/test_auth_magic_link.py
+++ b/tests/e2e/test_auth_magic_link.py
@@ -1,3 +1,4 @@
+# Target: Admin Dashboard (Lambda HTMX)
 # E2E Tests: Magic Link Authentication (User Story 1)
 #
 # Tests magic link authentication flows:

--- a/tests/e2e/test_auth_oauth.py
+++ b/tests/e2e/test_auth_oauth.py
@@ -1,3 +1,4 @@
+# Target: Admin Dashboard (Lambda HTMX)
 # E2E Tests: OAuth Authentication (User Story 2)
 #
 # Tests OAuth authentication flows:

--- a/tests/e2e/test_cache_hit_rate.py
+++ b/tests/e2e/test_cache_hit_rate.py
@@ -1,3 +1,4 @@
+# Target: Admin Dashboard (Lambda HTMX)
 """E2E tests for cache hit rate validation.
 
 Feature: 1020-validate-cache-hit-rate

--- a/tests/e2e/test_circuit_breaker.py
+++ b/tests/e2e/test_circuit_breaker.py
@@ -1,3 +1,4 @@
+# Target: Admin Dashboard (Lambda HTMX)
 # E2E Tests: Circuit Breaker Behavior (User Story 8)
 #
 # Tests circuit breaker state transitions:

--- a/tests/e2e/test_cleanup.py
+++ b/tests/e2e/test_cleanup.py
@@ -1,3 +1,4 @@
+# Target: Admin Dashboard (Lambda HTMX)
 # E2E Tests: Manual Cleanup Utilities
 #
 # This module provides manual cleanup utilities for test data.

--- a/tests/e2e/test_client_cache.py
+++ b/tests/e2e/test_client_cache.py
@@ -1,3 +1,4 @@
+# Target: Admin Dashboard (Lambda HTMX)
 """E2E Tests: Client-Side IndexedDB Cache (User Story 5 - Phase 7)
 
 Tests client-side caching functionality for connectivity resilience:

--- a/tests/e2e/test_config_crud.py
+++ b/tests/e2e/test_config_crud.py
@@ -1,3 +1,4 @@
+# Target: Admin Dashboard (Lambda HTMX)
 # E2E Tests: Configuration CRUD (User Story 3)
 #
 # Tests configuration create, read, update, delete operations:

--- a/tests/e2e/test_dashboard_buffered.py
+++ b/tests/e2e/test_dashboard_buffered.py
@@ -1,3 +1,4 @@
+# Target: Admin Dashboard (Lambda HTMX)
 # E2E Tests: Dashboard BUFFERED Response Mode (Feature 016)
 #
 # Validates that the dashboard Lambda returns proper JSON responses

--- a/tests/e2e/test_failure_injection.py
+++ b/tests/e2e/test_failure_injection.py
@@ -1,3 +1,4 @@
+# Target: Admin Dashboard (Lambda HTMX)
 # E2E Tests: Failure Injection (User Story 4)
 #
 # Tests error handling paths through failure injection:

--- a/tests/e2e/test_financial_pipeline.py
+++ b/tests/e2e/test_financial_pipeline.py
@@ -1,3 +1,4 @@
+# Target: Admin Dashboard (Lambda HTMX)
 """
 Financial News Pipeline E2E Tests with Synthetic Data
 ======================================================

--- a/tests/e2e/test_full_pipeline.py
+++ b/tests/e2e/test_full_pipeline.py
@@ -1,3 +1,4 @@
+# Target: Admin Dashboard (Lambda HTMX)
 """
 Full Pipeline E2E Test for Sentiment Analyzer
 

--- a/tests/e2e/test_live_update_latency.py
+++ b/tests/e2e/test_live_update_latency.py
@@ -1,3 +1,4 @@
+# Target: Admin Dashboard (Lambda HTMX)
 """E2E tests for live update latency validation.
 
 Feature 1019: Validate Live Update Latency

--- a/tests/e2e/test_market_status.py
+++ b/tests/e2e/test_market_status.py
@@ -1,3 +1,4 @@
+# Target: Admin Dashboard (Lambda HTMX)
 # E2E Tests: Market Status (User Story 12)
 #
 # Tests market status functionality:

--- a/tests/e2e/test_metrics_auth.py
+++ b/tests/e2e/test_metrics_auth.py
@@ -1,3 +1,4 @@
+# Target: Admin Dashboard (Lambda HTMX)
 """E2E tests for /api/v2/metrics endpoint authentication.
 
 Feature 1059: E2E Test for /api/v2/metrics Auth Scenarios

--- a/tests/e2e/test_multi_resolution_dashboard.py
+++ b/tests/e2e/test_multi_resolution_dashboard.py
@@ -1,3 +1,4 @@
+# Target: Admin Dashboard (Lambda HTMX)
 """E2E Tests: Multi-Resolution Dashboard (Feature 1009 - Phase 8)
 
 Tests complete user journey for the multi-resolution sentiment dashboard:

--- a/tests/e2e/test_notification_preferences.py
+++ b/tests/e2e/test_notification_preferences.py
@@ -1,3 +1,4 @@
+# Target: Admin Dashboard (Lambda HTMX)
 # E2E Tests: Notification Preferences API (Issue #124)
 #
 # Tests the notification preferences API:

--- a/tests/e2e/test_notifications.py
+++ b/tests/e2e/test_notifications.py
@@ -1,3 +1,4 @@
+# Target: Admin Dashboard (Lambda HTMX)
 # E2E Tests: Notification Delivery Pipeline (User Story 6)
 #
 # Tests notification creation, delivery, and tracking:

--- a/tests/e2e/test_observability.py
+++ b/tests/e2e/test_observability.py
@@ -1,3 +1,4 @@
+# Target: Admin Dashboard (Lambda HTMX)
 # E2E Tests: Observability (User Story 11)
 #
 # Tests CloudWatch and X-Ray observability:

--- a/tests/e2e/test_quota.py
+++ b/tests/e2e/test_quota.py
@@ -1,3 +1,4 @@
+# Target: Admin Dashboard (Lambda HTMX)
 # E2E Tests: Alert Email Quota Tracking (Issue #125)
 #
 # Tests the alert email quota API:

--- a/tests/e2e/test_rate_limiting.py
+++ b/tests/e2e/test_rate_limiting.py
@@ -1,3 +1,4 @@
+# Target: Admin Dashboard (Lambda HTMX)
 # E2E Tests: Rate Limiting Enforcement (User Story 7)
 #
 # Tests rate limiting behavior:

--- a/tests/e2e/test_resolution_switch_perf.py
+++ b/tests/e2e/test_resolution_switch_perf.py
@@ -1,3 +1,4 @@
+# Target: Admin Dashboard (Lambda HTMX)
 """Performance test for resolution switching latency.
 
 Validates SC-002 from specs/1009-realtime-multi-resolution: Resolution switching

--- a/tests/e2e/test_sentiment.py
+++ b/tests/e2e/test_sentiment.py
@@ -1,3 +1,4 @@
+# Target: Admin Dashboard (Lambda HTMX)
 # E2E Tests: Sentiment and Volatility Data (User Story 4)
 #
 # Tests sentiment and volatility data endpoints:

--- a/tests/e2e/test_sentiment_history_regression.py
+++ b/tests/e2e/test_sentiment_history_regression.py
@@ -1,3 +1,4 @@
+# Target: Admin Dashboard (Lambda HTMX)
 # E2E Tests: Sentiment History Regression (PRs #782, #783)
 #
 # Regression tests for the sentiment history 500 bug:

--- a/tests/e2e/test_session_consistency_preprod.py
+++ b/tests/e2e/test_session_consistency_preprod.py
@@ -1,3 +1,4 @@
+# Target: Admin Dashboard (Lambda HTMX)
 """E2E tests for Feature 014 Session Consistency (preprod).
 
 These tests run against the preprod environment and validate:

--- a/tests/e2e/test_skeleton_loading.py
+++ b/tests/e2e/test_skeleton_loading.py
@@ -1,3 +1,4 @@
+# Target: Admin Dashboard (Lambda HTMX)
 """
 Feature 1021: Skeleton Loading UI E2E Tests
 ============================================

--- a/tests/e2e/test_sse.py
+++ b/tests/e2e/test_sse.py
@@ -1,3 +1,4 @@
+# Target: Admin Dashboard (Lambda HTMX)
 # E2E Tests: SSE Streaming (User Story 10)
 #
 # Tests Server-Sent Events functionality:

--- a/tests/e2e/test_sse_connection_preprod.py
+++ b/tests/e2e/test_sse_connection_preprod.py
@@ -1,3 +1,4 @@
+# Target: Admin Dashboard (Lambda HTMX)
 # E2E Tests: SSE Connection Health (Preprod)
 #
 # Validates that SSE Lambda is running correctly and dashboard can connect.

--- a/tests/e2e/test_sse_reconnection.py
+++ b/tests/e2e/test_sse_reconnection.py
@@ -1,3 +1,4 @@
+# Target: Admin Dashboard (Lambda HTMX)
 """E2E Tests: SSE Auto-Reconnection (User Story 5 - Phase 7)
 
 Tests SSE connection resilience and reconnection behavior:

--- a/tests/e2e/test_ticker_validation.py
+++ b/tests/e2e/test_ticker_validation.py
@@ -1,3 +1,4 @@
+# Target: Admin Dashboard (Lambda HTMX)
 # E2E Tests: Ticker Validation (User Story 9)
 #
 # Tests ticker validation and search:


### PR DESCRIPTION
## Summary
- **Sign-in fix**: Migrated UserMenu from custom dropdown to Radix DropdownMenu. Root cause was CSS stacking context + self-occluding backdrop hiding the menu on both desktop sidebar and mobile header. Radix Portal escapes all stacking contexts.
- **6 new Playwright tests**: 3 sentiment visibility tests (AAPL chart, time range, multi-ticker) + 3 sign-in interaction tests (desktop, mobile, Escape key)
- **49 test files labeled**: All Playwright test files now have `Target: Customer Dashboard` or `Target: Admin Dashboard` header comments
- **Makefile enforcement**: `check-test-target-headers` target added to `make validate` chain
- **Documentation**: CLAUDE.md two-dashboard table updated with test suite mapping, `frontend/tests/e2e/README.md` added

## Test plan
- [x] TypeScript compiles clean (`npx tsc --noEmit`)
- [x] Next.js production build succeeds
- [x] 186 frontend Playwright tests pass across 5 browser projects (0 failures)
- [x] 3690 backend Python tests pass
- [x] `make check-test-target-headers` passes (0 files missing headers)
- [ ] Manual: Click Guest button on Amplify URL after deploy → menu appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)