### PR TITLE
fix(deploy): Lower CloudFront origin timeout to 60s

### DIFF
--- a/infrastructure/terraform/modules/cloudfront_sse/variables.tf
+++ b/infrastructure/terraform/modules/cloudfront_sse/variables.tf
@@ -24,9 +24,9 @@ variable "price_class" {
 }
 
 variable "origin_read_timeout" {
-  description = "Origin read timeout in seconds (FR-003: max 180s for streaming)"
+  description = "Origin read timeout in seconds (FR-003: 60s default, 180s requires quota increase)"
   type        = number
-  default     = 180
+  default     = 60
 }
 
 variable "origin_keepalive_timeout" {


### PR DESCRIPTION
## Summary

- Lower `origin_read_timeout` from 180s to 60s — CloudFront's default maximum is 60s. The 180s value requires a service quota increase request via AWS Support.
- This unblocks CloudFront distribution creation. Can bump to 180s later after quota approval.

## Test plan

- [ ] CI checks pass
- [ ] CloudFront distribution creates successfully on next deploy
- [ ] SSE connections work with 60s timeout (Lambda SSE handler should send keepalive pings within this window)

🤖 Generated with [Claude Code](https://claude.com/claude-code)