### PR TITLE
fix(deploy): Ignore CW log group tags (IAM bootstrap gap)

### DIFF
--- a/infrastructure/terraform/modules/api_gateway/main.tf
+++ b/infrastructure/terraform/modules/api_gateway/main.tf
@@ -800,6 +800,12 @@ resource "aws_cloudwatch_log_group" "api_gateway" {
   tags = merge(var.tags, {
     Name = "${var.environment}-api-gateway-logs"
   })
+
+  # Deployer has logs:TagLogGroup (legacy) but not logs:TagResource (new AWS API).
+  # Ignore tag changes until admin applies IAM update in ci-user-policy.tf.
+  lifecycle {
+    ignore_changes = [tags, tags_all]
+  }
 }
 
 # API Gateway Usage Plan (Rate Limiting)


### PR DESCRIPTION
Deployer has `logs:TagLogGroup` (legacy) but not `logs:TagResource` (new AWS API). The IAM policy fix is in code (`ci-user-policy.tf` from #806) but deployer can't update its own policy.

Workaround: `ignore_changes = [tags, tags_all]` on the CloudWatch log group until admin applies IAM update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)