### PR TITLE
fix(1378): add moved block for waf_cloudfront count migration (Phase 1 retry)

### DIFF
--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -1018,6 +1018,18 @@ module "waf_cloudfront" {
   }
 }
 
+# Feature 1378: state migration for the count added above. Before count,
+# resources lived at module.waf_cloudfront.*; adding count (even at 1) moves
+# them to module.waf_cloudfront[0].*. Without this block Terraform plans a
+# destroy+recreate of the live WebACL, which deadlocks: the destroy fails with
+# WAFAssociatedItemException (CloudFront still references it) and the recreate
+# fails with WAFDuplicateItemException. This is idempotent — once count=0
+# (Phase 2) deletes the ACL, the block becomes a no-op.
+moved {
+  from = module.waf_cloudfront
+  to   = module.waf_cloudfront[0]
+}
+
 # ===================================================================
 # Module: SNS Topic (for Analysis Triggers)
 # ===================================================================


### PR DESCRIPTION
## Why

Phase 1 (#909) failed at `terraform apply`. Adding `count` to `module.waf_cloudfront` without a `moved` block made Terraform plan a **destroy + recreate** of the live CloudFront WebACL instead of just disassociating it:

```
module.waf_cloudfront.aws_wafv2_web_acl.main:    Destroying...
module.waf_cloudfront[0].aws_wafv2_web_acl.main: Creating...
Error: deleting WAFv2 WebACL: WAFAssociatedItemException
Error: creating WAFv2 WebACL: WAFDuplicateItemException
```

The destroy deadlocked (CloudFront still references the ACL) and the recreate failed (the physical ACL still exists = duplicate). Verified against live AWS: WAF `7db84507` still exists and CloudFront `EBROYRE5NRUTV` still has it as `WebACLId` — nothing was disassociated.

## Fix

Module-level `moved` block so Terraform recognizes the existing resources migrated to `[0]` (no destroy/recreate). With Phase 1 tfvars unchanged (`enable_waf=false`, `enable_cloudfront_waf=true`), this apply will:

- migrate state (no API call)
- drop `web_acl_id` from the CloudFront distribution (disassociate; Terraform waits for Status=Deployed)
- keep the WAF ACL alive

Phase 2 then flips `enable_cloudfront_waf=false` to delete the now-unassociated ACL cleanly. The block is idempotent and becomes a no-op once count=0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)