### PR TITLE
fix(1368): Pin python-hcl2==7.3.1 — unblock deploy pipeline

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -51,4 +51,4 @@ pytest-playwright>=0.7.2  # Pytest fixtures for Playwright (0.7.2 adds pytest 9.
 playwright>=1.49.0        # Browser automation (requires: playwright install)
 
 # Terraform parsing - Feature 075 (validation gaps)
-python-hcl2>=4.3.0
+python-hcl2==7.3.1  # Pinned: 8.x wraps all identifiers in literal quotes, breaking HCL parsing tests


### PR DESCRIPTION
## Summary
- Pin `python-hcl2==7.3.1` in `requirements-dev.txt` (was `>=4.3.0`)
- v8.1.2 wraps all HCL identifiers in literal double-quotes, breaking CORS tests
- Caused 3 consecutive deploy pipeline failures (preprod never deployed)

## Root Cause
`requirements-dev.txt` had `python-hcl2>=4.3.0`. CI resolved to `8.1.2` which changed parsing behavior — all identifiers get wrapped in literal `"` characters. The CORS tests compare against unquoted strings, so every comparison failed.

## Test plan
- [x] All 5 `TestCORSNoWildcard` tests pass locally with 7.3.1
- [ ] Deploy pipeline unit tests pass in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)