### PR TITLE
fix(e2e): Fix accessibility tree race condition in Playwright tests (1270/1271)

### DIFF
--- a/frontend/tests/e2e/chaos-accessibility.spec.ts
+++ b/frontend/tests/e2e/chaos-accessibility.spec.ts
@@ -2,6 +2,7 @@
 import { test, expect } from '@playwright/test';
 import AxeBuilder from '@axe-core/playwright';
 import { triggerHealthBanner, getBannerLocator } from './helpers/chaos-helpers';
+import { waitForAccessibilityTree } from './helpers/a11y-helpers';
 
 /**
  * Chaos: Accessibility During Degraded States (Feature 1265, US4/FR-010/SC-005)
@@ -28,6 +29,12 @@ test.describe('Chaos: Accessibility During Degradation', () => {
 
     const banner = getBannerLocator(page);
     await expect(banner).toBeVisible();
+
+    // Wait for accessibility tree to stabilize (ARIA attributes are computed async)
+    await waitForAccessibilityTree(page, {
+      selector: '[role="alert"]',
+      attributes: ['aria-live'],
+    });
 
     // Run axe-core scan for WCAG 2.1 AA
     const results = await new AxeBuilder({ page })
@@ -66,6 +73,12 @@ test.describe('Chaos: Accessibility During Degradation', () => {
       page.getByText(/something went wrong/i),
     ).toBeVisible({ timeout: 5000 });
 
+    // Wait for error boundary to fully render with accessible buttons
+    await waitForAccessibilityTree(page, {
+      selector: 'button',
+      attributes: ['type'],
+    });
+
     // Run axe-core scan
     const results = await new AxeBuilder({ page })
       .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
@@ -100,6 +113,12 @@ test.describe('Chaos: Accessibility During Degradation', () => {
     await expect(
       page.getByText(/something went wrong/i),
     ).toBeVisible({ timeout: 5000 });
+
+    // Wait for error boundary buttons to be fully accessible
+    await waitForAccessibilityTree(page, {
+      selector: 'button',
+      attributes: ['type'],
+    });
 
     // Verify buttons exist and have accessible names
     const tryAgainButton = page.getByRole('button', { name: /try again/i });

--- a/frontend/tests/e2e/chaos-cross-browser.spec.ts
+++ b/frontend/tests/e2e/chaos-cross-browser.spec.ts
@@ -27,7 +27,7 @@ test.describe('Chaos: Cross-Browser Validation', () => {
     await triggerHealthBanner(page);
     const banner = getBannerLocator(page);
     await expect(banner).toBeVisible();
-    await expect(banner).toHaveAttribute('aria-live', 'assertive');
+    await expect(banner).toHaveAttribute('aria-live', 'assertive', { timeout: 3000 });
   });
 
   // T042: Cached data persists across browsers

--- a/frontend/tests/e2e/chaos-degradation.spec.ts
+++ b/frontend/tests/e2e/chaos-degradation.spec.ts
@@ -39,7 +39,7 @@ test.describe('Chaos: API Degradation', () => {
     await expect(banner).toBeVisible();
 
     // Verify accessibility attributes
-    await expect(banner).toHaveAttribute('aria-live', 'assertive');
+    await expect(banner).toHaveAttribute('aria-live', 'assertive', { timeout: 3000 });
 
     // Verify console telemetry event
     const bannerEvent = consoleMessages.find((m) =>

--- a/frontend/tests/e2e/error-visibility-banner.spec.ts
+++ b/frontend/tests/e2e/error-visibility-banner.spec.ts
@@ -219,7 +219,7 @@ test.describe('API Health Banner Visibility', () => {
     await expect(banner).toBeVisible({ timeout: 5000 });
 
     // Verify role="alert" with aria-live="assertive" for screen readers
-    await expect(banner).toHaveAttribute('aria-live', 'assertive');
+    await expect(banner).toHaveAttribute('aria-live', 'assertive', { timeout: 3000 });
 
     // Verify dismiss button has accessible label
     const dismissButton = page.getByRole('button', {

--- a/frontend/tests/e2e/helpers/a11y-helpers.ts
+++ b/frontend/tests/e2e/helpers/a11y-helpers.ts
@@ -1,0 +1,43 @@
+import { Page } from '@playwright/test';
+
+interface A11yWaitOptions {
+  /** CSS selector for the element to check */
+  selector: string;
+  /** ARIA attributes that must have non-empty values */
+  attributes?: string[];
+  /** Maximum wait time in ms (default: 5000) */
+  timeout?: number;
+}
+
+/**
+ * Wait for the browser's accessibility tree to stabilize for a given element.
+ *
+ * Bridges the gap between DOM visibility (element in viewport) and
+ * accessibility readiness (ARIA attributes computed). Use between
+ * toBeVisible() and AxeBuilder.analyze().
+ *
+ * Why this exists: toBeVisible() confirms the element is in the DOM,
+ * but ARIA attributes and accessible names are computed asynchronously
+ * by the browser. Running axe-core before this computation completes
+ * produces false-positive violations.
+ */
+export async function waitForAccessibilityTree(
+  page: Page,
+  options: A11yWaitOptions
+): Promise<void> {
+  const { selector, attributes = [], timeout = 5000 } = options;
+
+  await page.waitForFunction(
+    ({ sel, attrs }) => {
+      const el = document.querySelector(sel);
+      if (!el) return false;
+      if (attrs.length === 0) return true;
+      return attrs.every((attr: string) => {
+        const val = el.getAttribute(attr);
+        return val !== null && val !== '';
+      });
+    },
+    { sel: selector, attrs: attributes },
+    { timeout, polling: 50 }
+  );
+}

--- a/frontend/tests/e2e/helpers/chaos-helpers.ts
+++ b/frontend/tests/e2e/helpers/chaos-helpers.ts
@@ -233,15 +233,17 @@ export async function triggerHealthBanner(page: Page): Promise<void> {
 
   const searchInput = page.getByPlaceholder(/search tickers/i);
 
-  // 3 search interactions to accumulate failures
+  // 3 search interactions to accumulate failures.
+  // Wait for the 503 response after each search to confirm the failure was recorded,
+  // rather than using a blind waitForTimeout.
   await searchInput.fill('AAPL');
-  await page.waitForTimeout(1500);
+  await page.waitForResponse((resp) => resp.status() === 503);
   await searchInput.fill('');
   await searchInput.fill('GOOG');
-  await page.waitForTimeout(1500);
+  await page.waitForResponse((resp) => resp.status() === 503);
   await searchInput.fill('');
   await searchInput.fill('MSFT');
-  await page.waitForTimeout(1500);
+  await page.waitForResponse((resp) => resp.status() === 503);
 
   // Wait for banner to appear
   const banner = getBannerLocator(page);

--- a/frontend/tests/e2e/sanity.spec.ts
+++ b/frontend/tests/e2e/sanity.spec.ts
@@ -137,7 +137,7 @@ test.describe('Critical User Path - Sanity Tests', () => {
         await expect(button).toBeVisible();
         await button.click();
         // The expect below will wait for button state to update
-        await expect(button).toHaveAttribute('aria-pressed', 'true');
+        await expect(button).toHaveAttribute('aria-pressed', 'true', { timeout: 3000 });
 
         // Verify chart still has data
         await expect(chartContainer).toHaveAttribute(
@@ -173,24 +173,24 @@ test.describe('Critical User Path - Sanity Tests', () => {
         name: 'Toggle price candles',
       });
       await expect(priceToggle).toBeVisible();
-      await expect(priceToggle).toHaveAttribute('aria-pressed', 'true');
+      await expect(priceToggle).toHaveAttribute('aria-pressed', 'true', { timeout: 3000 });
       await priceToggle.click();
-      await expect(priceToggle).toHaveAttribute('aria-pressed', 'false');
+      await expect(priceToggle).toHaveAttribute('aria-pressed', 'false', { timeout: 3000 });
 
       // Toggle sentiment line off
       const sentimentToggle = page.getByRole('button', {
         name: 'Toggle sentiment line',
       });
       await expect(sentimentToggle).toBeVisible();
-      await expect(sentimentToggle).toHaveAttribute('aria-pressed', 'true');
+      await expect(sentimentToggle).toHaveAttribute('aria-pressed', 'true', { timeout: 3000 });
       await sentimentToggle.click();
-      await expect(sentimentToggle).toHaveAttribute('aria-pressed', 'false');
+      await expect(sentimentToggle).toHaveAttribute('aria-pressed', 'false', { timeout: 3000 });
 
       // Toggle both back on
       await priceToggle.click();
-      await expect(priceToggle).toHaveAttribute('aria-pressed', 'true');
+      await expect(priceToggle).toHaveAttribute('aria-pressed', 'true', { timeout: 3000 });
       await sentimentToggle.click();
-      await expect(sentimentToggle).toHaveAttribute('aria-pressed', 'true');
+      await expect(sentimentToggle).toHaveAttribute('aria-pressed', 'true', { timeout: 3000 });
     });
   });
 
@@ -532,7 +532,7 @@ test.describe('Critical User Path - Sanity Tests', () => {
 
       // Verify sentiment toggle is pressed (active)
       const sentimentToggle = page.getByRole('button', { name: 'Toggle sentiment line' });
-      await expect(sentimentToggle).toHaveAttribute('aria-pressed', 'true');
+      await expect(sentimentToggle).toHaveAttribute('aria-pressed', 'true', { timeout: 3000 });
 
       // Extract sentiment count
       const ariaLabel = await chartContainer.getAttribute('aria-label');
@@ -545,11 +545,11 @@ test.describe('Critical User Path - Sanity Tests', () => {
 
       // Toggle sentiment off
       await sentimentToggle.click();
-      await expect(sentimentToggle).toHaveAttribute('aria-pressed', 'false');
+      await expect(sentimentToggle).toHaveAttribute('aria-pressed', 'false', { timeout: 3000 });
 
       // Toggle back on
       await sentimentToggle.click();
-      await expect(sentimentToggle).toHaveAttribute('aria-pressed', 'true');
+      await expect(sentimentToggle).toHaveAttribute('aria-pressed', 'true', { timeout: 3000 });
 
       // Aria-label should still show sentiment data (data persists across toggle)
       await expect(chartContainer).toHaveAttribute(
@@ -600,14 +600,14 @@ test.describe('Critical User Path - Sanity Tests', () => {
       await expect(oneYearButton).toBeVisible();
       await oneYearButton.click();
       // The expect below will wait for button state to update
-      await expect(oneYearButton).toHaveAttribute('aria-pressed', 'true');
+      await expect(oneYearButton).toHaveAttribute('aria-pressed', 'true', { timeout: 3000 });
 
       // Step 3: Set Day resolution
       const dayResButton = page.getByRole('button', { name: 'Day resolution' });
       await expect(dayResButton).toBeVisible();
       await dayResButton.click();
       // The expect below will wait for button state to update
-      await expect(dayResButton).toHaveAttribute('aria-pressed', 'true');
+      await expect(dayResButton).toHaveAttribute('aria-pressed', 'true', { timeout: 3000 });
 
       // Step 4: Now switch to AAPL ticker
       await searchInput.clear();
@@ -629,8 +629,8 @@ test.describe('Critical User Path - Sanity Tests', () => {
       const oneYearButtonAfterSwitch = page.getByRole('button', { name: '1Y time range' });
       const dayResButtonAfterSwitch = page.getByRole('button', { name: 'Day resolution' });
 
-      await expect(oneYearButtonAfterSwitch).toHaveAttribute('aria-pressed', 'true');
-      await expect(dayResButtonAfterSwitch).toHaveAttribute('aria-pressed', 'true');
+      await expect(oneYearButtonAfterSwitch).toHaveAttribute('aria-pressed', 'true', { timeout: 3000 });
+      await expect(dayResButtonAfterSwitch).toHaveAttribute('aria-pressed', 'true', { timeout: 3000 });
     });
 
     /**


### PR DESCRIPTION
## Summary
- Root cause: `toBeVisible()` confirms DOM presence, but browser accessibility tree (ARIA attributes, accessible names) updates asynchronously. Axe-core and ARIA assertions ran during this gap.
- Created `waitForAccessibilityTree()` helper that polls for ARIA attributes before axe scan
- Added `{ timeout: 3000 }` to all ARIA attribute assertions after visibility checks
- Replaced 3 blind `waitForTimeout(1500)` calls with `page.waitForResponse()` event-based waits

## Files fixed
- `chaos-accessibility.spec.ts` — the 3 consistently-failing tests (NOT "flaky")
- `chaos-degradation.spec.ts` — `aria-live` race
- `error-visibility-banner.spec.ts` — `aria-live` race
- `chaos-cross-browser.spec.ts` — `aria-live` race
- `sanity.spec.ts` — 14 `aria-pressed` race conditions
- `chaos-helpers.ts` — blind waits → event-based waits

## Test plan
- [x] These ARE tests — the fix makes them deterministic
- [ ] CI Playwright Chaos Tests job passes without retries

🤖 Generated with [Claude Code](https://claude.com/claude-code)