### PR TITLE
fix(deploy): Remove restricted header + add SetWebACL IAM

### DIFF
--- a/infrastructure/terraform/ci-user-policy.tf
+++ b/infrastructure/terraform/ci-user-policy.tf
@@ -253,7 +253,8 @@ data "aws_iam_policy_document" "ci_deploy_core" {
       "apigateway:DELETE",
       "apigateway:PATCH",
       "apigateway:TagResource",
-      "apigateway:UntagResource"
+      "apigateway:UntagResource",
+      "apigateway:SetWebACL"
     ]
     resources = [
       "arn:aws:apigateway:*::/restapis",

--- a/infrastructure/terraform/modules/cloudfront_sse/main.tf
+++ b/infrastructure/terraform/modules/cloudfront_sse/main.tf
@@ -20,12 +20,12 @@ locals {
 # ===================================================================
 # Origin Request Policy (FR-004)
 # ===================================================================
-# Forward auth and trace headers to Lambda origin.
-# SSE connections need Authorization, Last-Event-ID (reconnection),
-# and trace headers for observability.
+# Forward trace headers to Lambda origin.
+# SSE connections need Last-Event-ID (reconnection) and trace headers
+# for observability. Auth is handled by OAC SigV4 (not client headers).
 resource "aws_cloudfront_origin_request_policy" "sse_headers" {
   name    = "${var.environment}-sse-origin-request-policy"
-  comment = "Forward auth and trace headers for SSE streaming (Feature 1255)"
+  comment = "Forward trace headers for SSE streaming (Feature 1255)"
 
   cookies_config {
     cookie_behavior = "all" # Forward all cookies (refresh token in httpOnly cookie)
@@ -35,7 +35,6 @@ resource "aws_cloudfront_origin_request_policy" "sse_headers" {
     header_behavior = "whitelist"
     headers {
       items = [
-        "Authorization",
         "Origin",
         "Last-Event-ID",
         "X-User-ID",


### PR DESCRIPTION
## Summary

Two deploy blockers from the #811 merge run:

- **CloudFront Origin Request Policy**: Remove `Authorization` from whitelisted headers — it's a restricted header in CloudFront origin request policies. OAC handles SigV4 signing, so the client auth header isn't needed or allowed.
- **WAF-to-API Gateway Association**: Add `apigateway:SetWebACL` to deployer IAM policy. WAF association requires permissions on both the WAF side (`wafv2:AssociateWebACL`, added in #809) and the API Gateway side.

## Test plan

- [ ] CI PR checks pass (lint, security, cost)
- [ ] Deploy creates WAF association without AccessDeniedException
- [ ] CloudFront origin request policy creates without InvalidArgument error
- [ ] Note: `apigateway:SetWebACL` IAM will need manual admin apply (bootstrap gap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)