### PR TITLE
fix(deploy): Lower timeout in module call site (main.tf)

### DIFF
--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -904,8 +904,8 @@ module "cloudfront_sse" {
   # FR-005: WAF WebACL (CLOUDFRONT scope)
   waf_web_acl_arn = module.waf_cloudfront.web_acl_arn
 
-  # FR-003: 180s origin timeout for streaming
-  origin_read_timeout = 180
+  # FR-003: 60s default max (180s requires AWS quota increase)
+  origin_read_timeout = 60
 
   # FR-009: PriceClass_100 (US/Canada/Europe)
   price_class = "PriceClass_100"


### PR DESCRIPTION
## Summary

- #813 only changed the default in `variables.tf`, but `main.tf:908` passes `origin_read_timeout = 180` explicitly, overriding the default.
- This changes the call site to 60s to match. Deploy still failing on `InvalidOriginReadTimeout` because of this override.

## Test plan

- [ ] CI checks pass
- [ ] CloudFront distribution creates on next deploy (60s is within default range)

🤖 Generated with [Claude Code](https://claude.com/claude-code)