### PR TITLE
fix(deps): Pin pydantic in dev requirements for Playwright CI verification

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,6 +16,9 @@
 # Include production dependencies
 -r requirements.txt
 
+# Override: moto[all]==5.1.22 requires pydantic<=2.12.4, but requirements.txt pins 2.12.5
+pydantic==2.12.4
+
 # Testing Framework
 pytest==9.0.2           # Compatible with pytest-asyncio 1.3.0
 pytest-cov==7.1.0       # Coverage reporting


### PR DESCRIPTION
## Summary
- Pin `pydantic==2.12.4` in `requirements-dev.txt` to resolve version conflict with `moto[all]==5.1.22`
- This mirrors the existing fix in `requirements-ci.txt`
- **DO NOT AUTO-MERGE** — this PR exists to verify that Playwright Chaos Tests run to completion

## Context
Playwright Chaos Tests have been CANCELLED on every PR since their introduction (#835, #837, #838).
Auto-merge kills the workflow before the non-required Playwright job completes. We have accumulated
4 PRs of Playwright fixes but have zero evidence they work in CI.

This PR intentionally avoids auto-merge so we can observe the full CI run, download the Playwright
HTML report artifacts, and assess the current state of the chaos E2E tests.

## What to watch
- [ ] `Playwright Chaos Tests` job reaches COMPLETED (not CANCELLED)
- [ ] `playwright-chaos-report` artifact is downloadable
- [ ] Results documented in `specs/1279-playwright-verify/results.md`

## Files changed
- `requirements-dev.txt`: +2 lines (comment + pydantic pin)

## Test plan
- [ ] Verify `pip install -r requirements-dev.txt` succeeds (no version conflict)
- [ ] Verify all CI jobs pass (Lint, Run Tests, Secrets Scan)
- [ ] Verify Playwright Chaos Tests runs to completion
- [ ] Download and review Playwright HTML report artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)