### PR TITLE
test(m1-wi6): verifiable Google OAuth prep — spec, interactive capture, redaction

### DIFF
--- a/docs/cleanup-pristine/m1-verifier-convention.md
+++ b/docs/cleanup-pristine/m1-verifier-convention.md
@@ -90,10 +90,28 @@ an edit to this table in a signed commit — never at attestation time.
 | `auth-guest-04-alerts-redirect` | 5 | Guest bounced off `/alerts`: signin page rendered (Q-M1-2 resolved 2026-07-23: strip middleware gate, client-side guard redirects) | starts `/auth/signin`, query `redirect=%2Falerts` + `upgrade=true`; NOT `/alerts` | none additional required (redirect is client-side, no backend leg) | signin-page selector present | forbidden `anonymous 201 max_count:1` still holds across the spec; redirect via `router.replace` so no `/alerts` history entry |
 | `next-version.txt` | 4 | n/a (text artifact) | n/a | n/a | n/a | installed Next.js >= 14.2.25; guest set re-captured green against bumped build |
 | `auth-oauth-01-signin-buttons` | 6 | Google button visible on signin page | `/auth/signin` | `GET /api/v2/auth/oauth/urls 200` (non-empty providers) | Google button selector | |
-| `auth-oauth-02-callback-return` | 6 | Callback completing (loading/redirect state acceptable) | `/auth/callback*` | `POST /api/v2/auth/oauth/callback 200` | — | |
+| `auth-oauth-02-callback-return` | 6 | Callback completing (loading/redirect state acceptable) | `/auth/callback*` **or** `/` (transient client-side nav; `main_status` may be null) | `POST /api/v2/auth/oauth/callback 200` (**this auth-log leg is the gate, not the screenshot URL**) | — | WI-6 amendment (a)+(e): capture_mode interactive; verifier trace-checks `id_token.iss = accounts.google.com` before trace destruction |
 | `auth-oauth-03-identity` | 6 | UserMenu shows non-Guest display name or masked email; session chip in open menu | `/` | none additional | UserMenu, text NOT "Guest" | |
-| `auth-oauth-04-post-reload` | 6 | Same identity as 03 after F5 | `/` | `POST /api/v2/auth/refresh 200` | identity probe equal to step-03 | forbidden: zero `anonymous 201` in oauth spec; TRACE SPOT-CHECK |
-| `auth-oauth-05-alerts-page` | 6 | Alerts page rendered for the signed-in Google user | ends `/alerts` | none additional | named alerts-page selector present | |
+| `auth-oauth-04-post-reload` | 6 | Same identity as 03 after F5 | `/` | `POST /api/v2/auth/refresh 200` | identity probe equal to step-03 (lineage-tied to row-02 login) | forbidden: `anonymous 201` **max_count:1** (one inherent pre-login guest mint — amendment (d)); TRACE SPOT-CHECK |
+| `auth-oauth-05-alerts-page` | 6 | Alerts page rendered for the signed-in Google user | ends `/alerts` | none additional | named alerts-page selector present (`h1:has-text("Alerts")`) | lineage-tied to row-02 login |
+
+### WI-6 amendments (feature 1375, signed pre-capture per this document's rule that a WI refines its own rows via a signed table edit — never at attestation time)
+
+- **(a)** Row `auth-oauth-02` `page_url` tolerance `{/auth/callback*, /}`; the `POST /oauth/callback 200`
+  auth-log leg is the gate (the callback page is transient and may have redirected to `/` by screenshot
+  time; `main_status` may be null on client-side nav).
+- **(b)** `capture_mode: interactive` for `auth-oauth.spec.ts` — Google bot-detects automation, so rows
+  02–05 are captured once, headed, with a real human Google login in a clean context. Not headless-repeatable.
+- **(c)** Rows 03–05 identity MUST be lineage-tied to the row-02 login (same run/session), not an
+  arbitrary non-guest cookie. The attestation reason states the session origin is the row-02 Google login.
+- **(d)** Row `auth-oauth-04` forbidden rule is `anonymous 201` `max_count:1` (was "zero"). The root-layout
+  `SessionProvider` (`frontend/src/app/layout.tsx`) mints one inherent guest on the clean-context signin
+  load; `verify.forbid` counts spec-wide at teardown and cannot be scoped post-login, so the "no silent
+  re-guest" guarantee is carried by the row-04 identity-equality probe. A second `anonymous 201` fails.
+- **(e)** Row `auth-oauth-02` trace spot-check (restore-critical class): the verifier confirms in the raw
+  trace, BEFORE it is destroyed, both `POST /oauth/callback 200` AND that the returned `id_token`'s `iss`
+  claim = `accounts.google.com` — proving a genuine Google leg rather than a reused Cognito session. The
+  trace is NEVER sealed (it carries a refresh token); redact `code`/token fields before sealing (FR-9).
 
 ## Attestation contents
 

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -11,6 +11,12 @@
 /playwright/.cache/
 /test-results/
 
+# OAuth verification: never commit auth/session artifacts or raw traces (they carry
+# live tokens). Sealed evidence is redacted PNGs + manifest + attestation only (WI-6 FR-9).
+/tests/e2e/.auth/
+**/storageState*.json
+**/trace.zip
+
 # Next.js
 /.next/
 /out/

--- a/frontend/tests/e2e/auth-oauth.spec.ts
+++ b/frontend/tests/e2e/auth-oauth.spec.ts
@@ -1,0 +1,172 @@
+// Target: Customer Dashboard (Next.js/Amplify)
+/**
+ * M1 WI-6: Google OAuth sign-in, verifiable on preprod.
+ *
+ * Canonical rows auth-oauth-01..05 (docs/cleanup-pristine/m1-verifier-convention.md,
+ * as amended for WI-6: capture_mode=interactive, row-02 page_url {/auth/callback*, /}
+ * gated on POST /oauth/callback 200, rows 03-05 lineage-tied to the row-02 login,
+ * row-04 forbidden anonymous 201 max_count:1).
+ *
+ * WHY THIS IS INTERACTIVE, NOT HEADLESS (spec 1375, AR#1):
+ * Google bot-detects automated browsers on its consent screen, so rows 02-05 cannot
+ * be produced by a repeatable headless run. This spec is captured ONCE, HEADED, with a
+ * real human completing the Google login in a CLEAN browser context (cookies cleared,
+ * so the Google leg genuinely runs and no stale Cognito state is reused). Attested
+ * capture_mode: interactive. The verifier proves the identity is really Google by
+ * checking id_token.iss = accounts.google.com in the raw trace before it is destroyed.
+ *
+ * DO NOT run this before WI-6 is deployed (PR #932 applied + google-oauth secret
+ * populated). Before enablement, /oauth/urls is empty and the button is absent: a red
+ * here is EXPECTED, not a spec defect.
+ *
+ * RUN (preprod, headed, one interactive login):
+ *   PREPROD_FRONTEND_URL=https://main.d29tlmksqcx494.amplifyapp.com VERIFICATION=1 \
+ *     npx playwright test auth-oauth --project="Desktop Chrome" --headed
+ */
+import { test, expect } from './helpers/verification';
+
+// 3 minutes: a human completes the Google consent screen mid-test.
+test.setTimeout(180_000);
+
+test.describe('auth-oauth: Google sign-in (interactive capture)', () => {
+  test('Google user signs in, identity survives reload, reaches /alerts', async ({
+    page,
+    context,
+    verify,
+  }) => {
+    // One inherent pre-login guest mint is allowed: the root-layout SessionProvider
+    // (app/layout.tsx) mints an anonymous session on the clean-context signin load.
+    // A SECOND would mean a signed-in reload silently re-guested (the real regression).
+    verify.forbid({
+      method: 'POST',
+      path: '/api/v2/auth/anonymous',
+      status: 201,
+      max_count: 1,
+    });
+
+    // Clean context so the Google leg truly runs (R-3: no reused Cognito session).
+    await context.clearCookies();
+
+    // Observe auth response bodies/statuses via LISTENER only (interception is banned
+    // + detected on preprod). Normalizes API Gateway stage prefixes like /{stage}/api/..
+    type AuthObs = { path: string; status: number; user_id?: string };
+    const auth: AuthObs[] = [];
+    page.on('response', (r) => {
+      let pathname: string;
+      try {
+        const raw = new URL(r.url()).pathname;
+        const apiIdx = raw.indexOf('/api/');
+        pathname = apiIdx !== -1 ? raw.slice(apiIdx) : raw;
+      } catch {
+        return;
+      }
+      if (!pathname.startsWith('/api/v2/auth/')) return;
+      const status = r.status();
+      const rec: AuthObs = { path: pathname, status };
+      auth.push(rec);
+      if (pathname.endsWith('/anonymous') || pathname.endsWith('/refresh')) {
+        r.json()
+          .then((b: { user_id?: string }) => (rec.user_id = b.user_id))
+          .catch(() => {});
+      }
+    });
+
+    const waitForAuth = async (
+      pred: (a: AuthObs) => boolean,
+      timeout = 170_000
+    ): Promise<AuthObs> => {
+      const deadline = Date.now() + timeout;
+      // eslint-disable-next-line no-constant-condition
+      while (true) {
+        const hit = auth.find(pred);
+        if (hit) return hit;
+        if (Date.now() > deadline)
+          throw new Error('timed out waiting for a matching auth request');
+        await page.waitForTimeout(500);
+      }
+    };
+
+    // ── Row 01: Google button visible on signin; /oauth/urls 200 non-empty ──
+    await page.goto('/auth/signin');
+    await page.waitForLoadState('networkidle');
+    const urls = auth.find((a) => a.path.endsWith('/oauth/urls'));
+    expect(
+      urls?.status,
+      'GET /oauth/urls returned 200 (run this AFTER WI-6 is deployed)'
+    ).toBe(200);
+    const googleButton = page.getByRole('button', {
+      name: /Continue with Google/i,
+    });
+    await expect(
+      googleButton,
+      'Google button rendered (providers non-empty)'
+    ).toBeVisible();
+    await verify.shot('signin-buttons', {
+      expected_ui_state:
+        'Signin page shows "Continue with Google"; GET /oauth/urls 200 non-empty providers',
+      probe: { selector: 'text=Continue with Google' },
+    });
+
+    // ── ACTION REQUIRED: human completes the Google login ──
+    // Clicking triggers window.location.href = authorize_url (full nav to Cognito →
+    // Google). The owner signs in with the test Google account on the real consent
+    // screen. Playwright waits for the callback POST to land.
+    // eslint-disable-next-line no-console
+    console.log(
+      '\n\n>>> ACTION REQUIRED: complete the Google sign-in in the browser window. <<<\n\n'
+    );
+    await googleButton.click();
+
+    // ── Row 02: callback completes — POST /oauth/callback 200 is the real gate ──
+    // (page_url may be /auth/callback* OR already / by screenshot time — amendment (a))
+    const callback = await waitForAuth((a) => a.path.endsWith('/oauth/callback'));
+    expect(callback.status, 'POST /oauth/callback returned 200').toBe(200);
+    await verify.shot('callback-return', {
+      expected_ui_state:
+        'OAuth callback completed: POST /oauth/callback 200 in auth log (page may have redirected to /)',
+    });
+
+    // Land on the dashboard for the identity probes.
+    await page.waitForURL((u) => new URL(u).pathname === '/', { timeout: 30_000 });
+    await page.waitForLoadState('networkidle');
+
+    // ── Row 03: UserMenu shows a non-Guest identity ──
+    const trigger = page.locator('[data-testid="user-menu-trigger"]').first();
+    await expect(trigger).toBeVisible();
+    const identityRow03 = (await trigger.innerText()).trim();
+    expect(identityRow03, 'signed-in identity is not "Guest"').not.toBe('Guest');
+    await verify.shot('identity', {
+      expected_ui_state:
+        'Header UserMenu shows the Google display name / masked email (NOT "Guest")',
+      probe: { selector: '[data-testid="user-menu-trigger"]' },
+    });
+
+    // ── Row 04: same identity after F5; POST /refresh 200; no second anonymous ──
+    const authCountBeforeReload = auth.length;
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+    await verify.shot('post-reload', {
+      expected_ui_state:
+        'After F5, still the same Google identity; POST /refresh 200; no new anonymous 201',
+      probe: { selector: '[data-testid="user-menu-trigger"]' },
+    });
+    const identityRow04 = (await trigger.innerText()).trim();
+    expect(identityRow04, 'identity unchanged across reload').toBe(identityRow03);
+    const refreshedAfterReload = auth
+      .slice(authCountBeforeReload)
+      .some((a) => a.path.endsWith('/refresh') && a.status === 200);
+    expect(refreshedAfterReload, 'reload restored via POST /refresh 200').toBe(true);
+
+    // ── Row 05: signed-in Google user reaches /alerts (WI-5 gate lets them through) ──
+    await page.goto('/alerts');
+    await page.waitForLoadState('networkidle');
+    expect(new URL(page.url()).pathname, 'authenticated user stays on /alerts').toBe(
+      '/alerts'
+    );
+    await verify.shot('alerts-page', {
+      expected_ui_state:
+        'Alerts page rendered for the signed-in Google user (page_url ends /alerts)',
+      probe: { selector: 'h1:has-text("Alerts")' },
+    });
+  });
+});

--- a/scripts/redact-oauth-evidence.py
+++ b/scripts/redact-oauth-evidence.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Redact secret-bearing fields from a WI-6 OAuth verification manifest before sealing.
+
+Milestone 1, WI-6 (spec 1375), FR-9. A sealed evidence commit is GPG-signed and
+append-only — the worst possible place for a live credential. The verification
+manifest records `auth_requests` as {method, path, status} only (no bodies, no
+tokens), so the one real leak vector is a step's `page_url` carrying the OAuth
+`?code=` (and, defensively, `state`/token params). This script scrubs those in
+place and refuses to leave anything token-shaped behind.
+
+The raw Playwright trace (which DOES carry tokens) is never sealed — it is
+gitignored and destroyed after the verifier's local spot-check (FR-7). This
+script only touches the manifest that gets committed.
+
+Usage:
+    python scripts/redact-oauth-evidence.py <manifest.json> [--check]
+
+    (default)  redact in place, print what changed
+    --check    exit non-zero if anything sensitive is present (no writes); use
+               as a pre-seal gate in CI or before `git commit -S`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+# Query params that must never appear in sealed evidence.
+SENSITIVE_QUERY_KEYS = {"code", "state", "access_token", "id_token", "refresh_token"}
+REDACTED = "REDACTED"
+
+# Token-shaped strings anywhere in the JSON (belt-and-suspenders): a JWT (three
+# base64url segments) or a long opaque bearer. Kept deliberately conservative so
+# it does not maul ordinary ids.
+_JWT = re.compile(r"\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{5,}\b")
+
+
+def redact_url(url: str) -> tuple[str, list[str]]:
+    """Return (clean_url, removed_keys). Strips SENSITIVE_QUERY_KEYS from the query."""
+    parts = urlsplit(url)
+    if not parts.query:
+        return url, []
+    pairs = parse_qsl(parts.query, keep_blank_values=True)
+
+    # A param needs redaction only if it is sensitive AND not already redacted,
+    # so re-running (or --check on an already-clean manifest) is a no-op.
+    def needs(k: str, v: str) -> bool:
+        return k.lower() in SENSITIVE_QUERY_KEYS and v != REDACTED
+
+    removed = [k for k, v in pairs if needs(k, v)]
+    if not removed:
+        return url, []
+    cleaned = [(k, REDACTED if needs(k, v) else v) for k, v in pairs]
+    return urlunsplit(parts._replace(query=urlencode(cleaned))), removed
+
+
+def scrub(node: object, changes: list[str]) -> object:
+    """Recursively redact page_url query secrets and any token-shaped strings."""
+    if isinstance(node, dict):
+        out: dict = {}
+        for key, value in node.items():
+            if key == "page_url" and isinstance(value, str):
+                cleaned, removed = redact_url(value)
+                if removed:
+                    changes.append(f"page_url: stripped {sorted(set(removed))}")
+                out[key] = cleaned
+            else:
+                out[key] = scrub(value, changes)
+        return out
+    if isinstance(node, list):
+        return [scrub(v, changes) for v in node]
+    if isinstance(node, str) and _JWT.search(node):
+        changes.append("token-shaped string redacted")
+        return _JWT.sub(REDACTED, node)
+    return node
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("manifest", help="path to {spec}.manifest.json")
+    ap.add_argument(
+        "--check",
+        action="store_true",
+        help="fail (non-zero) if anything sensitive is present; do not write",
+    )
+    args = ap.parse_args()
+
+    try:
+        with open(args.manifest, encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"ERROR: cannot read manifest: {exc}", file=sys.stderr)
+        return 2
+
+    changes: list[str] = []
+    cleaned = scrub(data, changes)
+
+    if args.check:
+        if changes:
+            print("FAIL: sealed manifest still contains sensitive data:")
+            for c in changes:
+                print(f"  - {c}")
+            return 1
+        print("PASS: no sensitive fields present in manifest.")
+        return 0
+
+    if not changes:
+        print("No sensitive fields found; manifest unchanged.")
+        return 0
+
+    with open(args.manifest, "w", encoding="utf-8") as fh:
+        json.dump(cleaned, fh, indent=2)
+        fh.write("\n")
+    print(f"Redacted {len(changes)} item(s) in {args.manifest}:")
+    for c in changes:
+        print(f"  - {c}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/specs/1375-wi6-google-oauth-enablement/plan.md
+++ b/specs/1375-wi6-google-oauth-enablement/plan.md
@@ -1,0 +1,149 @@
+# Plan: M1 WI-6 — Verifiable Google OAuth Enablement (preprod)
+
+**Feature:** 1375-wi6-google-oauth-enablement · **Spec:** ./spec.md · **Branch:** `wi6-enable-google-idp`
+
+## Technical Context
+
+- **Language/stack:** Terraform (HCL, AWS provider ~>5.0); TypeScript/Playwright (Next.js frontend E2E).
+- **Change surface is tiny by design.** OAuth code + secret-wiring already merged (Features 1169–1193,
+  1370). Confirmed in-tree: `main.tf:119` secret data source → `local.google_oauth.client_id` →
+  `local.enabled_oauth_providers` (`main.tf:138`) → Lambda `ENABLED_OAUTH_PROVIDERS` (`main.tf:468`),
+  and → Cognito module `google_client_id/secret` (`main.tf:159`). IdP resource `google.tf:13`, `count`
+  gated on `contains([...lower(p)...],"google")` from `var.cognito_identity_providers` only.
+- **The only infra delta:** `cognito_identity_providers = ["Google"]` in `preprod.tfvars` (staged, HOLD
+  commit `9629502`, draft PR #932).
+- **Live baseline (this session):** `/oauth/urls` `{"providers":{},"state":""}`; IdPs `[]`; secret empty;
+  exact hosted-UI error `Login option is not available. Please try another one`.
+- **Deploy mechanism:** `deploy.yml` runs `terraform apply -auto-approve` on push to main → **merging
+  #932 IS the apply.** Secret must be populated first (FR-1) so all four parts land together.
+- **Test harness:** `frontend/tests/e2e/helpers/verification.ts` (`verify.shot`/`verify.forbid`/response
+  listener; `VERIFICATION=1`→`trace:'on'`). Template: `auth-guest.spec.ts`. **No route interception**
+  (banned + detected on preprod targets).
+- **Verifier authority:** `docs/cleanup-pristine/m1-verifier-convention.md` (rows `auth-oauth-01..05`).
+
+## The Four-Parts Sequence (the anti-whack-a-mole model)
+
+```
+OWNER (gated)                         AUTOMATED (single terraform apply on #932 merge)
+─────────────                         ─────────────────────────────────────────────
+1. Google client  ─┐
+   (client_id/secret)                  ┌─ part 3: Cognito Google IdP created
+2. put-secret-value ┼─ secret populated ┤    (google.tf count←tfvars list; creds←secret)
+   into google-oauth │  BEFORE apply     └─ part 4: Lambda ENABLED_OAUTH_PROVIDERS="google"
+                     │                        (local←secret.client_id != "")
+3. mark #932 ready ──┘  ── merge ⇒ deploy.yml terraform apply ⇒ parts 3+4 consistent together
+```
+Testing between steps is the trap: any probe before the single apply sees an inconsistent subset and
+errors. **Do not test mid-sequence.** Verify only after the apply, via `verify-oauth-deploy.sh`.
+
+## Owner Runbook (FR-2 — single authoritative copy)
+
+> Secrets stay on the owner's machine; never pasted into chat or committed.
+
+**Step A — Google Cloud console (create the OAuth client):** *(personal Gmail is fine for preprod — no
+separate account needed. DQ-2/DQ-3 resolved.)*
+1. Google Cloud console (signed in with the personal Gmail) → create a project e.g. `sentiment-preprod`
+   (or reuse one). APIs & Services.
+2. **OAuth consent screen** → User type **External** → fill app name/support email → **add the personal
+   Gmail as a Test user**. Leave in **Testing** (do NOT need "Publish"). *Gotcha: External+Testing only
+   admits listed test users; a missing test user yields `access_denied` at capture (R-1/T010).*
+3. Credentials → *Create Credentials* → *OAuth client ID* → Application type **Web application**.
+4. **Authorized redirect URI** (exact, Cognito domain — NOT the Amplify URL):
+   `https://preprod-sentiment-218795110243.auth.us-east-1.amazoncognito.com/oauth2/idpresponse`
+5. (Scopes `email`, `profile`, `openid`.) Create → copy **Client ID** + **Client secret**.
+   *Note: the login Gmail becomes a federated user in the preprod pool with its real email — fine for
+   preprod verification.*
+
+**Step B — populate the secret (owner's terminal, preprod creds):**
+```bash
+aws secretsmanager put-secret-value \
+  --secret-id preprod/sentiment-analyzer/google-oauth \
+  --region us-east-1 \
+  --secret-string '{"client_id":"<CLIENT_ID>","client_secret":"<CLIENT_SECRET>"}'
+```
+Verify shape (no secret echoed): `aws secretsmanager get-secret-value --secret-id
+preprod/sentiment-analyzer/google-oauth --region us-east-1 --query 'SecretString' --output text | jq 'keys'`
+→ must show `["client_id","client_secret"]`.
+
+**Step C — release the hold:** mark draft PR #932 *Ready for review* → merge. deploy.yml auto-applies.
+FR-8 guard blocks the apply if the secret is still empty (belt-and-suspenders).
+
+**Step D — verify the deploy (after apply completes):**
+```bash
+./scripts/verify-oauth-deploy.sh preprod   # expects: Lambda env, Cognito IdP, /oauth/urls 200 ≥1 provider
+```
+Capture stdout → `docs/cleanup-pristine/evidence/m1/wi6-preprod/verify-oauth-deploy.txt`.
+
+## Implementation Approach
+
+### A. Infra (WI-6.3–6.5)
+- No terraform edits beyond the staged tfvars line. **Watch the apply plan for unexpected
+  `preprod-dashboard` Lambda changes (Issue #491 drift) — stop and `terraform import` if seen** (EC-3).
+- **FR-8 guard:** add a pre-apply check in the deploy workflow (before `terraform apply`) that reads the
+  `google-oauth` secret's `client_id` and fails if empty while `preprod.tfvars` contains `"Google"` in
+  `cognito_identity_providers`. Pure shell + `aws`/`jq`; no AWS resource. Delivered in its own small PR
+  (not #932) so #932 stays a clean single-line diff.
+- WAF integration gate will be RED for unrelated SQLi/XSS (EC-4) — expected; the deploy still succeeds.
+
+### B. Tests (WI-6.6 — `frontend/tests/e2e/auth-oauth.spec.ts`)
+- Copy the `auth-guest.spec.ts` structure: `import { test, expect } from './helpers/verification'`,
+  response listener (no interception). **`verify.forbid({method:'POST',
+  path:'/api/v2/auth/anonymous', status:201, max_count:1})`** — NOT 0. `SessionProvider` is in the ROOT
+  layout (`app/layout.tsx:54`), so a clean-context load of `/auth/signin` fires `useSessionInit` and
+  mints exactly one inherent pre-login guest (no cookie → `/refresh` fails → one `anonymous 201`). A
+  **second** mint would mean a signed-in reload silently re-guested — that's the real regression the rule
+  catches. The "session survived without re-guesting" guarantee is carried by the **row-04 identity
+  probe** (still the Google identity, `/refresh 200`, not "Guest"), since `forbid` counts across the
+  whole spec at teardown and cannot be scoped post-login.
+- **Row 01** (headless-capable): `goto('/auth/signin')`, assert `GET /oauth/urls 200` non-empty via
+  listener, `verify.shot('signin-buttons', {probe:{selector:'text=Continue with Google'}})`. The Google
+  button has **no `data-testid`** (C1) — probe by accessible name `Continue with Google`
+  (`oauth-buttons.tsx:65`).
+- **Run config (target=preprod):** the manifest self-labels `preprod` only if `PREPROD_FRONTEND_URL`
+  equals `https://main.d29tlmksqcx494.amplifyapp.com` exactly (`verification.ts:174-178`); the Playwright
+  `baseURL` (for `goto('/')`) must be the same. Any other value → `localhost-mock` → convention hard-fail.
+- **Rows 02–05** (headed interactive, one run): clean context → click Google → owner completes Google
+  login → callback. `verify.shot('callback-return')` gated on listener `POST /oauth/callback 200` (accept
+  page_url `{/auth/callback*, /}`). Then `identity`/`post-reload`(F5)/`alerts-page`, identity probes
+  lineage-checked against row 03.
+- Selectors: confirm the real Google-button `data-testid` in `oauth-buttons.tsx` and a signed-in
+  UserMenu identity probe during Stage-7 task authoring (don't guess).
+
+### C. Convention amendment (WI-6.6, pre-capture, signed)
+Edit `m1-verifier-convention.md` rows for `auth-oauth-02` (page_url tolerance + callback-POST gate),
+add `capture_mode: interactive` note and the rows 03–05 lineage requirement. Signed commit **before**
+capture (convention forbids attestation-time edits).
+
+### D. Attestation + seal (WI-6.7)
+Run with `VERIFICATION=1` → hand run dir + convention to an **independent verifier agent**. Verifier
+spot-checks `trace.zip` locally (row 04 restore), then trace destroyed. Redact (FR-9) → seal
+`attestation.json` + manifest + PNGs + `verify-oauth-deploy.txt` in a GPG-signed commit under
+`docs/cleanup-pristine/evidence/m1/wi6-preprod/`. `.gitignore` any storageState/auth artifacts.
+
+## Constitution / Standards Check
+
+| Gate | Status |
+|---|---|
+| No new AWS resources without asking | PASS — IdP is created by *existing* module code the tfvars line activates; no hand-authored net-new resource. FR-8 guard is shell, not infra. Watch plan for surprises. |
+| Google-only (Q-M1-1); never "GitHub" | PASS — tfvars is `["Google"]` only. |
+| GPG-signed commits; secrets never in git/chat | PASS — runbook keeps secrets on owner's machine; FR-9 redaction; `.gitignore` auth artifacts. |
+| Independent verifier; no self-attestation | PASS — FR-7 separate agent + local trace spot-check. |
+| No mocked auth on preprod target | PASS — no route interception; interactive real login. |
+| Branch/PR hygiene | PASS — #932 stays intact on this branch; FR-8 guard + specs land as separate PRs off fresh main. |
+
+## Adversarial Review #2
+
+Read the full suite (spec + plan) focusing on drift introduced by the Stage-4 clarifications and on
+cross-artifact consistency with the actual harness (`verification.ts`) and app (`SessionProvider`).
+
+| Severity | Drift / inconsistency | Resolution |
+|---|---|---|
+| **HIGH** | **Canonical convention vs. app reality.** Row `auth-oauth-04` mandates "zero `anonymous 201`," but root-layout `SessionProvider` (`app/layout.tsx:54`) mints one inherent guest on the clean-context signin load; `forbid` counts spec-wide at teardown (`verification.ts:322-330`) and cannot be scoped post-login. The rule as written would hard-fail on correct behavior. | Amend row-04 to `max_count:1` (amendment (d)); "no silent re-guest" carried by the row-04 identity-equality probe. Spec DoD + plan §B updated. |
+| **MEDIUM (drift from C1)** | plan §B referenced a `[data-testid=...google...]` selector; C1 established the button has **no** data-testid. | plan §B fixed to `text=Continue with Google` (accessible name, `oauth-buttons.tsx:65`). |
+| **MEDIUM** | Manifest `target` self-labels `preprod` only if `PREPROD_FRONTEND_URL` === the exact Amplify URL (`verification.ts:174-178`); a wrong/missing value silently yields `localhost-mock` → convention hard-fail, wasting a capture. | plan §B "Run config" note added; becomes an explicit Stage-7 task + a pre-capture assertion. |
+| **LOW** | Row-02 `auth_requests` are per-step (reset each `shot`); the callback POST must be captured in the step where it lands. | plan §B: fire the row-02 `shot` **after** the listener sees `POST /oauth/callback 200`. |
+| **LOW (consistency confirmed)** | redirect_uri `origin+pathname` = `.../auth/callback` (C3) matches the Cognito callback allowlist (EC-6); scopes `email profile openid` match `google.tf:23` and the runbook. | No action; verified consistent. |
+
+**Gate: 0 CRITICAL, 0 HIGH remaining.** The one HIGH (convention-vs-reality) is resolved by amendment
+(d) which lands in the same signed pre-capture convention edit already required. Drift from clarifications
+reconciled. Proceed to Stage 6.

--- a/specs/1375-wi6-google-oauth-enablement/spec.md
+++ b/specs/1375-wi6-google-oauth-enablement/spec.md
@@ -1,0 +1,266 @@
+# Spec: M1 WI-6 — Verifiable Google OAuth Enablement (preprod)
+
+**Feature:** 1375-wi6-google-oauth-enablement
+**Milestone:** GitHub Milestone #1 "Verifiable user-auth (non-SSE)", Work Item 6 (final item; M1 is 5/6).
+**Branch:** `wi6-enable-google-idp` (holds staged HOLD commit `9629502` / draft PR #932).
+**Target:** Customer Dashboard (Next.js/Amplify) on **preprod** — `https://main.d29tlmksqcx494.amplifyapp.com/`.
+**Status:** DRAFT (Stage 1 of battleplan).
+
+---
+
+## 1. Context & Framing
+
+This is **not** greenfield OAuth. The OAuth implementation already shipped and merged across
+Features 1169–1193 (federation fields, callback route, state/CSRF), 1245/1373 (button render
+gating), and 1370 (Secrets-Manager wiring in Terraform). WI-6 is **enablement + verifiable
+attestation** of that existing code on preprod — nothing more.
+
+The owner has been hitting recurring "whack-a-mole" OAuth errors. Root cause, confirmed by live
+probe this session: **Google OAuth is four coupled parts, none currently wired**, and testing
+between steps guarantees an error because the parts only become consistent at a single
+`terraform apply`.
+
+### The four coupled parts (live state, verified 2026-07-23)
+| Part | Mechanism | Current state |
+|---|---|---|
+| 1. Google OAuth client | Google Cloud console (web app; redirect = Cognito `/oauth2/idpresponse`) | **not created** (owner-gated) |
+| 2. Secret `preprod/sentiment-analyzer/google-oauth` | `{"client_id","client_secret"}` JSON | **empty** (`client_id=""`) |
+| 3. Cognito Google IdP | `modules/cognito/google.tf`, `count` gated on tfvars list | **absent** (`[]`) |
+| 4. Lambda `ENABLED_OAUTH_PROVIDERS` | `main.tf:138`, derived from secret's `client_id != ""` | **unset** |
+
+### Exact error captured (live probe + owner-confirmed screen)
+- Normal app flow: Google button **correctly hidden** — `GET /api/v2/auth/oauth/urls` → `{"providers":{},"state":""}` (200). No error reachable here.
+- Manual hosted-UI (`identity_provider=Google`, my probe): **`Login option is not available. Please try another one`** — 302 → 401 on the Cognito `/login` page, because the pool has zero IdPs.
+- **Owner's actual screen (confirmed 2026-07-23):** `https://preprod-sentiment-218795110243.auth.us-east-1.amazoncognito.com/error?error=Invalid%20state` — "An error was encountered with the requested page. / Invalid state". Cognito rejecting the OAuth `state` (CSRF) param at its own domain.
+
+Multiple symptoms, one root cause (nothing wired); the symptom depends on the entry path and on stale
+Cognito-domain state cookies (states are single-use — a refresh/back-button replay throws "Invalid
+state"). This is the whack-a-mole. The fix is **not** reactive config poking — it is landing all four
+parts in one apply, then testing through the real app button in a **fresh incognito context**.
+
+### Terraform reality (confirmed in current tree)
+Feature 1370's secret-wiring is **already merged**: `main.tf:119` reads the secret via
+`data.aws_secretsmanager_secret_version.google_oauth`; `local.google_oauth.client_id`
+(with a `try()` → empty fallback) feeds both `local.enabled_oauth_providers` (→ Lambda env)
+and the Cognito module's `google_client_id/secret`. **The only remaining infra delta is one
+tfvars line** — `cognito_identity_providers = ["Google"]` — already staged in HOLD commit `9629502`.
+
+---
+
+## 2. User Stories
+
+**US-1 (Owner — credential provisioning).** As the repo owner, I provision a Google OAuth web
+client and populate the `google-oauth` secret myself (secrets never enter chat or git), following
+a single crisp runbook, so that a subsequent deploy lights up all four parts together.
+
+**US-2 (Customer — sign in with Google).** As a customer on the preprod dashboard, I see a
+"Continue with Google" button on `/auth/signin`, complete Google consent, land back authenticated
+with a non-Guest identity that survives a page reload, and can reach `/alerts`.
+
+**US-3 (Independent verifier — attestation).** As a verifier who did **not** implement or run the
+tests, I judge the `auth-oauth-01..05` evidence against the canonical expected-state table, spot-check
+the raw Playwright trace for the restore-critical step, and seal a signed attestation — so "done"
+means independently proven, not self-asserted.
+
+---
+
+## 3. Functional Requirements
+
+- **FR-1 (single-apply consistency).** Enabling Google MUST make all four coupled parts consistent
+  in one `terraform apply`. The secret MUST be populated **before** the apply that adds the tfvars
+  line, so the IdP and `ENABLED_OAUTH_PROVIDERS` land together. (deploy.yml auto-applies on merge to
+  main → merging PR #932 IS the apply.)
+- **FR-2 (owner runbook).** Produce one authoritative, copy-pasteable runbook for the two
+  owner-gated steps (Google console client; `put-secret-value`) with the **exact** redirect URI,
+  scopes, secret id, and JSON shape. No secrets in the runbook examples.
+- **FR-3 (tfvars enablement).** The infra change is exactly `cognito_identity_providers = ["Google"]`
+  (Google-only per Q-M1-1; **never** add "GitHub" — its IdP points at the GitHub Actions OIDC issuer
+  and is known-broken). Delivered via draft PR #932, marked ready **only after** FR-1's secret is populated.
+- **FR-4 (deploy verification).** After the apply, `./scripts/verify-oauth-deploy.sh preprod` MUST
+  pass (Lambda env non-empty, Cognito IdP present, Lambda↔Cognito consistency, `/oauth/urls` 200 with
+  ≥1 provider). Its stdout is captured as `evidence/.../verify-oauth-deploy.txt`.
+- **FR-5 (instrumented specs).** Author `frontend/tests/e2e/auth-oauth.spec.ts` implementing
+  canonical rows `auth-oauth-01..05` using the existing `helpers/verification` harness
+  (`verify.shot`, `verify.forbid`, response listener — **no route interception**, banned on preprod).
+  Row 01 (button visible + `GET /oauth/urls 200` non-empty) is fully headless-automatable and has
+  no identity dependency. Rows 02–05 run inside the **single interactive capture** of FR-6.
+- **FR-6 (real-identity capture — HEADED, INTERACTIVE, single-window).** Rows 02–05 require a
+  genuine completed Google identity. Google bot-detects automated browsers on its consent screen, and
+  every headless path to a `POST /oauth/callback 200` is either blocked or a false-green via Cognito
+  hosted-UI session reuse. Therefore rows 02–05 are captured in **one headed run** where the owner
+  performs **one real interactive Google login** in a **clean browser context** (cookies cleared, so
+  the Google leg genuinely runs — no silent session reuse). All of rows 02→03→04→05 are captured in
+  that same run from that same login, so their identity is **lineage-tied** to the real Google auth
+  (rows 03–05 otherwise prove only "a non-guest session," not "Google"). The run is attested as
+  `capture_mode: interactive` — it is **not** headless-repeatable, and the attestation reason states
+  the session origin is the row-02 Google login. No route interception; no mocked auth on preprod
+  (convention hard-fail). See **Risk R-1** for provisioning and cadence.
+- **FR-7 (independent attestation + seal — NO token-bearing artifacts sealed).** Run with
+  `VERIFICATION=1` (trace on) so the verifier can spot-check row-04 restore from the raw trace. Hand
+  the run directory + the verifier convention to an **independent verifier agent** (never the
+  implementer). The verifier spot-checks `trace.zip` **locally**, then it is **destroyed — never
+  sealed**. Only these are sealed in a GPG-signed commit under
+  `docs/cleanup-pristine/evidence/m1/wi6-preprod/`: `attestation.json`, `{spec}.manifest.json`, the
+  step PNGs, and `verify-oauth-deploy.txt`. See **FR-9** for the redaction that makes those safe.
+- **FR-8 (pre-apply poison guard).** Add a lightweight CI/script guard (no AWS resource) that **fails
+  the plan/apply** if `cognito_identity_providers` contains "Google" while the `google-oauth` secret's
+  `client_id` is empty. Converts the EC-1 footgun (a premature #932 merge auto-applying a
+  poisoned-empty-creds IdP that `ignore_changes` then can't repair) from "discipline" into a blocked
+  merge. Runs in the deploy workflow before `terraform apply`.
+- **FR-9 (evidence redaction).** Before sealing, redact secret-bearing fields from the manifest and
+  any surviving artifact: row-02 `page_url` `code=` param, and any `access_token`/`id_token`/
+  `refresh_token` in captured bodies. The Playwright `storageState`/auth artifacts MUST be
+  `.gitignore`d and never placed in a sealed path. A sealed evidence commit must contain **zero live
+  credentials** (a signed, append-only commit is the worst possible place for a refresh token).
+
+## 4. Success Criteria (Definition of Done)
+
+DoD = all five canonical rows attested PASS by an independent verifier, plus the verify-script capture.
+Rows are authoritative in `docs/cleanup-pristine/m1-verifier-convention.md`:
+
+| Row | Must show | page_url | Required auth log | Probe |
+|---|---|---|---|---|
+| `auth-oauth-01-signin-buttons` | Google button visible | `/auth/signin` | `GET /oauth/urls 200` (non-empty providers) | Google button selector |
+| `auth-oauth-02-callback-return` | Callback completing | `/auth/callback*` **or** `/` (transient nav) | `POST /oauth/callback 200` (**this auth-log leg is the real gate**, not the screenshot URL) | — |
+| `auth-oauth-03-identity` | UserMenu non-Guest name / masked email | `/` | none additional | UserMenu text ≠ "Guest"; **same run/login as row 02** |
+| `auth-oauth-04-post-reload` | Same identity after F5 | `/` | `POST /refresh 200` | identity == step-03; **TRACE SPOT-CHECK**; forbidden: `anonymous 201` **max_count:1** (one inherent pre-login guest mint — see amendment (d)) |
+| `auth-oauth-05-alerts-page` | Alerts page rendered for signed-in Google user | ends `/alerts` | none additional | alerts-page selector; same run/login as row 02 |
+
+**Convention amendment required BEFORE capture (signed commit).** Per the convention, a WI may refine
+its own rows via a signed edit to the canonical table — never at attestation time. Before capture, amend
+`m1-verifier-convention.md` to record: (a) row-02 `page_url` tolerance `{/auth/callback*, /}` with the
+`POST /oauth/callback 200` leg as the gate (the callback page is transient and may have already
+redirected by screenshot time; `main_status` may be null on client-side nav); (b) `capture_mode:
+interactive` for the oauth spec (not headless-repeatable); (c) rows 03–05 identity must be lineage-tied
+to the row-02 login; **(d) row-04 forbidden rule `anonymous 201` `max_count:1` (was "zero")** — the
+global root-layout `SessionProvider` (`app/layout.tsx:54`) mints exactly one inherent guest on the
+clean-context signin load before login; `forbid` counts spec-wide at teardown and can't be scoped
+post-login, so the "no silent re-guest" guarantee is carried by the row-04 identity-equality probe;
+**(e) row-02 trace spot-check** — the verifier confirms in the raw trace (before destruction) both
+`POST /oauth/callback 200` and that the returned `id_token.iss = accounts.google.com`, proving a real
+Google leg rather than a reused Cognito session. This is the compensating control that makes
+`capture_mode: interactive` sound (AR#3). This amendment is itself part of WI-6's sealed record.
+
+Plus: `evidence/.../verify-oauth-deploy.txt` captured; overall verifier verdict `pass`;
+sealed in a GPG-signed commit; attestation hash-referenced from that commit; **zero live credentials in
+the sealed commit** (FR-9).
+
+## 5. Edge Cases & Failure Modes
+
+- **EC-1 early merge (secret empty).** If PR #932 applies while the secret is empty: `google.tf:14`
+  `count` gates on the tfvars list only, so a Google IdP **is** created with `client_id=""`;
+  `ENABLED_OAUTH_PROVIDERS` stays empty (button still hidden). Result: broken IdP invisible to the app
+  but changing the hosted-UI error. **Mitigation:** #932 stays DRAFT until the secret is populated (FR-1).
+- **EC-2 `ignore_changes` on `client_secret`.** `google.tf:34` ignores `provider_details.client_secret`
+  after create. If the IdP is ever created with an empty/wrong secret, a later secret fix will **not**
+  re-push through terraform — requires a resource taint/replace. Runbook must order secret-before-apply
+  to avoid ever creating it wrong.
+- **EC-3 Issue #491 dashboard-Lambda TF state drift.** If the apply's plan shows unexpected
+  `preprod-dashboard` Lambda changes, **stop and import first** — do not let auto-apply churn it.
+- **EC-4 WAF integration gate RED (red herring).** `tests/e2e/test_waf_protection.py` returns 200 not
+  403 for SQLi/XSS and fails **every** preprod deploy's integration gate. Unrelated to auth; the deploy
+  itself SUCCEEDS. Do not be derailed.
+- **EC-5 redirect URI mismatch.** Google client's authorized redirect URI must be **exactly**
+  `https://preprod-sentiment-218795110243.auth.us-east-1.amazoncognito.com/oauth2/idpresponse`
+  (Cognito domain, not the Amplify URL). A mismatch yields Google `redirect_uri_mismatch`.
+- **EC-6 callback-URL allowlist.** Cognito app-client callback URLs already include
+  `https://main.d29tlmksqcx494.amplifyapp.com/auth/callback`; confirm still present post-apply.
+
+## 6. Out of Scope (do not absorb)
+
+- **Prod rollout** (Google prod client, `prod.tfvars`) — separate follow-up (provisioning-plan W2/W10).
+- **GitHub IdP** — known-broken (Q-M1-1); never enable.
+- **Out-of-charter M1 debt** — WAF SQLi/XSS gate; alerts-API snake_case gap; magic-link descope
+  (Q-M1-4). Tracked separately; flag only if one blocks WI-6.
+- **Local-dev OAuth** (spec 1323), **frontend error-visibility hardening** (provisioning-plan W11) —
+  not required for the preprod DoD.
+
+## 7. Risks (the hard parts, named)
+
+- **R-1 (real Google identity vs. bot-detection) — the central risk.** Google blocks automated
+  browsers on its login/consent screen, so rows 02–05 cannot be produced by a repeatable headless run.
+  **Mitigation:** headed, interactive, single-window capture (FR-6). The owner performs one real Google
+  login (any Google account the owner controls — a throwaway or a dedicated `sentiment-preprod-test@`
+  is fine; it is used **interactively once per capture**, not stored as an automation credential).
+  **Cadence:** re-run is interactive each time; there is no persisted session to expire between runs
+  because each capture starts from a clean context and does a fresh login. **Owner dependency:** the
+  Google login account is an owner-gated prerequisite (added to §Owner-gated steps), distinct from the
+  OAuth *client* of FR-2.
+- **R-2 (credential leak into sealed history).** `trace:'on'` records full bodies incl. refresh
+  tokens; the row-02 callback URL embeds a Cognito `code`. A sealed, signed, append-only commit is the
+  worst place for these. **Mitigation:** FR-9 redaction + FR-7 (trace spot-checked locally then
+  destroyed, never sealed) + `.gitignore` for auth/storageState artifacts.
+- **R-3 (false green via session reuse).** A lingering Cognito hosted-UI session cookie can yield
+  `POST /oauth/callback 200` with no real Google leg. **Mitigation:** clean browser context per capture
+  (cookies cleared) so the Google leg genuinely runs; FR-6.
+- **R-4 (poisoned IdP from premature apply).** EC-1/EC-2: one premature "ready" on #932 with an empty
+  secret permanently poisons the IdP (`ignore_changes[client_secret]` blocks repair). **Mitigation:**
+  FR-8 automated pre-apply guard + #932 stays DRAFT until the secret is populated.
+- **R-5 (owner-observed "Invalid state").** Owner hit `/error?error=Invalid state` on the Cognito
+  domain. Consistent with the unwired state + a stale single-use state cookie from manual testing.
+  **Mitigation:** post-wiring, test only through the real app Google button in a **fresh incognito
+  context** (already required by R-3's clean context). **Watch:** if "Invalid state" recurs in a clean
+  context through the real app flow *after* enablement, that is a **Feature-1193 OAuth-state (CSRF) bug**,
+  not a wiring gap — escalate as a distinct defect at T010 capture, do not silently retry.
+
+## 8. Hard Constraints
+
+- No new AWS resources without asking (the Cognito IdP is created by *existing* module code the tfvars
+  line activates — not a net-new hand-authored resource; still, watch the plan).
+- All commits GPG-signed. Secrets never in chat or git.
+- Trust contract item 7: independent verifier + sealed evidence; implementer never self-attests.
+- Owner gates each push/merge cycle and performs the Google-console + `put-secret-value` steps.
+
+## 9. Owner-Gated Prerequisites (blocking; owner performs)
+
+1. **Google OAuth web client** (FR-2): create in Google Cloud console; authorized redirect URI exactly
+   `https://preprod-sentiment-218795110243.auth.us-east-1.amazoncognito.com/oauth2/idpresponse`; scopes
+   `email profile openid`; capture `client_id` + `client_secret`.
+2. **Populate the secret** (FR-1): `aws secretsmanager put-secret-value --secret-id
+   preprod/sentiment-analyzer/google-oauth --secret-string '{"client_id":"…","client_secret":"…"}'`
+   (owner runs locally; secret never enters chat/git).
+3. **Google login account for the interactive capture** (R-1): a Google account the owner controls, used
+   interactively once during the FR-6 headed capture. Not an automation credential; not stored.
+4. **Mark PR #932 ready → merge** (push-gate): only after step 2; deploy.yml auto-applies.
+
+## Adversarial Review #1
+
+Independent reviewer (separate agent, security-first) attacked spec.md. Findings and resolutions:
+
+| Severity | Finding | Resolution |
+|---|---|---|
+| CRITICAL | Row 02 (`POST /oauth/callback 200`) not honestly automatable headless — `code` requires a human past Google's bot-detected consent; session-reuse = false green. | **FR-6 rewritten** to headed interactive single-window capture; row 02 gated on the callback POST auth-log leg, `capture_mode: interactive`. Convention amendment required pre-capture. |
+| CRITICAL | Rows 03–05 prove only "a non-guest session," not "Google." | FR-6 + DoD table: rows 03–05 **lineage-tied** to the row-02 login (same run/session); attestation states origin. |
+| HIGH | `trace:'on'` + sealing bakes a live refresh token / callback `code` into permanent signed history. | **FR-7 + FR-9 added:** trace spot-checked locally then destroyed, never sealed; redact `code`/token fields; `.gitignore` auth artifacts; zero live creds in sealed commit. |
+| HIGH | `Risk R-1` was a dangling reference (no Risks section existed). | **§7 Risks added** (R-1..R-4) with concrete mitigations. |
+| HIGH | storageState origin unspecified; first-run seeding paradox; no owner for the Google test account. | Design pivoted **off** storageState-seeding to interactive login; §9 adds the Google login account as an owner-gated prerequisite (R-1). |
+| MEDIUM | EC-1/EC-2 poison-IdP guarded only by "keep #932 draft" (discipline, not a control). | **FR-8 added:** pre-apply CI guard fails the apply if tfvars has "Google" while the secret `client_id` is empty. |
+| MEDIUM | Row-02 `page_url`/`main_status` timing fragility (callback page redirects fast). | DoD table: row-02 `page_url` tolerance `{/auth/callback*, /}`, callback POST is the gate; recorded in the required convention amendment. |
+| MEDIUM | Cognito session reuse false green. | **R-3 + FR-6:** clean context per capture, fresh Google leg. |
+| LOW | Token expiry mid-run flake; FR-6 under-scoped into one bullet. | Interactive-per-run removes cross-run expiry; FR-6/§9/R-1 split the mechanics out. |
+| LOW (cleared) | `verify-oauth-deploy.sh` exists; google.tf count-gate + `ignore_changes` confirmed. | No action; verified, not assumed. |
+
+**Gate: 0 CRITICAL, 0 HIGH remaining.** Both CRITICALs resolved by the interactive-capture pivot;
+both token-leak/dangling-risk HIGHs resolved by FR-7/FR-9 and §7. Proceed to Stage 3 (Plan).
+
+## Clarifications
+
+Self-answered from the codebase (not asked interactively). Evidence cited.
+
+| # | Question | Answer | Evidence |
+|---|---|---|---|
+| C1 | Row-01 Google-button probe selector? | No `data-testid` on the button; probe by accessible name **`Continue with Google`** (`getByRole('button',{name:/Continue with Google/i})` or `text=Continue with Google`). | `oauth-buttons.tsx:65` `label:'Continue with Google'`; rendered `<Button>` (`:78`). |
+| C2 | How does row-01 know providers are non-empty? | Buttons render **iff** `hasOAuthProviders` (`availableProviders.length>0`), which comes straight from `GET /oauth/urls`. Button visible ⟺ providers non-empty. Also assert the 200 via the response listener. | `signin/page.tsx:53` `hasOAuthProviders`; `:81` `{hasOAuthProviders && <OAuthButtons/>}`; `:24` `authApi.getOAuthUrls()`. |
+| C3 | Row-02 endpoint + terminal route + redirect_uri? | Callback calls `handleCallback(code, provider, state, redirectUri)` → `POST /api/v2/auth/oauth/callback`; on success `router.push('/')`. `redirectUri = origin + pathname` = `https://main.d29…amplifyapp.com/auth/callback` (matches Cognito callback allowlist, EC-6). Confirms row-02 gate + page_url `{/auth/callback*, /}`. | `callback/page.tsx:114-125`. |
+| C4 | Rows 03–05 non-Guest identity probe? | `displayName = isAnonymous ? 'Guest' : user?.email?.split('@')[0] || 'User'` on `[data-testid="user-menu-trigger"]`; open menu shows masked `user.email`. Probe: trigger text ≠ "Guest"; menu shows email. | `user-menu.tsx:57-59, 75, 82, 108-112`. |
+| C5 | Does row-01 also require non-empty `state`? | No — the convention row requires **non-empty providers** only. `state` is the Feature-1193 CSRF token, exercised in the row-02 flow, not gated by row 01. | `m1-verifier-convention.md` row `auth-oauth-01`. |
+
+**Deferred questions — RESOLVED at the Phase 2 pause (2026-07-23):**
+- **DQ-1 (answered):** Owner's actual screen was `/error?error=Invalid state` on the Cognito domain (see
+  §1). Recorded; risk R-5 added; same root cause (unwired) — not a new blocker.
+- **DQ-2/DQ-3 (answered):** No preprod GCP project yet; owner has a personal Gmail only. **Decision:**
+  personal Gmail is sufficient for preprod — owns the GCP project AND is the capture login. Runbook Step A
+  expanded with project creation + consent-screen (External/Testing) + add-Gmail-as-test-user. A dedicated
+  account is a prod-time nicety, not required now.
+
+**No CRITICAL/HIGH depends on the deferred questions.** Proceed.

--- a/specs/1375-wi6-google-oauth-enablement/tasks.md
+++ b/specs/1375-wi6-google-oauth-enablement/tasks.md
@@ -1,0 +1,127 @@
+# Tasks: M1 WI-6 — Verifiable Google OAuth Enablement (preprod)
+
+**Feature:** 1375-wi6-google-oauth-enablement · **Spec:** ./spec.md · **Plan:** ./plan.md
+
+Legend: `[P]` = parallelizable with the owner-gated credential steps. Gate markers: 🔒 owner-gated.
+
+## Phase A — Pre-work (no owner gate; do before the merge)
+
+- **T001 [P] (FR-5, WI-6.6)** Author `frontend/tests/e2e/auth-oauth.spec.ts`. **Author-only before the
+  gate — do NOT execute against preprod before T008's apply**: `/oauth/urls` is empty and the Google
+  button absent until then, so a pre-gate run is red *by design*, not a spec defect (the mid-sequence
+  trap). Green execution happens only in T010.
+  - Header `// Target: Customer Dashboard (Next.js/Amplify)`; `import { test, expect } from
+    './helpers/verification'`; response listener (no `page.route`).
+  - `verify.forbid({method:'POST', path:'/api/v2/auth/anonymous', status:201, max_count:1})`.
+  - Row 01 (`signin-buttons`): `goto('/auth/signin')`; assert listener saw `GET /oauth/urls 200`
+    non-empty; `verify.shot('signin-buttons',{probe:{selector:'text=Continue with Google'}})`.
+  - Rows 02–05 in one interactive block: clean context → click Google → **owner completes Google login**
+    → `verify.shot('callback-return')` after listener sees `POST /oauth/callback 200`
+    → `shot('identity')` (probe `[data-testid="user-menu-trigger"]` text ≠ "Guest")
+    → F5 → `shot('post-reload')` (`/refresh 200`, identity == row-03)
+    → `goto('/alerts')` → `shot('alerts-page')`.
+- **T002 [P] (FR-5, C4)** During T001 authoring, confirm real selectors in-app (don't guess): signed-in
+  UserMenu identity probe (`user-menu.tsx:75/82`) and the alerts-page landmark selector. Record in T001.
+- **T003 [P] (FR-8, EC-1/EC-2, R-4)** Author the pre-apply poison guard: a shell check (`aws`+`jq`) that
+  fails if `preprod.tfvars` `cognito_identity_providers` contains "Google" while the `google-oauth`
+  secret's `client_id` is empty. **Placement (exact):** in the deploy-preprod job **after** "Configure
+  AWS Credentials", **before** "Terraform Plan" (so creds exist to read the secret and it *prevents*, not
+  just detects). **Match must be HCL-aware** (comment-stripped — a naive `grep "Google"` false-matches
+  the tfvars comment block), e.g. `terraform console`/`jq`-parse rather than `grep`. Only fails on the
+  exact poison combo (Google-in-tfvars + empty secret); prod unaffected (no Google in prod.tfvars). Ship
+  as its own small PR off fresh `origin/main` (keep #932 a clean one-line diff).
+- **T004 [P] (convention; ⛔ BLOCKS T010 — must be a signed commit BEFORE any capture)** Amend
+  `docs/cleanup-pristine/m1-verifier-convention.md` rows per plan: (a) row-02 `page_url {/auth/callback*,
+  /}` + callback-POST gate; (b) `capture_mode: interactive`; (c) rows 03–05 lineage-tied; (d) row-04
+  forbidden `anonymous 201 max_count:1`; **(e) row-02 trace spot-check (AR#3): the verifier confirms in
+  the raw trace, before destruction, both `POST /oauth/callback 200` AND that the returned `id_token`'s
+  `iss` = `accounts.google.com` — proving a real Google leg, not a reused Cognito session. This is the
+  compensating control that makes `capture_mode: interactive` sound.** Convention forbids attestation-time
+  edits, so this lands first.
+- **T005 [P] (FR-9, R-2)** Add `.gitignore` entries for Playwright `storageState`/auth artifacts and the
+  run's `trace.zip`. Author the seal-time redaction step and **enumerate exactly the sealed fields it
+  scrubs**: manifest step `page_url` (`code=` param), any `auth_requests`/body `access_token`/`id_token`/
+  `refresh_token`. **Also confirm the row-02 PNG does not render `code`/token text in-page** (screenshots
+  are viewport-only with no URL bar, so a raster leak is unlikely, but an in-page render would evade text
+  redaction). Sealed set must carry zero live creds.
+
+## Phase B — Owner-gated (🔒 blocking; owner performs; secrets never in chat/git)
+
+- **T006 🔒 (FR-2, runbook Step A, DQ-2/DQ-3)** Owner creates the Google OAuth **Web application** client;
+  redirect URI exactly `https://preprod-sentiment-218795110243.auth.us-east-1.amazoncognito.com/oauth2/idpresponse`;
+  scopes `email profile openid`; captures client_id/secret.
+- **T007 🔒 (FR-1, Step B)** Owner `put-secret-value` into `preprod/sentiment-analyzer/google-oauth`
+  (valid JSON `{"client_id","client_secret"}`); verifies `keys` == `["client_id","client_secret"]`.
+- **T008 🔒 (FR-3, Step C, EC-3)** Owner marks **PR #932 ready → merge**. deploy.yml auto-applies. FR-8
+  guard (T003) must be merged first so it can block a mis-sequenced apply. **Watch the plan for
+  unexpected `preprod-dashboard` Lambda changes (Issue #491) — stop and `terraform import` if seen.**
+
+## Phase C — Post-apply (automated after the single apply)
+
+- **T009 (FR-4, WI-6.5)** Run `./scripts/verify-oauth-deploy.sh preprod`; capture stdout →
+  `docs/cleanup-pristine/evidence/m1/wi6-preprod/verify-oauth-deploy.txt`. (Expect the unrelated WAF
+  integration gate RED, EC-4 — not a blocker.)
+- **T010 🔒 (FR-6, WI-6.7)** Owner-assisted **headed interactive** capture: `PREPROD_FRONTEND_URL` set to
+  the exact Amplify URL, Playwright `baseURL` same, `VERIFICATION=1`, clean context. Owner completes the
+  one real Google login. Produces the run dir (manifest + PNGs + trace).
+- **T011 (FR-7)** Hand the run dir + `m1-verifier-convention.md` to an **independent verifier agent**
+  (never the implementer). Verifier judges rows 01–05 vs the canonical table and, from the raw
+  `trace.zip` locally, spot-checks **both**: row-04 restore (`/refresh 200`, same user_id) **and row-02
+  authenticity (amendment (e)) — `POST /oauth/callback 200` present AND `id_token.iss =
+  accounts.google.com`.** Row-02's Google provenance is confirmed from ground truth, not the
+  implementer's manifest.
+- **T012 (FR-7, FR-9)** On PASS **and after** the T011 trace spot-checks are recorded in the
+  attestation: run the T005 redaction; **then destroy the trace** (never before the row-02 + row-04
+  checks); seal `attestation.json` + `{spec}.manifest.json` + step PNGs + `verify-oauth-deploy.txt` in a
+  **GPG-signed commit** under `docs/cleanup-pristine/evidence/m1/wi6-preprod/`. Verify zero live creds in
+  the diff before signing.
+- **T013** Update memory `m1-milestone-progress.md`: WI-6 done → **M1 6/6**. Note prod rollout + M1 debt
+  (WAF, alerts snake_case, magic-link) remain out of charter.
+
+## Analyze — Requirement → Task Coverage
+
+| Requirement | Task(s) | Covered |
+|---|---|---|
+| FR-1 single-apply consistency | T007, T008 | ✅ |
+| FR-2 owner runbook | plan §Runbook, T006 | ✅ |
+| FR-3 tfvars enablement (Google-only) | T008 (PR #932) | ✅ |
+| FR-4 deploy verification | T009 | ✅ |
+| FR-5 instrumented specs | T001, T002 | ✅ |
+| FR-6 real-identity headed capture | T010 | ✅ |
+| FR-7 independent attestation + seal | T011, T012 | ✅ |
+| FR-8 pre-apply poison guard | T003 | ✅ |
+| FR-9 evidence redaction | T005, T012 | ✅ |
+| EC-1/EC-2 poison IdP | T003 (guard) + T008 sequencing | ✅ |
+| EC-3 #491 drift | T008 (watch/import) | ✅ |
+| EC-4 WAF red herring | T009 (noted, not a blocker) | ✅ |
+| EC-5 redirect URI | T006 (exact URI) | ✅ |
+| EC-6 callback allowlist | C3 (already present) + T009 | ✅ |
+| DoD rows auth-oauth-01..05 | T001, T004, T010, T011 | ✅ |
+| Convention amendment (a-d) | T004 | ✅ |
+
+**Coverage: every FR and edge case maps to ≥1 task.** No orphan requirements; no task without a
+requirement. `verify-oauth-deploy.sh` (FR-4) and the OAuth code (all FRs' substrate) pre-exist.
+
+## Adversarial Review #3
+
+Independent reviewer read spec + plan + tasks together against ground truth (deploy.yml apply sequence,
+google.tf gate, main.tf wiring, live convention). Findings and resolutions:
+
+| Severity | Finding | Resolution |
+|---|---|---|
+| HIGH | Row-02 Google-authenticity was verifier-unconfirmable: trace destroyed after the row-04 check only, so the Google leg was judged from the implementer-built manifest — a self-assertion loophole in `capture_mode: interactive`. | **Amendment (e) added** (T004): verifier spot-checks row-02 in the trace — `POST /oauth/callback 200` + `id_token.iss = accounts.google.com` — before destruction. T011/T012 reordered so trace dies only after both checks. |
+| MEDIUM | FR-8 guard placement/match under-specified (needs creds; naive `grep "Google"` false-matches the tfvars comment). | T003: pinned to post-"Configure AWS Credentials"/pre-"Terraform Plan"; HCL-aware (comment-stripped) match. |
+| MEDIUM | T001 `[P]` for authoring but green execution is gated on T008's apply; risk of misreading a pre-gate red as a spec bug. | T001: "author-only; do not execute pre-gate; empty-providers red is expected." |
+| LOW | T004 is a hard precondition of T010, not a peer `[P]`. | T004 marked "⛔ BLOCKS T010". |
+| LOW | T005 didn't enumerate scrubbed fields or the in-page-render risk. | T005: field list enumerated + row-02 PNG in-page-render check added. |
+| (cleared) | FR-8 feasibility, T003/T008 merge-timeline safety, no surviving contradictions. | Reviewer confirmed guard is essential (not scope creep) and the merge timeline has no poison window. |
+
+**Highest-risk task: T010** (owner-assisted headed interactive capture) — single-shot, CI-irreproducible,
+three distinct waste/false-green modes (target-mislabel → `localhost-mock` hard-fail; Cognito session
+reuse → false green; trace token leak). Amendment (e) + the exact-URL config note are its guardrails.
+
+**Most likely rework:** a wasted/re-run interactive capture (T010) — target-mislabel silently
+downgrading the manifest to `localhost-mock`, or the row-02 authenticity check surfacing late. Both are
+now pre-empted by the plan §B run-config note and amendment (e).
+
+**Gate: 0 CRITICAL, 0 HIGH remaining. READY FOR IMPLEMENTATION.**


### PR DESCRIPTION
## What
WI-6 enablement + attestation harness. The OAuth **code already shipped** (Features 1169–1193, 1370); the only infra delta is PR #932's one tfvars line. This PR adds the verification prep, off fresh main:

- **`specs/1375-wi6-google-oauth-enablement/{spec,plan,tasks}.md`** — full battleplan artifacts (3 adversarial reviews, 0 CRITICAL / 0 HIGH), the owner runbook, and the four-parts single-apply sequencing model.
- **`frontend/tests/e2e/auth-oauth.spec.ts`** — canonical rows `auth-oauth-01..05`. **Headed interactive single-window capture**: Google bot-detects automation, so rows 02–05 run once with a real human login in a clean context, lineage-tied to the row-02 login.
- **`m1-verifier-convention.md`** amendments (a)–(e): row-02 `page_url` tolerance + callback-POST gate; `capture_mode: interactive`; rows 03–05 lineage; row-04 `anonymous 201 max_count:1` (root-layout SessionProvider mints one inherent guest); **row-02 trace check `id_token.iss = accounts.google.com`** before trace destruction (the interactive-capture integrity control).
- **`scripts/redact-oauth-evidence.py`** — strips `code`/token fields from the manifest before sealing (idempotent; `--check` gate). The raw trace is never sealed (it carries a refresh token).
- **`frontend/.gitignore`** — never commit `storageState`/auth artifacts or `trace.zip`.

## Why the interactive pivot
Rows 02–05 need a real completed Google identity, and Google blocks browser automation on its consent screen. Every headless path is either bot-blocked or a false-green via Cognito session reuse. One owner-performed headed login in a clean context is the honest, least-brittle answer — and the `iss=accounts.google.com` trace check keeps it verifier-confirmable, not self-asserted.

## Relationship to other PRs
- FR-8 pre-apply poison guard ships in **#933** (deploy.yml) — merge that before #932 is marked ready.
- Enablement is **#932** (the `["Google"]` tfvars line), still HELD until the `google-oauth` secret is populated.

No infrastructure change in this PR (specs/tests/docs only).

Part of M1 WI-6 (Milestone #1, final item).

🤖 Generated with [Claude Code](https://claude.com/claude-code)