### PR TITLE
fix(1377): gate Cognito OAuth IdP count on static list (unblock deploy)

### DIFF
--- a/infrastructure/terraform/modules/cognito/github.tf
+++ b/infrastructure/terraform/modules/cognito/github.tf
@@ -7,8 +7,13 @@
 # 2. Store client_id and client_secret in Secrets Manager
 # 3. Add callback URL: https://{domain}.auth.{region}.amazoncognito.com/oauth2/idpresponse
 
+# count gates on the STATIC enabled_identity_providers list (plan-time known).
+# It must NOT depend on github_client_id, which is sourced from a Secrets
+# Manager data source and is unknown until apply — Terraform forbids
+# count/for_each depending on apply-time-unknown values. The client_id value
+# still flows into provider_details below, where apply-time-unknown is allowed.
 resource "aws_cognito_identity_provider" "github" {
-  count = var.github_client_id != "" ? 1 : 0
+  count = contains([for p in var.enabled_identity_providers : lower(p)], "github") ? 1 : 0
 
   user_pool_id  = aws_cognito_user_pool.main.id
   provider_name = "GitHub"

--- a/infrastructure/terraform/modules/cognito/google.tf
+++ b/infrastructure/terraform/modules/cognito/google.tf
@@ -5,8 +5,13 @@
 # 2. Store client_id and client_secret in Secrets Manager
 # 3. Add callback URL: https://{domain}.auth.{region}.amazoncognito.com/oauth2/idpresponse
 
+# count gates on the STATIC enabled_identity_providers list (plan-time known).
+# It must NOT depend on google_client_id, which is sourced from a Secrets
+# Manager data source and is unknown until apply — Terraform forbids
+# count/for_each depending on apply-time-unknown values. The client_id value
+# still flows into provider_details below, where apply-time-unknown is allowed.
 resource "aws_cognito_identity_provider" "google" {
-  count = var.google_client_id != "" ? 1 : 0
+  count = contains([for p in var.enabled_identity_providers : lower(p)], "google") ? 1 : 0
 
   user_pool_id  = aws_cognito_user_pool.main.id
   provider_name = "Google"


### PR DESCRIPTION
## Why

The deploy (after the TF 1.9.8 fix let `init` pass) now fails at `terraform refresh`:

```
Error: Invalid count argument
  on modules/cognito/github.tf line 11:
  count = var.github_client_id != "" ? 1 : 0
The "count" value depends on resource attributes that cannot be determined until apply
```

Feature 1370 (#904) wired `github/google_client_id` from a `data.aws_secretsmanager_secret_version` that reads secrets **created in the same apply**, so the value is unknown at plan time. Terraform forbids `count`/`for_each` from depending on apply-time-unknown values. This aborts the whole apply — stranding the WAF cost teardown (#903).

## Fix

Gate `count` on the **static** `enabled_identity_providers` list (plan-time known). The `client_id`/`client_secret` still flow into `provider_details`, where apply-time-unknown is fine. This matches the user pool client's `supported_identity_providers`, which already uses the same static list.

```hcl
count = contains([for p in var.enabled_identity_providers : lower(p)], "github") ? 1 : 0
```

## Behavior

`cognito_identity_providers` is unset in `preprod.tfvars` → `[]` → both IdPs `count = 0` → OAuth stays dormant until an operator **both** adds the provider to the list **and** populates the secret. `terraform validate` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)