### PR TITLE
ci(m1-wi6): pre-apply guard blocks poisoned Google Cognito IdP (FR-8)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -783,6 +783,42 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ vars.AWS_REGION }}
 
+      # M1 WI-6 (spec 1375, FR-8): fail the apply if Google is enabled in tfvars while
+      # the google-oauth secret's client_id is empty. Without this, a premature merge of
+      # the tfvars line auto-applies a poisoned Cognito Google IdP (empty creds) that
+      # modules/cognito/google.tf's lifecycle ignore_changes[client_secret] cannot repair.
+      # HCL-aware (comment-stripped), not a naive grep. Runs post-cred, pre-plan.
+      - name: OAuth enablement guard (Preprod)
+        run: |
+          set -euo pipefail
+          # Comment-stripped assignment line for cognito_identity_providers.
+          ASSIGN="$(sed -E 's/#.*$//' preprod.tfvars \
+            | grep -E '^[[:space:]]*cognito_identity_providers[[:space:]]*=' || true)"
+          if echo "$ASSIGN" | grep -qiE '"google"'; then
+            GOOGLE_ENABLED=1
+          else
+            GOOGLE_ENABLED=0
+          fi
+
+          CLIENT_ID="$(aws secretsmanager get-secret-value \
+            --secret-id preprod/sentiment-analyzer/google-oauth \
+            --region "${{ vars.AWS_REGION }}" \
+            --query SecretString --output text 2>/dev/null \
+            | jq -r '.client_id // ""' 2>/dev/null || echo "")"
+
+          if [ "$GOOGLE_ENABLED" = "1" ] && [ -z "$CLIENT_ID" ]; then
+            echo "::error::OAuth enablement guard FAILED — Google is enabled in preprod.tfvars but the"
+            echo "::error::google-oauth secret client_id is EMPTY. Applying now would create a poisoned"
+            echo "::error::Cognito Google IdP (empty creds) that ignore_changes[client_secret] cannot repair."
+            echo "Populate the secret first:"
+            echo "  aws secretsmanager put-secret-value --secret-id preprod/sentiment-analyzer/google-oauth \\"
+            echo "    --region ${{ vars.AWS_REGION }} --secret-string '{\"client_id\":\"…\",\"client_secret\":\"…\"}'"
+            echo "See specs/1375-wi6-google-oauth-enablement/plan.md (owner runbook)."
+            exit 1
+          fi
+          if [ -n "$CLIENT_ID" ]; then HAS_ID=yes; else HAS_ID=no; fi
+          echo "PASS: OAuth enablement guard (google_enabled=$GOOGLE_ENABLED, secret_client_id_present=$HAS_ID)."
+
       - name: Upload Lambda Packages to S3 (Preprod)
         run: |
           SHA="${{ needs.build.outputs.artifact-sha }}"


### PR DESCRIPTION
## What
Adds a pre-apply guard to `deploy-preprod` that **fails the run if `cognito_identity_providers` enables Google in `preprod.tfvars` while the `google-oauth` secret's `client_id` is empty.**

## Why
`deploy.yml` auto-applies terraform on merge to main. `modules/cognito/google.tf` gates the Google IdP `count` on the tfvars list only (not `client_id`), and `lifecycle { ignore_changes = [provider_details["client_secret"]] }` means an IdP created with **empty creds cannot be repaired** by a later secret update — it needs a manual taint/replace. A premature merge of the tfvars line while the secret is empty would **permanently poison** the preprod Google IdP.

Converts "keep PR #932 draft" from discipline into an actual control (spec 1375: FR-8 / EC-1 / EC-2 / R-4).

## Behavior
- Runs post-AWS-creds, pre-`terraform plan`. HCL-aware (comment-stripped) match, not a naive grep.
- **No-op today** (no Google in tfvars → guard passes → normal deploy). Prod unaffected.

## Merge ordering
Merge this **before** PR #932 is marked ready.

Part of M1 WI-6. Full plan: `specs/1375-wi6-google-oauth-enablement/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)