### PR TITLE
feat(1245): Fix OAuth sign-in flow

### DIFF
--- a/frontend/src/app/auth/callback/page.tsx
+++ b/frontend/src/app/auth/callback/page.tsx
@@ -45,13 +45,21 @@ function CallbackContent() {
     if (hasProcessed) return;
     setHasProcessed(true);
 
-    // Handle OAuth provider denial (user clicked "Deny" or error occurred)
+    // Feature 1245: Handle OAuth provider errors with user-friendly messages (FR-010)
     if (errorParam) {
+      // Clear stale OAuth state to prevent re-triggering failed flow
+      sessionStorage.removeItem('oauth_provider');
+      sessionStorage.removeItem('oauth_state');
+
       setStatus('error');
+      const errorMessages: Record<string, string> = {
+        access_denied: 'Sign-in was cancelled. You can try again or continue as guest.',
+        unauthorized_client: 'This sign-in method is not configured. Please try email sign-in.',
+        server_error: 'Something went wrong with sign-in. Please try again.',
+        invalid_request: 'The sign-in request was invalid. Please try again.',
+      };
       setErrorMessage(
-        errorDescription
-          ? `Authentication failed: ${errorDescription}`
-          : 'Authentication was cancelled'
+        errorMessages[errorParam] || 'Sign-in failed. Please try again or use email sign-in.'
       );
       return;
     }
@@ -218,9 +226,18 @@ function CallbackContent() {
         {errorMessage || authError || 'An error occurred during authentication.'}
       </p>
 
-      <Button onClick={() => router.push('/auth/signin')} className="mt-4">
-        Try again
-      </Button>
+      <div className="mt-4 flex flex-col items-center gap-2">
+        <Button onClick={() => router.push('/auth/signin')}>
+          Try again
+        </Button>
+        {/* Feature 1245: Continue as guest option on all error states */}
+        <a
+          href="/"
+          className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+        >
+          Continue as guest
+        </a>
+      </div>
     </motion.div>
   );
 }

--- a/frontend/src/app/auth/signin/page.tsx
+++ b/frontend/src/app/auth/signin/page.tsx
@@ -1,12 +1,45 @@
 'use client';
 
+import { useEffect, useState } from 'react';
 import { motion } from 'framer-motion';
 import { LayoutDashboard } from 'lucide-react';
 import { MagicLinkForm } from '@/components/auth/magic-link-form';
 import { OAuthButtons, AuthDivider } from '@/components/auth/oauth-buttons';
 import { Card } from '@/components/ui/card';
+import { authApi } from '@/lib/api/auth';
 
 export default function SignInPage() {
+  // Feature 1245: Dynamically discover available OAuth providers
+  const [availableProviders, setAvailableProviders] = useState<string[]>();
+  const [providersLoaded, setProvidersLoaded] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function fetchProviders() {
+      try {
+        const data = await authApi.getOAuthUrls();
+        if (!cancelled) {
+          setAvailableProviders(Object.keys(data.providers));
+        }
+      } catch {
+        // Graceful degradation (FR-009): if API unreachable, show email only
+        if (!cancelled) {
+          setAvailableProviders([]);
+        }
+      } finally {
+        if (!cancelled) {
+          setProvidersLoaded(true);
+        }
+      }
+    }
+
+    fetchProviders();
+    return () => { cancelled = true; };
+  }, []);
+
+  const hasOAuthProviders = availableProviders && availableProviders.length > 0;
+
   return (
     <div className="min-h-screen flex items-center justify-center bg-background px-4 py-12">
       <motion.div
@@ -32,13 +65,15 @@ export default function SignInPage() {
             </p>
           </div>
 
-          {/* OAuth buttons */}
-          <OAuthButtons />
+          {/* Feature 1245: OAuth buttons — only shown for configured providers */}
+          {hasOAuthProviders && (
+            <>
+              <OAuthButtons availableProviders={availableProviders} />
+              <AuthDivider />
+            </>
+          )}
 
-          {/* Divider */}
-          <AuthDivider />
-
-          {/* Magic link form */}
+          {/* Magic link form — always rendered immediately (FR-009) */}
           <MagicLinkForm />
         </Card>
 

--- a/frontend/src/components/auth/oauth-buttons.tsx
+++ b/frontend/src/components/auth/oauth-buttons.tsx
@@ -95,13 +95,27 @@ export function OAuthButton({ provider, className, disabled }: OAuthButtonProps)
 interface OAuthButtonsProps {
   className?: string;
   disabled?: boolean;
+  availableProviders?: string[];
 }
 
-export function OAuthButtons({ className, disabled }: OAuthButtonsProps) {
+export function OAuthButtons({ className, disabled, availableProviders }: OAuthButtonsProps) {
+  if (!availableProviders || availableProviders.length === 0) {
+    return null;
+  }
+
+  const providers: OAuthProvider[] = (['google', 'github'] as const).filter(
+    (p) => availableProviders.includes(p),
+  );
+
+  if (providers.length === 0) {
+    return null;
+  }
+
   return (
     <div className={cn('space-y-3', className)}>
-      <OAuthButton provider="google" disabled={disabled} />
-      <OAuthButton provider="github" disabled={disabled} />
+      {providers.map((provider) => (
+        <OAuthButton key={provider} provider={provider} disabled={disabled} />
+      ))}
     </div>
   );
 }

--- a/frontend/src/hooks/use-session-init.ts
+++ b/frontend/src/hooks/use-session-init.ts
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef } from 'react';
 import { useAuthStore } from '@/stores/auth-store';
+import { SESSION_INIT_TIMEOUT_MS } from '@/lib/constants';
 
 /**
  * Hook for automatic session initialization on app load.
@@ -49,13 +50,27 @@ export function useSessionInit() {
 
     initAttempted.current = true;
 
+    // Clear stale OAuth sessionStorage keys from previous auth attempts
+    sessionStorage.removeItem('oauth_provider');
+    sessionStorage.removeItem('oauth_state');
+
     const initializeSession = async () => {
       try {
         // TODO: In future, call /refresh endpoint here to restore session from httpOnly cookie
-        // For now, create anonymous session
-        await signInAnonymous();
+        // For now, create anonymous session with timeout protection
+        await Promise.race([
+          signInAnonymous(),
+          new Promise<never>((_, reject) =>
+            setTimeout(() => reject(new Error('timeout')), SESSION_INIT_TIMEOUT_MS)
+          ),
+        ]);
         setInitialized(true);
       } catch (err) {
+        if (err instanceof Error && err.message === 'timeout') {
+          setError('Session initialization timed out. Please refresh.');
+          setInitialized(true);
+          return;
+        }
         const message = err instanceof Error ? err.message : 'Failed to initialize session';
         setError(message);
         // Still mark as initialized to prevent retry loops

--- a/frontend/tests/e2e/signin-interaction.spec.ts
+++ b/frontend/tests/e2e/signin-interaction.spec.ts
@@ -59,3 +59,51 @@ test.describe('Sign-In Interaction', () => {
     await expect(menuItem).not.toBeVisible({ timeout: 3_000 });
   });
 });
+
+test.describe('OAuth Flow Regression (Feature 1245)', () => {
+  test.setTimeout(15_000);
+
+  test('sign-in page shows only email when no OAuth configured', async ({ page }) => {
+    await page.route('**/api/v2/auth/oauth/urls', route =>
+      route.fulfill({
+        status: 200,
+        body: JSON.stringify({ providers: {}, state: '' }),
+        contentType: 'application/json',
+      })
+    );
+
+    await page.goto('/auth/signin');
+
+    // No OAuth provider buttons should be visible
+    await expect(page.getByRole('button', { name: /google/i })).not.toBeVisible();
+    await expect(page.getByRole('button', { name: /github/i })).not.toBeVisible();
+
+    // Magic link email form should still be present
+    await expect(page.getByPlaceholder(/email/i)).toBeVisible();
+  });
+
+  test('magic link form loads immediately without waiting for provider check', async ({ page }) => {
+    await page.goto('/auth/signin');
+
+    // Email input should be visible within 2 seconds (before providers resolve)
+    await expect(page.getByPlaceholder(/email/i)).toBeVisible({ timeout: 2_000 });
+  });
+
+  test('session recovers after failed OAuth redirect', async ({ page }) => {
+    await page.goto('/auth/callback?error=access_denied');
+
+    // Should show cancellation message
+    await expect(page.getByText(/cancelled/i)).toBeVisible();
+
+    // Should offer a way to continue as guest
+    const recoveryLink = page.getByRole('link', { name: /guest|continue/i });
+    await expect(recoveryLink).toBeVisible();
+  });
+
+  test('OAuth callback error shows user-friendly message', async ({ page }) => {
+    await page.goto('/auth/callback?error=server_error');
+
+    // Should show a friendly error message
+    await expect(page.getByText(/something went wrong/i)).toBeVisible();
+  });
+});

--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -398,7 +398,10 @@ module "dashboard_lambda" {
     # Blind spot fix: Add missing Cognito OAuth env vars (cognito.py expects these)
     COGNITO_DOMAIN = module.cognito.domain
     # COGNITO_CLIENT_SECRET not set - module has generate_secret=false, code handles None
-    COGNITO_REDIRECT_URI    = length(var.cognito_callback_urls) > 0 ? var.cognito_callback_urls[0] : ""
+    COGNITO_REDIRECT_URI = length(var.cognito_callback_urls) > 0 ? var.cognito_callback_urls[0] : ""
+    # Feature 1245: Dynamic OAuth provider detection + redirect URI selection
+    ENABLED_OAUTH_PROVIDERS = join(",", compact([var.google_oauth_client_id != "" ? "google" : "", var.github_oauth_client_id != "" ? "github" : ""]))
+    FRONTEND_URL            = var.frontend_url
     TICKER_CACHE_BUCKET     = aws_s3_bucket.ticker_cache.id
     SSE_POLL_INTERVAL       = tostring(var.sse_poll_interval)
     ENVIRONMENT             = var.environment

--- a/infrastructure/terraform/variables.tf
+++ b/infrastructure/terraform/variables.tf
@@ -137,6 +137,12 @@ variable "github_oauth_client_secret" {
   sensitive   = true
 }
 
+variable "frontend_url" {
+  description = "Customer dashboard URL (e.g., https://main.d29tlmksqcx494.amplifyapp.com). Used for OAuth callback redirect URI selection."
+  type        = string
+  default     = ""
+}
+
 # Feature 1203: CloudFront variables removed - Amplify serves frontend directly
 
 # ===================================================================

--- a/src/lambdas/dashboard/auth.py
+++ b/src/lambdas/dashboard/auth.py
@@ -2002,40 +2002,55 @@ def _mask_email(email: str | None) -> str | None:
 
 
 # T092: OAuth URLs
-def get_oauth_urls(table: Any) -> OAuthURLsResponse:
+def _resolve_redirect_uri(origin: str) -> str:
+    """Resolve the OAuth redirect URI based on request origin.
+
+    Feature 1245: Dynamically selects redirect URI so local dev against
+    deployed API works without configuration changes.
+
+    Security: Only allows origins in the explicit allowlist to prevent
+    open redirect attacks.
+    """
+    frontend_url = os.environ.get("FRONTEND_URL", "").rstrip("/")
+    allowed_origins = {"http://localhost:3000"}
+    if frontend_url:
+        allowed_origins.add(frontend_url)
+
+    # Match origin against allowlist (scheme+host only)
+    origin_clean = origin.rstrip("/") if origin else ""
+    if origin_clean in allowed_origins:
+        return f"{origin_clean}/auth/callback"
+
+    # Fallback: deployed URL if set, otherwise localhost
+    if frontend_url:
+        return f"{frontend_url}/auth/callback"
+    return "http://localhost:3000/auth/callback"
+
+
+def get_oauth_urls(table: Any, origin: str = "") -> OAuthURLsResponse:
     """Get OAuth authorization URLs for supported providers.
 
     Feature 1185: Generates and stores OAuth state for CSRF protection.
-    Each provider gets its own state to prevent provider confusion attacks.
-    State is included in authorize URLs and must be validated on callback.
+    Feature 1245: Only returns configured providers. Uses dynamic redirect URI.
 
     Args:
         table: DynamoDB Table resource for storing state
+        origin: Request Origin header for redirect URI selection
 
     Returns:
         OAuthURLsResponse with provider URLs and state
     """
     config = CognitoConfig.from_env()
 
-    # Feature 1185: Generate separate state per provider for A13 validation
-    google_state = generate_state()
-    github_state = generate_state()
+    # Feature 1245: Only generate URLs for enabled providers
+    enabled_str = os.environ.get("ENABLED_OAUTH_PROVIDERS", "")
+    enabled_providers = {p.strip().lower() for p in enabled_str.split(",") if p.strip()}
 
-    # Store state for Google (includes PKCE code_verifier)
-    google_oauth_state = store_oauth_state(
-        table=table,
-        state_id=google_state,
-        provider="google",
-        redirect_uri=config.redirect_uri,
-    )
+    if not enabled_providers:
+        return OAuthURLsResponse(providers={}, state="")
 
-    # Store state for GitHub (includes PKCE code_verifier)
-    github_oauth_state = store_oauth_state(
-        table=table,
-        state_id=github_state,
-        provider="github",
-        redirect_uri=config.redirect_uri,
-    )
+    # Feature 1245: Resolve redirect URI from request origin
+    redirect_uri = _resolve_redirect_uri(origin)
 
     # Feature 1222: Derive PKCE code_challenge from code_verifier (FR-007)
     import base64
@@ -2045,27 +2060,56 @@ def get_oauth_urls(table: Any) -> OAuthURLsResponse:
         digest = hashlib.sha256(verifier.encode("ascii")).digest()
         return base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
 
-    google_challenge = _derive_code_challenge(google_oauth_state.code_verifier)
-    github_challenge = _derive_code_challenge(github_oauth_state.code_verifier)
+    providers: dict[str, Any] = {}
+    first_state = ""
+
+    if "google" in enabled_providers:
+        google_state = generate_state()
+        google_oauth_state = store_oauth_state(
+            table=table,
+            state_id=google_state,
+            provider="google",
+            redirect_uri=redirect_uri,
+        )
+        google_challenge = _derive_code_challenge(google_oauth_state.code_verifier)
+        providers["google"] = {
+            "authorize_url": config.get_authorize_url(
+                "Google",
+                state=google_state,
+                code_challenge=google_challenge,
+                redirect_uri_override=redirect_uri,
+            ),
+            "icon": "google",
+            "state": google_state,
+        }
+        if not first_state:
+            first_state = google_state
+
+    if "github" in enabled_providers:
+        github_state = generate_state()
+        github_oauth_state = store_oauth_state(
+            table=table,
+            state_id=github_state,
+            provider="github",
+            redirect_uri=redirect_uri,
+        )
+        github_challenge = _derive_code_challenge(github_oauth_state.code_verifier)
+        providers["github"] = {
+            "authorize_url": config.get_authorize_url(
+                "GitHub",
+                state=github_state,
+                code_challenge=github_challenge,
+                redirect_uri_override=redirect_uri,
+            ),
+            "icon": "github",
+            "state": github_state,
+        }
+        if not first_state:
+            first_state = github_state
 
     return OAuthURLsResponse(
-        providers={
-            "google": {
-                "authorize_url": config.get_authorize_url(
-                    "Google", state=google_state, code_challenge=google_challenge
-                ),
-                "icon": "google",
-                "state": google_state,  # Provider-specific state
-            },
-            "github": {
-                "authorize_url": config.get_authorize_url(
-                    "GitHub", state=github_state, code_challenge=github_challenge
-                ),
-                "icon": "github",
-                "state": github_state,  # Provider-specific state
-            },
-        },
-        state=google_state,  # Default for backward compatibility
+        providers=providers,
+        state=first_state,  # Backward compatibility
     )
 
 

--- a/src/lambdas/dashboard/router_v2.py
+++ b/src/lambdas/dashboard/router_v2.py
@@ -542,7 +542,10 @@ def get_oauth_urls():
     Feature 1185: Generates OAuth state for CSRF protection.
     """
     table = get_users_table()
-    result = auth_service.get_oauth_urls(table)
+    # Feature 1245: Pass Origin header for dynamic redirect URI selection
+    event = auth_router.current_event.raw_event
+    origin = event.get("headers", {}).get("origin", "")
+    result = auth_service.get_oauth_urls(table, origin=origin)
     return json_response(200, result.model_dump(), _get_no_cache_headers())
 
 

--- a/src/lambdas/shared/auth/cognito.py
+++ b/src/lambdas/shared/auth/cognito.py
@@ -83,6 +83,7 @@ class CognitoConfig:
         provider: str,
         state: str | None = None,
         code_challenge: str | None = None,
+        redirect_uri_override: str | None = None,
     ) -> str:
         """Build OAuth authorize URL for a provider.
 
@@ -90,12 +91,13 @@ class CognitoConfig:
             provider: OAuth provider name (google, github)
             state: CSRF state token
             code_challenge: PKCE code_challenge (S256, base64url-encoded)
+            redirect_uri_override: Feature 1245 — dynamic redirect URI per request origin
         """
         params = {
             "client_id": self.client_id,
             "response_type": "code",
             "scope": "openid email profile",
-            "redirect_uri": self.redirect_uri,
+            "redirect_uri": redirect_uri_override or self.redirect_uri,
             "identity_provider": provider.capitalize(),
         }
         if state:

--- a/tests/unit/lambdas/dashboard/test_auth_us2.py
+++ b/tests/unit/lambdas/dashboard/test_auth_us2.py
@@ -224,6 +224,7 @@ class TestGetOAuthUrls:
                 "COGNITO_DOMAIN": "myapp",
                 "AWS_REGION": "us-east-1",
                 "COGNITO_REDIRECT_URI": "https://app.example.com/callback",
+                "ENABLED_OAUTH_PROVIDERS": "google,github",
             },
         ):
             response = get_oauth_urls(table)

--- a/tests/unit/test_oauth_provider_filter.py
+++ b/tests/unit/test_oauth_provider_filter.py
@@ -1,0 +1,148 @@
+"""Unit tests for Feature 1245: OAuth provider filtering.
+
+Tests the get_oauth_urls() function behavior when ENABLED_OAUTH_PROVIDERS
+controls which providers are returned, and when the origin parameter
+controls redirect_uri selection.
+"""
+
+import os
+from unittest.mock import MagicMock, patch
+from urllib.parse import parse_qs, urlparse
+
+from src.lambdas.dashboard.auth import OAuthURLsResponse, get_oauth_urls
+
+# Common Cognito environment variables used across all tests
+COGNITO_ENV = {
+    "COGNITO_USER_POOL_ID": "us-east-1_TestPool",
+    "COGNITO_CLIENT_ID": "test-client-id",
+    "COGNITO_DOMAIN": "testapp",
+    "AWS_REGION": "us-east-1",
+    "COGNITO_REDIRECT_URI": "https://example.com/auth/callback",
+    "FRONTEND_URL": "https://example.com",
+}
+
+
+class TestOAuthProviderFilter:
+    """Tests for Feature 1245: ENABLED_OAUTH_PROVIDERS filtering."""
+
+    def test_empty_enabled_providers_returns_empty(self):
+        """ENABLED_OAUTH_PROVIDERS='' returns empty providers and empty state."""
+        table = MagicMock()
+
+        with patch.dict(os.environ, {**COGNITO_ENV, "ENABLED_OAUTH_PROVIDERS": ""}):
+            response = get_oauth_urls(table)
+
+        assert isinstance(response, OAuthURLsResponse)
+        assert response.providers == {}
+        assert response.state == ""
+        # Table should not be called when no providers are enabled
+        table.put_item.assert_not_called()
+
+    def test_single_provider_google_only(self):
+        """ENABLED_OAUTH_PROVIDERS='google' returns only google provider."""
+        table = MagicMock()
+        table.put_item.return_value = {}
+
+        with patch.dict(
+            os.environ, {**COGNITO_ENV, "ENABLED_OAUTH_PROVIDERS": "google"}
+        ):
+            response = get_oauth_urls(table)
+
+        assert "google" in response.providers
+        assert "github" not in response.providers
+        assert response.providers["google"]["icon"] == "google"
+        assert "authorize_url" in response.providers["google"]
+        assert response.state != ""
+
+    def test_multiple_providers_google_and_github(self):
+        """ENABLED_OAUTH_PROVIDERS='google,github' returns both providers."""
+        table = MagicMock()
+        table.put_item.return_value = {}
+
+        with patch.dict(
+            os.environ, {**COGNITO_ENV, "ENABLED_OAUTH_PROVIDERS": "google,github"}
+        ):
+            response = get_oauth_urls(table)
+
+        assert "google" in response.providers
+        assert "github" in response.providers
+        assert response.providers["google"]["icon"] == "google"
+        assert response.providers["github"]["icon"] == "github"
+        assert "authorize_url" in response.providers["google"]
+        assert "authorize_url" in response.providers["github"]
+        assert response.state != ""
+
+
+class TestOAuthOriginRedirect:
+    """Tests for Feature 1245: Origin-based redirect URI selection."""
+
+    def test_localhost_origin_uses_localhost_redirect(self):
+        """Origin http://localhost:3000 produces redirect_uri with localhost."""
+        table = MagicMock()
+        table.put_item.return_value = {}
+
+        with patch.dict(
+            os.environ, {**COGNITO_ENV, "ENABLED_OAUTH_PROVIDERS": "google"}
+        ):
+            response = get_oauth_urls(table, origin="http://localhost:3000")
+
+        authorize_url = response.providers["google"]["authorize_url"]
+        parsed = urlparse(authorize_url)
+        params = parse_qs(parsed.query)
+
+        assert "redirect_uri" in params
+        assert "localhost:3000" in params["redirect_uri"][0]
+
+    def test_evil_origin_does_not_leak_into_redirect(self):
+        """Origin https://evil.com must NOT appear in redirect_uri (open redirect prevention)."""
+        table = MagicMock()
+        table.put_item.return_value = {}
+
+        with patch.dict(
+            os.environ, {**COGNITO_ENV, "ENABLED_OAUTH_PROVIDERS": "google"}
+        ):
+            response = get_oauth_urls(table, origin="https://evil.com")
+
+        authorize_url = response.providers["google"]["authorize_url"]
+        parsed = urlparse(authorize_url)
+        params = parse_qs(parsed.query)
+
+        assert "redirect_uri" in params
+        redirect_uri = params["redirect_uri"][0]
+        assert "evil.com" not in redirect_uri
+        # Should fall back to FRONTEND_URL
+        assert "example.com" in redirect_uri
+
+
+class TestOAuthPKCENonRegression:
+    """PKCE non-regression: all authorize URLs must include code_challenge params."""
+
+    def test_authorize_urls_contain_pkce_params(self):
+        """Every provider authorize_url must have code_challenge and code_challenge_method=S256."""
+        table = MagicMock()
+        table.put_item.return_value = {}
+
+        with patch.dict(
+            os.environ,
+            {**COGNITO_ENV, "ENABLED_OAUTH_PROVIDERS": "google,github"},
+        ):
+            response = get_oauth_urls(table)
+
+        for provider_name, provider_data in response.providers.items():
+            authorize_url = provider_data["authorize_url"]
+            parsed = urlparse(authorize_url)
+            params = parse_qs(parsed.query)
+
+            assert (
+                "code_challenge" in params
+            ), f"{provider_name} authorize_url missing code_challenge"
+            assert (
+                params["code_challenge"][0] != ""
+            ), f"{provider_name} code_challenge is empty"
+            assert (
+                "code_challenge_method" in params
+            ), f"{provider_name} authorize_url missing code_challenge_method"
+            assert params["code_challenge_method"][0] == "S256", (
+                f"{provider_name} code_challenge_method is "
+                f"{params['code_challenge_method'][0]}, expected S256"
+            )


### PR DESCRIPTION
## Summary
- **Backend**: `get_oauth_urls()` filters by `ENABLED_OAUTH_PROVIDERS` env var — unconfigured providers omitted from API response. Dynamic redirect URI via `Origin` header so local dev against deployed API works.
- **Frontend**: OAuth buttons only render for available providers. Magic link form renders immediately. Callback errors show user-friendly messages (`access_denied` → "cancelled", `server_error` → "went wrong"). "Continue as guest" link on all error states. Session init timeout prevents "Initializing session..." hang.
- **Infrastructure**: `ENABLED_OAUTH_PROVIDERS` + `FRONTEND_URL` env vars added to Lambda. `frontend_url` Terraform variable added.
- **Security**: Open redirect prevention — Origin validated against hardcoded allowlist. PKCE preserved (verified by unit test).

## Test plan
- [x] 6 new backend unit tests pass (provider filter, redirect URI, open redirect, PKCE)
- [x] 4 new Playwright tests (no-OAuth sign-in, magic link immediate, OAuth error recovery, error messages)
- [x] 3696 backend tests pass (0 failures)
- [x] Next.js build + TypeScript type check pass
- [x] All pre-commit hooks pass (ruff, bandit, tfsec, checkov)
- [ ] Manual: Verify sign-in page on Amplify shows only email (no Google/GitHub buttons)

🤖 Generated with [Claude Code](https://claude.com/claude-code)