### PR TITLE
fix(iam): deployer denied cognito-idp:CreateIdentityProvider — unblocks M1 WI-6 Google OAuth

### DIFF
--- a/.checkov.baseline
+++ b/.checkov.baseline
@@ -27,6 +27,7 @@
                 {
                     "resource": "aws_iam_policy_document.ci_deploy_monitoring",
                     "check_ids": [
+                        "CKV_AWS_109",
                         "CKV_AWS_111",
                         "CKV_AWS_356"
                     ]

--- a/infrastructure/terraform/ci-user-policy.tf
+++ b/infrastructure/terraform/ci-user-policy.tf
@@ -601,6 +601,12 @@ data "aws_iam_policy_document" "ci_deploy_monitoring" {
   # Note: These require unconditional access for Terraform state refresh AND
   # for bootstrap operations on resources that don't yet have the required tags.
   # TagResource/UpdateUserPoolClient are here to avoid chicken-egg with tag conditions.
+  #
+  # Feature 1375 (M1 WI-6 Google OAuth): IdentityProvider write actions must be
+  # unconditional too. AWS does NOT populate the cognito-idp:ResourceTag/Name
+  # condition key in the auth context for CreateIdentityProvider (the IdP sub-resource
+  # doesn't exist yet), so a tag-gated grant is an effective deny — same chicken-egg
+  # as UpdateUserPoolClient. Update/Delete kept alongside for lifecycle symmetry.
   statement {
     sid    = "CognitoIDPList"
     effect = "Allow"
@@ -619,7 +625,11 @@ data "aws_iam_policy_document" "ci_deploy_monitoring" {
       "cognito-idp:TagResource",
       "cognito-idp:UntagResource",
       "cognito-idp:ListTagsForResource",
-      "cognito-idp:UpdateUserPoolClient"
+      "cognito-idp:UpdateUserPoolClient",
+      # Feature 1375: unconditional IdP writes (tag condition unenforceable at create)
+      "cognito-idp:CreateIdentityProvider",
+      "cognito-idp:UpdateIdentityProvider",
+      "cognito-idp:DeleteIdentityProvider"
     ]
     resources = ["*"]
   }
@@ -653,6 +663,14 @@ data "aws_iam_policy_document" "ci_deploy_monitoring" {
 
   # Cognito Identity Pools - List/Get operations (require wildcard)
   # Note: These require unconditional access for Terraform state refresh
+  #
+  # Feature 1375 (M1 WI-6): CreateIdentityPool is the identity-pool twin of the
+  # CreateIdentityProvider chicken-egg above — AWS can't evaluate the
+  # cognito-identity:ResourceTag/Name condition on a pool that doesn't exist yet,
+  # so the tag-gated grant is an effective deny. Create/Update/Delete kept here for
+  # lifecycle symmetry. NOTE: SetIdentityPoolRoles is deliberately NOT here — it
+  # stays tag-scoped in CognitoIdentity (role-assignment is the privilege-escalation
+  # surface; keep it constrained).
   statement {
     sid    = "CognitoIdentityList"
     effect = "Allow"
@@ -660,7 +678,11 @@ data "aws_iam_policy_document" "ci_deploy_monitoring" {
       "cognito-identity:ListIdentityPools",
       "cognito-identity:DescribeIdentityPool",
       "cognito-identity:GetIdentityPoolRoles",
-      "cognito-identity:ListTagsForResource"
+      "cognito-identity:ListTagsForResource",
+      # Feature 1375: unconditional pool writes (tag condition unenforceable at create)
+      "cognito-identity:CreateIdentityPool",
+      "cognito-identity:UpdateIdentityPool",
+      "cognito-identity:DeleteIdentityPool"
     ]
     resources = ["*"]
   }


### PR DESCRIPTION
## Why

The M1 WI-6 Google OAuth go-live apply (#932, merged) **failed at terraform apply**:

```
AccessDenied: cognito-idp:CreateIdentityProvider on userpool/us-east-1_9wiDkddRF
  user: sentiment-analyzer-preprod-deployer
```

Live state stayed **clean** (no half-state): the IdP create was the first cognito op, was denied, and terraform aborted before touching the live OAuth path (`/oauth/urls` empty, Cognito IdPs `[]`, dashboard client still `["COGNITO"]`).

## Root cause

`ci-user-policy.tf` grants `cognito-idp:CreateIdentityProvider` **only** inside the tag-gated `CognitoIDP` statement (`StringLike cognito-idp:ResourceTag/Name = ["*-sentiment-*"]`). AWS does **not** populate that condition key in the auth context for `CreateIdentityProvider` — the IdP sub-resource doesn't exist yet — so the grant is an **effective deny**. Identical chicken-egg already solved for `UpdateUserPoolClient`, which sits unconditionally in `CognitoIDPList`.

## Fix

- Add `Create/Update/DeleteIdentityProvider` to the unconditional `CognitoIDPList` statement (matches the `UpdateUserPoolClient` precedent).
- Preempt the identical **latent twin**: `cognito-identity:CreateIdentityPool` → added to `CognitoIdentityList`.
- `SetIdentityPoolRoles` **deliberately left tag-scoped** — role assignment is the privilege-escalation surface.
- Checkov `CKV_AWS_109` baselined for `ci_deploy_monitoring` (+1 line; unconstrained deployer grants are inherent and already baselined).

No net-new AWS resources; +6 action strings within the `ci_deploy_monitoring` 6144-char budget.

## Apply path

Deployer self-applies (`ci_deploy_iam` grants `iam:CreatePolicyVersion` on `policy/CIDeploy*`). Policy-update + IdP-create land in the same apply with no dep edge, so the **first** post-merge apply may transient-deny on IAM propagation — self-heals on one re-run.

## Follow-up (not in this PR)

Neither existing IAM validator catches condition-gated-create effective-deny. A condition-aware IAM validator is warranted (`/add-methodology`, template repo).