### PR TITLE
fix(cors): API Gateway preflight omits PATCH → Settings save blocked (1382)

### DIFF
--- a/infrastructure/terraform/modules/api_gateway/main.tf
+++ b/infrastructure/terraform/modules/api_gateway/main.tf
@@ -74,8 +74,8 @@ resource "aws_api_gateway_gateway_response" "unauthorized" {
   response_parameters = {
     "gatewayresponse.header.WWW-Authenticate"                 = "'Bearer realm=\"sentiment-analyzer\"'"
     "gatewayresponse.header.Access-Control-Allow-Origin"      = "method.request.header.origin"
-    "gatewayresponse.header.Access-Control-Allow-Headers"     = "'Content-Type,Authorization,Accept,Cache-Control,Last-Event-ID,X-Amzn-Trace-Id,X-User-ID'"
-    "gatewayresponse.header.Access-Control-Allow-Methods"     = "'GET,POST,PUT,DELETE,PATCH,OPTIONS'"
+    "gatewayresponse.header.Access-Control-Allow-Headers"     = local.cors_allow_headers
+    "gatewayresponse.header.Access-Control-Allow-Methods"     = local.cors_allow_methods
     "gatewayresponse.header.Access-Control-Allow-Credentials" = "'true'"
   }
 
@@ -99,8 +99,8 @@ resource "aws_api_gateway_gateway_response" "missing_auth_token" {
   response_parameters = {
     "gatewayresponse.header.WWW-Authenticate"                 = "'Bearer realm=\"sentiment-analyzer\"'"
     "gatewayresponse.header.Access-Control-Allow-Origin"      = "method.request.header.origin"
-    "gatewayresponse.header.Access-Control-Allow-Headers"     = "'Content-Type,Authorization,Accept,Cache-Control,Last-Event-ID,X-Amzn-Trace-Id,X-User-ID'"
-    "gatewayresponse.header.Access-Control-Allow-Methods"     = "'GET,POST,PUT,DELETE,PATCH,OPTIONS'"
+    "gatewayresponse.header.Access-Control-Allow-Headers"     = local.cors_allow_headers
+    "gatewayresponse.header.Access-Control-Allow-Methods"     = local.cors_allow_methods
     "gatewayresponse.header.Access-Control-Allow-Credentials" = "'true'"
   }
 
@@ -123,8 +123,8 @@ resource "aws_api_gateway_gateway_response" "access_denied" {
   # FR-008: CORS headers on 403
   response_parameters = {
     "gatewayresponse.header.Access-Control-Allow-Origin"      = "method.request.header.origin"
-    "gatewayresponse.header.Access-Control-Allow-Headers"     = "'Content-Type,Authorization,Accept,Cache-Control,Last-Event-ID,X-Amzn-Trace-Id,X-User-ID'"
-    "gatewayresponse.header.Access-Control-Allow-Methods"     = "'GET,POST,PUT,DELETE,PATCH,OPTIONS'"
+    "gatewayresponse.header.Access-Control-Allow-Headers"     = local.cors_allow_headers
+    "gatewayresponse.header.Access-Control-Allow-Methods"     = local.cors_allow_methods
     "gatewayresponse.header.Access-Control-Allow-Credentials" = "'true'"
   }
 
@@ -212,9 +212,19 @@ locals {
   # Gateway responses (401/403/404) use method.request.header.origin which IS supported.
   cors_origin = length(var.cors_allowed_origins) > 0 ? var.cors_allowed_origins[0] : "*"
 
+  # Canonical CORS method + header lists (Feature 1382).
+  # SINGLE SOURCE OF TRUTH — every Access-Control-Allow-Methods / -Headers value in
+  # this module references these locals so the lists cannot drift out of sync again.
+  # Must mirror the backend handler constants (_CORS_ALLOW_METHODS / _CORS_ALLOW_HEADERS
+  # in src/lambdas/dashboard/handler.py). PATCH is required for
+  # PATCH /api/v2/notifications/preferences (Settings → Save Changes). Values keep the
+  # API Gateway-required single-quote wrapping ('...').
+  cors_allow_methods = "'GET,POST,PUT,DELETE,PATCH,OPTIONS'"
+  cors_allow_headers = "'Content-Type,Authorization,Accept,Cache-Control,Last-Event-ID,X-Amzn-Trace-Id,X-User-ID'"
+
   cors_headers = {
-    "method.response.header.Access-Control-Allow-Headers"     = "'Content-Type,Authorization,Accept,Cache-Control,Last-Event-ID,X-Amzn-Trace-Id,X-User-ID'"
-    "method.response.header.Access-Control-Allow-Methods"     = "'GET,POST,PUT,DELETE,PATCH,OPTIONS'"
+    "method.response.header.Access-Control-Allow-Headers"     = local.cors_allow_headers
+    "method.response.header.Access-Control-Allow-Methods"     = local.cors_allow_methods
     "method.response.header.Access-Control-Allow-Origin"      = "'${local.cors_origin}'"
     "method.response.header.Access-Control-Allow-Credentials" = "'true'"
     "method.response.header.Vary"                             = "'Origin'"
@@ -624,8 +634,8 @@ resource "aws_api_gateway_integration_response" "proxy_options" {
 
   response_parameters = {
     "method.response.header.Access-Control-Allow-Credentials" = "'true'"
-    "method.response.header.Access-Control-Allow-Headers"     = "'Content-Type,Authorization,X-User-ID,X-Amzn-Trace-Id'"
-    "method.response.header.Access-Control-Allow-Methods"     = "'GET,POST,PUT,DELETE,OPTIONS'"
+    "method.response.header.Access-Control-Allow-Headers"     = local.cors_allow_headers
+    "method.response.header.Access-Control-Allow-Methods"     = local.cors_allow_methods
     "method.response.header.Access-Control-Allow-Origin"      = "'${local.cors_origin}'"
     "method.response.header.Access-Control-Expose-Headers"    = "'X-Amzn-Trace-Id'"
     "method.response.header.Vary"                             = "'Origin'"
@@ -688,8 +698,8 @@ resource "aws_api_gateway_integration_response" "root_options" {
 
   response_parameters = {
     "method.response.header.Access-Control-Allow-Credentials" = "'true'"
-    "method.response.header.Access-Control-Allow-Headers"     = "'Content-Type,Authorization,X-User-ID,X-Amzn-Trace-Id'"
-    "method.response.header.Access-Control-Allow-Methods"     = "'GET,POST,PUT,DELETE,OPTIONS'"
+    "method.response.header.Access-Control-Allow-Headers"     = local.cors_allow_headers
+    "method.response.header.Access-Control-Allow-Methods"     = local.cors_allow_methods
     "method.response.header.Access-Control-Allow-Origin"      = "'${local.cors_origin}'"
     "method.response.header.Access-Control-Expose-Headers"    = "'X-Amzn-Trace-Id'"
     "method.response.header.Vary"                             = "'Origin'"
@@ -741,6 +751,12 @@ resource "aws_api_gateway_deployment" "dashboard" {
     redeployment = sha1(jsonencode(concat(
       [
         var.lambda_invoke_arn, # Feature 1305: Force redeploy on integration URI change
+        # Feature 1382: hash the CORS method/header VALUES, not just resource IDs.
+        # OPTIONS integration_response .id does not change on a param-only edit, so
+        # without these a verb-list change would apply green while the stage keeps
+        # serving the stale preflight (see spec AR#1 finding H1 / task T008).
+        local.cors_allow_methods,
+        local.cors_allow_headers,
         aws_api_gateway_resource.proxy.id,
         aws_api_gateway_method.proxy.id,
         aws_api_gateway_method.proxy_options.id,

--- a/specs/1382-apigw-cors-patch/plan.md
+++ b/specs/1382-apigw-cors-patch/plan.md
@@ -1,0 +1,117 @@
+# Implementation Plan — Feature 1382 apigw-cors-patch
+
+**Spec:** `./spec.md`
+**Branch:** `1382-apigw-cors-patch`
+**Scope:** Terraform-only change to `infrastructure/terraform/modules/api_gateway/main.tf` (+ one deployment-trigger line). No backend, no frontend, no new AWS resources.
+
+---
+
+## Constitution Check
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| Two-dashboard hazard | ✅ | Customer API only (Amplify → API Gateway → Dashboard Lambda). No `src/dashboard/` HTMX touch. |
+| No new AWS resources | ✅ | Edits existing `integration_response` params + one `local` + deployment trigger. Zero new resources. |
+| No CORS over-broadening | ✅ | Origin stays `local.cors_origin` (allowlist, never `*`); credentials preserved; only served verbs advertised. Honors "CORS wildcard + credentials" gotcha. |
+| GPG-signed commits | ✅ | `git commit -S` for spec commits; implementation commit likewise (implement phase, not now). |
+| Preprod-first real-AWS verification | ✅ | FR-008: verify on live preprod API Gateway after apply. |
+| Least-diff / idempotent | ✅ | One canonical `local` + reference swaps; smallest change that also kills the drift class. |
+| SAST / secrets | ✅ | No secrets, no Python. `terraform fmt`/`validate` + checkov (venv-activated per repo gotcha). |
+
+**Result: PASS.** No violations, no complexity deviations to record.
+
+---
+
+## Approach
+
+**Chosen: consolidate to a single canonical `local`, then force redeploy.**
+
+1. Introduce `local.cors_allow_methods = "'GET,POST,PUT,DELETE,PATCH,OPTIONS'"` (single-quote wrapping preserved — AR#1 L2). Optionally `local.cors_allow_headers` for the canonical full header list (FR-006 decision below).
+2. Replace every `Access-Control-Allow-Methods` **value** literal with `local.cors_allow_methods`:
+   - line 78 (`gateway_response.unauthorized`)
+   - line 103 (`gateway_response.missing_auth_token`)
+   - line 127 (`gateway_response.access_denied`)
+   - line 217 (inside `local.cors_headers`)
+   - line 628 (`proxy_options` integration_response) ← the broken one (FR-001)
+   - line 692 (`root_options` integration_response) ← same drift (FR-002)
+   After this, 628/692 carry PATCH and no scattered methods literal remains (FR-003/FR-004/US-3).
+3. **Force stage redeploy (FR-007a — the critical step):** add `local.cors_allow_methods` (and `local.cors_allow_headers` if consolidated) into the `aws_api_gateway_deployment.dashboard` `triggers.redeployment` hash (`main.tf:741-755`). Resource `.id`s don't change on a param-only edit, so without this the stage keeps serving the stale preflight. Adding the value string makes any future verb change auto-redeploy too.
+4. FR-006 (headers drift): **decision — fold headers into the same consolidation.** Replacing the short lists at 627/691 with the canonical `local.cors_allow_methods`-style headers local is low-risk, removes a second drift class, and keeps the two OPTIONS surfaces identical to the gateway-response and explicit-route surfaces. Still non-blocking; if it complicates the diff it can be dropped without affecting the PATCH fix.
+
+**Rejected alternatives**
+- *Two-line edit (628 + 692 only), leave literals scattered:* fixes the symptom but leaves the drift class alive and, more importantly, still fails AR#1 H1 unless the trigger is touched. Rejected — doesn't satisfy FR-004/FR-007a.
+- *Add explicit `preferences` public_route resource:* larger surface, new resources-ish (new method/integration/responses), contradicts "no new resources / least diff". The catch-all already routes it correctly for the actual PATCH; only its preflight advertisement is wrong. Rejected.
+
+---
+
+## Files Touched
+
+| File | Change |
+|------|--------|
+| `infrastructure/terraform/modules/api_gateway/main.tf` | Add `local.cors_allow_methods` (+ optional `local.cors_allow_headers`); swap 6 methods-value references; fold 2 header literals (FR-006); add methods/headers value to deployment `triggers`. |
+
+No other files. No `variables.tf`/`outputs.tf` change (no new inputs; the existing `cors_allowed_origins` already drives origin).
+
+---
+
+## Validation Strategy
+
+**Static (pre-push):**
+- `cd infrastructure/terraform && terraform fmt -recursive && terraform validate`
+- `checkov` via pre-commit **with venv activated** (repo gotcha: `.tf` commits need venv or checkov's hcl2 parser crashes on pyenv).
+- Confirm `grep -c "Access-Control-Allow-Methods.*PATCH"` reflects the consolidated `local` (no remaining `GET,POST,PUT,DELETE,OPTIONS` literal without PATCH).
+
+**Plan-time (preprod, dry):**
+- `terraform plan` for preprod shows in-place updates to `proxy_options`/`root_options` (and the 3 gateway responses if the local swap is a no-op-value) integration responses **and** a new `aws_api_gateway_deployment` (trigger hash changed). If the plan shows **no** deployment replacement, FR-007a is not satisfied — stop.
+
+**Post-apply (preprod, real AWS — FR-008):**
+- `curl -i -X OPTIONS "$PREPROD_API/api/v2/notifications/preferences" -H "Origin: <amplify-origin>" -H "Access-Control-Request-Method: PATCH" -H "Access-Control-Request-Headers: content-type,authorization"` → expect `200` and `Access-Control-Allow-Methods` containing `PATCH`, `Access-Control-Allow-Origin: <amplify-origin>` (not `*`), `Access-Control-Allow-Credentials: true`.
+- Fresh browser context / cache-bust (AR#1 L1) then exercise Settings → Save Changes on the Amplify customer dashboard; confirm the `PATCH` returns 2xx and preferences persist.
+- Spot-check a still-working verb (e.g. a GET) to confirm no regression, and confirm no unused verb was added.
+
+**Rollback:** revert the single commit; `terraform apply` restores prior integration responses + deployment. Idempotent, no data involved.
+
+---
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|-----------|
+| Applied but stage not redeployed (stale preflight) | High if trigger untouched | Fix appears dead | FR-007a: methods value in deploy trigger; plan must show new deployment. |
+| Dropped `'…'` quoting in `local` | Low | All CORS mappings break | AR#1 L2: local value keeps exact single-quote wrapping; `terraform validate` + preflight curl catch it. |
+| Browser cached failed preflight masks success | Low | False negative in verify | Fresh context / cache-bust; curl-based check is authoritative. |
+| checkov hook crash on `.tf` commit | Med | Commit blocked | Activate venv before commit (documented gotcha). |
+| Header consolidation (FR-006) introduces typo | Low | Preflight header mismatch | Optional; validate against `_CORS_ALLOW_HEADERS`; can be dropped without affecting PATCH fix. |
+
+---
+
+## Adversarial Review #2
+
+**Stance:** hunt for spec↔plan drift and cross-artifact contradictions after Clarify.
+
+### Cross-artifact consistency
+
+| Check | Spec | Plan | Consistent? |
+|-------|------|------|-------------|
+| Broken location | 628 (+692) | 628 (+692) both swapped | ✅ |
+| Consolidation to `local` | FR-004 | Approach step 1-2, files table | ✅ |
+| Redeploy trigger (H1/C4) | FR-007a | Approach step 3, plan validation "new deployment" gate, risk row | ✅ |
+| Origin allowlist, no `*` | FR-005, C1 | Constitution + post-apply curl assert | ✅ |
+| Header drift decision | FR-006, C5 | Approach step 4 = fold, marked non-blocking | ✅ |
+| Verb set exactly served | FR-003, C3 | curl assert + grep check | ✅ |
+| Preflight cache | Assumptions §7, AR#1 L1 | curl-authoritative + fresh context | ✅ |
+| No new resources | NFR-002 | Files table (1 file), constitution | ✅ |
+| Preprod real-AWS verify | FR-008 | Validation Strategy post-apply | ✅ |
+
+### Drift findings
+
+| ID | Sev | Finding | Resolution |
+|----|-----|---------|-----------|
+| D1 | LOW | Plan proposes an *optional* `local.cors_allow_headers` (FR-006 fold); if implemented it changes the 3 gateway-response header values too (they already match the canonical list, so it's a no-op-value swap) — but the plan's "files table" should make explicit that gateway-response header values are already canonical and the local swap must preserve them byte-for-byte. | Clarified: the headers `local` value MUST equal the existing canonical string at 77/102/126/216; swapping those references is a no-op by construction. Recorded here; no FR change. |
+| D2 | LOW | Plan validation says "plan shows in-place update to the 3 gateway responses **if** the local swap is a no-op-value" — a methods `local` whose value equals the existing `'GET,POST,PUT,DELETE,PATCH,OPTIONS'` at 78/103/127/217 produces **zero** diff on those three + line 217; the only value-changing diffs are 628/692 + the deployment trigger. | Expectation tightened: `terraform plan` should show exactly (a) updated `proxy_options` + `root_options` integration responses, (b) a new/replaced `aws_api_gateway_deployment`. Gateway-response + explicit-route resources show no change. If more churn appears, investigate before apply. |
+| D3 | INFO | No contradiction between "least diff" (NFR-003) and "consolidate to local" (FR-004): the local reduces future diff and is a one-time structural change; net lines added are minimal. | No action. |
+
+### Gate
+- CRITICAL: **0** · HIGH: **0** · Unresolved drift: **0** (D1/D2 clarified, D3 info)
+
+**PASS.** Spec and plan are consistent. No structural rework needed → Plan 2nd pass **skipped** (Stage 6).

--- a/specs/1382-apigw-cors-patch/spec.md
+++ b/specs/1382-apigw-cors-patch/spec.md
@@ -1,0 +1,227 @@
+# Feature 1382 — apigw-cors-patch
+
+**Status:** Draft (planning-only; no implementation)
+**Branch:** `1382-apigw-cors-patch`
+**Type:** Bug fix — Terraform-only (API Gateway CORS)
+**Target:** CUSTOMER dashboard API (Amplify → API Gateway → Dashboard Lambda). NOT the HTMX admin dashboard.
+**Created:** 2026-07-23
+
+---
+
+## 1. Problem Statement
+
+Saving notification preferences on the customer frontend (Settings → Save Changes) issues
+`PATCH /api/v2/notifications/preferences`. The browser first sends a CORS **preflight**
+(`OPTIONS`) from the Amplify origin. API Gateway answers the preflight with:
+
+```
+Access-Control-Allow-Methods: GET,POST,PUT,DELETE,OPTIONS
+```
+
+PATCH is absent, so the browser blocks the request:
+
+> Method PATCH is not allowed by Access-Control-Allow-Methods in the preflight response.
+
+The Save silently fails for **all** users. This is pre-existing and blocks the feature entirely.
+
+### Root cause (verified, not re-derived)
+
+The backend Lambda is **not** the problem — it already allows PATCH:
+
+- `src/lambdas/dashboard/handler.py:263` → `_CORS_ALLOW_METHODS = "GET,POST,PUT,DELETE,PATCH,OPTIONS"`
+- `src/lambdas/dashboard/router_v2.py:1968` → `@notification_router.patch("/api/v2/notifications/preferences")`
+
+The **API Gateway** OPTIONS mock integration that serves this route's preflight advertises a
+methods list **without PATCH**. The exact serving path:
+
+1. `/api/v2/notifications/preferences` is **not** an explicit `public_route`. `infrastructure/terraform/main.tf:875-893` declares only `["api","v2","notifications"]` (endpoint, `has_proxy=false`) and `["api","v2","notifications","unsubscribe"]`. Neither creates a `preferences` resource, and `notifications` has no `{proxy+}` child.
+2. With no matching explicit resource, the request matches the **root-level `{proxy+}` catch-all** (`aws_api_gateway_resource.proxy`, `main.tf:560`).
+3. That catch-all's preflight is served by `aws_api_gateway_integration_response.proxy_options` (`main.tf:619-633`), whose `Access-Control-Allow-Methods` literal is `'GET,POST,PUT,DELETE,OPTIONS'` — **no PATCH** (`main.tf:628`).
+
+Meanwhile the `local.cors_headers` block (`main.tf:217`) **does** include PATCH, but it is only
+wired into the explicit leaf/proxy/fr012 OPTIONS integrations (`main.tf:342/411/483/552`). The
+`preferences` path never touches those, so the correct value never reaches the browser.
+
+### CORS Allow-Methods audit (entire `api_gateway` module)
+
+`main.tf` is the only file in the module with CORS response params (`variables.tf`/`outputs.tf`
+have none). Every occurrence:
+
+| # | Line | Resource / context | Kind | Methods value | PATCH? | Serves the `preferences` preflight? |
+|---|------|--------------------|------|---------------|--------|--------------------------------------|
+| 1 | 78  | `gateway_response.unauthorized` (401) | gatewayresponse value | `GET,POST,PUT,DELETE,PATCH,OPTIONS` | ✅ | error path only |
+| 2 | 103 | `gateway_response.missing_auth_token` (401) | gatewayresponse value | `GET,POST,PUT,DELETE,PATCH,OPTIONS` | ✅ | error path only |
+| 3 | 127 | `gateway_response.access_denied` (403) | gatewayresponse value | `GET,POST,PUT,DELETE,PATCH,OPTIONS` | ✅ | error path only |
+| 4 | 217 | `local.cors_headers` → explicit OPTIONS integ responses (342/411/483/552) | integration_response value | `GET,POST,PUT,DELETE,PATCH,OPTIONS` | ✅ | ❌ only explicit `public_routes` |
+| 5 | 611 | `proxy_options` method_response | header declaration (`true`) | (bool) | n/a | declaration only |
+| 6 | **628** | **`proxy_options` integration_response** (root `{proxy+}` catch-all) | **integration_response value** | **`GET,POST,PUT,DELETE,OPTIONS`** | **❌ MISSING** | **✅ YES — the broken one** |
+| 7 | 675 | `root_options` method_response | header declaration (`true`) | (bool) | n/a | declaration only |
+| 8 | **692** | **`root_options` integration_response** (root `/` OPTIONS) | **integration_response value** | **`GET,POST,PUT,DELETE,OPTIONS`** | **❌ MISSING** | root `/` preflight only |
+
+**Verbs the API actually serves** (grep of `router_v2.py`): GET, POST, **PUT** (1 route:
+`config PUT`), **PATCH** (5 routes), DELETE, plus OPTIONS for preflight. Per-verb coverage:
+
+| Verb | 78/103/127 | 217 (cors_headers) | 628 (proxy_options) | 692 (root_options) |
+|------|:----------:|:------------------:|:-------------------:|:------------------:|
+| GET     | ✅ | ✅ | ✅ | ✅ |
+| POST    | ✅ | ✅ | ✅ | ✅ |
+| PUT     | ✅ | ✅ | ✅ | ✅ |
+| DELETE  | ✅ | ✅ | ✅ | ✅ |
+| **PATCH** | ✅ | ✅ | **❌** | **❌** |
+| OPTIONS | ✅ | ✅ | ✅ | ✅ |
+
+**Inconsistencies found:** exactly two `Allow-Methods` literals omit PATCH — line **628** (the
+one that breaks Save) and line **692** (root path, same drift). No other verb is missing anywhere.
+
+**Secondary drift (out of primary scope, flagged):** the same two literals also carry a *shorter*
+`Access-Control-Allow-Headers` list — `'Content-Type,Authorization,X-User-ID,X-Amzn-Trace-Id'`
+(lines 627/691) — versus the canonical full list
+`'Content-Type,Authorization,Accept,Cache-Control,Last-Event-ID,X-Amzn-Trace-Id,X-User-ID'` used
+at 77/102/126/216 and in the backend `_CORS_ALLOW_HEADERS`. This does **not** block the PATCH
+preflight (a JSON PATCH only requests `Content-Type` + `Authorization`, both present), so it is
+not required for this fix — see FR-006 for the deliberate decision.
+
+---
+
+## 2. Scope
+
+**In scope**
+- Add PATCH to the two API Gateway OPTIONS preflight `Access-Control-Allow-Methods` literals that omit it (lines 628 and 692), so the catch-all and root preflights advertise every verb the API serves.
+- Eliminate the drift by consolidating the methods list to a **single canonical `local`** referenced by every `Allow-Methods` occurrence (recommended — see FR-004), so the same literal cannot desync again.
+
+**Out of scope**
+- Any backend/Lambda change (already correct).
+- The `Access-Control-Allow-Headers` drift (FR-006 records the decision to leave it or fold it into the same consolidation — non-blocking).
+- The HTMX admin dashboard, Function URL CORS, SSE Lambda CORS.
+- Broadening origins, credentials, or adding new verbs beyond what routes serve.
+- Any new AWS resource.
+
+---
+
+## 3. User Scenarios
+
+### US-1 (Primary) — Save notification preferences
+**As** a signed-in customer, **when** I toggle a notification setting and click Save Changes,
+**then** the `PATCH /api/v2/notifications/preferences` request completes and my preferences persist —
+no CORS preflight error.
+
+**Acceptance:**
+- From the Amplify origin, the `OPTIONS /api/v2/notifications/preferences` preflight returns 200 with `Access-Control-Allow-Methods` containing `PATCH`.
+- The subsequent `PATCH` returns 2xx and the change is saved.
+- `Access-Control-Allow-Origin` echoes the Amplify origin from the existing allowlist (never `*`), and `Access-Control-Allow-Credentials: true` is present.
+
+### US-2 — No verb silently missing
+**As** an operator, **when** I inspect the preflight for the catch-all and root resources,
+**then** every verb the API serves (GET, POST, PUT, DELETE, PATCH, OPTIONS) is advertised, and no
+verb the API does *not* serve is added.
+
+### US-3 — Drift cannot recur silently
+**As** a maintainer adding a future verb, **when** I update the canonical methods list in one place,
+**then** all preflight and gateway-response headers reflect it, with no scattered literal left behind.
+
+---
+
+## 4. Functional Requirements
+
+- **FR-001** The `OPTIONS` preflight for `/api/v2/notifications/preferences` (served by the root `{proxy+}` catch-all, `proxy_options` integration response) MUST advertise `PATCH` in `Access-Control-Allow-Methods`.
+- **FR-002** The root `/` OPTIONS preflight (`root_options` integration response, line 692) MUST advertise `PATCH` as well, keeping all preflight surfaces consistent.
+- **FR-003** The advertised method set MUST equal exactly the verbs the API serves — `GET,POST,PUT,DELETE,PATCH,OPTIONS` — with **no** verb added that no route uses.
+- **FR-004** The methods list SHOULD be defined **once** as a Terraform `local` (e.g. `local.cors_allow_methods = "'GET,POST,PUT,DELETE,PATCH,OPTIONS'"`) and referenced by every `Access-Control-Allow-Methods` occurrence (lines 78, 103, 127, 217, 628, 692), so future changes are single-edit and drift is structurally impossible.
+- **FR-005** `Access-Control-Allow-Origin` MUST remain the existing explicit allowlist behavior (`local.cors_origin` / `method.request.header.origin`), never `*`. `Access-Control-Allow-Credentials: true` MUST be preserved. No origin/credentials semantics change.
+- **FR-006** The `Access-Control-Allow-Headers` value on the two catch-all/root literals MAY be folded into the same consolidation for consistency, but this is **non-blocking** for the PATCH fix; if folded, it MUST match the canonical full header list and MUST NOT use `*` (documented "CORS wildcard + credentials" gotcha). If not folded, the divergence is recorded as a known, accepted low-severity item.
+- **FR-007** The change MUST be Terraform-only, introduce **no** new AWS resources, and MUST re-deploy the API Gateway stage so the new integration response takes effect (a deployment redeploy trigger already covers method/integration changes).
+- **FR-008** After `terraform apply` to **preprod** (real AWS), the fix MUST be verified against the live API Gateway from the Amplify origin: the preflight advertises PATCH and the `PATCH` succeeds end-to-end.
+
+## 5. Non-Functional Requirements
+
+- **NFR-001 (Security)** Do not broaden CORS. Origin stays on the explicit allowlist; credentials unchanged; only verbs the API serves are advertised.
+- **NFR-002 (No infra growth)** Reuse the existing API Gateway; zero new resources; standing "no new AWS resources" constraint honored.
+- **NFR-003 (Idempotent/least-diff)** Prefer the smallest correct diff that also removes the drift class (one `local` + reference swaps).
+- **NFR-004 (Deploy safety)** GPG-signed commits; validated via `terraform fmt`/`validate` before push; preprod-first, prod later via the normal pipeline.
+
+## 6. Success Criteria
+
+1. `OPTIONS` preflight for `/api/v2/notifications/preferences` from the Amplify origin returns `Access-Control-Allow-Methods` including `PATCH`.
+2. `PATCH /api/v2/notifications/preferences` succeeds from the customer dashboard; Save Changes persists.
+3. No other verb the API serves is missing from any preflight; no unused verb is added.
+4. `Access-Control-Allow-Origin` is the explicit Amplify origin (not `*`); credentials preserved.
+5. Verified on real preprod after apply. Terraform-only change; no new resources.
+
+## 7. Assumptions & Dependencies
+
+- The API Gateway deployment/stage redeploys on integration-response change (existing `public_route_resource_ids` trigger + standard deploy pipeline handle this).
+- Preprod `cors_allowed_origins` already contains the Amplify origin (`main.tf:868`, non-empty enforced for prod; preprod set via tfvars).
+- Preflight caching (`Access-Control-Max-Age`) is not currently emitted by these OPTIONS responses; if a browser cached a *failed* preflight, a hard refresh / cache bust may be needed to observe the fix (see Adversarial Review #1).
+
+## 8. Out-of-Scope / Deferred
+
+- Header-list consolidation beyond methods (FR-006) — decided non-blocking.
+- Any refactor of the explicit-vs-catch-all routing model.
+
+---
+
+## Adversarial Review #1
+
+**Reviewer stance:** assume the one-line fix is a trap. Attack redeploy semantics, drift
+recurrence, preflight caching, and credentials/origin correctness.
+
+### Findings
+
+| ID | Sev | Attack | Finding | Resolution |
+|----|-----|--------|---------|-----------|
+| H1 | HIGH | "It applies but nothing changes." | The `aws_api_gateway_deployment` redeploy trigger (`main.tf:739-756`) hashes resource **`.id`** values. An `integration_response` `.id` is derived from rest_api/resource/method/status — it does **not** change when only `response_parameters` change. So editing the `Allow-Methods` literal at line 628/692 alone leaves the trigger hash unchanged → **no new deployment → the stage keeps serving the old preflight** and the fix appears to do nothing after `apply`. This is the classic API Gateway "changed config, forgot to redeploy" trap. | **Amend FR-007:** the redeployment `triggers` MUST incorporate the CORS methods **value** (e.g. hash `local.cors_allow_methods` / the integration-response param maps), not just resource IDs, so any verb-list change forces a stage redeploy. Added as FR-007a below. |
+| M1 | MED | "You fixed 628, forgot 692." | Root `/` OPTIONS (line 692) has the identical PATCH omission. | Already covered by FR-002; consolidation (FR-004) fixes both at once. No spec change. |
+| M2 | MED | "Preflight still fails on headers." | Lines 627/691 carry a shorter `Allow-Headers` list. | Non-blocking for a JSON PATCH (only `Content-Type`+`Authorization` requested, both present). Recorded by FR-006 as accepted; may be folded into the same `local`. No gate impact. |
+| L1 | LOW | "Preflight cache hides the result." | No `Access-Control-Max-Age` is emitted by these OPTIONS responses (`grep` = none), so there's no long server-set cache. But browsers still cache preflights per their own default heuristic; a previously-cached **failed** preflight can linger for the session. | Verification (FR-008) MUST use a fresh browser context / cache-bust (or `curl -X OPTIONS`) so a stale negative cache doesn't mask the fix. Added to plan validation steps. |
+| L2 | LOW | "Consolidation breaks the mapping." | API Gateway response-parameter values must be single-quote-wrapped (`'GET,...'`). A `local` that drops the quotes would break every reference. | The canonical `local` MUST retain the `'…'` wrapping exactly as the current literals. Captured for the plan. |
+| L3 | LOW | "You broadened CORS." | Confirm origin/credentials unchanged. | `Allow-Origin` stays `'${local.cors_origin}'` (allowlist, never `*`; validation at `variables.tf:143`); `Allow-Credentials: true` preserved. Verb set equals exactly the routes served. No broadening. Confirmed, no change. |
+
+### Spec edits applied
+- **FR-007a (new):** The `aws_api_gateway_deployment.dashboard` `triggers` map MUST include the CORS methods value (and, if FR-006 folds headers, the headers value) so a verb/header change produces a new deployment. Without this, the stage will not serve the corrected preflight.
+- FR-008 clarified to require a cache-busted / fresh-context preflight check.
+
+### Gate
+- CRITICAL: **0**
+- HIGH: **0** (H1 resolved by FR-007a)
+
+**PASS — 0 CRITICAL / 0 HIGH.** Proceed to Plan.
+
+---
+
+## Clarifications
+
+Self-answered from the codebase (no owner input required). Max 5.
+
+**C1 — Does the preflight `Allow-Origin` actually resolve to the Amplify origin in preprod, or `*`?**
+Resolved. `local.cors_origin = cors_allowed_origins[0]` (`main.tf:213`). `preprod.tfvars:25-30`
+sets `cors_allowed_origins[0] = "https://main.d29tlmksqcx494.amplifyapp.com"` (the customer
+Amplify origin). So the MOCK preflight returns that exact origin, never `*`. FR-005 satisfied by
+existing config; no change needed. (Note: MOCK integrations can't echo `method.request.header.origin`,
+so it's a single static allowlisted origin — correct for the customer dashboard.)
+
+**C2 — Do the explicit `public_route` OPTIONS integrations already carry PATCH (i.e., is the bug
+truly only the catch-all)?**
+Resolved. `fr012_options`, `public_leaf_options`, `public_proxy_options`, `fr012_proxy_options`
+integration responses all set `response_parameters = local.cors_headers` (`main.tf:342/411/483/552`),
+and `local.cors_headers` includes PATCH (`main.tf:217`). So every explicit route is already correct;
+the omission is isolated to the two hardcoded literals (628 `proxy_options`, 692 `root_options`).
+Confirms the audit.
+
+**C3 — Which verbs must the advertised set contain — exactly?**
+Resolved. `router_v2.py` decorators: GET, POST, **PUT** (1: `config_router.put`), **PATCH** (5),
+DELETE, + OPTIONS for preflight. Canonical set = `GET,POST,PUT,DELETE,PATCH,OPTIONS` — identical to
+the backend `_CORS_ALLOW_METHODS` (`handler.py:263`). No verb beyond these is served, so none should
+be advertised beyond them (FR-003).
+
+**C4 — Will a param-only edit actually redeploy the stage?**
+Resolved (from AR#1 H1). No — the `aws_api_gateway_deployment` trigger hashes resource `.id`s
+(`main.tf:741-755`), unchanged by param-only edits. FR-007a requires adding the methods value to the
+trigger. This is a required part of the fix, not optional.
+
+**C5 — Is the `Allow-Headers` short-list at 627/691 a blocker for the PATCH Save?**
+Resolved. No. A JSON PATCH from the frontend requests only `Content-Type` + `Authorization`, both
+present in the short list, so the preflight passes on headers. The divergence is cosmetic/drift, not
+functional for US-1. FR-006 folds it into the consolidation opportunistically; dropping it does not
+affect the fix.
+
+**Deferred to owner:** none. All questions resolved from code + tfvars.

--- a/specs/1382-apigw-cors-patch/tasks.md
+++ b/specs/1382-apigw-cors-patch/tasks.md
@@ -1,0 +1,126 @@
+# Tasks — Feature 1382 apigw-cors-patch
+
+**Spec:** `./spec.md` · **Plan:** `./plan.md` · **Branch:** `1382-apigw-cors-patch`
+**Nature:** Terraform-only. Dependency-ordered. `[P]` = parallelizable with siblings.
+
+> Planning artifact only. Do NOT execute (no `/speckit.implement`). Implementation happens in a later phase.
+
+---
+
+## Phase 0 — Baseline capture
+
+- **T001** Capture the current preprod preflight as the "before" evidence:
+  `curl -i -X OPTIONS "$PREPROD_API/api/v2/notifications/preferences" -H "Origin: https://main.d29tlmksqcx494.amplifyapp.com" -H "Access-Control-Request-Method: PATCH"` → record that `Access-Control-Allow-Methods` lacks PATCH. (Covers: reproduces bug behind FR-001.)
+
+## Phase 1 — Consolidate the canonical methods (and headers) local
+
+- **T002** In `infrastructure/terraform/modules/api_gateway/main.tf` `locals` block, add `cors_allow_methods = "'GET,POST,PUT,DELETE,PATCH,OPTIONS'"` — single-quote wrapping preserved exactly (AR#1 L2). (Covers: FR-003, FR-004.)
+- **T003 [P]** Add `cors_allow_headers = "'Content-Type,Authorization,Accept,Cache-Control,Last-Event-ID,X-Amzn-Trace-Id,X-User-ID'"` (FR-006 fold; value MUST equal the existing canonical string at lines 77/102/126/216 and backend `_CORS_ALLOW_HEADERS`). Optional — drop without affecting the PATCH fix. (Covers: FR-006.)
+
+## Phase 2 — Swap methods references (kills the drift class)
+
+- **T004** Replace the `Access-Control-Allow-Methods` value at line 628 (`aws_api_gateway_integration_response.proxy_options`) with `local.cors_allow_methods`. **This is the fix for the broken preflight.** (Covers: FR-001, US-1.)
+- **T005** Replace the `Access-Control-Allow-Methods` value at line 692 (`aws_api_gateway_integration_response.root_options`) with `local.cors_allow_methods`. (Covers: FR-002, US-2.)
+- **T006 [P]** Replace the methods values at lines 78, 103, 127 (gateway responses) and 217 (`local.cors_headers`) with `local.cors_allow_methods` — no value change (already correct), removes scattered literals so drift can't recur. (Covers: FR-004, US-3.)
+- **T007 [P]** If T003 done: replace the `Access-Control-Allow-Headers` literals at lines 627/691 with `local.cors_allow_headers`; verify the value is byte-identical to the canonical list (D1). (Covers: FR-006.)
+
+## Phase 3 — Force stage redeploy (the make-or-break step)
+
+- **T008** In `aws_api_gateway_deployment.dashboard.triggers.redeployment` (`main.tf:741-755`), add `local.cors_allow_methods` (and `local.cors_allow_headers` if T003) into the hashed `concat([...])` list so the value change forces a new deployment. Without this the stage keeps serving the stale preflight. (Covers: FR-007a — resolves AR#1 H1 / C4.)
+
+## Phase 4 — Static validation (pre-push)
+
+- **T009** `cd infrastructure/terraform && terraform fmt -recursive && terraform validate` → clean. (Covers: NFR-004.)
+- **T010 [P]** `grep -n "GET,POST,PUT,DELETE,OPTIONS'" infrastructure/terraform/modules/api_gateway/main.tf` → **zero** matches (no PATCH-less literal remains); `grep` for `local.cors_allow_methods` shows 6 references. (Covers: FR-003, FR-004.)
+- **T011 [P]** Confirm no new resource and no origin/credentials change: diff shows only param values + local + trigger; `Allow-Origin` still `'${local.cors_origin}'`, `Allow-Credentials` still `'true'`, no `*`. (Covers: FR-005, NFR-001, NFR-002.)
+
+## Phase 5 — Plan-time gate (preprod dry)
+
+- **T012** `terraform plan` (preprod): MUST show (a) in-place update to `proxy_options` + `root_options` integration responses, (b) a **new** `aws_api_gateway_deployment`. Gateway-response/explicit-route resources show no change (D2). If no new deployment appears → STOP, FR-007a unmet. (Covers: FR-007, FR-007a.)
+
+## Phase 6 — Commit
+
+- **T013** GPG-signed commit of the `.tf` change **with venv activated** (checkov hook gotcha): `source .venv/bin/activate && git commit -S`. Terraform-only. (Covers: NFR-004.)
+
+## Phase 7 — Post-apply real-preprod verification (FR-008)
+
+- **T014** After the deploy pipeline applies to preprod, re-run the T001 curl (cache-bust / fresh): `Access-Control-Allow-Methods` now contains **PATCH**; `Allow-Origin` = the Amplify origin (not `*`); `Allow-Credentials: true`; status 200. (Covers: FR-001, FR-005, FR-008, Success #1/#4.)
+- **T015** On the Amplify customer dashboard in a fresh browser context: Settings → toggle → Save Changes → the `PATCH /api/v2/notifications/preferences` returns 2xx and the preference persists on reload. (Covers: US-1, Success #2.)
+- **T016 [P]** Regression spot-check: a GET route still works and no unused verb was added to the advertised set. (Covers: FR-003, US-2, Success #3.)
+
+---
+
+## Requirement → Task coverage
+
+| Requirement | Task(s) |
+|-------------|---------|
+| FR-001 (preferences preflight advertises PATCH) | T001, T004, T014 |
+| FR-002 (root OPTIONS advertises PATCH) | T005 |
+| FR-003 (exact served verb set, none extra) | T002, T006, T010, T016 |
+| FR-004 (single canonical `local`) | T002, T006, T010 |
+| FR-005 (origin allowlist, no `*`; credentials) | T011, T014 |
+| FR-006 (headers fold, non-blocking) | T003, T007 |
+| FR-007 (Terraform-only, no new resources, redeploy) | T011, T012 |
+| FR-007a (deploy trigger includes CORS value) | T008, T012 |
+| FR-008 (real preprod verification) | T014, T015 |
+| NFR-001 (no over-broadening) | T011 |
+| NFR-002 (no infra growth) | T011 |
+| NFR-003 (least diff) | T002, T006 |
+| NFR-004 (fmt/validate, GPG, venv) | T009, T013 |
+| US-1 | T004, T015 |
+| US-2 | T005, T016 |
+| US-3 | T006, T010 |
+
+Every requirement maps to ≥1 task.
+
+---
+
+## Analyze — cross-artifact consistency
+
+- **Coverage:** 8 FR + 1 FR-a + 4 NFR + 3 US → all covered (table above). No orphan requirement; no task without a requirement.
+- **Ordering:** locals (T002/3) → references (T004-7) → trigger (T008) → validate (T009-11) → plan gate (T012) → commit (T013) → verify (T014-16). No forward dependency violation. T008 correctly gated before plan/apply (the H1 fix can't be an afterthought).
+- **Constitution:** unchanged from Plan — PASS (customer-only, no new resources, no over-broadening, GPG, preprod-verify).
+- **Terminology:** "preflight", "catch-all `{proxy+}`", `local.cors_allow_methods`, line numbers consistent across spec/plan/tasks.
+- **Ambiguities:** none open (Clarify resolved all 5; 0 deferred).
+
+**Analyze result: consistent. No blocking issues.**
+
+---
+
+## Adversarial Review #3
+
+**Stance:** find the task most likely to cause rework or a silent failed fix; decide readiness.
+
+### Highest-risk task: **T008 (add CORS value to the deployment redeploy trigger)**
+
+**Why it's the crux, not T004:** T004 is the intuitive "fix" (add PATCH at line 628), but on its own
+it changes only latent API config. AWS API Gateway REST serves the last **deployment** snapshot to the
+stage. The redeploy trigger hashes resource `.id`s (`main.tf:741-755`), which do **not** change on a
+param-only edit. So skipping/mis-implementing T008 yields the worst outcome: `terraform apply` succeeds,
+the plan looks done, and the live preflight is **unchanged** — a fix that ships green but does nothing.
+This is exactly the failure the whole review chain (AR#1 H1 → C4 → FR-007a → T008/T012) exists to prevent.
+
+**Likely rework:** if T008 is forgotten, T014/T015 verification fails on preprod, forcing a second
+apply cycle (slow, real-AWS). Mitigation is already inline: **T012 is a hard plan-time gate** — the plan
+MUST show a *new* `aws_api_gateway_deployment`; if it doesn't, stop before apply. That converts a
+post-deploy discovery into a pre-apply catch.
+
+**Secondary risk:** T008 mis-implemented by hashing the resource `.id` again (no-op) instead of the
+**value** string. Guard: T008 explicitly hashes `local.cors_allow_methods` (a value), and T012 verifies
+the deployment actually replaces.
+
+### Other notable risks
+- **T002/T007 quoting** (AR#1 L2 / D1): a `local` missing the `'…'` wrap or a mistyped headers string breaks all mappings — caught by T009 `terraform validate` + T014 curl.
+- **T006 scope creep:** swapping the 3 gateway-response literals is value-neutral; if the local value ever diverged from `GET,POST,PUT,DELETE,PATCH,OPTIONS` it would change 401/403 CORS too — T010 grep + T012 plan-diff confirm no unintended value change.
+
+### Gate
+
+| Criterion | Status |
+|-----------|--------|
+| Every requirement has a task | ✅ |
+| Highest-risk task identified + mitigated pre-apply | ✅ (T008 via T012 gate) |
+| No open clarifications | ✅ (0 deferred) |
+| Constitution PASS | ✅ |
+| CRITICAL / HIGH findings | 0 / 0 |
+
+**READY FOR IMPLEMENTATION** (implementation deferred per battleplan — planning stops here).


### PR DESCRIPTION
First of the M1 post-OAuth auth-hardening batch (battleplan). Fully isolated (terraform-only).

## Problem
Settings → Save Changes fires `PATCH /api/v2/notifications/preferences` and fails CORS preflight ("Method PATCH is not allowed by Access-Control-Allow-Methods"). Backend already allows PATCH (`handler.py` `_CORS_ALLOW_METHODS`; route at router_v2.py:1968); the API Gateway preflight didn't advertise it. Affects **all** users.

## Root cause (full audit)
`/api/v2/notifications/preferences` is not an explicit public route → falls through to the root `{proxy+}` catch-all, whose OPTIONS preflight is served by `proxy_options` (main.tf:628) = `'GET,POST,PUT,DELETE,OPTIONS'` (no PATCH). `root_options` (692) had the same gap.

## Fix
- Consolidated all scattered CORS `Allow-Methods`/`Allow-Headers` literals (6+6 locations) into canonical `local.cors_allow_methods`/`local.cors_allow_headers` (mirrors backend `_CORS_ALLOW_METHODS`) so they can't drift again. PATCH now advertised everywhere the API serves it.
- **Redeploy-trigger fix:** added the CORS locals to `aws_api_gateway_deployment.dashboard` `triggers.redeployment`. Param-only edits don't change an integration_response `.id`, so without this `apply` goes green while the stage serves stale preflight.
- `Allow-Origin` untouched (explicit allowlist, never `*`); `Allow-Credentials: true` preserved.

## Verify (post-apply)
Watch the plan for a **new `aws_api_gateway_deployment`** (if absent, the trigger didn't take). Then `curl -X OPTIONS .../api/v2/notifications/preferences` with `Access-Control-Request-Method: PATCH` → 200 with PATCH in Allow-Methods; then Settings → Save Changes persists.

Includes the full speckit trail (spec/plan/tasks + 3 adversarial reviews).