### PR TITLE
feat(1365-1367): Add @external-api test tiering — nightly workflow for real API tests

### DIFF
--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -1,0 +1,88 @@
+# Nightly External-API E2E Tests
+# ===============================
+#
+# Runs @external-api tagged Playwright tests against real Tiingo/Finnhub APIs.
+# These tests are excluded from PR checks (--grep-invert "@external-api") to
+# avoid rate-limiting API keys on every PR.
+#
+# Schedule: Daily at 2am UTC (GitHub may drift up to 15 min)
+#
+# IMPORTANT: GitHub auto-disables scheduled workflows after 60 days of repo
+# inactivity (no pushes, no PRs). The workflow_dispatch trigger allows manual
+# re-enablement. The README badge shows "no status" when disabled, making
+# staleness visible.
+
+name: Nightly External-API E2E
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  PYTHON_VERSION: '3.13'
+
+jobs:
+  external-api-e2e:
+    name: External-API E2E Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Python ${{ env.PYTHON_VERSION }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: 'pip'
+
+      - name: Install Python dependencies
+        run: pip install -r requirements-ci.txt
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '18'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        run: cd frontend && npm ci
+
+      - name: Install Playwright Chromium
+        run: cd frontend && npx playwright install chromium --with-deps
+
+      - name: Run external-API E2E tests
+        run: |
+          cd frontend
+          npx playwright test \
+            --grep "@external-api" \
+            --project="Desktop Chrome" \
+            --workers=1 \
+            --retries=1 \
+            --reporter=html,list
+        env:
+          CI: 'true'
+          TIINGO_API_KEY: ${{ secrets.TIINGO_API_KEY }}
+          FINNHUB_API_KEY: ${{ secrets.FINNHUB_API_KEY }}
+
+      - name: Upload Playwright HTML report
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: nightly-e2e-report
+          path: frontend/playwright-report/
+          retention-days: 7
+
+      - name: Upload Playwright test results
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: nightly-e2e-results
+          path: frontend/test-results/
+          retention-days: 7

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -318,11 +318,14 @@ jobs:
       - name: Run E2E tests
         run: |
           cd frontend
+          # Exclude @external-api tests — they hit real Tiingo/Finnhub APIs.
+          # Run nightly via nightly-e2e.yml instead. DO NOT REMOVE this flag.
           timeout 900 npx playwright test tests/e2e/*.spec.ts \
             --project="Desktop Chrome" \
             --workers=4 \
             --retries=0 \
-            --reporter=html,list
+            --reporter=html,list \
+            --grep-invert "@external-api"
 
       - name: Upload Playwright HTML report
         uses: actions/upload-artifact@v7

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A cloud-hosted Sentiment Analyzer service built with serverless AWS architecture
 
 [![PR Checks](https://github.com/traylorre/sentiment-analyzer-gsk/actions/workflows/pr-checks.yml/badge.svg)](https://github.com/traylorre/sentiment-analyzer-gsk/actions/workflows/pr-checks.yml)
 [![Deploy Pipeline](https://github.com/traylorre/sentiment-analyzer-gsk/actions/workflows/deploy.yml/badge.svg)](https://github.com/traylorre/sentiment-analyzer-gsk/actions/workflows/deploy.yml)
+[![Nightly External-API E2E](https://github.com/traylorre/sentiment-analyzer-gsk/actions/workflows/nightly-e2e.yml/badge.svg)](https://github.com/traylorre/sentiment-analyzer-gsk/actions/workflows/nightly-e2e.yml)
 
 ```mermaid
 %%{init: {"theme": "dark", "themeVariables": {"primaryColor": "#4A90A4", "tertiaryColor": "#2d2d2d", "lineColor": "#88CCFF", "primaryTextColor": "#FFFFFF", "clusterBkg": "#2d2d2d", "clusterBorder": "#555555"}, "flowchart": {"curve": "basis", "nodeSpacing": 50, "rankSpacing": 60}}}%%

--- a/frontend/tests/e2e/chart-zoom-data.spec.ts
+++ b/frontend/tests/e2e/chart-zoom-data.spec.ts
@@ -11,7 +11,7 @@ import { skipWithoutDataApis } from './helpers/data-api-guard';
  *
  * Uses real API data (not mocks) to test actual zoom/fitContent behavior.
  */
-test.describe('Chart Zoom Data Visibility', () => {
+test.describe('Chart Zoom Data Visibility', { tag: '@external-api' }, () => {
   test.beforeEach(async () => {
     await skipWithoutDataApis(test);
   });

--- a/frontend/tests/e2e/sanity.spec.ts
+++ b/frontend/tests/e2e/sanity.spec.ts
@@ -3,7 +3,7 @@ import { test, expect } from '@playwright/test';
 import { waitForAuth } from './helpers/auth-helper';
 import { skipWithoutDataApis } from './helpers/data-api-guard';
 
-test.describe('Critical User Path - Sanity Tests', () => {
+test.describe('Critical User Path - Sanity Tests', { tag: '@external-api' }, () => {
   test.beforeEach(async ({ page }) => {
     await skipWithoutDataApis(test);
     await page.goto('/');

--- a/frontend/tests/e2e/sentiment-visibility.spec.ts
+++ b/frontend/tests/e2e/sentiment-visibility.spec.ts
@@ -3,7 +3,7 @@ import { test, expect } from '@playwright/test';
 import { waitForAuth } from './helpers/auth-helper';
 import { skipWithoutDataApis } from './helpers/data-api-guard';
 
-test.describe('Sentiment Data Visibility', () => {
+test.describe('Sentiment Data Visibility', { tag: '@external-api' }, () => {
   test.setTimeout(30000);
 
   test.beforeEach(async () => {


### PR DESCRIPTION
## Summary
- Tag 22 external-API tests (3 files) with `@external-api` for Playwright grep filtering
- Exclude `@external-api` from PR checks via `--grep-invert` so Tiingo/Finnhub APIs are never hit on PRs
- Create `nightly-e2e.yml` scheduled workflow (2am UTC daily, `--workers=1`, `--retries=1`) for real API validation
- Add README badge for nightly run staleness detection

## Architecture

```
Tier 1: PR Checks (every PR)
  └── --grep-invert "@external-api" → excludes real API tests
  └── Uses mocked data only

Tier 2: Nightly (2am UTC daily)
  └── --grep "@external-api" → runs only real API tests
  └── --workers=1 (serial, rate-limit friendly)
  └── GitHub secrets for API keys
```

## Verification
- [x] `--grep @external-api` matches 110 tests (22 × 5 projects) across 3 files
- [x] `--grep-invert @external-api` matches 1015 remaining tests
- [x] Total test count unchanged (1125)
- [x] Both YAML files pass syntax validation
- [x] README badge added

## Test plan
- [x] Local `--list` verification for all grep combinations
- [x] YAML syntax validation (`yaml.safe_load`)
- [ ] CI PR checks run (should exclude external-api tests)
- [ ] Manual `workflow_dispatch` trigger for nightly workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)