### PR TITLE
[HOLD] infra(m1-wi6): enable Google Cognito IdP (merge only AFTER secret populated)

### DIFF
--- a/infrastructure/terraform/preprod.tfvars
+++ b/infrastructure/terraform/preprod.tfvars
@@ -70,3 +70,16 @@ enable_extended_cloudwatch_alarms = false
 # fails with WAFAssociatedItemException. Once this deploy reaches
 # Status=Deployed, PHASE 2 sets this to false to delete the orphaned ACL.
 enable_cloudfront_waf = true
+
+# M1 WI-6: enable Google as a Cognito social identity provider.
+# Google-only per Q-M1-1 (GitHub's IdP points at the GitHub Actions OIDC issuer
+# and is a known-broken follow-up — do NOT add "GitHub" here).
+#
+# SEQUENCING (critical): the Cognito Google IdP (modules/cognito/google.tf) and
+# the Lambda's ENABLED_OAUTH_PROVIDERS (main.tf:138, derived from the secret's
+# client_id being non-empty) both take effect at `terraform apply`. Populate
+# preprod/sentiment-analyzer/google-oauth (client_id/client_secret) BEFORE the
+# apply that includes this line, so the IdP and the enabled-providers env land
+# together. Secret-without-IdP yields Cognito "Invalid state"; IdP-without-secret
+# yields a broken provider.
+cognito_identity_providers = ["Google"]


### PR DESCRIPTION
## ⚠️ DO NOT MERGE until the google-oauth secret is populated

Draft on purpose. `deploy.yml` runs `terraform apply -auto-approve` on every push to `main`, so merging this **before** the secret exists would create a Google Cognito IdP with empty credentials.

## What this does
Adds `cognito_identity_providers = ["Google"]` to `preprod.tfvars`. On the next apply this:
1. Creates the Cognito Google identity provider (`modules/cognito/google.tf`, gated on `"google"` in the list).
2. Together with a populated secret, sets the dashboard Lambda's `ENABLED_OAUTH_PROVIDERS` (`main.tf:138`, derived from the secret's `client_id != ""`) → `/api/v2/auth/oauth/urls` returns Google → the signin page renders the Google button.

Google-only per **Q-M1-1** (GitHub's IdP targets the GitHub Actions OIDC issuer — known-broken follow-up, out of M1).

## Owner sequence before marking ready
1. Google Cloud Console → OAuth **Web** client. Redirect URI: `https://preprod-sentiment-218795110243.auth.us-east-1.amazoncognito.com/oauth2/idpresponse`; scopes `email`, `profile`, `openid`.
2. `aws secretsmanager put-secret-value --secret-id preprod/sentiment-analyzer/google-oauth --secret-string '{"client_id":"…","client_secret":"…"}'`
3. **Then** mark this PR ready → merge → auto-apply. Watch the plan for unexpected **dashboard Lambda** changes (Issue #491 drift); stop and import first if seen.
4. `./scripts/verify-oauth-deploy.sh preprod`.

Verified current state at authoring: secret `client_id` empty, zero Cognito IdPs, app client supports only `COGNITO`, `ENABLED_OAUTH_PROVIDERS` unset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)