### PR TITLE
fix(e2e): Use addInitScript for error boundary — flag must survive navigation

### DIFF
--- a/frontend/tests/e2e/chaos-accessibility.spec.ts
+++ b/frontend/tests/e2e/chaos-accessibility.spec.ts
@@ -62,12 +62,12 @@ test.describe('Chaos: Accessibility During Degradation', () => {
   test('error boundary fallback has zero critical accessibility violations', async ({
     page,
   }) => {
-    // Force error boundary
-    await page.evaluate(() => {
+    // Force error boundary — must use addInitScript so the flag survives navigation.
+    // page.evaluate() sets it on the CURRENT page; goto() loads a NEW page without it.
+    await page.addInitScript(() => {
       (window as any).__TEST_FORCE_ERROR = true;
     });
     await page.goto('/');
-    await page.waitForTimeout(1000);
 
     await expect(
       page.getByText(/something went wrong/i),
@@ -103,12 +103,11 @@ test.describe('Chaos: Accessibility During Degradation', () => {
   test('error boundary buttons are keyboard-focusable with accessible labels', async ({
     page,
   }) => {
-    // Force error boundary
-    await page.evaluate(() => {
+    // Force error boundary — addInitScript survives navigation
+    await page.addInitScript(() => {
       (window as any).__TEST_FORCE_ERROR = true;
     });
     await page.goto('/');
-    await page.waitForTimeout(1000);
 
     await expect(
       page.getByText(/something went wrong/i),

--- a/frontend/tests/e2e/chaos-error-boundary.spec.ts
+++ b/frontend/tests/e2e/chaos-error-boundary.spec.ts
@@ -23,12 +23,13 @@ test.describe('Chaos: Error Boundary', () => {
    * Sets the global flag, then triggers a re-render by navigating.
    */
   async function forceErrorBoundary(page: import('@playwright/test').Page) {
-    await page.evaluate(() => {
+    // Must use addInitScript — page.evaluate() sets the flag on the current page,
+    // but goto() loads a NEW page where the flag doesn't exist.
+    // addInitScript runs before any page JS, so the flag is set when ErrorTrigger renders.
+    await page.addInitScript(() => {
       (window as any).__TEST_FORCE_ERROR = true;
     });
-    // Trigger re-render — navigate to dashboard which re-mounts ErrorTrigger
     await page.goto('/');
-    await page.waitForTimeout(1000);
   }
 
   // T022: Error boundary fallback renders with recovery actions
@@ -64,14 +65,11 @@ test.describe('Chaos: Error Boundary', () => {
     const banner = getBannerLocator(page);
     await expect(banner).toBeVisible();
 
-    // Now force error boundary on top of degradation
-    await page.evaluate(() => {
+    // Now force error boundary on top of degradation — addInitScript survives navigation
+    await page.addInitScript(() => {
       (window as any).__TEST_FORCE_ERROR = true;
     });
-
-    // Navigate to trigger re-render within the error boundary scope
     await page.goto('/');
-    await page.waitForTimeout(1000);
 
     // Error boundary fallback should now be visible
     await expect(


### PR DESCRIPTION
## Summary
The actual root cause of the "flaky" Playwright tests.

`page.evaluate()` sets `__TEST_FORCE_ERROR` on the **current** page. `page.goto('/')` loads a **new** page where the flag doesn't exist. The error boundary never triggers. The test times out.

`page.addInitScript()` runs before any page JS on every navigation, so the flag exists when ErrorTrigger renders.

## Test plan
- [ ] CI Playwright Chaos Tests job **passes** — this is the test that has failed on every PR this session

🤖 Generated with [Claude Code](https://claude.com/claude-code)