### PR TITLE
fix(configs): config delete silently broken in prod (snake_case/camelCase mapping)

### DIFF
--- a/frontend/src/lib/api/configs.ts
+++ b/frontend/src/lib/api/configs.ts
@@ -3,33 +3,115 @@ import type {
   Configuration,
   ConfigurationList,
   CreateConfigRequest,
+  TickerConfig,
   UpdateConfigRequest,
 } from '@/types/config';
+
+// M1 WI-5: the backend speaks snake_case (config_id, timeframe_days, ...), the
+// frontend types are camelCase, and client.ts does a bare response.json() with
+// no transform. Previously configsApi cast the raw response straight to the
+// camelCase type, so `configId`/`updatedAt` were ALWAYS undefined — the delete
+// dialog (gated on `!!configId`) never opened and dates rendered "Invalid Date".
+// It stayed hidden because the only path that exercised delete lost its session
+// on reload (broken local mock) and skipped it. Map explicitly, both directions.
+
+/** Raw snake_case configuration as returned by the backend. */
+interface RawConfiguration {
+  config_id: string;
+  name: string;
+  tickers: TickerConfig[];
+  timeframe_days: number;
+  include_extended_hours: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+interface RawConfigurationList {
+  configurations: RawConfiguration[];
+  max_allowed: number;
+}
+
+function mapConfiguration(raw: RawConfiguration): Configuration {
+  return {
+    configId: raw.config_id,
+    name: raw.name,
+    tickers: raw.tickers ?? [],
+    timeframeDays: raw.timeframe_days,
+    includeExtendedHours: raw.include_extended_hours,
+    createdAt: raw.created_at,
+    updatedAt: raw.updated_at,
+  };
+}
+
+function mapConfigurationList(raw: RawConfigurationList): ConfigurationList {
+  return {
+    configurations: (raw.configurations ?? []).map(mapConfiguration),
+    maxAllowed: raw.max_allowed,
+  };
+}
+
+/**
+ * Map a camelCase create/update request to the snake_case body the backend
+ * expects. Without this, `timeframe_days` / `include_extended_hours` were never
+ * sent, so the backend silently fell back to defaults (7 days, no extended
+ * hours) and the user's chosen settings were dropped.
+ */
+function toConfigBody(
+  req: CreateConfigRequest | UpdateConfigRequest
+): Record<string, unknown> {
+  const body: Record<string, unknown> = {};
+  if (req.name !== undefined) body.name = req.name;
+  if (req.tickers !== undefined) body.tickers = req.tickers;
+  if (req.timeframeDays !== undefined) body.timeframe_days = req.timeframeDays;
+  if (req.includeExtendedHours !== undefined) {
+    body.include_extended_hours = req.includeExtendedHours;
+  }
+  return body;
+}
 
 export const configsApi = {
   /**
    * List all configurations for the current user
    */
-  list: () =>
-    api.get<ConfigurationList>('/api/v2/configurations'),
+  list: async (): Promise<ConfigurationList> => {
+    const raw = await api.get<RawConfigurationList>('/api/v2/configurations');
+    return mapConfigurationList(raw);
+  },
 
   /**
    * Get a single configuration by ID
    */
-  get: (configId: string) =>
-    api.get<Configuration>(`/api/v2/configurations/${configId}`),
+  get: async (configId: string): Promise<Configuration> => {
+    const raw = await api.get<RawConfiguration>(
+      `/api/v2/configurations/${configId}`
+    );
+    return mapConfiguration(raw);
+  },
 
   /**
    * Create a new configuration
    */
-  create: (config: CreateConfigRequest) =>
-    api.post<Configuration>('/api/v2/configurations', config),
+  create: async (config: CreateConfigRequest): Promise<Configuration> => {
+    const raw = await api.post<RawConfiguration>(
+      '/api/v2/configurations',
+      toConfigBody(config)
+    );
+    return mapConfiguration(raw);
+  },
 
   /**
    * Update an existing configuration
    */
-  update: (configId: string, updates: UpdateConfigRequest) =>
-    api.patch<Configuration>(`/api/v2/configurations/${configId}`, updates),
+  update: async (
+    configId: string,
+    updates: UpdateConfigRequest
+  ): Promise<Configuration> => {
+    const raw = await api.patch<RawConfiguration>(
+      `/api/v2/configurations/${configId}`,
+      toConfigBody(updates)
+    );
+    return mapConfiguration(raw);
+  },
 
   /**
    * Delete a configuration

--- a/frontend/tests/e2e/helpers/clean-state.ts
+++ b/frontend/tests/e2e/helpers/clean-state.ts
@@ -46,14 +46,17 @@ export async function createTestConfig(page: Page, name: string): Promise<void> 
 
   const mockConfigId = `mock-config-${Date.now()}`;
   const now = new Date().toISOString();
+  // M1 WI-5: mocks MUST mirror the real backend contract (snake_case). They
+  // previously used camelCase, which masked the configsApi mapping bug — the
+  // real API returns snake_case and configsApi now maps it.
   const mockConfig = {
-    configId: mockConfigId,
+    config_id: mockConfigId,
     name,
     tickers: [{ symbol: 'AAPL', name: 'Apple Inc', exchange: 'NASDAQ' }],
-    timeframeDays: 30,
-    includeExtendedHours: false,
-    createdAt: now,
-    updatedAt: now,
+    timeframe_days: 30,
+    include_extended_hours: false,
+    created_at: now,
+    updated_at: now,
   };
 
   // Mock configurations endpoint — handles both GET (list) and POST (create).
@@ -71,7 +74,7 @@ export async function createTestConfig(page: Page, name: string): Promise<void> 
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify({ configurations: [mockConfig], maxAllowed: 5 }),
+        body: JSON.stringify({ configurations: [mockConfig], max_allowed: 5 }),
       });
     } else {
       await route.continue();

--- a/frontend/tests/unit/lib/api/configs.test.ts
+++ b/frontend/tests/unit/lib/api/configs.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { configsApi } from '@/lib/api/configs';
+import { api } from '@/lib/api/client';
+
+// Mock the API client
+vi.mock('@/lib/api/client', () => ({
+  api: {
+    get: vi.fn(),
+    post: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+const mockGet = api.get as unknown as ReturnType<typeof vi.fn>;
+const mockPost = api.post as unknown as ReturnType<typeof vi.fn>;
+const mockPatch = api.patch as unknown as ReturnType<typeof vi.fn>;
+
+// Raw backend shape is snake_case; the mapper must produce camelCase.
+const rawConfig = {
+  config_id: 'cfg-123',
+  name: 'Tech Giants',
+  tickers: [{ symbol: 'AAPL', name: 'Apple Inc', exchange: 'NASDAQ' }],
+  timeframe_days: 30,
+  include_extended_hours: true,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-02T00:00:00Z',
+};
+
+describe('configsApi mapping (M1 WI-5)', () => {
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => vi.resetAllMocks());
+
+  describe('list', () => {
+    it('maps snake_case list response to camelCase (config_id -> configId)', async () => {
+      mockGet.mockResolvedValueOnce({
+        configurations: [rawConfig],
+        max_allowed: 5,
+      });
+
+      const result = await configsApi.list();
+
+      expect(result.maxAllowed).toBe(5);
+      const cfg = result.configurations[0];
+      // The bug: these were undefined before the mapper existed.
+      expect(cfg.configId).toBe('cfg-123');
+      expect(cfg.updatedAt).toBe('2026-01-02T00:00:00Z');
+      expect(cfg.timeframeDays).toBe(30);
+      expect(cfg.includeExtendedHours).toBe(true);
+      expect(cfg.tickers[0].symbol).toBe('AAPL');
+    });
+
+    it('tolerates a missing configurations array', async () => {
+      mockGet.mockResolvedValueOnce({ max_allowed: 2 });
+      const result = await configsApi.list();
+      expect(result.configurations).toEqual([]);
+      expect(result.maxAllowed).toBe(2);
+    });
+  });
+
+  describe('get', () => {
+    it('maps a single snake_case config to camelCase', async () => {
+      mockGet.mockResolvedValueOnce(rawConfig);
+      const cfg = await configsApi.get('cfg-123');
+      expect(cfg.configId).toBe('cfg-123');
+      expect(cfg.createdAt).toBe('2026-01-01T00:00:00Z');
+    });
+  });
+
+  describe('create', () => {
+    it('sends a snake_case body and maps the snake_case response', async () => {
+      mockPost.mockResolvedValueOnce(rawConfig);
+
+      const cfg = await configsApi.create({
+        name: 'Tech Giants',
+        tickers: ['AAPL'],
+        timeframeDays: 30,
+        includeExtendedHours: true,
+      });
+
+      // Request body must be snake_case (backend ignored camelCase -> defaults).
+      const [, body] = mockPost.mock.calls[0];
+      expect(body).toEqual({
+        name: 'Tech Giants',
+        tickers: ['AAPL'],
+        timeframe_days: 30,
+        include_extended_hours: true,
+      });
+      // Response mapped.
+      expect(cfg.configId).toBe('cfg-123');
+    });
+  });
+
+  describe('update', () => {
+    it('sends only the provided fields in snake_case', async () => {
+      mockPatch.mockResolvedValueOnce(rawConfig);
+
+      await configsApi.update('cfg-123', { timeframeDays: 7 });
+
+      const [, body] = mockPatch.mock.calls[0];
+      expect(body).toEqual({ timeframe_days: 7 });
+    });
+  });
+});


### PR DESCRIPTION
## The bug (production, not just tests)

The backend returns `config_id` / `timeframe_days` / `created_at` (snake_case); the frontend `Configuration` type is camelCase (`configId`, `updatedAt`); and `client.ts` does a bare `response.json()` with no transform. `configsApi` cast the raw response straight to the camelCase type, so **`configId` and `updatedAt` were always `undefined`**:

- The config **delete confirmation dialog is gated on `!!deletingConfigId`** → clicking delete did **nothing**, in production.
- Dates rendered "Updated Invalid Date".
- `config-list` used `key={config.configId}` → React "unique key prop" warnings.

The request side had the mirror gap: `timeframeDays` / `includeExtendedHours` were sent camelCase, so the backend ignored them and used defaults — the user's chosen settings were silently dropped on create.

## Why it went unnoticed

`config-crud` E2E "passed" by accident: its cleanup reloads `/configs`, the (previously broken) local mock minted a *new* anonymous user on reload, the config vanished, and delete was skipped. The E2E config mocks were also camelCase, masking the contract mismatch. The M1 WI-5 change (correct session persistence + honest local mock) made the reload keep the session, so delete was finally exercised — and this bug surfaced.

## Fix

Explicit `mapConfiguration` (snake→camel, response) and `toConfigBody` (camel→snake, request) in `configsApi` for list/get/create/update. Aligned the E2E config mocks (`createTestConfig`) to the real snake_case contract.

## Verification
- New unit tests lock the mapper (list/get/create/update, both directions): `tests/unit/lib/api/configs.test.ts`.
- Full local E2E suite: **182 passed / 0 failed / 23 skipped** (config-crud now genuinely deletes; no regressions).
- Typecheck + eslint clean.

Note: alerts have the same latent snake_case gap (out of scope here) — flagged separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)