### PR TITLE
fix(cors): Add CORS headers to env-gated 404 responses (1268)

### DIFF
--- a/frontend/tests/e2e/cors-env-gated-404.spec.ts
+++ b/frontend/tests/e2e/cors-env-gated-404.spec.ts
@@ -1,0 +1,82 @@
+// Target: Customer Dashboard (Next.js/Amplify)
+import { test, expect } from '@playwright/test';
+
+/**
+ * CORS: Env-Gated 404 Responses (Feature 1268)
+ *
+ * Validates that the frontend can handle 404 responses from env-gated
+ * chaos endpoints. Uses page.route() to intercept requests and simulate
+ * the server response.
+ *
+ * Note (AR3-004): page.route() intercepts at the Playwright network layer
+ * BEFORE browser CORS enforcement. These tests validate frontend 404
+ * handling, not CORS enforcement itself. CORS correctness is validated
+ * by unit tests (test_cors_404_headers.py) and integration tests.
+ */
+test.describe('CORS: Env-Gated 404 Responses (Feature 1268)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForTimeout(1000);
+  });
+
+  test('fetch reads 404 body when CORS headers present', async ({ page }) => {
+    // Intercept chaos API call and return 404 with CORS headers
+    await page.route('**/chaos/experiments', (route) => {
+      route.fulfill({
+        status: 404,
+        contentType: 'application/json',
+        headers: {
+          'Access-Control-Allow-Origin': '*',
+          'Access-Control-Allow-Credentials': 'true',
+          'Vary': 'Origin',
+        },
+        body: JSON.stringify({ detail: 'Not found' }),
+      });
+    });
+
+    // Execute fetch in page context and verify response is readable
+    const result = await page.evaluate(async () => {
+      try {
+        const response = await fetch('/chaos/experiments');
+        const body = await response.json();
+        return {
+          ok: response.ok,
+          status: response.status,
+          body,
+        };
+      } catch (e) {
+        return { error: String(e) };
+      }
+    });
+
+    expect(result).not.toHaveProperty('error');
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(404);
+    expect(result.body).toEqual({ detail: 'Not found' });
+  });
+
+  test('404 response body contains expected detail message', async ({
+    page,
+  }) => {
+    // Simulate an env-gated 404 with the exact response body
+    await page.route('**/chaos/experiments', (route) => {
+      route.fulfill({
+        status: 404,
+        contentType: 'application/json',
+        headers: {
+          'Vary': 'Origin',
+        },
+        body: JSON.stringify({ detail: 'Not found' }),
+      });
+    });
+
+    const result = await page.evaluate(async () => {
+      const response = await fetch('/chaos/experiments');
+      const body = await response.json();
+      return { status: response.status, detail: body.detail };
+    });
+
+    expect(result.status).toBe(404);
+    expect(result.detail).toBe('Not found');
+  });
+});

--- a/src/lambdas/dashboard/handler.py
+++ b/src/lambdas/dashboard/handler.py
@@ -15,7 +15,10 @@ For On-Call Engineers:
 For Developers:
     - Uses AWS Lambda Powertools LambdaFunctionUrlResolver for routing
     - Static files served from /static/ prefix
-    - CORS enabled for all origins (demo configuration)
+    - CORS handled at infrastructure level (Lambda Function URL config)
+    - Exception: env-gated 404 responses include application-level CORS
+      headers (Feature 1268) because neither API Gateway nor Function URL
+      adds CORS to Lambda-returned responses
 
 Auth (Feature 1039):
     - All /api/* endpoints use session-based auth via Bearer token
@@ -96,6 +99,14 @@ CHAOS_EXPERIMENTS_TABLE = os.environ.get("CHAOS_EXPERIMENTS_TABLE", "")
 ENVIRONMENT = os.environ["ENVIRONMENT"]
 SSE_LAMBDA_URL = os.environ.get("SSE_LAMBDA_URL", "")
 
+# Feature 1268: Allowed CORS origins for env-gated responses
+# Parsed from comma-separated CORS_ORIGINS env var (set by Terraform from var.cors_allowed_origins)
+_CORS_ALLOWED_ORIGINS: set[str] = {
+    origin.strip()
+    for origin in os.environ.get("CORS_ORIGINS", "").split(",")
+    if origin.strip()
+}
+
 # Module-level init logging (FR-028)
 logger.info(
     "Dashboard Lambda starting",
@@ -120,11 +131,16 @@ def _is_dev_environment() -> bool:
     return ENVIRONMENT.lower() in _DEV_ENVIRONMENTS
 
 
-_NOT_FOUND_RESPONSE = Response(
-    status_code=404,
-    content_type="application/json",
-    body=orjson.dumps({"detail": "Not found"}).decode(),
-)
+def _get_request_origin() -> str | None:
+    """Extract Origin header from current Powertools request.
+
+    Returns None if Origin header is missing or if called outside
+    a request context (defensive).
+    """
+    try:
+        return app.current_event.headers.get("origin")
+    except Exception:
+        return None
 
 
 # Path to static dashboard files
@@ -223,18 +239,58 @@ def _get_chaos_user_id_from_event(event: dict) -> str | None:
     return auth_context.user_id
 
 
-_NOT_FOUND_RESPONSE = Response(
-    status_code=404,
-    content_type="application/json",
-    body=orjson.dumps({"detail": "Not found"}).decode(),
-)
+def _make_not_found_response(origin: str | None = None) -> Response:
+    """Create 404 response with conditional CORS headers for env-gated routes.
+
+    Feature 1268: When the requesting origin is in the allowed CORS origins
+    list, includes Access-Control-Allow-Origin and related headers so browsers
+    can read the response body. Without these headers, browsers block the
+    response entirely (opaque CORS failure).
+
+    This is intentionally application-level CORS for a specific case:
+    env-gated routes return 404 BEFORE the normal pipeline processes the
+    request, and neither API Gateway (AWS_PROXY pass-through) nor Lambda
+    Function URL (AWS_IAM auth only) adds CORS headers to Lambda-returned
+    responses.
+
+    Args:
+        origin: The Origin header from the request, or None.
+
+    Returns:
+        Response with 404 status, JSON body, and conditional CORS headers.
+    """
+    headers: dict[str, str] = {"Vary": "Origin"}
+
+    if origin and origin in _CORS_ALLOWED_ORIGINS:
+        headers.update(
+            {
+                "Access-Control-Allow-Origin": origin,
+                "Access-Control-Allow-Credentials": "true",
+                "Access-Control-Allow-Methods": "GET,POST,PUT,DELETE,PATCH,OPTIONS",
+                "Access-Control-Allow-Headers": (
+                    "Content-Type,Authorization,Accept,Cache-Control,"
+                    "Last-Event-ID,X-Amzn-Trace-Id,X-User-ID"
+                ),
+            }
+        )
+        logger.debug(
+            "Env-gated 404 with CORS",
+            extra={"origin": origin},
+        )
+
+    return Response(
+        status_code=404,
+        content_type="application/json",
+        body=orjson.dumps({"detail": "Not found"}).decode(),
+        headers=headers,
+    )
 
 
 @app.get("/")
 def serve_index():
     """Serve the main dashboard HTML page (locked down in prod/preprod)."""
     if not _is_dev_environment():
-        return _NOT_FOUND_RESPONSE
+        return _make_not_found_response(_get_request_origin())
     index_path = STATIC_DIR / "index.html"
     if not index_path.exists():
         logger.error("index.html not found", extra={"path": str(index_path)})
@@ -255,7 +311,7 @@ def serve_index():
 def serve_favicon():
     """Serve the favicon.ico file (locked down in prod/preprod)."""
     if not _is_dev_environment():
-        return _NOT_FOUND_RESPONSE
+        return _make_not_found_response(_get_request_origin())
     favicon_path = STATIC_DIR / "favicon.ico"
     if not favicon_path.exists():
         return Response(
@@ -276,7 +332,7 @@ def serve_favicon():
 def serve_chaos():
     """Serve the chaos testing UI page (locked down in prod/preprod)."""
     if not _is_dev_environment():
-        return _NOT_FOUND_RESPONSE
+        return _make_not_found_response(_get_request_origin())
     chaos_path = STATIC_DIR / "chaos.html"
     if not chaos_path.exists():
         logger.error("chaos.html not found", extra={"path": str(chaos_path)})
@@ -297,7 +353,7 @@ def serve_chaos():
 def serve_static(filename: str):
     """Serve static dashboard files (locked down in prod/preprod)."""
     if not _is_dev_environment():
-        return _NOT_FOUND_RESPONSE
+        return _make_not_found_response(_get_request_origin())
     if filename not in ALLOWED_STATIC_FILES:
         logger.warning(
             "Static file request for non-whitelisted file",
@@ -342,7 +398,7 @@ def serve_static(filename: str):
 def api_index():
     """API index listing all available endpoints (locked down in prod/preprod)."""
     if not _is_dev_environment():
-        return _NOT_FOUND_RESPONSE
+        return _make_not_found_response(_get_request_origin())
     return Response(
         status_code=200,
         content_type="application/json",
@@ -825,7 +881,7 @@ def get_articles_v2():
 def create_chaos_experiment():
     """Create a new chaos experiment (locked down in prod/preprod)."""
     if not _is_dev_environment():
-        return _NOT_FOUND_RESPONSE
+        return _make_not_found_response(_get_request_origin())
     event = app.current_event.raw_event
     user_id = _get_chaos_user_id_from_event(event)
     if user_id is None:
@@ -888,7 +944,7 @@ def create_chaos_experiment():
 def list_chaos_experiments():
     """List chaos experiments (locked down in prod/preprod)."""
     if not _is_dev_environment():
-        return _NOT_FOUND_RESPONSE
+        return _make_not_found_response(_get_request_origin())
     event = app.current_event.raw_event
     user_id = _get_chaos_user_id_from_event(event)
     if user_id is None:
@@ -921,7 +977,7 @@ def list_chaos_experiments():
 def get_chaos_experiment(experiment_id: str):
     """Get chaos experiment by ID (locked down in prod/preprod)."""
     if not _is_dev_environment():
-        return _NOT_FOUND_RESPONSE
+        return _make_not_found_response(_get_request_origin())
     event = app.current_event.raw_event
     user_id = _get_chaos_user_id_from_event(event)
     if user_id is None:
@@ -950,7 +1006,7 @@ def get_chaos_experiment(experiment_id: str):
 def start_chaos_experiment(experiment_id: str):
     """Start a chaos experiment (locked down in prod/preprod)."""
     if not _is_dev_environment():
-        return _NOT_FOUND_RESPONSE
+        return _make_not_found_response(_get_request_origin())
     event = app.current_event.raw_event
     user_id = _get_chaos_user_id_from_event(event)
     if user_id is None:
@@ -999,7 +1055,7 @@ def start_chaos_experiment(experiment_id: str):
 def stop_chaos_experiment(experiment_id: str):
     """Stop a running chaos experiment (locked down in prod/preprod)."""
     if not _is_dev_environment():
-        return _NOT_FOUND_RESPONSE
+        return _make_not_found_response(_get_request_origin())
     event = app.current_event.raw_event
     user_id = _get_chaos_user_id_from_event(event)
     if user_id is None:
@@ -1041,7 +1097,7 @@ def stop_chaos_experiment(experiment_id: str):
 def get_chaos_experiment_report(experiment_id: str):
     """Get chaos experiment report (locked down in prod/preprod)."""
     if not _is_dev_environment():
-        return _NOT_FOUND_RESPONSE
+        return _make_not_found_response(_get_request_origin())
     event = app.current_event.raw_event
     user_id = _get_chaos_user_id_from_event(event)
     if user_id is None:
@@ -1077,7 +1133,7 @@ def get_chaos_experiment_report(experiment_id: str):
 def delete_chaos_experiment(experiment_id: str):
     """Delete a chaos experiment (locked down in prod/preprod)."""
     if not _is_dev_environment():
-        return _NOT_FOUND_RESPONSE
+        return _make_not_found_response(_get_request_origin())
     event = app.current_event.raw_event
     user_id = _get_chaos_user_id_from_event(event)
     if user_id is None:

--- a/tests/e2e/test_cors_404_e2e.py
+++ b/tests/e2e/test_cors_404_e2e.py
@@ -1,0 +1,63 @@
+"""E2E: Verify CORS headers on env-gated 404 in preprod (Feature 1268).
+
+Requires deployed preprod environment with CORS_ORIGINS configured.
+May be deferred to gameday if preprod is not available.
+
+These tests make real HTTP calls to the preprod API Gateway endpoint
+with explicit Origin headers to verify CORS header presence/absence.
+"""
+
+import os
+
+import httpx
+import pytest
+
+PREPROD_API_URL = os.environ.get("PREPROD_API_URL", "")
+# Preprod CORS origins (should match Terraform var.cors_allowed_origins)
+PREPROD_CORS_ORIGIN = os.environ.get(
+    "PREPROD_CORS_ORIGIN", "https://preprod.sentiment-analyzer.example.com"
+)
+
+
+@pytest.mark.preprod
+class TestEnvGated404CorsE2E:
+    """E2E: Verify CORS headers on env-gated 404 in preprod.
+
+    Requires deployed preprod environment. May be deferred to gameday.
+    """
+
+    @pytest.fixture(autouse=True)
+    def skip_if_no_url(self):
+        if not PREPROD_API_URL:
+            pytest.skip("PREPROD_API_URL not set")
+
+    def test_chaos_endpoint_404_has_cors(self):
+        """Hit chaos endpoint in preprod, verify CORS headers present."""
+        response = httpx.get(
+            f"{PREPROD_API_URL}/chaos/experiments",
+            headers={"Origin": PREPROD_CORS_ORIGIN},
+            timeout=10,
+        )
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Not found"
+        # Verify CORS headers are present for valid origin
+        assert (
+            response.headers.get("access-control-allow-origin") == PREPROD_CORS_ORIGIN
+        )
+        assert response.headers.get("vary") == "Origin"
+        assert response.headers.get("access-control-allow-credentials") == "true"
+
+    def test_chaos_endpoint_404_no_cors_bad_origin(self):
+        """Hit chaos endpoint with unknown origin, verify no CORS origin."""
+        bad_origin = "https://evil.attacker.example.com"
+        response = httpx.get(
+            f"{PREPROD_API_URL}/chaos/experiments",
+            headers={"Origin": bad_origin},
+            timeout=10,
+        )
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Not found"
+        # Verify CORS origin header is NOT present for unknown origin
+        assert "access-control-allow-origin" not in response.headers
+        # Vary: Origin should still be present
+        assert response.headers.get("vary") == "Origin"

--- a/tests/integration/test_cors_404_integration.py
+++ b/tests/integration/test_cors_404_integration.py
@@ -1,0 +1,126 @@
+"""Integration tests for CORS on env-gated 404 responses (Feature 1268).
+
+These test the full handler invocation path:
+handler.py -> Powertools resolver -> route handler -> _make_not_found_response
+
+Note: These do NOT test through API Gateway. API Gateway behavior
+(AWS_PROXY pass-through) is verified by E2E tests in preprod.
+"""
+
+import importlib
+import json
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Set env before imports
+os.environ.setdefault("DYNAMODB_TABLE", "test-sentiment-items")
+os.environ.setdefault("SENTIMENTS_TABLE", "test-sentiment-items")
+os.environ.setdefault("USERS_TABLE", "test-sentiment-users")
+os.environ.setdefault("ENVIRONMENT", "test")
+os.environ.setdefault("CHAOS_EXPERIMENTS_TABLE", "test-chaos-experiments")
+
+from tests.conftest import make_event
+
+
+def _reload_handler(env: str, cors_origins: str = ""):
+    """Reload handler with specific ENVIRONMENT and CORS_ORIGINS."""
+    env_overrides = {"ENVIRONMENT": env}
+    if cors_origins:
+        env_overrides["CORS_ORIGINS"] = cors_origins
+    else:
+        env_overrides["CORS_ORIGINS"] = ""
+    with patch.dict(os.environ, env_overrides):
+        import src.lambdas.dashboard.handler as handler_module
+
+        importlib.reload(handler_module)
+        return handler_module
+
+
+@pytest.fixture
+def mock_lambda_context():
+    ctx = MagicMock()
+    ctx.function_name = "test-dashboard"
+    ctx.memory_limit_in_mb = 128
+    ctx.invoked_function_arn = "arn:aws:lambda:us-east-1:123456789:function:test"
+    ctx.aws_request_id = "test-request-id"
+    return ctx
+
+
+@pytest.mark.integration
+class TestEnvGated404CorsIntegration:
+    """Integration tests for CORS on env-gated 404 responses (Feature 1268).
+
+    These test the full handler invocation path:
+    handler.py -> Powertools resolver -> route handler -> _make_not_found_response
+
+    Note: These do NOT test through API Gateway. API Gateway behavior
+    (AWS_PROXY pass-through) is verified by E2E tests in preprod.
+    """
+
+    @pytest.fixture(autouse=True)
+    def restore_handler(self):
+        """Restore handler to test environment after each test."""
+        yield
+        _reload_handler("test")
+
+    def test_chaos_endpoint_404_cors_through_handler(self, mock_lambda_context):
+        """Full handler path returns 404 with CORS for valid origin."""
+        test_origin = "https://dashboard.example.com"
+        handler = _reload_handler("preprod", cors_origins=test_origin)
+        event = make_event(
+            method="GET",
+            path="/chaos/experiments",
+            headers={"origin": test_origin},
+        )
+        response = handler.lambda_handler(event, mock_lambda_context)
+        assert response["statusCode"] == 404
+        headers = response.get("headers", {})
+        assert headers.get("Access-Control-Allow-Origin") == test_origin
+        assert headers.get("Access-Control-Allow-Credentials") == "true"
+        assert headers.get("Vary") == "Origin"
+        body = json.loads(response["body"])
+        assert body["detail"] == "Not found"
+
+    def test_dashboard_root_404_cors_through_handler(self, mock_lambda_context):
+        """Dashboard root / returns 404 with CORS in non-dev."""
+        test_origin = "https://dashboard.example.com"
+        handler = _reload_handler("preprod", cors_origins=test_origin)
+        event = make_event(
+            method="GET",
+            path="/",
+            headers={"origin": test_origin},
+        )
+        response = handler.lambda_handler(event, mock_lambda_context)
+        assert response["statusCode"] == 404
+        headers = response.get("headers", {})
+        assert headers.get("Access-Control-Allow-Origin") == test_origin
+
+    def test_static_file_404_cors_through_handler(self, mock_lambda_context):
+        """Static file route returns 404 with CORS in non-dev."""
+        test_origin = "https://dashboard.example.com"
+        handler = _reload_handler("preprod", cors_origins=test_origin)
+        event = make_event(
+            method="GET",
+            path="/static/app.js",
+            headers={"origin": test_origin},
+        )
+        response = handler.lambda_handler(event, mock_lambda_context)
+        assert response["statusCode"] == 404
+        headers = response.get("headers", {})
+        assert headers.get("Access-Control-Allow-Origin") == test_origin
+
+    def test_no_cors_when_origins_env_empty(self, mock_lambda_context):
+        """No CORS headers when CORS_ORIGINS env var is empty."""
+        handler = _reload_handler("preprod", cors_origins="")
+        event = make_event(
+            method="GET",
+            path="/chaos/experiments",
+            headers={"origin": "https://some-origin.example.com"},
+        )
+        response = handler.lambda_handler(event, mock_lambda_context)
+        assert response["statusCode"] == 404
+        headers = response.get("headers", {})
+        assert "Access-Control-Allow-Origin" not in headers
+        assert headers.get("Vary") == "Origin"

--- a/tests/unit/test_chaos_security.py
+++ b/tests/unit/test_chaos_security.py
@@ -21,11 +21,14 @@ os.environ.setdefault("CHAOS_EXPERIMENTS_TABLE", "test-chaos-experiments")
 from tests.conftest import make_event
 
 
-def _reload_handler_with_env(env_value: str):
-    """Reload handler module with a specific ENVIRONMENT value."""
+def _reload_handler_with_env(env_value: str, cors_origins: str = ""):
+    """Reload handler module with a specific ENVIRONMENT value and optional CORS_ORIGINS."""
     import importlib
 
-    with patch.dict(os.environ, {"ENVIRONMENT": env_value}):
+    env_overrides = {"ENVIRONMENT": env_value}
+    if cors_origins:
+        env_overrides["CORS_ORIGINS"] = cors_origins
+    with patch.dict(os.environ, env_overrides):
         import src.lambdas.dashboard.handler as handler_module
 
         importlib.reload(handler_module)
@@ -125,6 +128,50 @@ class TestChaosEnvironmentGating:
         event = make_event(method="POST", path="/chaos/experiments/fake-id/start")
         response = handler.lambda_handler(event, mock_lambda_context)
         assert response["statusCode"] == 404
+
+    def test_chaos_route_404_has_cors_for_valid_origin(self, mock_lambda_context):
+        """Env-gated 404 includes CORS headers when Origin is in allowed list."""
+        test_origin = "https://test.example.com"
+        handler = _reload_handler_with_env("preprod", cors_origins=test_origin)
+        event = make_event(
+            method="GET",
+            path="/chaos/experiments",
+            headers={"origin": test_origin},
+        )
+        response = handler.lambda_handler(event, mock_lambda_context)
+        assert response["statusCode"] == 404
+        headers = response.get("headers", {})
+        assert headers.get("Access-Control-Allow-Origin") == test_origin
+        assert headers.get("Access-Control-Allow-Credentials") == "true"
+        assert headers.get("Vary") == "Origin"
+
+    def test_chaos_route_404_no_cors_for_unknown_origin(self, mock_lambda_context):
+        """Env-gated 404 omits CORS origin for unknown Origin header."""
+        handler = _reload_handler_with_env(
+            "preprod", cors_origins="https://allowed.example.com"
+        )
+        event = make_event(
+            method="GET",
+            path="/chaos/experiments",
+            headers={"origin": "https://evil.example.com"},
+        )
+        response = handler.lambda_handler(event, mock_lambda_context)
+        assert response["statusCode"] == 404
+        headers = response.get("headers", {})
+        assert "Access-Control-Allow-Origin" not in headers
+        assert headers.get("Vary") == "Origin"
+
+    def test_chaos_route_404_no_cors_for_missing_origin(self, mock_lambda_context):
+        """Env-gated 404 omits CORS origin when no Origin header sent."""
+        handler = _reload_handler_with_env(
+            "preprod", cors_origins="https://allowed.example.com"
+        )
+        event = make_event(method="GET", path="/chaos/experiments")
+        response = handler.lambda_handler(event, mock_lambda_context)
+        assert response["statusCode"] == 404
+        headers = response.get("headers", {})
+        assert "Access-Control-Allow-Origin" not in headers
+        assert headers.get("Vary") == "Origin"
 
 
 # ===================================================================

--- a/tests/unit/test_cors_404_headers.py
+++ b/tests/unit/test_cors_404_headers.py
@@ -1,0 +1,125 @@
+"""Unit tests for CORS on env-gated 404 responses (Feature 1268).
+
+Tests the _make_not_found_response() function which conditionally adds
+CORS headers to 404 responses when the requesting origin is in the
+allowed origins list (_CORS_ALLOWED_ORIGINS).
+
+Approach: Reload handler module with CORS_ORIGINS set to control
+_CORS_ALLOWED_ORIGINS (parsed at module level).
+"""
+
+import importlib
+import json
+import os
+from unittest.mock import patch
+
+import pytest
+
+# Set env before any handler import
+os.environ.setdefault("DYNAMODB_TABLE", "test-sentiment-items")
+os.environ.setdefault("SENTIMENTS_TABLE", "test-sentiment-items")
+os.environ.setdefault("USERS_TABLE", "test-sentiment-users")
+os.environ.setdefault("ENVIRONMENT", "test")
+os.environ.setdefault("CHAOS_EXPERIMENTS_TABLE", "test-chaos-experiments")
+
+ALLOWED_ORIGIN = "https://example.com"
+SECOND_ORIGIN = "https://app.example.com"
+CORS_ORIGINS_VALUE = f"{ALLOWED_ORIGIN},{SECOND_ORIGIN}"
+
+
+def _reload_handler_with_cors(cors_origins: str = CORS_ORIGINS_VALUE):
+    """Reload handler module with specific CORS_ORIGINS."""
+    with patch.dict(os.environ, {"CORS_ORIGINS": cors_origins}):
+        import src.lambdas.dashboard.handler as handler_module
+
+        importlib.reload(handler_module)
+        return handler_module
+
+
+class TestMakeNotFoundResponse:
+    """Unit tests for _make_not_found_response (Feature 1268)."""
+
+    @pytest.fixture(autouse=True)
+    def setup_handler(self):
+        """Reload handler with CORS origins before each test, restore after."""
+        self.handler = _reload_handler_with_cors()
+        yield
+        # Restore original environment
+        _reload_handler_with_cors("")
+
+    def test_valid_origin_includes_cors_headers(self):
+        """CORS headers present when origin is in allowed list."""
+        response = self.handler._make_not_found_response(ALLOWED_ORIGIN)
+        assert response.headers.get("Access-Control-Allow-Origin") == ALLOWED_ORIGIN
+        assert response.headers.get("Access-Control-Allow-Credentials") == "true"
+        assert "GET" in response.headers.get("Access-Control-Allow-Methods", "")
+        assert "Content-Type" in response.headers.get(
+            "Access-Control-Allow-Headers", ""
+        )
+
+    def test_invalid_origin_omits_cors_origin(self):
+        """Access-Control-Allow-Origin omitted for unknown origin."""
+        response = self.handler._make_not_found_response("https://evil.com")
+        assert "Access-Control-Allow-Origin" not in response.headers
+
+    def test_none_origin_omits_cors_origin(self):
+        """Access-Control-Allow-Origin omitted when origin is None."""
+        response = self.handler._make_not_found_response(None)
+        assert "Access-Control-Allow-Origin" not in response.headers
+
+    def test_empty_origin_omits_cors_origin(self):
+        """Access-Control-Allow-Origin omitted for empty string origin."""
+        response = self.handler._make_not_found_response("")
+        assert "Access-Control-Allow-Origin" not in response.headers
+
+    def test_response_body_is_not_found(self):
+        """Response body is always {"detail": "Not found"}."""
+        response = self.handler._make_not_found_response(ALLOWED_ORIGIN)
+        body = json.loads(response.body)
+        assert body == {"detail": "Not found"}
+
+    def test_response_status_is_404(self):
+        """Response status code is always 404."""
+        response = self.handler._make_not_found_response(ALLOWED_ORIGIN)
+        assert response.status_code == 404
+
+    def test_vary_origin_always_present(self):
+        """Vary: Origin header is always present regardless of origin."""
+        # With valid origin
+        response = self.handler._make_not_found_response(ALLOWED_ORIGIN)
+        assert response.headers.get("Vary") == "Origin"
+
+        # With no origin
+        response = self.handler._make_not_found_response(None)
+        assert response.headers.get("Vary") == "Origin"
+
+        # With invalid origin
+        response = self.handler._make_not_found_response("https://evil.com")
+        assert response.headers.get("Vary") == "Origin"
+
+    def test_no_wildcard_origin(self):
+        """Access-Control-Allow-Origin never uses wildcard *."""
+        response = self.handler._make_not_found_response(ALLOWED_ORIGIN)
+        assert response.headers.get("Access-Control-Allow-Origin") != "*"
+
+    def test_credentials_header_with_valid_origin(self):
+        """Access-Control-Allow-Credentials is 'true' when origin valid."""
+        response = self.handler._make_not_found_response(ALLOWED_ORIGIN)
+        assert response.headers.get("Access-Control-Allow-Credentials") == "true"
+
+    def test_multiple_allowed_origins(self):
+        """Only the requesting origin is reflected, not all allowed origins."""
+        response = self.handler._make_not_found_response(SECOND_ORIGIN)
+        assert response.headers.get("Access-Control-Allow-Origin") == SECOND_ORIGIN
+        # Verify the other origin is NOT in the header
+        assert ALLOWED_ORIGIN not in response.headers.get(
+            "Access-Control-Allow-Origin", ""
+        )
+
+    def test_whitespace_in_cors_origins_handled(self):
+        """Origins with whitespace around commas are still matched."""
+        handler = _reload_handler_with_cors("  https://a.com , https://b.com  ")
+        response = handler._make_not_found_response("https://a.com")
+        assert response.headers.get("Access-Control-Allow-Origin") == "https://a.com"
+        response = handler._make_not_found_response("https://b.com")
+        assert response.headers.get("Access-Control-Allow-Origin") == "https://b.com"

--- a/tests/unit/test_dashboard_handler.py
+++ b/tests/unit/test_dashboard_handler.py
@@ -586,9 +586,13 @@ class TestSecurityMitigations:
         """
         P0-5: Test CORS is delegated to Lambda Function URL.
 
-        CORS is now handled at the infrastructure level (Lambda Function URL
+        CORS is handled at the infrastructure level (Lambda Function URL
         configuration in Terraform), NOT at the application level. This prevents
         duplicate CORS headers which browsers reject.
+
+        Exception: Feature 1268 adds CORS headers to env-gated 404 responses
+        specifically, because neither Lambda Function URL (AWS_IAM auth) nor
+        API Gateway (AWS_PROXY pass-through) adds CORS to Lambda-returned responses.
 
         See: infrastructure/terraform/main.tf for CORS configuration.
         """
@@ -613,6 +617,10 @@ class TestSecurityMitigations:
 
         CORS middleware was removed to prevent duplicate CORS headers.
         Lambda Function URL handles CORS exclusively.
+
+        Exception: Feature 1268 adds CORS headers to env-gated 404 responses
+        specifically, because neither Lambda Function URL (AWS_IAM auth) nor
+        API Gateway (AWS_PROXY pass-through) adds CORS to Lambda-returned responses.
 
         With Powertools APIGatewayRestResolver, CORS is configured via
         the CORSConfig parameter, not middleware. Verify no CORS config


### PR DESCRIPTION
## Summary
- Replace static `_NOT_FOUND_RESPONSE` with `_make_not_found_response()` that conditionally adds CORS headers
- Parse `CORS_ORIGINS` env var (already provisioned by Terraform) for origin validation
- Update all 12 env-gated call sites in handler.py
- Remove dead code (duplicate `_NOT_FOUND_RESPONSE` definitions)

## Test plan
- [x] 11 unit tests: valid/invalid/missing origins, Vary header, credentials, whitespace
- [x] 3 chaos security tests: CORS through full handler invocation
- [x] 4 integration tests: chaos/dashboard/static route 404s with CORS
- [x] Playwright test: frontend 404 handling
- [x] E2E test: preprod chaos 404 CORS verification (skip-guarded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)