### PR TITLE
fix(e2e): Fix remaining Playwright chaos test failures (1275/1276/1277)

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -320,6 +320,22 @@ jobs:
           cd frontend
           timeout 300 npx playwright test tests/e2e/chaos-*.spec.ts \
             --project="Desktop Chrome" \
-            --reporter=list
+            --reporter=html,list
+
+      - name: Upload Playwright HTML report
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: playwright-chaos-report
+          path: frontend/playwright-report/
+          retention-days: 7
+
+      - name: Upload Playwright test results
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: playwright-chaos-results
+          path: frontend/test-results/
+          retention-days: 7
 
     timeout-minutes: 5

--- a/frontend/src/components/ui/error-trigger.tsx
+++ b/frontend/src/components/ui/error-trigger.tsx
@@ -1,15 +1,20 @@
 'use client';
 
-import { type ReactNode } from 'react';
+import { type ReactNode, useState, useEffect } from 'react';
 
 /**
- * Test-only error trigger wrapper (Feature 1265).
+ * Test-only error trigger wrapper (Feature 1265, fixed in 1275).
  *
  * When `window.__TEST_FORCE_ERROR` is set to `true`, this component throws
  * during render, which is caught by the nearest React ErrorBoundary.
  *
+ * SSR-safe: Uses useEffect to detect the flag after hydration, avoiding
+ * hydration mismatches. The flag check cannot happen during SSR (no window)
+ * or during hydration (must match server HTML). Instead, useEffect fires
+ * after mount, sets state, and the subsequent re-render throws.
+ *
  * Production-stripped: Only active when NODE_ENV !== 'production'.
- * In production builds, this is a transparent passthrough.
+ * In production builds, ErrorTriggerInner is tree-shaken away.
  */
 
 declare global {
@@ -22,16 +27,40 @@ interface ErrorTriggerProps {
   children: ReactNode;
 }
 
-export function ErrorTrigger({ children }: ErrorTriggerProps) {
-  // In production, this is a transparent passthrough
-  if (process.env.NODE_ENV === 'production') {
-    return <>{children}</>;
-  }
+/**
+ * Inner component that uses hooks for SSR-safe error detection.
+ * Separated from the outer ErrorTrigger to avoid conditional hook calls
+ * (Rules of Hooks: hooks must be called unconditionally).
+ */
+function ErrorTriggerInner({ children }: ErrorTriggerProps) {
+  const [shouldError, setShouldError] = useState(false);
 
-  // In dev/test, check the global flag during render
-  if (typeof window !== 'undefined' && window.__TEST_FORCE_ERROR) {
+  // Check the flag after mount (post-hydration). This avoids the SSR/hydration
+  // mismatch: server renders children, hydration matches, then this effect fires
+  // and triggers a clean re-render that throws.
+  useEffect(() => {
+    if (typeof window !== 'undefined' && window.__TEST_FORCE_ERROR) {
+      setShouldError(true);
+    }
+  }, []);
+
+  if (shouldError) {
     throw new Error('TEST_FORCE_ERROR: Intentional error triggered by E2E test');
   }
 
   return <>{children}</>;
+}
+
+/**
+ * Outer wrapper: production passthrough, non-production delegates to inner.
+ * No hooks here — safe to early-return in production.
+ */
+export function ErrorTrigger({ children }: ErrorTriggerProps) {
+  // In production, this is a transparent passthrough (zero overhead).
+  // Tree shaking eliminates ErrorTriggerInner from the production bundle.
+  if (process.env.NODE_ENV === 'production') {
+    return <>{children}</>;
+  }
+
+  return <ErrorTriggerInner>{children}</ErrorTriggerInner>;
 }

--- a/frontend/tests/e2e/chaos-cached-data.spec.ts
+++ b/frontend/tests/e2e/chaos-cached-data.spec.ts
@@ -1,6 +1,7 @@
 // Target: Customer Dashboard (Next.js/Amplify)
 import { test, expect } from '@playwright/test';
 import { blockAllApi } from './helpers/chaos-helpers';
+import { mockTickerDataApis } from './helpers/mock-api-data';
 
 /**
  * Chaos: Cached Data Resilience (Feature 1265, US1/FR-015)
@@ -11,22 +12,26 @@ import { blockAllApi } from './helpers/chaos-helpers';
  */
 test.describe('Chaos: Cached Data Resilience', () => {
   test.beforeEach(async ({ page }) => {
-    // Navigate and load actual data — tests assert "previously loaded data"
-    // persists during API outages, so data must exist before chaos injection.
+    // Feature 1276: Mock search/OHLC/sentiment APIs with pre-canned data.
+    // Chaos tests verify cache resilience, not data fetching. Mocking
+    // eliminates Tiingo/Finnhub latency that caused 17s timeouts.
+    await mockTickerDataApis(page);
+
+    // Navigate and load data — mocked APIs respond instantly
     await page.goto('/');
     const searchInput = page.getByPlaceholder(/search tickers/i);
     await searchInput.fill('AAPL');
     const suggestion = page.getByRole('option', { name: /AAPL/i });
-    await expect(suggestion).toBeVisible({ timeout: 10000 });
+    await expect(suggestion).toBeVisible({ timeout: 5000 });
     await suggestion.click();
-    // Wait for chart data to fully render (proven pattern from sanity.spec.ts)
+    // Wait for chart data to render (instant with mocks, 5s safety margin)
     const chartContainer = page.locator(
       '[role="img"][aria-label*="Price and sentiment chart"]',
     );
     await expect(chartContainer).toHaveAttribute(
       'aria-label',
       /[1-9]\d* price candles/,
-      { timeout: 15000 },
+      { timeout: 5000 },
     );
   });
 

--- a/frontend/tests/e2e/chaos-cross-browser.spec.ts
+++ b/frontend/tests/e2e/chaos-cross-browser.spec.ts
@@ -5,6 +5,7 @@ import {
   triggerHealthBanner,
   getBannerLocator,
 } from './helpers/chaos-helpers';
+import { mockTickerDataApis } from './helpers/mock-api-data';
 
 /**
  * Chaos: Cross-Browser Validation (Feature 1265, US5)
@@ -32,21 +33,23 @@ test.describe('Chaos: Cross-Browser Validation', () => {
 
   // T042: Cached data persists across browsers
   test('cached data persists during API outage', async ({ page }) => {
-    // Load actual data first — the beforeEach only navigates.
-    // Tests assert "previously loaded data" persists, so data must exist.
+    // Feature 1276: Mock data APIs for instant loading (was ~17s with real APIs)
+    await mockTickerDataApis(page);
+
+    // Load data — the beforeEach only navigates, so we must search + select here.
     const searchInput = page.getByPlaceholder(/search tickers/i);
     await searchInput.fill('AAPL');
     const suggestion = page.getByRole('option', { name: /AAPL/i });
-    await expect(suggestion).toBeVisible({ timeout: 10000 });
+    await expect(suggestion).toBeVisible({ timeout: 5000 });
     await suggestion.click();
-    // Wait for chart data to render
+    // Wait for chart data to render (instant with mocks, 5s safety margin)
     const chartContainer = page.locator(
       '[role="img"][aria-label*="Price and sentiment chart"]',
     );
     await expect(chartContainer).toHaveAttribute(
       'aria-label',
       /[1-9]\d* price candles/,
-      { timeout: 15000 },
+      { timeout: 5000 },
     );
 
     const mainContent = page.locator('main');

--- a/frontend/tests/e2e/helpers/mock-api-data.ts
+++ b/frontend/tests/e2e/helpers/mock-api-data.ts
@@ -1,0 +1,170 @@
+// Target: Customer Dashboard (Next.js/Amplify)
+/**
+ * Pre-canned API response data for chaos tests (Feature 1276).
+ *
+ * Chaos cached-data tests verify that previously loaded data persists
+ * during API outages. They don't test data fetching correctness.
+ * Mocking the search/OHLC/sentiment APIs eliminates external API
+ * dependency (Tiingo/Finnhub) and makes data loading instant (<1s).
+ *
+ * Shapes match the actual API contracts:
+ * - TickerSearchResponse: src/lib/api/tickers.ts
+ * - OHLCResponse: src/types/chart.ts
+ * - SentimentHistoryResponse: src/types/chart.ts
+ */
+
+import type { Page } from '@playwright/test';
+
+// ─── Mock Data ──────────────────────────────────────────────────────────────
+
+/** Pre-canned search response for AAPL */
+const MOCK_TICKER_SEARCH_RESPONSE = {
+  results: [
+    { symbol: 'AAPL', name: 'Apple Inc', exchange: 'NASDAQ' },
+  ],
+};
+
+/** Generate N price candles starting from a base date */
+function generateCandles(count: number): Array<{
+  date: string;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  volume: number;
+}> {
+  const candles = [];
+  const baseDate = new Date('2026-03-01');
+  let price = 178.5;
+
+  for (let i = 0; i < count; i++) {
+    const date = new Date(baseDate);
+    date.setDate(baseDate.getDate() + i);
+    // Skip weekends
+    if (date.getDay() === 0 || date.getDay() === 6) continue;
+
+    const open = price;
+    const high = price + Math.random() * 3;
+    const low = price - Math.random() * 2;
+    const close = low + Math.random() * (high - low);
+    price = close;
+
+    candles.push({
+      date: date.toISOString().split('T')[0],
+      open: Math.round(open * 100) / 100,
+      high: Math.round(high * 100) / 100,
+      low: Math.round(low * 100) / 100,
+      close: Math.round(close * 100) / 100,
+      volume: Math.floor(50_000_000 + Math.random() * 30_000_000),
+    });
+  }
+  return candles;
+}
+
+/** Generate N sentiment points matching candle dates */
+function generateSentimentPoints(
+  count: number,
+): Array<{
+  date: string;
+  score: number;
+  source: string;
+  confidence: number;
+  label: string;
+}> {
+  const points = [];
+  const baseDate = new Date('2026-03-01');
+
+  for (let i = 0; i < count; i++) {
+    const date = new Date(baseDate);
+    date.setDate(baseDate.getDate() + i);
+    if (date.getDay() === 0 || date.getDay() === 6) continue;
+
+    const score = 0.3 + Math.random() * 0.5; // 0.3 to 0.8
+    points.push({
+      date: date.toISOString().split('T')[0],
+      score: Math.round(score * 1000) / 1000,
+      source: 'aggregated',
+      confidence: 0.85,
+      label: score > 0.6 ? 'positive' : score > 0.4 ? 'neutral' : 'negative',
+    });
+  }
+  return points;
+}
+
+// Pre-generate data so all tests get consistent shapes
+const CANDLES = generateCandles(30);
+const SENTIMENT_POINTS = generateSentimentPoints(30);
+
+/** Pre-canned OHLC response for AAPL */
+const MOCK_OHLC_RESPONSE = {
+  ticker: 'AAPL',
+  candles: CANDLES,
+  time_range: '1M',
+  start_date: CANDLES[0]?.date ?? '2026-03-01',
+  end_date: CANDLES[CANDLES.length - 1]?.date ?? '2026-03-28',
+  count: CANDLES.length,
+  source: 'tiingo',
+  cache_expires_at: new Date(Date.now() + 3600_000).toISOString(),
+  resolution: 'D',
+  resolution_fallback: false,
+  fallback_message: null,
+};
+
+/** Pre-canned sentiment history response for AAPL */
+const MOCK_SENTIMENT_RESPONSE = {
+  ticker: 'AAPL',
+  source: 'aggregated',
+  history: SENTIMENT_POINTS,
+  start_date: SENTIMENT_POINTS[0]?.date ?? '2026-03-01',
+  end_date: SENTIMENT_POINTS[SENTIMENT_POINTS.length - 1]?.date ?? '2026-03-28',
+  count: SENTIMENT_POINTS.length,
+};
+
+// ─── Route Interception ─────────────────────────────────────────────────────
+
+/**
+ * Set up page.route() interceptions for ticker search, OHLC, and sentiment
+ * endpoints. Returns instantly with pre-canned data, bypassing external APIs.
+ *
+ * Call this BEFORE page.goto('/') or before the search interaction.
+ *
+ * When blockAllApi() is called later in the test, Playwright's LIFO route
+ * matching ensures the broader `** /api/**` pattern takes precedence,
+ * correctly simulating a full API outage for the chaos assertions.
+ *
+ * @returns A cleanup function that removes all mock routes
+ */
+export async function mockTickerDataApis(page: Page): Promise<() => Promise<void>> {
+  // Mock ticker search — match any search query
+  await page.route('**/api/v2/tickers/search**', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(MOCK_TICKER_SEARCH_RESPONSE),
+    }),
+  );
+
+  // Mock OHLC data — match any ticker's OHLC endpoint
+  await page.route('**/api/v2/tickers/*/ohlc**', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(MOCK_OHLC_RESPONSE),
+    }),
+  );
+
+  // Mock sentiment history — match any ticker's sentiment endpoint
+  await page.route('**/api/v2/tickers/*/sentiment/history**', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(MOCK_SENTIMENT_RESPONSE),
+    }),
+  );
+
+  return async () => {
+    await page.unroute('**/api/v2/tickers/search**');
+    await page.unroute('**/api/v2/tickers/*/ohlc**');
+    await page.unroute('**/api/v2/tickers/*/sentiment/history**');
+  };
+}


### PR DESCRIPTION
## Summary
Three root causes behind the last 5 failing Playwright tests:

**1275 — Error boundary SSR hydration**: `ErrorTrigger` checked `window.__TEST_FORCE_ERROR` during render, but React 18 hydration reuses server HTML without re-executing render functions. Fix: `useEffect` detects flag post-hydration, triggers re-render that throws.

**1276 — Cached data API timeout**: Tests searched AAPL against mock API hitting external endpoints (~17s). Fix: `page.route()` interception with pre-canned data. Instant responses.

**1277 — CI artifacts missing**: No screenshots or HTML reports on failure. Fix: `--reporter=html,list` + `actions/upload-artifact` for `playwright-report/` and `test-results/`.

## Test plan
- [ ] **CI Playwright Chaos Tests job passes** — all 33 chaos tests green
- [ ] Playwright artifacts uploaded on failure (visible in Actions run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)