### PR TITLE
fix(tests): Fix flaky cache stats assertion in threadsafe test

### DIFF
--- a/tests/unit/shared/test_quota_tracker_threadsafe.py
+++ b/tests/unit/shared/test_quota_tracker_threadsafe.py
@@ -150,9 +150,11 @@ class TestQuotaTrackerThreadSafety:
             t.join()
 
         stats = get_quota_cache_stats()
-        # First read is a miss, rest are hits
-        assert stats["misses"] == 1
-        assert stats["hits"] == (num_threads * reads_per_thread) - 1
+        # Under concurrency, multiple threads may miss the cache before the
+        # first read populates it. Use >= instead of == to avoid flaky failures
+        # under CPU contention (same pattern as circuit_breaker_threadsafe).
+        assert stats["misses"] >= 1
+        assert stats["hits"] + stats["misses"] == num_threads * reads_per_thread
 
     def test_record_call_with_high_contention(self, mock_table):
         """Many threads hitting same service simultaneously."""


### PR DESCRIPTION
## Summary
`test_cache_stats_are_thread_safe` asserted exactly 1 cache miss (`== 1`) across 10 concurrent threads. Under CPU contention, multiple threads can race to `get_tracker()` before the cache is populated, causing 2+ misses. Changed to `>= 1` and verify `hits + misses == total` instead. Matches the pattern already used in `circuit_breaker_threadsafe` tests.

## Root cause
Line 154: `assert stats["misses"] == 1` — assumes sequential cache population, but 10 threads start simultaneously. The race window is tiny but manifests under heavy load.

## Test plan
- [x] 10/10 threadsafe tests pass
- [x] 100/100 runs of the specific test pass locally
- [x] 3696 unit tests pass (pre-push hooks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)