### PR TITLE
fix(e2e): Fix SkipInfo import path — unblocks integration tests

### DIFF
--- a/tests/e2e/test_cloudfront_sse.py
+++ b/tests/e2e/test_cloudfront_sse.py
@@ -13,7 +13,7 @@ import os
 import httpx
 import pytest
 
-from tests.conftest import SkipInfo
+from tests.e2e.conftest import SkipInfo
 
 skip = SkipInfo(
     condition=os.getenv("AWS_ENV") != "preprod",

--- a/tests/e2e/test_cognito_auth.py
+++ b/tests/e2e/test_cognito_auth.py
@@ -15,7 +15,7 @@ import os
 import httpx
 import pytest
 
-from tests.conftest import SkipInfo
+from tests.e2e.conftest import SkipInfo
 
 skip = SkipInfo(
     condition=os.getenv("AWS_ENV") != "preprod",

--- a/tests/e2e/test_waf_protection.py
+++ b/tests/e2e/test_waf_protection.py
@@ -13,7 +13,7 @@ import os
 import httpx
 import pytest
 
-from tests.conftest import SkipInfo
+from tests.e2e.conftest import SkipInfo
 
 skip = SkipInfo(
     condition=os.getenv("AWS_ENV") != "preprod",


### PR DESCRIPTION
SkipInfo is in `tests/e2e/conftest.py`, not `tests/conftest.py`. Wrong import caused collection errors in CI, blocking deploy after terraform apply succeeded.

3 files fixed: test_cognito_auth.py, test_waf_protection.py, test_cloudfront_sse.py

🤖 Generated with [Claude Code](https://claude.com/claude-code)