### PR TITLE
fix(e2e): Fix 7 remaining Playwright chaos test failures (1272/1273/1274)

### DIFF
--- a/frontend/tests/e2e/chaos-accessibility.spec.ts
+++ b/frontend/tests/e2e/chaos-accessibility.spec.ts
@@ -16,9 +16,13 @@ import { waitForAccessibilityTree } from './helpers/a11y-helpers';
  * focus management). Manual screen reader testing is out of scope.
  */
 test.describe('Chaos: Accessibility During Degradation', () => {
+  // a11y tests stack triggerHealthBanner + waitForAccessibilityTree + AxeBuilder.analyze
+  // which legitimately takes longer than standard E2E tests due to axe-core scanning overhead
+  test.setTimeout(30_000);
+
   test.beforeEach(async ({ page }) => {
     await page.goto('/');
-    await page.waitForTimeout(2000);
+    await page.waitForLoadState('networkidle');
   });
 
   // T025: Health banner has zero critical a11y violations
@@ -36,8 +40,10 @@ test.describe('Chaos: Accessibility During Degradation', () => {
       attributes: ['aria-live'],
     });
 
-    // Run axe-core scan for WCAG 2.1 AA
+    // Run axe-core scan for WCAG 2.1 AA — scoped to the banner element
+    // to reduce scan time from ~2-3s (full page) to ~0.5-1s (component only)
     const results = await new AxeBuilder({ page })
+      .include('[role="alert"]')
       .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
       .analyze();
 

--- a/frontend/tests/e2e/chaos-cached-data.spec.ts
+++ b/frontend/tests/e2e/chaos-cached-data.spec.ts
@@ -11,9 +11,23 @@ import { blockAllApi } from './helpers/chaos-helpers';
  */
 test.describe('Chaos: Cached Data Resilience', () => {
   test.beforeEach(async ({ page }) => {
-    // Navigate and wait for initial data to render
+    // Navigate and load actual data — tests assert "previously loaded data"
+    // persists during API outages, so data must exist before chaos injection.
     await page.goto('/');
-    await page.waitForTimeout(3000);
+    const searchInput = page.getByPlaceholder(/search tickers/i);
+    await searchInput.fill('AAPL');
+    const suggestion = page.getByRole('option', { name: /AAPL/i });
+    await expect(suggestion).toBeVisible({ timeout: 10000 });
+    await suggestion.click();
+    // Wait for chart data to fully render (proven pattern from sanity.spec.ts)
+    const chartContainer = page.locator(
+      '[role="img"][aria-label*="Price and sentiment chart"]',
+    );
+    await expect(chartContainer).toHaveAttribute(
+      'aria-label',
+      /[1-9]\d* price candles/,
+      { timeout: 15000 },
+    );
   });
 
   // T013: Previously loaded data remains visible during API outage
@@ -33,8 +47,8 @@ test.describe('Chaos: Cached Data Resilience', () => {
     // Now block all API calls — simulate complete outage
     await blockAllApi(page, 503);
 
-    // Wait for any pending requests to fail
-    await page.waitForTimeout(2000);
+    // Brief settle for in-flight React Query refetch requests to hit the route block
+    await page.waitForTimeout(500);
 
     // Dashboard should still have rendered content — NOT empty/blank
     const childCountDuringChaos = await mainContent.locator('> *').count();
@@ -56,8 +70,8 @@ test.describe('Chaos: Cached Data Resilience', () => {
     // Block with timeout error
     await page.route('**/api/**', (route) => route.abort('timedout'));
 
-    // Wait for timeout errors to propagate
-    await page.waitForTimeout(2000);
+    // Brief settle for in-flight React Query refetch requests to hit the route block
+    await page.waitForTimeout(500);
 
     // Dashboard should still have content
     const textDuring = await mainContent.textContent();

--- a/frontend/tests/e2e/chaos-cross-browser.spec.ts
+++ b/frontend/tests/e2e/chaos-cross-browser.spec.ts
@@ -32,12 +32,30 @@ test.describe('Chaos: Cross-Browser Validation', () => {
 
   // T042: Cached data persists across browsers
   test('cached data persists during API outage', async ({ page }) => {
+    // Load actual data first — the beforeEach only navigates.
+    // Tests assert "previously loaded data" persists, so data must exist.
+    const searchInput = page.getByPlaceholder(/search tickers/i);
+    await searchInput.fill('AAPL');
+    const suggestion = page.getByRole('option', { name: /AAPL/i });
+    await expect(suggestion).toBeVisible({ timeout: 10000 });
+    await suggestion.click();
+    // Wait for chart data to render
+    const chartContainer = page.locator(
+      '[role="img"][aria-label*="Price and sentiment chart"]',
+    );
+    await expect(chartContainer).toHaveAttribute(
+      'aria-label',
+      /[1-9]\d* price candles/,
+      { timeout: 15000 },
+    );
+
     const mainContent = page.locator('main');
     const textBefore = await mainContent.textContent();
     expect(textBefore).toBeTruthy();
 
     await blockAllApi(page, 503);
-    await page.waitForTimeout(2000);
+    // Brief settle for in-flight React Query refetch requests to hit the route block
+    await page.waitForTimeout(500);
 
     const textDuring = await mainContent.textContent();
     expect(textDuring).toBeTruthy();
@@ -60,11 +78,15 @@ test.describe('Chaos: Cross-Browser Validation', () => {
       route.abort('connectionreset'),
     );
 
-    // Wait for at least 2 reconnection attempts
-    await page.waitForTimeout(5000);
-
-    // Should have multiple SSE requests (reconnection behavior works)
-    expect(sseRequests.length).toBeGreaterThanOrEqual(2);
+    // Wait for at least 2 reconnection attempts (poll instead of blind wait
+    // to avoid racing against exponential backoff timing — see Feature 1274)
+    await expect
+      .poll(() => sseRequests.length, {
+        message: 'Expected 2+ SSE reconnection attempts',
+        timeout: 15000,
+        intervals: [500],
+      })
+      .toBeGreaterThanOrEqual(2);
 
     if (sseRequests.length >= 2) {
       // Intervals should be > 0 (backoff is working, within 2x tolerance)

--- a/frontend/tests/e2e/global-setup.ts
+++ b/frontend/tests/e2e/global-setup.ts
@@ -45,8 +45,12 @@ async function cleanupStaleTestData() {
       }
     }
   } catch (error) {
-    // Non-fatal — cleanup is best-effort
-    console.log(`[global-setup] Cleanup skipped: ${error}`);
+    // Non-fatal — cleanup is best-effort.
+    // TypeError: fetch failed = API server not reachable yet (expected during startup)
+    const message = error instanceof TypeError
+      ? 'API not reachable yet (server may still be starting)'
+      : String(error);
+    console.log(`[global-setup] Cleanup skipped: ${message}`);
   }
 }
 

--- a/frontend/tests/e2e/helpers/a11y-helpers.ts
+++ b/frontend/tests/e2e/helpers/a11y-helpers.ts
@@ -5,7 +5,7 @@ interface A11yWaitOptions {
   selector: string;
   /** ARIA attributes that must have non-empty values */
   attributes?: string[];
-  /** Maximum wait time in ms (default: 5000) */
+  /** Maximum wait time in ms (default: 2000) */
   timeout?: number;
 }
 
@@ -25,7 +25,7 @@ export async function waitForAccessibilityTree(
   page: Page,
   options: A11yWaitOptions
 ): Promise<void> {
-  const { selector, attributes = [], timeout = 5000 } = options;
+  const { selector, attributes = [], timeout = 2000 } = options;
 
   await page.waitForFunction(
     ({ sel, attrs }) => {


### PR DESCRIPTION
## Summary
Three root causes behind all 7 remaining Playwright failures:

**1272 — a11y timeout stacking**: `triggerHealthBanner()` (5s) + `waitForAccessibilityTree()` (5s) + `AxeBuilder.analyze()` (3s) = 13s, exceeds test timeout. Fix: reduce helper timeout 5s→2s, add `test.setTimeout(30s)`, scope axe scan to component.

**1273 — cached data never loaded**: Tests asserted "previously loaded data survives outage" but never loaded any data. Dashboard was empty. Fix: search AAPL, select ticker, wait for chart render before chaos injection.

**1274 — SSE reconnect race**: `waitForTimeout(5000)` + count assertion races exponential backoff. Fix: `expect.poll()` with 15s timeout.

## Test plan
- [ ] **CI Playwright Chaos Tests job passes** — the job that has failed on every PR this entire session

🤖 Generated with [Claude Code](https://claude.com/claude-code)