### PR TITLE
fix(scripts): verify-oauth-deploy.sh wrong dashboard function name (M1 WI-6)

### DIFF
--- a/scripts/verify-oauth-deploy.sh
+++ b/scripts/verify-oauth-deploy.sh
@@ -54,7 +54,9 @@ fi
 # -------------------------------------------------------------------
 
 # 1. Lambda env var
-LAMBDA_NAME="${ENV}-dashboard"
+# NOTE: the dashboard function is named "{env}-sentiment-dashboard" (not "{env}-dashboard").
+# The wrong name also trips the deployer IAM scope (*-sentiment-*) → AccessDenied → false FAIL.
+LAMBDA_NAME="${ENV}-sentiment-dashboard"
 ENABLED="$(aws lambda get-function-configuration \
   --function-name "$LAMBDA_NAME" \
   --query 'Environment.Variables.ENABLED_OAUTH_PROVIDERS' \


### PR DESCRIPTION
The verifier queried `{env}-dashboard`; the real function is `{env}-sentiment-dashboard`. Wrong name → outside deployer IAM scope (`*-sentiment-*`) → AccessDenied → swallowed to empty → **false FAIL** on `ENABLED_OAUTH_PROVIDERS` even when OAuth is correctly enabled. Fixed. Verifier now passes end-to-end vs preprod (Lambda env=google, Cognito IdP=Google, /oauth/urls 200). A false-negative verifier would have invalidated the WI-6 attestation.