### PR TITLE
fix(1376): bump CI Terraform 1.6.0 -> 1.9.8 (fix expired provider signing key)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -818,7 +818,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v4
         with:
-          terraform_version: 1.6.0
+          terraform_version: 1.9.8
 
       - name: Terraform Init (Preprod)
         run: |
@@ -1291,7 +1291,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v4
         with:
-          terraform_version: 1.6.0
+          terraform_version: 1.9.8
 
       - name: Get Preprod Infrastructure Outputs
         id: infra
@@ -1867,7 +1867,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v4
         with:
-          terraform_version: 1.6.0
+          terraform_version: 1.9.8
 
       - name: Terraform Init (Production)
         run: |


### PR DESCRIPTION
## Why

The Deploy Pipeline on `main` failed at `terraform init`:

```
Error while installing hashicorp/aws v5.100.0: error checking signature:
openpgp: key expired
```

Terraform **1.6.0** (Oct 2023) can no longer verify current AWS provider signatures after HashiCorp's provider-signing GPG key rotated out of its trust bundle. This blocks **every** deploy regardless of content — it stranded the just-merged WAF cost reduction (#903) and OAuth (#904) before apply.

## Fix

Bump all three `terraform_version` pins in `deploy.yml` to **1.9.8** (past the key rotation). Config requires only `>= 1.0` with AWS `~> 5.0`, so no HCL changes.

## Note

Applying with 1.9.8 stamps `terraform_version` into remote state; older CLIs can no longer run against it. Intended and fine for this project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)