### PR TITLE
fix(1378): CloudFront WAF teardown phase 1 — disassociate, keep ACL

### DIFF
--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -990,7 +990,10 @@ module "cloudfront_sse" {
 # Independent from the API Gateway WAF (REGIONAL scope, Feature 1254).
 
 module "waf_cloudfront" {
-  count  = var.enable_waf ? 1 : 0
+  # Existence gated separately from enable_waf so the ACL can be kept alive
+  # while CloudFront disassociates (Phase 1), then deleted (Phase 2). See
+  # var.enable_cloudfront_waf.
+  count  = var.enable_cloudfront_waf ? 1 : 0
   source = "./modules/waf"
 
   environment  = var.environment

--- a/infrastructure/terraform/preprod.tfvars
+++ b/infrastructure/terraform/preprod.tfvars
@@ -62,3 +62,11 @@ enable_waf = false
 # bill $0.10 each beyond the 10-alarm free tier. Disabled to stay near free
 # tier. Core monitoring-module alarms and the SNS topic remain.
 enable_extended_cloudwatch_alarms = false
+
+# CloudFront WAF teardown — PHASE 1 (disassociate, keep the ACL).
+# enable_waf=false already drops web_acl_id from the CloudFront distribution.
+# Keep the ACL itself alive (true) for this apply so Terraform doesn't try to
+# delete it while CloudFront is still propagating the disassociation, which
+# fails with WAFAssociatedItemException. Once this deploy reaches
+# Status=Deployed, PHASE 2 sets this to false to delete the orphaned ACL.
+enable_cloudfront_waf = true

--- a/infrastructure/terraform/variables.tf
+++ b/infrastructure/terraform/variables.tf
@@ -217,3 +217,17 @@ variable "enable_extended_cloudwatch_alarms" {
   type        = bool
   default     = true
 }
+
+# Controls ONLY the existence of the CloudFront-scoped WAF Web ACL, decoupled
+# from enable_waf (which controls association). Deleting a CloudFront WAF is a
+# two-step transition: the distribution must first drop web_acl_id and finish
+# a global redeploy (~10-15 min) before the ACL can be deleted, or AWS returns
+# WAFAssociatedItemException. Phase 1: enable_waf=false (disassociate) +
+# enable_cloudfront_waf=true (keep ACL). Phase 2: enable_cloudfront_waf=false
+# (delete the now-orphaned ACL). Defaults true to match enable_waf for fresh
+# stacks where both create together.
+variable "enable_cloudfront_waf" {
+  description = "Whether the CloudFront-scoped WAF Web ACL resource exists. Decoupled from enable_waf to allow safe two-phase teardown (disassociate, then delete)."
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
## Why

The cost deploy (#903) deleted the regional WAF + alarms fine, but failed deleting the **CloudFront-scoped WAF**:

```
WAFAssociatedItemException: AWS WAF couldn't perform the operation because
your resource is ... associated with another resource.
```

Deleting a CloudFront WAF is a two-step transition: the distribution must drop `web_acl_id` **and finish a global redeploy** (~10-15 min) before the ACL can be deleted. `enable_waf=false` asked Terraform to disassociate **and** delete in one apply, racing the two.

## What (Phase 1 of 2)

Decouple CloudFront WAF *existence* from *association* via a new `var.enable_cloudfront_waf`:

- `main.tf`: `module.waf_cloudfront` count now gates on `enable_cloudfront_waf`.
- `preprod.tfvars`: `enable_waf=false` (drops `web_acl_id` from the distribution) **+** `enable_cloudfront_waf=true` (keeps the ACL). This apply **only disassociates** — no delete, no race.

## Phase 2 (follow-up PR)

Once this deploy reaches `Status=Deployed`, flip `enable_cloudfront_waf=false` to delete the now-orphaned ACL. That recovers the last ~$21/mo.

Already banked from #903: regional WAF (~$21/mo) + ~29 alarms (~$3/mo). `terraform validate` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)