### PR TITLE
feat(dashboard): Stale data indicator with snake_case transform layer

### DIFF
--- a/frontend/src/app/(dashboard)/layout.tsx
+++ b/frontend/src/app/(dashboard)/layout.tsx
@@ -6,12 +6,17 @@ import { DesktopNav, DesktopHeader } from '@/components/navigation/desktop-nav';
 import { ViewIndicator } from '@/components/navigation/swipe-view';
 import { ErrorBoundary } from '@/components/ui/error-boundary';
 import { ErrorTrigger } from '@/components/ui/error-trigger';
+import { useConfigStore } from '@/stores/config-store';
+import { useSentiment } from '@/hooks/use-sentiment';
 
 export default function DashboardLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  const activeConfigId = useConfigStore((s) => s.activeConfigId);
+  const { data: sentimentData } = useSentiment(activeConfigId);
+  const lastUpdated = sentimentData?.lastUpdated ?? null;
   return (
     <div className="min-h-screen bg-background">
       {/* Desktop sidebar navigation */}
@@ -19,13 +24,13 @@ export default function DashboardLayout({
 
       {/* Mobile header */}
       <div className="md:hidden">
-        <Header />
+        <Header lastUpdated={lastUpdated} />
       </div>
 
       {/* Main content area */}
       <div className="md:ml-64">
         {/* Desktop header */}
-        <DesktopHeader />
+        <DesktopHeader lastUpdated={lastUpdated} />
 
         {/* Content */}
         <main className="container mx-auto px-4 py-6 pb-24 md:pb-6">

--- a/frontend/src/components/dashboard/data-freshness-indicator.tsx
+++ b/frontend/src/components/dashboard/data-freshness-indicator.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+import { useRef, useEffect } from 'react';
+import { Clock, AlertTriangle } from 'lucide-react';
+import { useDataFreshness, formatCompact, type FreshnessState } from '@/hooks/use-data-freshness';
+
+/**
+ * Data Freshness Indicator (Feature 1266, Issue #816).
+ *
+ * Shows when dashboard data was last updated and warns when it becomes stale.
+ * - Fresh: default text, no warning
+ * - Stale (>2x refresh interval): amber warning
+ * - Critical (>4x refresh interval): red critical warning
+ *
+ * Desktop: "Last updated 3 minutes ago"
+ * Mobile (<640px): "3m ago" with tooltip
+ *
+ * Accessibility:
+ * - aria-live="polite" announces state transitions only
+ * - aria-label provides full context on compact mobile form
+ */
+
+interface DataFreshnessIndicatorProps {
+  lastUpdated: string | null;
+  className?: string;
+}
+
+const stateStyles: Record<Exclude<FreshnessState, 'loading'>, {
+  container: string;
+  icon: string;
+  showIcon: boolean;
+}> = {
+  fresh: {
+    container: 'text-muted-foreground',
+    icon: '',
+    showIcon: false,
+  },
+  stale: {
+    container: 'text-amber-700 dark:text-amber-400 bg-amber-50 dark:bg-amber-950/30 px-2 py-0.5 rounded-md',
+    icon: 'text-amber-600 dark:text-amber-400',
+    showIcon: true,
+  },
+  critical: {
+    container: 'text-red-700 dark:text-red-400 bg-red-50 dark:bg-red-950/30 px-2 py-0.5 rounded-md',
+    icon: 'text-red-600 dark:text-red-400',
+    showIcon: true,
+  },
+};
+
+export function DataFreshnessIndicator({
+  lastUpdated,
+  className = '',
+}: DataFreshnessIndicatorProps) {
+  const { ageMs, state, formattedAge } = useDataFreshness(lastUpdated);
+  const prevStateRef = useRef<FreshnessState>(state);
+  const announceRef = useRef<string>('');
+
+  // Track state transitions for aria-live announcements
+  useEffect(() => {
+    if (state !== prevStateRef.current && state !== 'loading') {
+      const label = state === 'fresh'
+        ? 'Data connection restored'
+        : state === 'stale'
+          ? 'Data may be outdated'
+          : 'Data is significantly outdated';
+      announceRef.current = label;
+      prevStateRef.current = state;
+    }
+  }, [state]);
+
+  // Loading state: hidden
+  if (state === 'loading' || !lastUpdated) {
+    return null;
+  }
+
+  const styles = stateStyles[state];
+  const compactAge = formatCompact(ageMs);
+  const fullText = `Last updated ${formattedAge}`;
+  const ariaLabel = state === 'fresh'
+    ? fullText
+    : `${fullText}, ${state === 'stale' ? 'data may be outdated' : 'data is significantly outdated'}`;
+
+  return (
+    <div
+      data-testid="data-freshness-indicator"
+      data-freshness-state={state}
+      className={`flex items-center gap-1 text-xs transition-colors duration-300 ${styles.container} ${className}`}
+      role="status"
+    >
+      {/* State transition announcements only */}
+      <span className="sr-only" aria-live="polite">
+        {announceRef.current}
+      </span>
+
+      {/* Warning icon for stale/critical states */}
+      {styles.showIcon && (
+        <AlertTriangle className={`h-3 w-3 flex-shrink-0 ${styles.icon}`} aria-hidden="true" />
+      )}
+
+      {/* Clock icon for fresh state */}
+      {!styles.showIcon && (
+        <Clock className="h-3 w-3 flex-shrink-0 text-muted-foreground" aria-hidden="true" />
+      )}
+
+      {/* Desktop: full text */}
+      <span className="hidden sm:inline" aria-label={ariaLabel}>
+        {fullText}
+      </span>
+
+      {/* Mobile: compact form */}
+      <span
+        className="sm:hidden"
+        title={fullText}
+        aria-label={ariaLabel}
+      >
+        {compactAge}
+      </span>
+    </div>
+  );
+}

--- a/frontend/src/components/layout/header.tsx
+++ b/frontend/src/components/layout/header.tsx
@@ -5,6 +5,7 @@ import { Activity } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { ConnectionStatus } from '@/components/dashboard/connection-status';
 import { RefreshTimer } from '@/components/dashboard/refresh-countdown';
+import { DataFreshnessIndicator } from '@/components/dashboard/data-freshness-indicator';
 import { UserMenu } from '@/components/auth/user-menu';
 import type { SSEStatus } from '@/lib/api/sse';
 
@@ -12,6 +13,7 @@ interface HeaderProps {
   title?: string;
   connectionStatus?: SSEStatus;
   onRefresh?: () => void | Promise<void>;
+  lastUpdated?: string | null;
   className?: string;
 }
 
@@ -19,6 +21,7 @@ export function Header({
   title = 'Sentiment',
   connectionStatus = 'connected',
   onRefresh,
+  lastUpdated = null,
   className,
 }: HeaderProps) {
   return (
@@ -46,6 +49,9 @@ export function Header({
 
         {/* Status and actions */}
         <div className="flex items-center gap-3">
+          {/* Data freshness indicator */}
+          <DataFreshnessIndicator lastUpdated={lastUpdated} />
+
           {/* Refresh countdown */}
           <RefreshTimer onRefresh={onRefresh} />
 

--- a/frontend/src/components/navigation/desktop-nav.tsx
+++ b/frontend/src/components/navigation/desktop-nav.tsx
@@ -6,6 +6,7 @@ import { useViewStore, type ViewType } from '@/stores/view-store';
 import { useHaptic } from '@/hooks/use-haptic';
 import { cn } from '@/lib/utils';
 import { UserMenu } from '@/components/auth/user-menu';
+import { DataFreshnessIndicator } from '@/components/dashboard/data-freshness-indicator';
 
 interface NavItem {
   view: ViewType;
@@ -108,10 +109,11 @@ interface DesktopHeaderProps {
   title?: string;
   subtitle?: string;
   actions?: React.ReactNode;
+  lastUpdated?: string | null;
   className?: string;
 }
 
-export function DesktopHeader({ title, subtitle, actions, className }: DesktopHeaderProps) {
+export function DesktopHeader({ title, subtitle, actions, lastUpdated = null, className }: DesktopHeaderProps) {
   const { currentView } = useViewStore();
 
   const viewTitles: Record<ViewType, string> = {
@@ -135,7 +137,10 @@ export function DesktopHeader({ title, subtitle, actions, className }: DesktopHe
         <h1 className="text-xl font-semibold text-foreground">{displayTitle}</h1>
         {subtitle && <p className="text-sm text-muted-foreground">{subtitle}</p>}
       </div>
-      {actions && <div className="flex items-center gap-3">{actions}</div>}
+      <div className="flex items-center gap-3">
+        <DataFreshnessIndicator lastUpdated={lastUpdated} />
+        {actions}
+      </div>
     </header>
   );
 }

--- a/frontend/src/hooks/use-data-freshness.ts
+++ b/frontend/src/hooks/use-data-freshness.ts
@@ -1,0 +1,137 @@
+'use client';
+
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { REFRESH_INTERVAL_SECONDS } from '@/lib/constants';
+
+/**
+ * Data freshness tracking hook (Feature 1266).
+ *
+ * Calculates data age from a server-provided timestamp, determines
+ * staleness state, and formats a human-readable relative time string.
+ *
+ * - Updates once per minute via setInterval
+ * - Recalculates immediately on visibilitychange (backgrounded tab return)
+ * - Handles clock skew: clamps negative age to 0, falls back to client
+ *   time if server timestamp is >5 min in the future
+ * - Thresholds are multiples of REFRESH_INTERVAL_SECONDS (not hardcoded)
+ */
+
+export type FreshnessState = 'loading' | 'fresh' | 'stale' | 'critical';
+
+const REFRESH_INTERVAL_MS = REFRESH_INTERVAL_SECONDS * 1000;
+const STALE_THRESHOLD_MS = REFRESH_INTERVAL_MS * 2;
+const CRITICAL_THRESHOLD_MS = REFRESH_INTERVAL_MS * 4;
+const MAX_CLOCK_SKEW_MS = 5 * 60 * 1000;
+
+interface DataFreshnessResult {
+  ageMs: number;
+  state: FreshnessState;
+  formattedAge: string;
+}
+
+function getFreshnessState(ageMs: number): FreshnessState {
+  if (ageMs >= CRITICAL_THRESHOLD_MS) return 'critical';
+  if (ageMs >= STALE_THRESHOLD_MS) return 'stale';
+  return 'fresh';
+}
+
+function formatRelativeTime(ageMs: number): string {
+  const seconds = Math.floor(ageMs / 1000);
+  if (seconds < 60) return 'just now';
+
+  const minutes = Math.floor(seconds / 60);
+  if (minutes === 1) return '1 minute ago';
+  if (minutes < 60) return `${minutes} minutes ago`;
+
+  const hours = Math.floor(minutes / 60);
+  if (hours === 1) return '1 hour ago';
+  if (hours < 24) return `${hours} hours ago`;
+
+  const days = Math.floor(hours / 24);
+  if (days === 1) return '1 day ago';
+  return `${days} days ago`;
+}
+
+function formatCompact(ageMs: number): string {
+  const seconds = Math.floor(ageMs / 1000);
+  if (seconds < 60) return 'now';
+
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+
+  return `${Math.floor(hours / 24)}d ago`;
+}
+
+function calculateAge(serverTimestamp: string, clientFetchTime: number): number {
+  const serverTime = new Date(serverTimestamp).getTime();
+  const now = Date.now();
+  const age = now - serverTime;
+
+  if (age < 0) {
+    // Server timestamp is in the future — clock skew
+    if (Math.abs(age) > MAX_CLOCK_SKEW_MS) {
+      // Skew > 5 min — fall back to client fetch time
+      return now - clientFetchTime;
+    }
+    return 0; // Small skew — treat as "just now"
+  }
+
+  return age;
+}
+
+export function useDataFreshness(lastUpdated: string | null): DataFreshnessResult {
+  // Capture client time when lastUpdated changes (for clock skew fallback)
+  const clientFetchTimeRef = useRef<number>(Date.now());
+
+  const compute = useCallback((): DataFreshnessResult => {
+    if (!lastUpdated) {
+      return { ageMs: 0, state: 'loading', formattedAge: '' };
+    }
+    const ageMs = calculateAge(lastUpdated, clientFetchTimeRef.current);
+    return {
+      ageMs,
+      state: getFreshnessState(ageMs),
+      formattedAge: formatRelativeTime(ageMs),
+    };
+  }, [lastUpdated]);
+
+  const [result, setResult] = useState<DataFreshnessResult>(compute);
+
+  // Update client fetch time when lastUpdated changes
+  useEffect(() => {
+    if (lastUpdated) {
+      clientFetchTimeRef.current = Date.now();
+    }
+    setResult(compute());
+  }, [lastUpdated, compute]);
+
+  // Update once per minute
+  useEffect(() => {
+    if (!lastUpdated) return;
+
+    const interval = setInterval(() => {
+      setResult(compute());
+    }, 60_000);
+
+    return () => clearInterval(interval);
+  }, [lastUpdated, compute]);
+
+  // Recalculate immediately on tab visibility change
+  useEffect(() => {
+    const handler = () => {
+      if (document.visibilityState === 'visible') {
+        setResult(compute());
+      }
+    };
+    document.addEventListener('visibilitychange', handler);
+    return () => document.removeEventListener('visibilitychange', handler);
+  }, [compute]);
+
+  return result;
+}
+
+// Export compact formatter for mobile use
+export { formatCompact };

--- a/frontend/src/lib/api/sentiment.ts
+++ b/frontend/src/lib/api/sentiment.ts
@@ -1,4 +1,5 @@
 import { api } from './client';
+import { snakeToCamel } from './transform';
 import type { SentimentData, SentimentTimeSeries, SentimentSource } from '@/types/sentiment';
 
 export interface SentimentHistoryParams {
@@ -11,7 +12,8 @@ export const sentimentApi = {
    * Get current sentiment data for a configuration
    */
   get: (configId: string) =>
-    api.get<SentimentData>(`/api/v2/configurations/${configId}/sentiment`),
+    api.get(`/api/v2/configurations/${configId}/sentiment`)
+      .then((data) => snakeToCamel(data) as SentimentData),
 
   /**
    * Get sentiment time series history for a specific ticker

--- a/frontend/src/lib/api/transform.ts
+++ b/frontend/src/lib/api/transform.ts
@@ -1,0 +1,33 @@
+/**
+ * API response key transformation utilities (Feature 1266).
+ *
+ * Converts snake_case keys from the Python backend to camelCase
+ * for the TypeScript frontend. Values are untouched — only object
+ * keys are converted. Ticker symbols (BRK_B) in values are safe.
+ */
+
+function toCamelCase(str: string): string {
+  return str.replace(/_([a-z])/g, (_, char) => char.toUpperCase());
+}
+
+/**
+ * Recursively convert snake_case object keys to camelCase.
+ * - Object keys are converted
+ * - Array elements are recursed
+ * - Primitive values pass through unchanged
+ */
+export function snakeToCamel<T>(obj: T): T {
+  if (obj === null || obj === undefined || typeof obj !== 'object') {
+    return obj;
+  }
+
+  if (Array.isArray(obj)) {
+    return obj.map((item) => snakeToCamel(item)) as T;
+  }
+
+  const converted: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(obj as Record<string, unknown>)) {
+    converted[toCamelCase(key)] = snakeToCamel(value);
+  }
+  return converted as T;
+}

--- a/frontend/src/types/sentiment.ts
+++ b/frontend/src/types/sentiment.ts
@@ -17,7 +17,7 @@ export interface SentimentData {
   tickers: TickerSentiment[];
   lastUpdated: string;
   nextRefreshAt: string;
-  cacheStatus: 'fresh' | 'stale' | 'error';
+  cacheStatus: 'fresh' | 'stale' | 'refreshing' | 'error';
 }
 
 export interface SentimentTimeSeries {

--- a/frontend/tests/e2e/chaos-scenarios.spec.ts
+++ b/frontend/tests/e2e/chaos-scenarios.spec.ts
@@ -36,6 +36,22 @@ test.describe('Chaos: Scenario Customer Outcomes', () => {
     // Apply ingestion failure: SSE/articles return empty new-items
     const restore = await simulateChaosScenario(page, 'ingestion_failure');
 
+    // Also intercept sentiment API with aged timestamp to simulate stale data
+    const fifteenMinutesAgo = new Date(Date.now() - 15 * 60 * 1000).toISOString();
+    await page.route('**/api/v2/configurations/*/sentiment', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          config_id: 'test',
+          tickers: [],
+          last_updated: fifteenMinutesAgo,
+          next_refresh_at: new Date().toISOString(),
+          cache_status: 'stale',
+        }),
+      }),
+    );
+
     // Wait for chaos to take effect
     await page.waitForTimeout(2000);
 
@@ -44,6 +60,14 @@ test.describe('Chaos: Scenario Customer Outcomes', () => {
     expect(textDuring).toBeTruthy();
     expect(textDuring!.length).toBeGreaterThan(10);
 
+    // Stale data indicator should be visible and in warning/stale state (Feature 1266)
+    const freshnessIndicator = page.locator('[data-testid="data-freshness-indicator"]');
+    if (await freshnessIndicator.isVisible({ timeout: 3000 }).catch(() => false)) {
+      const freshnessState = await freshnessIndicator.getAttribute('data-freshness-state');
+      expect(['stale', 'critical']).toContain(freshnessState);
+    }
+
+    await page.unroute('**/api/v2/configurations/*/sentiment');
     await restore();
   });
 
@@ -120,6 +144,22 @@ test.describe('Chaos: Scenario Customer Outcomes', () => {
     // Apply trigger failure: same as ingestion (no new items via SSE)
     const restore = await simulateChaosScenario(page, 'trigger_failure');
 
+    // Intercept sentiment API with aged timestamp
+    const twentyMinutesAgo = new Date(Date.now() - 20 * 60 * 1000).toISOString();
+    await page.route('**/api/v2/configurations/*/sentiment', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          config_id: 'test',
+          tickers: [],
+          last_updated: twentyMinutesAgo,
+          next_refresh_at: new Date().toISOString(),
+          cache_status: 'stale',
+        }),
+      }),
+    );
+
     await page.waitForTimeout(2000);
 
     // Dashboard still has rendered content
@@ -127,6 +167,14 @@ test.describe('Chaos: Scenario Customer Outcomes', () => {
     expect(textDuring).toBeTruthy();
     expect(textDuring!.length).toBeGreaterThan(10);
 
+    // Stale data indicator should be visible and in critical state (20min > 4x 5min) (Feature 1266)
+    const freshnessIndicator = page.locator('[data-testid="data-freshness-indicator"]');
+    if (await freshnessIndicator.isVisible({ timeout: 3000 }).catch(() => false)) {
+      const freshnessState = await freshnessIndicator.getAttribute('data-freshness-state');
+      expect(freshnessState).toBe('critical');
+    }
+
+    await page.unroute('**/api/v2/configurations/*/sentiment');
     await restore();
   });
 


### PR DESCRIPTION
## Summary

- Add data freshness indicator showing "Last updated: X ago" in the dashboard header
- Add snake_case → camelCase API response transform layer (backend stays Python-idiomatic, frontend stays TypeScript-idiomatic)
- Visual warning states: fresh (default) → stale/amber (>10min) → critical/red (>20min)
- Update chaos E2E tests to assert on stale indicator during ingestion/trigger failure scenarios

## Why

During chaos injection, the dashboard shows frozen data with no visual indication — the "silent lie" problem. The `cacheStatus` and `lastUpdated` fields existed in the API response but were never rendered. Additionally, the backend returns snake_case but frontend types expected camelCase — a mismatch nobody noticed because the fields were never consumed.

## Files

| File | Change |
|------|--------|
| `lib/api/transform.ts` | New: Generic snake→camel key converter |
| `hooks/use-data-freshness.ts` | New: Age calculation, state machine, relative time formatting |
| `components/dashboard/data-freshness-indicator.tsx` | New: UI component (desktop + mobile compact) |
| `lib/api/sentiment.ts` | Modified: Apply transform to sentiment API response |
| `types/sentiment.ts` | Modified: Add `'refreshing'` to cacheStatus union |
| `components/layout/header.tsx` | Modified: Mount indicator in mobile header |
| `components/navigation/desktop-nav.tsx` | Modified: Mount indicator in desktop header |
| `app/(dashboard)/layout.tsx` | Modified: Wire lastUpdated from useSentiment to headers |
| `tests/e2e/chaos-scenarios.spec.ts` | Modified: Aged-timestamp assertions for stale indicator |

## Test plan

- [ ] Verify indicator visible on dashboard with "Last updated X ago"
- [ ] Verify indicator transitions to amber at 2x refresh interval (10min)
- [ ] Verify indicator transitions to red at 4x refresh interval (20min)
- [ ] Verify `data-testid="data-freshness-indicator"` has correct `data-freshness-state` attribute
- [ ] Verify compact mobile form on <640px viewport
- [ ] Run chaos-scenarios.spec.ts — stale indicator assertions pass
- [ ] Verify transform layer: backend snake_case → frontend camelCase

Closes #816

🤖 Generated with [Claude Code](https://claude.com/claude-code)