### PR TITLE
fix(e2e): Fix SkipInfo import in test_function_url_restricted

### DIFF
--- a/tests/e2e/test_function_url_restricted.py
+++ b/tests/e2e/test_function_url_restricted.py
@@ -15,7 +15,7 @@ import os
 import httpx
 import pytest
 
-from tests.conftest import SkipInfo
+from tests.e2e.conftest import SkipInfo
 
 skip = SkipInfo(
     condition=os.getenv("AWS_ENV") != "preprod",


### PR DESCRIPTION
## Summary

- Fix `ImportError: cannot import name 'SkipInfo' from 'tests.conftest'` in `test_function_url_restricted.py`
- Same issue as #808 — `SkipInfo` lives in `tests.e2e.conftest`. This file was added in the Feature 1256 PR after #808 fixed the other files.
- This is the only remaining blocker — Terraform deploy to preprod succeeded on the previous run.

## Test plan

- [ ] CI checks pass
- [ ] E2E tests collect without ImportError
- [ ] Deploy pipeline reaches production

🤖 Generated with [Claude Code](https://claude.com/claude-code)