### PR TITLE
fix(ci): Disable playwright plugin in integration tests — unblocks deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1501,8 +1501,12 @@ jobs:
           # Increased from 480s due to Dashboard Lambda container deployment cold starts
           # See: specs/1041-increase-integ-test-timeout/spec.md
           set +e  # Don't exit on error
+          # Feature 1246: -p no:playwright prevents pytest-playwright from creating
+          # an event loop that conflicts with pytest-asyncio's auto-management.
+          # Playwright tests run separately via npx in the frontend test suite.
           timeout 720 pytest tests/ \
             -m "preprod" \
+            -p no:playwright \
             -v \
             --tb=short \
             --junitxml=preprod-test-results.xml


### PR DESCRIPTION
## Summary
`pytest-playwright` creates an event loop on plugin load even when no Playwright tests are selected. This conflicts with `pytest-asyncio`'s `asyncio_mode="auto"` + `asyncio_default_fixture_loop_scope="function"`, causing `RuntimeError: Runner.run() cannot be called from a running event loop` in ALL async integration tests.

**Fix**: Add `-p no:playwright` to the CI integration test pytest command. Playwright tests run separately via `npx playwright test` in the frontend suite.

**Previous fix** (PR #791) removed the manual `event_loop` fixture — that was a secondary issue. This PR addresses the primary cause.

## Root cause chain
1. CI installs `pytest-playwright` (needed for admin dashboard Python Playwright tests)
2. Plugin loads and creates an event loop during pytest startup
3. `pytest-asyncio` tries to create function-scoped loops via `asyncio.Runner`
4. `Runner.run()` fails because pytest-playwright's loop is already running
5. Result: 5 FAILED + 118 ERROR across all async tests

## Test plan
- [x] Local: `pytest tests/e2e/ --co -p no:playwright` collects 272 tests, 0 errors
- [x] Local: SSE tests skip cleanly with `-p no:playwright` (no RuntimeError)
- [ ] CI: Integration tests pass with the new flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)