### PR TITLE
fix(1253): Add deployment depends_on + logs:TagResource IAM

### DIFF
--- a/infrastructure/terraform/ci-user-policy.tf
+++ b/infrastructure/terraform/ci-user-policy.tf
@@ -386,6 +386,8 @@ data "aws_iam_policy_document" "ci_deploy_monitoring" {
       "logs:DeleteRetentionPolicy",
       "logs:TagLogGroup",
       "logs:UntagLogGroup",
+      "logs:TagResource",
+      "logs:UntagResource",
       "logs:ListTagsLogGroup",
       "logs:ListTagsForResource",
       "logs:PutMetricFilter",

--- a/infrastructure/terraform/modules/api_gateway/main.tf
+++ b/infrastructure/terraform/modules/api_gateway/main.tf
@@ -745,6 +745,19 @@ resource "aws_api_gateway_deployment" "dashboard" {
     aws_api_gateway_integration.lambda_root,
     aws_api_gateway_integration_response.proxy_options,
     aws_api_gateway_integration_response.root_options,
+    # Feature 1253: Public route integrations must exist before deployment
+    aws_api_gateway_integration.fr012_lambda,
+    aws_api_gateway_integration.fr012_options,
+    aws_api_gateway_integration.fr012_proxy_lambda,
+    aws_api_gateway_integration.fr012_proxy_options,
+    aws_api_gateway_integration.public_leaf_lambda,
+    aws_api_gateway_integration.public_leaf_options,
+    aws_api_gateway_integration.public_proxy_lambda,
+    aws_api_gateway_integration.public_proxy_options,
+    aws_api_gateway_integration_response.fr012_options,
+    aws_api_gateway_integration_response.fr012_proxy_options,
+    aws_api_gateway_integration_response.public_leaf_options,
+    aws_api_gateway_integration_response.public_proxy_options,
   ]
 }
 


### PR DESCRIPTION
## Summary
Fixes deploy failures after cycle hotfix (#805):

1. **Apply ordering race**: Deployment triggered before all public route integrations existed. Added all FR-012, leaf, and proxy integrations to `depends_on`.
2. **IAM gap**: `logs:TagResource` (new API) missing — policy only had deprecated `logs:TagLogGroup`. Added `logs:TagResource` and `logs:UntagResource`.

## Test plan
- [x] `terraform validate` passes
- [x] All pre-commit hooks pass
- [ ] Deploy pipeline should now succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)