### PR TITLE
fix(deploy): CI syncs dashboard Lambda ENABLED_OAUTH_PROVIDERS — M1 WI-6 Part B (durability)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1043,6 +1043,26 @@ jobs:
           echo "⏳ Step 2: Waiting for function update to complete..."
           aws lambda wait function-updated --function-name "$FUNC_NAME"
 
+          # Feature 1375: sync ENABLED_OAUTH_PROVIDERS onto $LATEST BEFORE publishing.
+          # Terraform cannot manage this env var (modules/lambda ignore_changes=[environment],
+          # Feature 1290), and update-function-code does not touch env — so without this the
+          # OAuth enable/disable derived from the secret never reaches the served alias version.
+          # update-function-configuration REPLACES the whole Variables map, so we merge.
+          echo "🔐 Step 2.5: Syncing ENABLED_OAUTH_PROVIDERS from terraform output..."
+          ENABLED_OAUTH="$(terraform output -raw enabled_oauth_providers 2>/dev/null || echo "")"
+          echo "  Desired ENABLED_OAUTH_PROVIDERS='${ENABLED_OAUTH}'"
+          CUR_ENV="$(aws lambda get-function-configuration --function-name "$FUNC_NAME" --query 'Environment.Variables' --output json)"
+          CUR_OAUTH="$(printf '%s' "$CUR_ENV" | python3 -c 'import sys,json;print(json.load(sys.stdin).get("ENABLED_OAUTH_PROVIDERS",""))')"
+          if [ "$CUR_OAUTH" != "$ENABLED_OAUTH" ]; then
+            echo "  Updating env (was '${CUR_OAUTH}')..."
+            NEW_ENV="$(printf '%s' "$CUR_ENV" | ENABLED_OAUTH="$ENABLED_OAUTH" python3 -c 'import sys,json,os;e=json.load(sys.stdin);e["ENABLED_OAUTH_PROVIDERS"]=os.environ["ENABLED_OAUTH"];print(json.dumps({"Variables":e}))')"
+            aws lambda update-function-configuration --function-name "$FUNC_NAME" --environment "$NEW_ENV" >/dev/null
+            aws lambda wait function-updated --function-name "$FUNC_NAME"
+            echo "  ✅ ENABLED_OAUTH_PROVIDERS synced to '${ENABLED_OAUTH}'"
+          else
+            echo "  Already '${CUR_OAUTH}', no change"
+          fi
+
           echo "📦 Step 3: Publishing immutable version..."
           VERSION=$(aws lambda publish-version \
             --function-name "$FUNC_NAME" \

--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -1482,6 +1482,15 @@ output "dashboard_api_url" {
   value       = module.api_gateway.api_endpoint
 }
 
+# Feature 1375: consumed by the CI dashboard-deploy step to set the Lambda's
+# ENABLED_OAUTH_PROVIDERS env var. Terraform cannot manage that env directly
+# (modules/lambda ignore_changes=[environment], Feature 1290), so CI sets it
+# out-of-band from this derived value before publishing the alias version.
+output "enabled_oauth_providers" {
+  description = "Comma-separated OAuth providers derived from populated secrets (Feature 1370/1375)"
+  value       = local.enabled_oauth_providers
+}
+
 output "api_gateway_id" {
   description = "ID of the Dashboard API Gateway"
   value       = module.api_gateway.api_id


### PR DESCRIPTION
## Why

Durable follow-up to the WI-6 Google OAuth go-live. During go-live we discovered the dashboard Lambda's `ENABLED_OAUTH_PROVIDERS` env **cannot be managed by terraform**: `modules/lambda/main.tf` sets `lifecycle { ignore_changes = [image_uri, environment] }` (Feature 1290, to break a circular dependency), so terraform ignores **all** env changes after create. The CI alias-based deploy only runs `update-function-code` (image), never env. Net effect: the OAuth enable/disable derived from the `google-oauth` secret (`local.enabled_oauth_providers`, Feature 1370) **never reached the served alias version**. Go-live required a one-time manual `update-function-configuration`.

## Fix (in-pipeline, reproducible-from-git)

- New terraform `output "enabled_oauth_providers"` exposes `local.enabled_oauth_providers`.
- Dashboard-deploy **Step 2.5** reads it and syncs `ENABLED_OAUTH_PROVIDERS` onto `$LATEST` **before** `publish-version`, so every published/aliased version carries the correct value.
- Merges into the existing `Variables` map (`update-function-configuration` replaces the whole map) and is **idempotent** (skips when already correct).

## Safety

- Deployer already holds `lambda:UpdateFunctionConfiguration` on sentiment functions. No new AWS resources.
- Env is already `google` live, so Step 2.5 **no-ops** on the next deploy — this change is safe and won't disturb the live state.
- `run:` block uses only trusted values (`github.sha`, `terraform output`, `aws` output) — no event-derived input, no injection surface.