### PR TITLE
fix(ci): Use requirements-ci.txt for Playwright chaos tests

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -300,7 +300,7 @@ jobs:
           cache: 'pip'
 
       - name: Install Python dependencies
-        run: pip install -r requirements.txt
+        run: pip install -r requirements-ci.txt
 
       - name: Set up Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary

- Fix Playwright Chaos Tests CI failure: `ModuleNotFoundError: No module named 'moto'`
- The local API server imports moto for mock DynamoDB, which is in requirements-ci.txt (CI-optimized, no heavy ML deps), not requirements.txt

## Test plan

- [ ] Verify `Playwright Chaos Tests` CI job passes (moto available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)