### PR TITLE
fix(auth): OAuth sign-in always failed — useSessionInit wiped callback sessionStorage (M1 WI-6)

### DIFF
--- a/frontend/src/hooks/use-session-init.ts
+++ b/frontend/src/hooks/use-session-init.ts
@@ -51,9 +51,16 @@ export function useSessionInit() {
 
     initAttempted.current = true;
 
-    // Clear stale OAuth sessionStorage keys from previous auth attempts
-    sessionStorage.removeItem('oauth_provider');
-    sessionStorage.removeItem('oauth_state');
+    // Clear stale OAuth sessionStorage keys from previous auth attempts.
+    // CRITICAL: skip on /auth/callback. SessionProvider (root layout) runs this
+    // on every page, and useSearchParams' Suspense boundary defers the callback
+    // page's own effect — so without this guard we wipe oauth_provider/oauth_state
+    // before the callback can read them, making every OAuth sign-in fail with
+    // "Authentication session expired" (the callback clears them itself after use).
+    if (!window.location.pathname.startsWith('/auth/callback')) {
+      sessionStorage.removeItem('oauth_provider');
+      sessionStorage.removeItem('oauth_state');
+    }
 
     const initializeSession = async () => {
       try {


### PR DESCRIPTION
## Symptom
Every Google OAuth sign-in on the deployed frontend fails with **"Authentication session expired"** and never reaches the backend (**no `POST /oauth/callback`** in the network log — only a benign `/auth/refresh 401`). Fails every time, independent of speed or a fresh incognito.

## Root cause
`useSessionInit` runs inside `SessionProvider` in the **root layout**, so it executes on *every* page including `/auth/callback`. It unconditionally cleared `oauth_provider`/`oauth_state` from sessionStorage on load. The callback page reads those keys to validate the in-flight OAuth flow, but `useSearchParams`' `<Suspense>` boundary defers the callback's own effect — so the root-layout clear runs **first** and wipes the keys before the callback reads them. Provider/state come back null → "session expired", client-side, before the code exchange.

## Fix
Skip the stale-key cleanup on `/auth/callback`. Every other page still cleans up abandoned-flow keys; the callback preserves them, reads/validates, then clears them itself.

## Validation
This is the documented **Feature 1363** production fix — `oauth-flow.spec.ts` literally says *"Blocked by useSessionInit clearing oauth_* sessionStorage before the callback page reads them. Requires production fix."* No test asserts the old unconditional clear.

Deploys via Amplify build on merge.