### PR TITLE
fix(e2e): Use system Python in CI for Playwright webServer

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -52,7 +52,9 @@ export default defineConfig({
             // Backend API server with mock DynamoDB
             // Provides ticker search, session auth, and other API endpoints
             // Uses the project's Python venv for dependencies
-            command: 'cd .. && .venv/bin/python scripts/run-local-api.py',
+            command: process.env.CI
+              ? 'cd .. && python scripts/run-local-api.py'
+              : 'cd .. && .venv/bin/python scripts/run-local-api.py',
             // Use API index endpoint for readiness check (returns 200 always)
             // /health returns 503 with mock DynamoDB, but API is still functional
             url: 'http://localhost:8000/api',


### PR DESCRIPTION
## Summary

- Fix Playwright Chaos Tests CI failure from PR #817
- webServer config uses `.venv/bin/python` which doesn't exist in CI runners
- Conditionally use `python` (system) when `CI` env var is set

## Test plan

- [ ] Verify `Playwright Chaos Tests` CI job starts the backend server successfully
- [ ] Verify local dev still uses `.venv/bin/python`

🤖 Generated with [Claude Code](https://claude.com/claude-code)