### PR TITLE
feat(1383): durable OAuth env + per-origin token-exchange redirect_uri

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1063,6 +1063,40 @@ jobs:
             echo "  Already '${CUR_OAUTH}', no change"
           fi
 
+          # Feature 1383: sync FRONTEND_URL + COGNITO_REDIRECT_URI onto $LATEST BEFORE publishing.
+          # Same rationale as the ENABLED_OAUTH_PROVIDERS block above — the Lambda env is
+          # Terraform-frozen (modules/lambda ignore_changes=[environment], Feature 1290), so these
+          # (previously set by hand during the WI-6 go-live) must be synced out-of-band from
+          # terraform outputs that mirror the Lambda env expressions exactly.
+          # CRITICAL: re-read CUR_ENV here so it reflects any ENABLED_OAUTH write just made above
+          # (reusing the stale map would revert it). We thread CUR_ENV across keys so a second
+          # write includes the first. Empty desired values are SKIPPED so we never clobber a
+          # correct value with "". update-function-configuration REPLACES the whole Variables map,
+          # so we always merge into the CURRENT map.
+          echo "🔐 Step 2.5b: Syncing FRONTEND_URL + COGNITO_REDIRECT_URI from terraform outputs..."
+          FRONTEND_URL_TF="$(terraform output -raw frontend_url 2>/dev/null || echo "")"
+          COGNITO_REDIRECT_TF="$(terraform output -raw cognito_redirect_uri 2>/dev/null || echo "")"
+          CUR_ENV="$(aws lambda get-function-configuration --function-name "$FUNC_NAME" --query 'Environment.Variables' --output json)"
+          for pair in "FRONTEND_URL=${FRONTEND_URL_TF}" "COGNITO_REDIRECT_URI=${COGNITO_REDIRECT_TF}"; do
+            KEY="${pair%%=*}"
+            DESIRED="${pair#*=}"
+            if [ -z "$DESIRED" ]; then
+              echo "  ${KEY}: desired empty — skip (not managed here, no clobber)"
+              continue
+            fi
+            CUR_VAL="$(printf '%s' "$CUR_ENV" | KEY="$KEY" python3 -c 'import sys,json,os;print(json.load(sys.stdin).get(os.environ["KEY"],""))')"
+            if [ "$CUR_VAL" != "$DESIRED" ]; then
+              echo "  Updating ${KEY} (was '${CUR_VAL}')..."
+              CUR_ENV="$(printf '%s' "$CUR_ENV" | KEY="$KEY" VAL="$DESIRED" python3 -c 'import sys,json,os;e=json.load(sys.stdin);e[os.environ["KEY"]]=os.environ["VAL"];print(json.dumps(e))')"
+              NEW_ENV="$(printf '%s' "$CUR_ENV" | python3 -c 'import sys,json;print(json.dumps({"Variables":json.load(sys.stdin)}))')"
+              aws lambda update-function-configuration --function-name "$FUNC_NAME" --environment "$NEW_ENV" >/dev/null
+              aws lambda wait function-updated --function-name "$FUNC_NAME"
+              echo "  ✅ ${KEY} synced to '${DESIRED}'"
+            else
+              echo "  ${KEY}: already '${CUR_VAL}', no change"
+            fi
+          done
+
           echo "📦 Step 3: Publishing immutable version..."
           VERSION=$(aws lambda publish-version \
             --function-name "$FUNC_NAME" \

--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -1491,6 +1491,22 @@ output "enabled_oauth_providers" {
   value       = local.enabled_oauth_providers
 }
 
+# Feature 1383: consumed by the CI dashboard-deploy step (deploy.yml "Step 2.5") to set the
+# Lambda's FRONTEND_URL / COGNITO_REDIRECT_URI env vars. Terraform cannot manage that env
+# directly (modules/lambda ignore_changes=[environment], Feature 1290), so CI syncs these
+# out-of-band before publishing the alias version. Each output MUST mirror the exact env
+# expression the dashboard Lambda uses (see the aws_lambda_function environment block above)
+# so the synced value equals what Terraform intends.
+output "frontend_url" {
+  description = "Customer dashboard URL synced onto the dashboard Lambda FRONTEND_URL env by CI (Feature 1383). Mirrors the FRONTEND_URL env expression exactly."
+  value       = var.frontend_url
+}
+
+output "cognito_redirect_uri" {
+  description = "Static OAuth token-exchange redirect URI synced onto COGNITO_REDIRECT_URI by CI (Feature 1383). Mirrors the COGNITO_REDIRECT_URI env expression exactly."
+  value       = length(var.cognito_callback_urls) > 0 ? var.cognito_callback_urls[0] : ""
+}
+
 output "api_gateway_id" {
   description = "ID of the Dashboard API Gateway"
   value       = module.api_gateway.api_id

--- a/infrastructure/terraform/preprod.tfvars
+++ b/infrastructure/terraform/preprod.tfvars
@@ -83,3 +83,21 @@ enable_cloudfront_waf = true
 # together. Secret-without-IdP yields Cognito "Invalid state"; IdP-without-secret
 # yields a broken provider.
 cognito_identity_providers = ["Google"]
+
+# Feature 1383: durable OAuth env (previously set manually during WI-6 go-live).
+# These feed two Terraform outputs (frontend_url, cognito_redirect_uri) that the CI
+# dashboard-deploy "Step 2.5" syncs onto the Lambda's FRONTEND_URL / COGNITO_REDIRECT_URI
+# env vars (the Lambda env is Terraform-frozen via ignore_changes=[environment], Feature 1290).
+#
+# frontend_url drives the OAuth redirect_uri allowlist (_resolve_redirect_uri, auth.py).
+frontend_url = "https://main.d29tlmksqcx494.amplifyapp.com"
+
+# cognito_callback_urls[0] feeds COGNITO_REDIRECT_URI (the static token-exchange fallback).
+# The Amplify callback MUST be index [0]. localhost is included to document the dev origin
+# the allowlist already permits. NOTE: the Cognito app client's registered callback URLs are
+# ignore_changes-frozen (modules/cognito/main.tf), so this list only affects the Lambda-env
+# output, not live Cognito registration.
+cognito_callback_urls = [
+  "https://main.d29tlmksqcx494.amplifyapp.com/auth/callback",
+  "http://localhost:3000/auth/callback",
+]

--- a/infrastructure/terraform/prod.tfvars
+++ b/infrastructure/terraform/prod.tfvars
@@ -42,6 +42,12 @@ cors_allowed_origins = [
   # Format: "https://main.<app-id>.amplifyapp.com"
 ]
 
+# TODO(1383): Set frontend_url + cognito_callback_urls[0] to the prod Amplify URL once
+# enable_amplify is turned on for prod and the URL is finalized (see TODO(1269) above).
+# The CI dashboard-deploy "Step 2.5" is empty-safe and will no-op FRONTEND_URL /
+# COGNITO_REDIRECT_URI until these are set. Do NOT copy the preprod URL here — prod uses a
+# different frontend URL. Left unset deliberately (owner question O1: prod canonical URL).
+
 # Feature 1054: JWT Secret for auth middleware
 # IMPORTANT: Use a strong, unique secret for production
 # The value is passed via TF_VAR_jwt_secret in CI - never commit the actual secret

--- a/specs/1383-oauth-env-durability/plan.md
+++ b/specs/1383-oauth-env-durability/plan.md
@@ -1,0 +1,354 @@
+# Implementation Plan: OAuth Env Durability + Per-Origin Token Exchange
+
+**Branch**: `1383-oauth-env-durability` | **Date**: 2026-07-23 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `specs/1383-oauth-env-durability/spec.md`
+
+> Authored by hand (speckit skills are branch-creating/interactive; this runs in an isolated
+> planning-only worktree). Structure follows `.specify/templates/plan-template.md`.
+
+## Summary
+
+Two independent deliverables, isolated for serialized merge:
+
+- **A) Durability (infra/CI, isolated):** Set `frontend_url` and `cognito_callback_urls` in
+  `preprod.tfvars`; add two Terraform outputs (`frontend_url`, `cognito_redirect_uri`) that
+  mirror the exact env expressions used at `main.tf:469` and `main.tf:465`; extend CI "Step 2.5"
+  in `.github/workflows/deploy.yml` to sync `FRONTEND_URL` and `COGNITO_REDIRECT_URI` onto the
+  dashboard Lambda `$LATEST` env from those outputs — same fetch→read-current→compare→merge-full-
+  map→`update-function-configuration`→`wait` shape as the existing `ENABLED_OAUTH_PROVIDERS`
+  block, plus an empty-value skip guard (AR1-F1). `prod.tfvars` deliberately deferred (AR1-F4).
+
+- **B) Correctness (code, auth.py merge hotspot):** Add an optional `redirect_uri_override` param
+  to `exchange_code_for_tokens` (`cognito.py`) and thread the already-state-validated per-request
+  `redirect_uri` from `handle_oauth_callback` (`auth.py:2215`) into it. Security holds because
+  `validate_oauth_state` (`oauth_state.py:220`) already enforces client `redirect_uri` ==
+  server-side stored authorize-time value before the exchange runs. Optional hardening: return
+  the stored value from `validate_oauth_state` and thread the server-side value.
+
+## Technical Context
+
+**Language/Version**: Python 3.13 (backend), YAML (GitHub Actions), HCL/Terraform 1.5+ (infra)
+**Primary Dependencies**: aws-lambda-powertools (routing), httpx (token exchange), boto3
+(DynamoDB state), AWS CLI + `terraform output` (CI), AWS Provider ~> 5.0
+**Storage**: DynamoDB OAuth state records (existing, read/validated — no schema change)
+**Testing**: pytest (unit, mocked httpx/moto), workflow-syntax lint (actionlint/yq), real-AWS
+preprod verification (manual, per constitution — preprod mirrors prod)
+**Target Platform**: AWS Lambda (`preprod-sentiment-dashboard`), GitHub Actions runner
+**Project Type**: web (backend Lambda + Next.js/Amplify customer frontend) — CUSTOMER dashboard only
+**Performance Goals**: N/A (config + single call-site thread-through; no hot-path change)
+**Constraints**: Dashboard Lambda env FROZEN in Terraform (`ignore_changes=[environment]`,
+Feature 1290) — env MUST flow via CI Step 2.5. No new AWS resources. `auth.py` is a merge hotspot
+shared with Features 1380/1381 — change must be minimal and localized. GPG-signed commits.
+**Scale/Scope**: 1 workflow file, 1 tfvars file (+ 1 deferred), ~2 Terraform outputs, 2 Python
+files, unit tests. Small blast radius except deploy.yml (critical path).
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Relevant constitution requirements (`.specify/memory/constitution.md`):
+
+| Requirement | Status | Notes |
+|---|---|---|
+| Auth on management/OAuth flows | PASS | Strengthens OAuth correctness; no new unauth surface. |
+| External API auth flows (OAuth) correct | PASS | Fixes redirect_uri correctness per OAuth spec. |
+| TLS in transit | PASS | All redirect_uris are https (Amplify) or localhost dev; token exchange over https. |
+| Secrets in managed store, never in source/logs | PASS | Only non-secret URLs echoed in Step 2.5 (FR-015). No secret touched. |
+| No raw user input into security-sensitive sinks | PASS | redirect_uri is allowlist+state validated before use (FR-011). |
+| IaC via Terraform, pinned providers, module layout | PASS | Outputs/tfvars only; no resource churn; env stays frozen by design. |
+| Least privilege / no new resources | PASS | FR-013: zero new AWS resources; reuses existing deploy IAM. |
+| SAST / no log injection | PASS | provider/uri already sanitized for logs in existing code; no new log of user input. |
+
+**Constitution gate: PASS.** No violations, no complexity-tracking entries required.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/1383-oauth-env-durability/
+├── spec.md              # Complete (+ Adversarial Review #1)
+├── plan.md              # This file (+ Adversarial Review #2)
+├── tasks.md             # Stage 7 (+ Adversarial Review #3)
+└── quickstart.md        # Optional verification recipe (Phase 1)
+```
+
+No `data-model.md` (no schema change) or `contracts/` (no new API surface) — the API request
+shape is unchanged; only the internal redirect_uri source changes.
+
+### Source Code (repository root)
+
+```text
+infrastructure/terraform/
+├── preprod.tfvars               # A: add frontend_url + cognito_callback_urls
+├── prod.tfvars                  # A: TODO(1383) breadcrumb only (deferred, AR1-F4)
+└── main.tf                      # A: add output "frontend_url" + output "cognito_redirect_uri"
+
+.github/workflows/
+└── deploy.yml                   # A: extend Step 2.5 (~line 1051-1066) to sync 2 more keys
+
+src/lambdas/
+├── shared/auth/cognito.py       # B: exchange_code_for_tokens gains redirect_uri_override param
+└── dashboard/auth.py            # B: thread redirect_uri at call site (line 2215) — MINIMAL
+
+tests/unit/
+├── shared/auth/test_cognito.py            # B: exchange uses override when provided; falls back
+└── dashboard/ (auth callback tests)       # B: callback threads validated redirect_uri
+```
+
+## Phase 0 — Research (resolved)
+
+All unknowns were resolved during spec authoring by reading the live code; no open research.
+
+1. **Does `terraform output` work in the Step 2.5 context?** YES — the dashboard-deploy job runs
+   with `working-directory: infrastructure/terraform` (deploy.yml:767) and already calls
+   `terraform output -raw enabled_oauth_providers` (deploy.yml:1052).
+2. **Is the callback redirect_uri already validated before exchange?** YES —
+   `validate_oauth_state` enforces equality against stored state (`oauth_state.py:220`) prior to
+   the exchange call (`auth.py:2215`). Security for Deliverable B is therefore pre-existing.
+3. **Does setting `cognito_callback_urls` mutate the live Cognito client?** NO —
+   `ignore_changes=[callback_urls]` (`modules/cognito/main.tf:146`). It only feeds the
+   Lambda-env-derived output. (AR1-F6)
+4. **Which output source is correct for COGNITO_REDIRECT_URI?** A NEW output computed from
+   `var.cognito_callback_urls[0]` (matches env expression `main.tf:465`), NOT the existing
+   `output "cognito_callback_urls"` (which returns the `ignore_changes`-drifted client attr).
+   (AR1-F7)
+5. **Prod values?** Unknown/undeployed — `prod.tfvars` has no Amplify config; `TODO(1269)`
+   placeholder stands. Defer (AR1-F4 / Clarification C4).
+
+## Phase 1 — Design
+
+### A) Terraform outputs (mirror env expressions exactly)
+
+```hcl
+# main.tf — near output "enabled_oauth_providers" (line ~1489)
+output "frontend_url" {
+  description = "Customer dashboard URL synced onto the dashboard Lambda FRONTEND_URL env by CI (Feature 1383). Terraform-frozen env; see deploy.yml Step 2.5."
+  value       = var.frontend_url
+}
+
+output "cognito_redirect_uri" {
+  description = "Static OAuth token-exchange redirect URI synced onto COGNITO_REDIRECT_URI by CI (Feature 1383). Mirrors the main.tf env expression exactly."
+  value       = length(var.cognito_callback_urls) > 0 ? var.cognito_callback_urls[0] : ""
+}
+```
+
+### A) preprod.tfvars
+
+```hcl
+# Feature 1383: durable OAuth env (was manually set during WI-6 go-live).
+frontend_url = "https://main.d29tlmksqcx494.amplifyapp.com"
+# Index [0] feeds COGNITO_REDIRECT_URI (main.tf:465). Cognito client callback
+# registration is ignore_changes-frozen, so this only affects the Lambda env output.
+cognito_callback_urls = [
+  "https://main.d29tlmksqcx494.amplifyapp.com/auth/callback",
+  "http://localhost:3000/auth/callback",
+]
+```
+
+### A) prod.tfvars (deferred)
+
+```hcl
+# TODO(1383): set frontend_url + cognito_callback_urls[0] to the prod Amplify URL once
+# enable_amplify is turned on for prod and the URL is finalized (see TODO(1269)). CI Step 2.5
+# is empty-safe and will no-op these keys until then. Do NOT copy the preprod URL here.
+```
+
+### A) deploy.yml Step 2.5 extension (design sketch, not final code)
+
+Reuse the exact idempotent shape, generalized to a per-key helper with an **empty-skip guard**:
+
+```bash
+# after the existing ENABLED_OAUTH_PROVIDERS sync, same CUR_ENV re-read or reuse
+sync_env_key () {   # $1=key  $2=desired
+  local key="$1" desired="$2"
+  if [ -z "$desired" ]; then echo "  ${key}: desired empty — skip (not managed here)"; return; fi
+  local cur; cur="$(printf '%s' "$CUR_ENV" | KEY="$key" python3 -c 'import sys,json,os;print(json.load(sys.stdin).get(os.environ["KEY"],""))')"
+  if [ "$cur" != "$desired" ]; then
+    CUR_ENV="$(printf '%s' "$CUR_ENV" | KEY="$key" VAL="$desired" python3 -c 'import sys,json,os;e=json.load(sys.stdin);e[os.environ["KEY"]]=os.environ["VAL"];print(json.dumps(e))')"
+    aws lambda update-function-configuration --function-name "$FUNC_NAME" --environment "{\"Variables\":$CUR_ENV}" >/dev/null
+    aws lambda wait function-updated --function-name "$FUNC_NAME"
+    echo "  ✅ ${key} synced"
+  else
+    echo "  ${key}: already correct, no change"
+  fi
+}
+FRONTEND_URL_TF="$(terraform output -raw frontend_url 2>/dev/null || echo "")"
+COGNITO_REDIRECT_TF="$(terraform output -raw cognito_redirect_uri 2>/dev/null || echo "")"
+sync_env_key FRONTEND_URL "$FRONTEND_URL_TF"
+sync_env_key COGNITO_REDIRECT_URI "$COGNITO_REDIRECT_TF"
+```
+
+Design notes:
+- Values pass to `python3` via env (`KEY`/`VAL`), never interpolated into shell → no injection.
+- `CUR_ENV` is threaded so multiple keys merge into ONE evolving map; unrelated keys preserved.
+- Empty-skip prevents the AR1-F1 clobber. Diverges intentionally from the ENABLED_OAUTH block.
+- Runs BEFORE `publish-version` (FR-008), same placement as today.
+- Implementer may keep the existing ENABLED_OAUTH inline block as-is and add the two new syncs
+  after it, OR refactor all three through `sync_env_key`. Refactoring all three is cleaner but
+  touches the proven block — see AR#2 for the risk trade-off; default is ADD-ONLY to minimize
+  critical-path risk.
+
+### B) cognito.py — exchange_code_for_tokens
+
+```python
+def exchange_code_for_tokens(
+    config: CognitoConfig,
+    code: str,
+    code_verifier: str | None = None,
+    redirect_uri_override: str | None = None,   # Feature 1383
+) -> CognitoTokens:
+    ...
+    data = {
+        "grant_type": "authorization_code",
+        "code": code,
+        "redirect_uri": redirect_uri_override or config.redirect_uri,   # Feature 1383
+    }
+```
+
+Mirrors the existing `get_authorize_url(..., redirect_uri_override=...)` convention (cognito.py:86).
+
+### B) auth.py — call site (MINIMAL, merge-hotspot)
+
+```python
+# auth.py:2215 — thread the already-state-validated redirect_uri
+tokens = exchange_code_for_tokens(
+    config, code, code_verifier=code_verifier, redirect_uri=redirect_uri,   # name matches param
+)
+```
+
+Only this one line changes in `auth.py`. `redirect_uri` here is the function parameter
+(`auth.py:2147`) that `validate_oauth_state` already proved equals the stored authorize-time
+value. No surrounding logic touched → clean serialized merge with 1380/1381.
+
+**Optional hardening (recorded, default OFF to keep auth.py minimal):** change
+`validate_oauth_state` to also return the stored `state.redirect_uri`, and thread THAT
+server-side value into the exchange. Removes reliance on the client value being equal (it is
+equal, but returning the server value is defense-in-depth). Costs a signature change to a shared
+function (`oauth_state.py`) touched by other OAuth features — deferred unless AR#2/clarify
+elevates it.
+
+### Merge-hotspot note (auth.py ↔ 1380/1381)
+
+`src/lambdas/dashboard/auth.py` is edited by Features 1380 and 1381 concurrently. This feature's
+footprint is a SINGLE line at the `exchange_code_for_tokens` call site (2215). Keep it a one-line
+kwarg addition; do not reflow, reorder, or reformat neighboring code. Merge these serially and
+resolve by taking both changes (they are line-disjoint from typical 1380/1381 edits, but confirm
+at merge time).
+
+## Phase 2 — Verification approach (preprod, real AWS)
+
+1. Deploy to preprod; confirm Step 2.5 logs "synced" for FRONTEND_URL + COGNITO_REDIRECT_URI on
+   first run, "already correct, no change" on a second run (idempotency, SC-002).
+2. `aws lambda get-function-configuration` shows both keys correct; unrelated keys intact (SC-003).
+3. Strip both keys manually → redeploy → confirm restored (SC-006, recreation survivability).
+4. Real Google sign-in from Amplify origin succeeds; inspect that token exchange used the origin
+   callback (SC-004). Negative: tampered redirect_uri rejected pre-exchange (SC-005).
+
+## Complexity Tracking
+
+No constitution violations → table intentionally empty.
+
+## Progress Tracking
+
+- [x] Phase 0 research complete (resolved during spec)
+- [x] Phase 1 design complete
+- [x] Constitution check (initial) PASS
+- [ ] Constitution re-check after AR#2
+- [ ] tasks.md generated (Stage 7)
+
+---
+
+## Adversarial Review #2
+
+**Stance**: Hunt for drift between spec and plan, cross-artifact contradictions, and design flaws
+the spec-level review (AR#1) could not see now that the design is concrete.
+
+### Drift checks (spec ↔ plan)
+
+| Spec item | Plan coverage | Drift? |
+|---|---|---|
+| FR-001/002 (preprod.tfvars values) | Phase 1 "preprod.tfvars" block | none |
+| FR-003/004 (two outputs, exact expressions) | Phase 1 "Terraform outputs" | none — plan uses `var.cognito_callback_urls[0]` with length guard, matching main.tf:465 |
+| FR-005/006/007/008 (Step 2.5 extend, idempotent, merge, ordering) | Phase 1 deploy.yml sketch + Phase 2 verify | none — empty-skip + full-map merge + pre-publish placement all present |
+| FR-009 (exchange override param) | Phase 1 cognito.py block | none |
+| FR-010 (thread at 2215) | Phase 1 auth.py block | none |
+| FR-011 (validate-before-exchange) | Phase 1 note + Phase 0 research #2 | none |
+| FR-012 (minimal auth.py) | Phase 1 "Merge-hotspot note" | none |
+| FR-013 (no new AWS resources) | Constitution check + Summary | none |
+| FR-014 (prod never gets preprod value) | Phase 1 prod.tfvars block (TODO only) | none |
+| FR-015 (no secret logging) | Constitution check + design note (env-passed vars) | none |
+
+No drift found. Every FR maps to a concrete plan element.
+
+### New findings at design granularity
+
+**AR2-F1 (MEDIUM → resolved): Two separate `update-function-configuration` calls thrash the map.**
+The `sync_env_key` sketch calls `update-function-configuration` once PER changed key, re-reading
+`CUR_ENV` from a threaded variable (not re-fetching from AWS). If both keys change on a fresh
+Lambda, that's two sequential update+wait cycles. Correctness holds (CUR_ENV is threaded so the
+second call includes the first key's change), but it's two API round-trips. *Resolution*:
+Acceptable — matches the existing block's one-key-one-update rhythm, keeps the diff minimal, and
+fresh-Lambda (both-change) is rare. Tasks note an OPTIONAL single-batched-update variant (compute
+both desired values, merge once, one update) for the implementer if they prefer. Not required.
+
+**AR2-F2 (MEDIUM → resolved): `CUR_ENV` reuse vs. the existing ENABLED_OAUTH block.** The existing
+block reads `CUR_ENV` once and builds `NEW_ENV` from it. If the new code reuses that SAME `CUR_ENV`
+variable AFTER the ENABLED_OAUTH block already issued an update, `CUR_ENV` would be stale (missing
+the just-written ENABLED_OAUTH value) — a merge that re-reads stale state could revert it.
+*Resolution*: The plan's helper threads `CUR_ENV` forward, but the SAFEST implementation re-reads
+`CUR_ENV` from `aws lambda get-function-configuration` AFTER the ENABLED_OAUTH block (or folds all
+three keys into one read→merge→write). Task T-DEPLOY must specify: re-fetch current env
+immediately before the new syncs, OR thread the same evolving map through all three keys. Elevated
+to an explicit task acceptance criterion. **This is the single most important implementation
+detail** — flagged for AR#3.
+
+**AR2-F3 (LOW → resolved): `terraform output -raw` on a list vs string.** `frontend_url` and
+`cognito_redirect_uri` are both string-valued outputs (the latter guards the index), so `-raw`
+works. The existing (unused-by-us) `cognito_callback_urls` output is a list and `-raw` would fail
+on it — but we deliberately do NOT use that output (AR1-F7). No action.
+
+**AR2-F4 (LOW → resolved): quickstart.md optionality.** Plan lists quickstart.md as optional. The
+verification recipe (Phase 2) is self-contained; a separate quickstart is not needed for a
+config+one-line change. Decision: fold verification into tasks.md rather than a separate file.
+
+**AR2-F5 (LOW): auth.py kwarg name must match the new param name.** Plan shows
+`exchange_code_for_tokens(config, code, code_verifier=..., redirect_uri=redirect_uri)` but the new
+param in cognito.py is named `redirect_uri_override`. The call site MUST use
+`redirect_uri_override=redirect_uri` (kwarg name = param name) or it's a TypeError. *Resolution*:
+Corrected here and carried into tasks — call site uses `redirect_uri_override=redirect_uri`.
+**(Genuine bug in the plan sketch; fixed.)**
+
+### Cross-artifact consistency
+
+- Clarifications C1–C5 are consistent with plan decisions (defer prod, keep static fallback,
+  add-only Step 2.5, Amplify-at-[0]+localhost, no new validation). No contradiction.
+- Owner question O1 (prod URL) is the only unresolved item; it does not block Deliverable A/B on
+  preprod and is correctly scoped as deferred.
+
+### Constitution re-check (post-design)
+
+Re-ran the gate table with concrete design: still PASS. The empty-skip guard (AR1-F1) and
+env-passed python3 vars (no shell interpolation) reinforce the "no secret leak / no injection"
+constitution items. No new resources. No violations.
+
+### Gate
+
+- CRITICAL: 0
+- HIGH: 0
+- MEDIUM: 0 open (AR2-F1, AR2-F2 resolved with task-level acceptance criteria)
+- LOW: 3 (AR2-F3/F4 resolved, AR2-F5 fixed)
+
+**AR#2 GATE: PASS. Drift: none. One genuine plan bug fixed (AR2-F5 kwarg name). One critical
+implementation detail elevated to AR#3 (AR2-F2 env re-read/merge ordering).**
+
+---
+
+## Plan 2nd Pass (Stage 6)
+
+**Outcome: SKIPPED (no structural drift).** AR#2 found zero spec↔plan drift. The only genuine
+defect (AR2-F5, wrong kwarg name in the auth.py sketch) was a localized one-token fix applied
+inline in the AR#2 section and carried into tasks (call site uses
+`redirect_uri_override=redirect_uri`). The one elevated concern (AR2-F2, env re-read/merge
+ordering in Step 2.5) is not a plan-structure change — it becomes an explicit acceptance
+criterion on the deploy task. No re-plan required.

--- a/specs/1383-oauth-env-durability/spec.md
+++ b/specs/1383-oauth-env-durability/spec.md
@@ -1,0 +1,426 @@
+# Feature Specification: OAuth Env Durability + Per-Origin Token Exchange
+
+**Feature Branch**: `1383-oauth-env-durability`
+**Created**: 2026-07-23
+**Status**: Draft
+**Input**: User description: "Make the two manually-set dashboard-Lambda OAuth env vars (FRONTEND_URL, COGNITO_REDIRECT_URI) durable via terraform-sourced CI sync (same pattern as ENABLED_OAUTH_PROVIDERS in PR #936), and fix the OAuth token exchange to use the same validated per-request redirect_uri as the authorize step instead of a static env value."
+
+> Authoring note: The `/speckit.*` skills in this repo run interactive, branch-creating
+> workflows (create-new-feature scripts, prompts). This feature is being produced inside an
+> isolated planning-only git worktree where branch creation and pushes are disallowed, so all
+> nine speckit artifacts were authored by hand following the `.specify/templates/*` structure.
+> Content and gating are identical to the skill output; only the invocation mechanism differs.
+
+## Context & Problem
+
+During the M1 WI-6 Google OAuth go-live, three dashboard-Lambda environment variables were set
+**manually** via live `aws lambda update-function-configuration` because Terraform cannot manage
+Lambda env (`modules/lambda` carries `lifecycle { ignore_changes = [image_uri, environment] }`,
+Feature 1290) and the CI dashboard-deploy step synced only ONE of them:
+
+| Env var | Durable today? | Drives |
+|---|---|---|
+| `ENABLED_OAUTH_PROVIDERS=google` | YES — PR #936, CI "Step 2.5" syncs from `terraform output enabled_oauth_providers` | Provider enablement + authorize URL generation |
+| `FRONTEND_URL=https://main.d29tlmksqcx494.amplifyapp.com` | NO — manual only | OAuth redirect_uri allowlist (`_resolve_redirect_uri`, `auth.py:2030`) |
+| `COGNITO_REDIRECT_URI=https://main.d29tlmksqcx494.amplifyapp.com/auth/callback` | NO — manual only | Static token-exchange redirect_uri (`cognito.py:162`) |
+
+Two independent facts make these "snowflakes":
+
+1. **Durability gap.** A Lambda recreation (or any recreation of `$LATEST` env) would lose
+   `FRONTEND_URL` and `COGNITO_REDIRECT_URI` because nothing reproduces them from source. Only
+   `ENABLED_OAUTH_PROVIDERS` is reconstructed by CI Step 2.5.
+
+2. **Correctness gap.** The authorize step uses a **dynamic, per-request** redirect_uri
+   (`get_authorize_url(..., redirect_uri_override=_resolve_redirect_uri(origin))`), but the
+   token exchange uses a **static** `config.redirect_uri` (from `COGNITO_REDIRECT_URI`). OAuth
+   requires the token-exchange redirect_uri to EXACTLY match the authorize redirect_uri. The
+   static value is why `COGNITO_REDIRECT_URI` had to be pinned by hand, and it breaks any origin
+   other than the pinned one (e.g. localhost dev against preprod). The frontend already sends its
+   real redirect_uri in the callback POST; the backend receives it but drops it.
+
+### Confirmed plumbing (file:line)
+
+- **Token-exchange drop-point**: `src/lambdas/dashboard/auth.py:2215` —
+  `tokens = exchange_code_for_tokens(config, code, code_verifier=code_verifier)` — the
+  `redirect_uri` parameter that `handle_oauth_callback` received (param declared at
+  `auth.py:2147`) is not passed through.
+- **Static redirect_uri used in exchange**: `src/lambdas/shared/auth/cognito.py:162` —
+  `"redirect_uri": config.redirect_uri` (config value comes from `COGNITO_REDIRECT_URI`,
+  `cognito.py:59`).
+- **Authorize already dynamic**: `auth.py:2101-2105` and `2123-2127` pass
+  `redirect_uri_override=redirect_uri` where `redirect_uri = _resolve_redirect_uri(origin)`
+  (`auth.py:2078`).
+- **Server-side stored redirect_uri**: `store_oauth_state(..., redirect_uri=redirect_uri)`
+  (`auth.py:2093/2097`, `2115/2119`) persists the authorize-time value.
+- **Allowlist validation already enforced on callback**: `handle_oauth_callback` calls
+  `validate_oauth_state(table, state_id=state, provider=provider, redirect_uri=redirect_uri)`
+  (`auth.py:2186-2192`), and `validate_oauth_state` REJECTS the request unless the client-sent
+  `redirect_uri` exactly equals the server-side stored `state.redirect_uri`
+  (`src/lambdas/shared/auth/oauth_state.py:220`). Because that stored value was produced by
+  `_resolve_redirect_uri` (allowlist-gated), by the time control reaches line 2215 the
+  `redirect_uri` is provably equal to an allowlist-validated authorize-time value.
+- **Durability pattern to copy**: CI "Step 2.5" at `.github/workflows/deploy.yml:1051-1066` —
+  fetch `terraform output -raw enabled_oauth_providers` → read current `Environment.Variables`
+  → compare → merge full Variables map → `update-function-configuration` → `wait
+  function-updated`; no-ops when already correct.
+- **Terraform env expressions** (source of truth for the outputs to add):
+  `FRONTEND_URL = var.frontend_url` (`main.tf:469`);
+  `COGNITO_REDIRECT_URI = length(var.cognito_callback_urls) > 0 ? var.cognito_callback_urls[0] : ""`
+  (`main.tf:465`).
+- **Existing output to mirror**: `output "enabled_oauth_providers"` (`main.tf:1489`).
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Durable OAuth env survives Lambda recreation (Priority: P1)
+
+As the platform operator, when the dashboard Lambda's `$LATEST` env is recreated (image swap,
+teardown/rebuild, or a fresh account bootstrap), a normal CI deploy must restore `FRONTEND_URL`
+and `COGNITO_REDIRECT_URI` to their correct values from Terraform-sourced config, with zero
+manual `aws lambda update-function-configuration` steps.
+
+**Why this priority**: This is the core durability defect. Today an env recreation silently
+breaks Google OAuth (redirect_uri allowlist collapses to localhost-only) with no code change and
+no obvious cause. It is a latent production-mirror outage.
+
+**Independent Test**: On preprod, manually strip `FRONTEND_URL` and `COGNITO_REDIRECT_URI` from
+`$LATEST`, trigger a dashboard deploy, and confirm both are restored to the expected values on
+the published/served version — with no manual env edit.
+
+**Acceptance Scenarios**:
+
+1. **Given** `FRONTEND_URL` and `COGNITO_REDIRECT_URI` are absent or wrong on `$LATEST`,
+   **When** the dashboard-deploy job runs, **Then** Step 2.5 sets both to the Terraform-output
+   values and the published version serves them.
+2. **Given** both env vars already equal the Terraform-output values, **When** the deploy runs
+   again, **Then** Step 2.5 detects no diff and performs no `update-function-configuration`
+   call (idempotent no-op) and logs "no change".
+3. **Given** the Variables map also contains unrelated keys (e.g. `SENTIMENTS_TABLE`,
+   `COGNITO_CLIENT_ID`), **When** Step 2.5 updates the OAuth keys, **Then** all unrelated keys
+   are preserved unchanged (full-map merge, never a replace).
+
+---
+
+### User Story 2 - Token exchange uses the same validated redirect_uri as authorize (Priority: P1)
+
+As an authenticating user (including a developer running the frontend on `localhost:3000`
+against the deployed preprod API), the OAuth authorization-code exchange must use the exact
+redirect_uri that was used at the authorize step, so the exchange is not rejected by the IdP for
+`redirect_uri` mismatch.
+
+**Why this priority**: This is the correctness defect that forced the manual pin. It also makes
+localhost-dev-against-preprod work without per-origin config, and removes the single-origin
+fragility of a static token-exchange redirect_uri.
+
+**Independent Test**: Complete a real Google sign-in from the preprod Amplify origin (token
+exchange succeeds), and separately confirm that a callback whose `redirect_uri` does not match
+the stored state value is rejected before any token exchange occurs.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user authorized from origin `O` (redirect_uri `O/auth/callback`), **When** the
+   callback POST arrives with that same redirect_uri and a valid state, **Then** the backend
+   exchanges the code using `O/auth/callback` (not the static `COGNITO_REDIRECT_URI`) and login
+   succeeds.
+2. **Given** a callback whose `redirect_uri` differs from the value stored in the OAuth state
+   record, **When** the backend validates state, **Then** the request is rejected with an
+   invalid-state error and NO token exchange is attempted.
+3. **Given** `COGNITO_REDIRECT_URI` is set to the Amplify callback and the request origin is the
+   Amplify origin, **When** login runs, **Then** behavior is unchanged from today (no
+   regression on the primary path).
+
+---
+
+### User Story 3 - Fresh-account/prod parity is explicit and non-breaking (Priority: P3)
+
+As the operator preparing prod (or a fresh account), the Terraform config must make the intended
+`frontend_url` / callback values explicit per environment so prod is not silently left with the
+empty defaults, and so this change never overwrites a correct prod value with a preprod one.
+
+**Why this priority**: Prod uses a different frontend URL than preprod, and prod's Amplify URL is
+not yet finalized in `prod.tfvars` (`cors_allowed_origins` has a `TODO(1269)` placeholder). This
+story records the decision rather than shipping a guessed prod value.
+
+**Independent Test**: `terraform output frontend_url` / `terraform output cognito_redirect_uri`
+resolve to environment-appropriate values for the selected `*.tfvars`, and the CI Step 2.5 logic
+is environment-agnostic (reads whatever the output yields).
+
+**Acceptance Scenarios**:
+
+1. **Given** `preprod.tfvars` sets `frontend_url` and `cognito_callback_urls`, **When**
+   `terraform output` runs for preprod, **Then** the outputs equal the preprod Amplify URL and
+   `.../auth/callback`.
+2. **Given** prod's Amplify URL is not yet finalized, **When** this feature ships, **Then**
+   `prod.tfvars` is either populated with the real prod URL or left with a documented,
+   deliberate decision (see Clarifications) — never a preprod value.
+
+### Edge Cases
+
+- **Empty Terraform output**: If `terraform output -raw frontend_url` returns empty (var
+  defaults to `""`), Step 2.5 MUST NOT wipe a correct existing Lambda value with an empty
+  string. Desired behavior: skip the update for an env var whose desired value is empty (treat
+  empty as "not managed here"), mirroring the safety of the existing ENABLED_OAUTH block but
+  without clobbering. (See Adversarial Review #1 — empty-clobber hazard.)
+- **`cognito_callback_urls` empty list**: `COGNITO_REDIRECT_URI` output expression must guard the
+  index (`length(...) > 0 ? [0] : ""`) exactly as `main.tf:465` does.
+- **Trailing-slash / normalization drift**: `_resolve_redirect_uri` strips a trailing slash on
+  `FRONTEND_URL`; the stored state redirect_uri and the client-sent one must normalize the same
+  way or `validate_oauth_state` will falsely reject. Confirm no new normalization is introduced.
+- **State record lacks redirect_uri**: If an older state row has no stored redirect_uri,
+  `validate_oauth_state` already rejects on mismatch; the exchange path must never fall back to
+  an unvalidated client value.
+- **Concurrent deploy env race**: Step 2.5 reads-then-writes the full Variables map; a
+  simultaneous unrelated env write could be lost. Deploys are serialized by the workflow
+  concurrency group, so this is out of scope but noted.
+- **deploy.yml injection**: Only trusted Terraform outputs and AWS CLI JSON flow through `run:`
+  blocks; values are passed via env to `python3` (never interpolated into shell), matching the
+  existing ENABLED_OAUTH block.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: `preprod.tfvars` MUST set `frontend_url = "https://main.d29tlmksqcx494.amplifyapp.com"`.
+- **FR-002**: `preprod.tfvars` MUST set `cognito_callback_urls` such that index `[0]` is
+  `"https://main.d29tlmksqcx494.amplifyapp.com/auth/callback"` (the value the static
+  `COGNITO_REDIRECT_URI` env is derived from). Note: the Cognito app client has
+  `ignore_changes=[callback_urls]` (`modules/cognito/main.tf:146`), so this change affects the
+  Lambda-env-derived output, not the live Cognito client registration.
+- **FR-003**: Terraform MUST expose an `output "frontend_url"` whose value equals the exact env
+  expression `var.frontend_url` (the same source `main.tf:469` uses for `FRONTEND_URL`).
+- **FR-004**: Terraform MUST expose an `output "cognito_redirect_uri"` whose value equals the
+  exact env expression `length(var.cognito_callback_urls) > 0 ? var.cognito_callback_urls[0] : ""`
+  (the same source `main.tf:465` uses for `COGNITO_REDIRECT_URI`).
+- **FR-005**: CI "Step 2.5" in `.github/workflows/deploy.yml` MUST be extended to sync
+  `FRONTEND_URL` and `COGNITO_REDIRECT_URI` onto the dashboard Lambda `$LATEST` env from
+  `terraform output -raw frontend_url` and `terraform output -raw cognito_redirect_uri`, using
+  the same fetch → read-current-map → compare → merge-full-map → `update-function-configuration`
+  → `wait function-updated` pattern already used for `ENABLED_OAUTH_PROVIDERS`.
+- **FR-006**: The Step 2.5 sync MUST be idempotent: when the current Lambda value already equals
+  the desired Terraform-output value, no `update-function-configuration` call is made.
+- **FR-007**: The Step 2.5 sync MUST preserve every other key in the Lambda `Environment.Variables`
+  map (merge, never replace the whole map with only OAuth keys).
+- **FR-008**: The Step 2.5 sync MUST run BEFORE `publish-version` so the served alias/version
+  carries the synced env, matching the existing ordering.
+- **FR-009**: `exchange_code_for_tokens` (`src/lambdas/shared/auth/cognito.py`) MUST accept a
+  per-request redirect_uri (new optional parameter, e.g. `redirect_uri_override: str | None`)
+  and use it for the token-exchange `redirect_uri` when provided, falling back to
+  `config.redirect_uri` otherwise — mirroring `get_authorize_url`'s existing
+  `redirect_uri_override` parameter.
+- **FR-010**: `handle_oauth_callback` (`src/lambdas/dashboard/auth.py`) MUST thread the request's
+  already-state-validated `redirect_uri` into `exchange_code_for_tokens` at the call site
+  (`auth.py:2215`).
+- **FR-011**: The redirect_uri used for the token exchange MUST be one that has passed
+  `validate_oauth_state` (i.e. equals the server-side stored authorize-time value). The system
+  MUST NOT pass a raw, un-validated client-supplied redirect_uri to the token exchange. (Today
+  this is guaranteed by the existing `validate_oauth_state` redirect_uri equality check at
+  `oauth_state.py:220`, which runs before line 2215.)
+- **FR-012**: The `auth.py` change MUST be minimal and localized to the callback token-exchange
+  call site (no refactor of surrounding logic), because `auth.py` is a known merge hotspot shared
+  with Features 1380 and 1381 (serialized merge).
+- **FR-013**: No new AWS resources are created; the dashboard-Lambda env remains
+  Terraform-frozen (`ignore_changes=[environment]`) and flows only via CI Step 2.5.
+- **FR-014**: `prod.tfvars` handling MUST be an explicit, documented decision (populate with the
+  real prod frontend URL, or deliberately defer) — never populated with a preprod value. (See
+  Clarifications.)
+- **FR-015**: Secrets MUST never be logged by the new Step 2.5 lines; only non-secret URLs are
+  echoed, consistent with the existing block.
+
+### Key Entities *(include if feature involves data)*
+
+- **Dashboard Lambda Environment (`$LATEST` Variables map)**: The frozen-in-Terraform,
+  CI-synced env of `preprod-sentiment-dashboard`. Relevant keys: `FRONTEND_URL`,
+  `COGNITO_REDIRECT_URI`, `ENABLED_OAUTH_PROVIDERS`.
+- **OAuth State record** (`oauth_state.py`): DynamoDB row storing `provider`, `redirect_uri`,
+  `code_verifier`, `created_at`, `used`. The stored `redirect_uri` is the authorize-time,
+  allowlist-validated value the exchange must match.
+- **Terraform outputs**: `frontend_url`, `cognito_redirect_uri` (new), `enabled_oauth_providers`
+  (existing) — the source of truth CI reads to reconstruct the frozen env.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A fresh dashboard deploy sets `FRONTEND_URL` and `COGNITO_REDIRECT_URI` on the
+  served Lambda version from Terraform-sourced config with ZERO manual steps (verified on real
+  preprod).
+- **SC-002**: Running the deploy a second time with env already correct produces a Step 2.5
+  "no change" log for both keys and issues zero `update-function-configuration` calls for them
+  (idempotent).
+- **SC-003**: After Step 2.5 runs, every pre-existing non-OAuth env key is byte-for-byte
+  unchanged (no clobber).
+- **SC-004**: A real Google sign-in from the preprod Amplify origin succeeds, and the token
+  exchange request carries `redirect_uri` equal to the origin's `/auth/callback` (not a
+  hardcoded static value).
+- **SC-005**: A callback with a redirect_uri that does not match the stored state value is
+  rejected before any token exchange (no open-redirect, no token theft path).
+- **SC-006**: Simulated env-strip + redeploy on preprod restores correct OAuth env (Lambda
+  "recreation" survivability demonstrated).
+- **SC-007**: `terraform output frontend_url` and `terraform output cognito_redirect_uri` return
+  environment-appropriate values for preprod; prod handling matches the recorded decision.
+
+## Assumptions
+
+- The dashboard-deploy job runs `terraform` in a directory where `terraform output` is available
+  (same context the existing `enabled_oauth_providers` fetch relies on).
+- `preprod-sentiment-dashboard` is the correct function name (already hardcoded in Step 2.5).
+- CUSTOMER dashboard only (Next.js/Amplify). The HTMX admin dashboard is untouched.
+- The frontend already sends `redirect_uri = window.location.origin + window.location.pathname`
+  in the callback POST (`frontend/src/app/auth/callback/page.tsx:115`) and the route handler
+  passes it into `handle_oauth_callback`.
+
+## Out of Scope
+
+- Removing the static `COGNITO_REDIRECT_URI` entirely (kept as fallback for FR-009; removal is a
+  follow-up once per-origin exchange is proven).
+- Un-freezing the Lambda env in Terraform (Feature 1290 constraint stands).
+- GitHub as an OAuth provider (Google-only per M1 WI-6).
+- Any change to the Cognito app client's registered callback URLs (frozen via
+  `ignore_changes`).
+
+---
+
+## Adversarial Review #1
+
+**Reviewer stance**: Assume the spec is wrong. Attack surfaces named by the battleplan:
+open-redirect via unvalidated redirect_uri; Step 2.5 clobbering other env vars; deploy.yml
+breaking the critical dashboard deploy; prod.tfvars not getting these (prod uses a different
+frontend URL); race where token redirect_uri != authorize.
+
+### Findings
+
+**AR1-F1 (HIGH → resolved in spec): Empty-output clobber.** The battleplan says "copy the
+ENABLED_OAUTH pattern," which updates whenever `CUR != DESIRED` — INCLUDING when `DESIRED` is
+empty. `var.frontend_url` defaults to `""` and `cognito_callback_urls` can be empty. If the
+outputs ever resolve empty (prod today, a bad tfvars, or a `terraform output` miss swallowed by
+`|| echo ""`), a naive copy would SET `FRONTEND_URL=""` / `COGNITO_REDIRECT_URI=""` on the
+Lambda, wiping a correct manually-set value and collapsing the redirect allowlist to
+localhost-only — the exact outage this feature exists to prevent, now triggered BY the fix.
+*Resolution*: FR-006 + Edge Case "Empty Terraform output" require Step 2.5 to SKIP the update
+when the desired value is empty (treat empty as "not managed here"). This diverges intentionally
+from the ENABLED_OAUTH block (whose empty is a legitimate "OAuth disabled" state). Documented as
+a deliberate, tested divergence, not an oversight. **Gate impact: would have been CRITICAL in
+prod; downgraded to resolved-HIGH by spec edit.**
+
+**AR1-F2 (HIGH → already safe): Open-redirect / token-theft via client redirect_uri.** The
+concern: threading a client-supplied redirect_uri into the token exchange could let an attacker
+redirect the code/token to an attacker origin. *Investigation*: The value threaded at
+`auth.py:2215` is the SAME `redirect_uri` that `validate_oauth_state` already checked for exact
+equality against the server-side stored `state.redirect_uri` (`oauth_state.py:220`), which was
+itself produced by the allowlist-gated `_resolve_redirect_uri` at authorize time. So the value
+is provably (a) allowlist-validated and (b) equal to the authorize-time value before it ever
+reaches the exchange. No new trust is extended. *Resolution*: FR-011 codifies this ordering
+constraint (validate-before-exchange) so a future refactor cannot reorder it. **Belt-and-
+suspenders option recorded in plan**: have `validate_oauth_state` RETURN the stored redirect_uri
+and thread the server-side value rather than the (equal) client value — removes any doubt.
+**Gate impact: no code-path vulnerability found; FR-011 hardens against regression.**
+
+**AR1-F3 (HIGH → resolved in spec): deploy.yml is the critical path.** A syntax error or a
+`set -e` abort in the extended Step 2.5 would break EVERY dashboard deploy, not just OAuth.
+*Resolution*: (1) The new logic mirrors the proven ENABLED_OAUTH block byte-for-byte in shape
+(fetch with `|| echo ""`, python3 for JSON via env-passed vars, guarded update, `wait`). (2)
+FR-007 mandates full-map merge. (3) Tasks include a `yq`/`actionlint`-style workflow-syntax
+check and a dry-run reasoning pass. (4) Empty-skip (AR1-F1) also prevents a failed output fetch
+from doing damage. **Gate impact: mitigated by pattern-fidelity + validation tasks.**
+
+**AR1-F4 (MEDIUM → deferred, documented): prod.tfvars not populated.** Confirmed: `prod.tfvars`
+sets none of `frontend_url` / `enable_amplify` / `cognito_callback_urls`, and prod's Amplify URL
+is an unfilled `TODO(1269)` placeholder in `cors_allowed_origins`. Prod Amplify may not even be
+deployed. Shipping a preprod URL to prod would be actively wrong (FR-014 forbids it).
+*Resolution*: Defer prod population with a documented decision (see Clarifications C4). The
+Step 2.5 logic is environment-agnostic and empty-safe (AR1-F1), so prod deploys will simply
+no-op these two keys until prod's real URL is filled in. Add a `TODO(1383)` breadcrumb in
+`prod.tfvars` next to the existing `TODO(1269)`. **Gate impact: not a blocker; explicit defer.**
+
+**AR1-F5 (MEDIUM → resolved by design): token redirect_uri != authorize race.** Concern: what
+if the redirect_uri at exchange differs from authorize? *Investigation*: They are the same
+object — authorize stores `_resolve_redirect_uri(origin)` into state; callback validates the
+client value equals that stored value; the fix threads that same validated value into exchange.
+There is no window where they diverge because validation gates the exchange. The ONLY remaining
+divergence risk is trailing-slash / normalization drift (Edge Case), which is pre-existing and
+unchanged by this feature. **Gate impact: none; design eliminates the race.**
+
+**AR1-F6 (LOW): Cognito client callback registration is frozen.** Setting `cognito_callback_urls`
+in `preprod.tfvars` will NOT re-register the Cognito app client's callback URLs because
+`modules/cognito/main.tf:146` has `ignore_changes=[callback_urls]`. This is fine — we only need
+the value to flow into the Lambda-env-derived output — but the spec must state it so a reviewer
+doesn't expect Cognito to change. *Resolution*: Called out in FR-002 and Out of Scope. **Gate
+impact: documentation only.**
+
+**AR1-F7 (LOW): Terraform output must mirror the env EXPRESSION, not `module.cognito.callback_urls`.**
+An existing `output "cognito_callback_urls"` returns `module.cognito.callback_urls` (the live,
+`ignore_changes`-drifted client attribute) — using THAT for Step 2.5 would sync whatever drift
+is on the client, not the intended value. *Resolution*: FR-004 requires a NEW
+`cognito_redirect_uri` output computed from `var.cognito_callback_urls[0]` (identical to the
+`main.tf:465` env expression), guaranteeing output == intended env. **Gate impact: prevents a
+subtle wrong-source bug.**
+
+### Edits applied to spec
+
+- Added Edge Case "Empty Terraform output" and tightened FR-006 to require empty-skip.
+- Added FR-011 (validate-before-exchange ordering) and FR-014 (prod never gets preprod value).
+- Added FR-002 note + Out-of-Scope entry on frozen Cognito callback registration.
+- Added FR-004 wording to compute from `var.cognito_callback_urls[0]`, not the drifted module output.
+
+### Gate
+
+- CRITICAL: 0
+- HIGH: 0 open (F1/F2/F3 resolved or shown already-safe)
+- MEDIUM: 0 open (F4 deferred-with-decision, F5 resolved-by-design)
+- LOW: 3 documented (F6, F7, and the pre-existing normalization edge case)
+
+**AR#1 GATE: PASS (0 CRITICAL / 0 HIGH open).**
+
+---
+
+## Clarifications
+
+Session 2026-07-23 (self-answered from live code/config; unanswerable items deferred to owner).
+
+### C1 — Should `prod.tfvars` also receive `frontend_url` / `cognito_callback_urls` now?
+
+**Answer: NO — defer (documented).** Evidence: `prod.tfvars` sets none of `frontend_url`,
+`enable_amplify`, or `cognito_callback_urls`; `cors_allowed_origins` still carries the
+`TODO(1269)` placeholder "Add Amplify production URL after enable_amplify is set." Prod's Amplify
+frontend URL is not finalized (and Amplify may not be deployed for prod). Shipping a value now
+would either be a guess or (worse) a copy of the preprod URL. Decision: leave `prod.tfvars`
+unpopulated, add a `TODO(1383)` breadcrumb next to `TODO(1269)`, and rely on the empty-safe
+Step 2.5 (AR1-F1) to no-op the two keys on prod deploys until the real URL exists. **Owner
+question O1** (below) records the one thing I cannot self-answer: the actual prod frontend URL.
+
+### C2 — Should the static `COGNITO_REDIRECT_URI` env var be removed now that the exchange is per-origin?
+
+**Answer: NO — keep as fallback.** `exchange_code_for_tokens` falls back to
+`config.redirect_uri` when no override is provided (FR-009). Keeping the env durable (Deliverable
+A) preserves a correct default for any code path that does not pass an override and de-risks the
+correctness change. Removal is an explicit follow-up (Out of Scope) once per-origin exchange is
+proven on preprod.
+
+### C3 — Add-only Step 2.5 vs. refactor all three keys through one helper?
+
+**Answer: ADD-ONLY by default.** The existing `ENABLED_OAUTH_PROVIDERS` block is proven on the
+critical deploy path. The lowest-risk change adds two new syncs after it (optionally via a small
+`sync_env_key` helper used ONLY by the two new keys). A full three-key refactor is cleaner but
+touches the working block; defer unless a reviewer insists. Recorded in plan Phase 1 + AR#2.
+
+### C4 — Should `cognito_callback_urls[0]` be the Amplify callback, and should localhost be included?
+
+**Answer: Amplify callback at index [0]; include localhost as a second entry.** Index `[0]` must
+be the Amplify callback because `main.tf:465` derives `COGNITO_REDIRECT_URI` from `[0]`. Including
+`http://localhost:3000/auth/callback` as a second entry documents the dev origin the allowlist
+(`_resolve_redirect_uri`) already permits; because the Cognito client is `ignore_changes`-frozen
+this list does not alter live Cognito registration, so ordering only matters for the env output.
+
+### C5 — Does the per-origin exchange need any new client-input validation?
+
+**Answer: NO new validation needed; existing state validation suffices.** `validate_oauth_state`
+already enforces client `redirect_uri == stored state.redirect_uri` (`oauth_state.py:220`) before
+the exchange, and the stored value came from the allowlist-gated `_resolve_redirect_uri`. FR-011
+codifies the validate-before-exchange ordering. Optional defense-in-depth (return + use the
+server-side stored value) is recorded in the plan, default OFF to keep the `auth.py` change to a
+single line (merge-hotspot constraint, FR-012).
+
+### Deferred to owner (cannot self-answer)
+
+- **O1 (prod frontend URL):** What is prod's canonical customer-dashboard URL (prod Amplify), and
+  is prod Amplify deployed yet? Needed before `prod.tfvars` can be populated (C1). Until answered,
+  prod deploys no-op these two keys (safe).

--- a/specs/1383-oauth-env-durability/tasks.md
+++ b/specs/1383-oauth-env-durability/tasks.md
@@ -1,0 +1,264 @@
+# Tasks: OAuth Env Durability + Per-Origin Token Exchange
+
+**Feature**: `1383-oauth-env-durability` | **Date**: 2026-07-23
+**Spec**: [spec.md](./spec.md) | **Plan**: [plan.md](./plan.md)
+
+> Hand-authored (speckit skills are branch-creating/interactive; planning-only worktree).
+> Structure follows `.specify/templates/tasks-template.md`. `[P]` = parallelizable (different
+> files, no ordering dependency).
+
+## Conventions
+
+- IDs: `T0xx`. Deliverable A (infra/CI) and Deliverable B (code) are independent and may proceed
+  in parallel; they touch disjoint files.
+- Every task lists the FR(s) it satisfies and its acceptance check.
+- Verification tasks require REAL preprod (constitution: preprod mirrors prod). No preprod tests
+  run locally.
+
+---
+
+## Phase 1 — Deliverable A: Durability (infra + CI)
+
+### T001 [P] — Add Terraform outputs `frontend_url` and `cognito_redirect_uri`
+- **File**: `infrastructure/terraform/main.tf` (near `output "enabled_oauth_providers"`, ~L1489)
+- **Do**: Add `output "frontend_url" { value = var.frontend_url }` and
+  `output "cognito_redirect_uri" { value = length(var.cognito_callback_urls) > 0 ? var.cognito_callback_urls[0] : "" }`
+  with descriptions. MUST mirror the env expressions at `main.tf:469` / `main.tf:465` exactly.
+  Do NOT reuse the existing list-valued `output "cognito_callback_urls"` (AR1-F7).
+- **FRs**: FR-003, FR-004
+- **Accept**: `terraform validate` passes; `terraform output frontend_url` and
+  `terraform output cognito_redirect_uri` are string-valued (not list); values match preprod
+  after T002.
+
+### T002 [P] — Populate `preprod.tfvars`
+- **File**: `infrastructure/terraform/preprod.tfvars`
+- **Do**: Add `frontend_url = "https://main.d29tlmksqcx494.amplifyapp.com"` and
+  `cognito_callback_urls = ["https://main.d29tlmksqcx494.amplifyapp.com/auth/callback", "http://localhost:3000/auth/callback"]`.
+  Index `[0]` MUST be the Amplify callback (feeds COGNITO_REDIRECT_URI). Comment that the Cognito
+  client is `ignore_changes`-frozen so this only feeds the Lambda-env output (AR1-F6, C4).
+- **FRs**: FR-001, FR-002
+- **Accept**: `terraform plan -var-file=preprod.tfvars` shows NO change to the Cognito app client
+  callback_urls (frozen), and the two new outputs resolve to the expected strings.
+
+### T003 — Add `TODO(1383)` breadcrumb to `prod.tfvars` (defer, do NOT populate)
+- **File**: `infrastructure/terraform/prod.tfvars`
+- **Do**: Add a comment next to `TODO(1269)`: prod `frontend_url` + `cognito_callback_urls[0]`
+  to be set once prod Amplify URL is finalized; Step 2.5 is empty-safe until then; never copy the
+  preprod URL. Do NOT set any value.
+- **FRs**: FR-014 (and Clarification C1, owner question O1)
+- **Accept**: `prod.tfvars` contains the breadcrumb and NO `frontend_url`/`cognito_callback_urls`
+  assignment.
+
+### T004 — Extend CI "Step 2.5" to sync FRONTEND_URL + COGNITO_REDIRECT_URI (CRITICAL PATH)
+- **File**: `.github/workflows/deploy.yml` (dashboard-deploy job, after the existing
+  ENABLED_OAUTH_PROVIDERS block at ~L1051-1066, BEFORE `publish-version` at ~L1067)
+- **Do**: Fetch `terraform output -raw frontend_url` and `terraform output -raw cognito_redirect_uri`
+  (each with `2>/dev/null || echo ""`). Sync each onto the Lambda env using the same
+  read-current-map → compare → merge-full-map → `update-function-configuration` → `wait
+  function-updated` shape as ENABLED_OAUTH_PROVIDERS. Pass values to `python3` via ENV VARS
+  (`KEY`/`VAL`), never shell-interpolated (injection-safe, FR-015).
+- **MANDATORY acceptance criteria (from AR2-F2 — the highest-risk detail)**:
+  1. **Env freshness**: Immediately before the new syncs, RE-FETCH the current env via
+     `aws lambda get-function-configuration ... --query 'Environment.Variables'` (so it includes
+     any ENABLED_OAUTH change just written), OR thread a single evolving map through all three
+     keys. MUST NOT reuse a stale pre-ENABLED_OAUTH `CUR_ENV`.
+  2. **Empty-skip guard (AR1-F1)**: If the desired Terraform value is empty, SKIP that key (log
+     "desired empty — skip"); never write an empty string over an existing value.
+  3. **Full-map merge (FR-007)**: The update MUST preserve every other env key.
+  4. **Idempotent (FR-006)**: When current == desired, issue NO update call; log "no change".
+  5. **Ordering (FR-008)**: Runs before `publish-version`.
+- **FRs**: FR-005, FR-006, FR-007, FR-008, FR-013, FR-015
+- **Accept**: workflow-syntax check passes (T005); dry-read of the block confirms all 5 criteria.
+
+### T005 [P] — Validate deploy.yml syntax + reason through the block
+- **File**: `.github/workflows/deploy.yml`
+- **Do**: Run `actionlint` (or `yq '.'` / `python3 -c 'import yaml,sys;yaml.safe_load(open("...")) '`)
+  to confirm the workflow still parses. Manually trace the merge logic for three cases:
+  (a) fresh Lambda both keys empty→set; (b) already-correct→no-op; (c) empty desired→skip.
+- **FRs**: FR-005, FR-006 (guards the critical deploy path, AR1-F3)
+- **Accept**: linter/parser exit 0; the three traced cases behave per T004 criteria.
+
+---
+
+## Phase 2 — Deliverable B: Correctness (per-origin token exchange)
+
+### T006 [P] — Add `redirect_uri_override` param to `exchange_code_for_tokens`
+- **File**: `src/lambdas/shared/auth/cognito.py` (~L130 signature, ~L162 data dict)
+- **Do**: Add `redirect_uri_override: str | None = None` to the signature; set the token-exchange
+  `data["redirect_uri"] = redirect_uri_override or config.redirect_uri`. Mirror the existing
+  `get_authorize_url(..., redirect_uri_override=...)` convention (cognito.py:86). Update the
+  docstring.
+- **FRs**: FR-009
+- **Accept**: signature + data dict updated; falls back to `config.redirect_uri` when override is
+  None/empty.
+
+### T007 — Thread validated redirect_uri at the callback exchange call site (MINIMAL, merge-hotspot)
+- **File**: `src/lambdas/dashboard/auth.py` (call site at L2215)
+- **Do**: Change ONLY line 2215 to
+  `tokens = exchange_code_for_tokens(config, code, code_verifier=code_verifier, redirect_uri_override=redirect_uri)`.
+  `redirect_uri` is the `handle_oauth_callback` param (L2147), already proven equal to the stored
+  authorize-time value by `validate_oauth_state` (which runs above, L2186-2192). Do NOT reflow,
+  reorder, or reformat neighboring lines (FR-012 — 1380/1381 merge hotspot). Kwarg name MUST be
+  `redirect_uri_override` (AR2-F5).
+- **FRs**: FR-010, FR-011, FR-012
+- **Accept**: single-line diff in auth.py; kwarg name matches T006 param; no other lines changed.
+
+### T008 [P] — Unit tests for cognito.py exchange override
+- **File**: `tests/unit/shared/auth/test_cognito.py`
+- **Do**: With mocked httpx, assert: (a) when `redirect_uri_override` is provided, the POST body
+  `redirect_uri` equals the override; (b) when omitted, it equals `config.redirect_uri`.
+- **FRs**: FR-009
+- **Accept**: both tests pass; `pytest tests/unit/shared/auth/test_cognito.py -q` green.
+
+### T009 [P] — Unit test for callback threading + validate-before-exchange ordering
+- **File**: existing dashboard auth callback test module (e.g. `tests/unit/dashboard/test_auth*.py`)
+- **Do**: Assert `handle_oauth_callback` passes the request `redirect_uri` into
+  `exchange_code_for_tokens` (patch/spy the exchange, assert kwarg). Add/confirm a negative test:
+  a callback whose `redirect_uri` != stored state value is rejected by `validate_oauth_state`
+  BEFORE any exchange call (spy asserts exchange NOT called).
+- **FRs**: FR-010, FR-011
+- **Accept**: positive + negative tests pass.
+
+---
+
+## Phase 3 — Verification (real preprod; constitution: no preprod tests locally)
+
+### T010 — Preprod: durability + idempotency + no-clobber
+- **Do**: Deploy to preprod. Confirm Step 2.5 logs "synced" for both keys on first run and
+  "no change" on a second run. `aws lambda get-function-configuration` shows both correct and all
+  unrelated env keys intact. Then strip both keys manually, redeploy, confirm restored.
+- **FRs**: FR-005/006/007; **SCs**: SC-001, SC-002, SC-003, SC-006
+- **Accept**: all four observations hold with zero manual env edits (beyond the deliberate strip).
+
+### T011 — Preprod: per-origin token exchange correctness + open-redirect negative
+- **Do**: Complete a real Google sign-in from the Amplify origin; confirm login succeeds and the
+  token exchange used the origin `/auth/callback`. Confirm a tampered-redirect_uri callback is
+  rejected before exchange.
+- **FRs**: FR-009/010/011; **SCs**: SC-004, SC-005
+- **Accept**: primary login works (no regression); tampered request rejected pre-exchange.
+
+### T012 [P] — Local gates before push
+- **Do**: `make validate`, `pytest tests/unit/ -q` (or the auth subsets), `terraform fmt -recursive`
+  + `terraform validate`, workflow lint (T005). GPG-signed commits. Pre-push security check
+  (`gh api ... code-scanning/alerts`).
+- **Accept**: all gates green; commits signed.
+
+---
+
+## Requirement → Task coverage
+
+| FR | Task(s) |
+|---|---|
+| FR-001 | T002 |
+| FR-002 | T002 |
+| FR-003 | T001 |
+| FR-004 | T001 |
+| FR-005 | T004, T005 |
+| FR-006 | T004, T005, T010 |
+| FR-007 | T004, T010 |
+| FR-008 | T004 |
+| FR-009 | T006, T008 |
+| FR-010 | T007, T009 |
+| FR-011 | T007, T009, T011 |
+| FR-012 | T007 |
+| FR-013 | T004 (no new resources) |
+| FR-014 | T003 |
+| FR-015 | T004, T005 |
+| SC-001..007 | T010, T011 |
+
+Every FR and SC maps to ≥1 task. No orphan requirements.
+
+## Parallelization
+
+- A-track: T001, T002, T005 are `[P]`; T003 independent; T004 depends on T001/T002 (needs outputs).
+- B-track: T006, T008, T009 are `[P]`; T007 depends on T006 (param must exist first).
+- A-track and B-track fully parallel (disjoint files).
+- T010/T011 require a deployed preprod (after A/B merged); T012 before push.
+
+---
+
+## Cross-Artifact Analysis (`/speckit.analyze` equivalent)
+
+Non-destructive consistency scan across spec.md, plan.md, tasks.md.
+
+### Coverage
+- **Requirements → tasks**: All 15 FRs and all 7 SCs map to ≥1 task (see table above). No orphans.
+- **Tasks → requirements**: Every task cites its FR(s). No task without a requirement anchor.
+- **User stories → tasks**: US1 (durability) → T001-T005, T010; US2 (per-origin exchange) →
+  T006-T009, T011; US3 (prod parity/defer) → T003. All stories covered.
+
+### Consistency
+- **Terminology**: "Step 2.5", "FRONTEND_URL", "COGNITO_REDIRECT_URI", "redirect_uri_override"
+  used identically across all three artifacts. Kwarg name reconciled to `redirect_uri_override`
+  everywhere (AR2-F5 fix propagated to T007).
+- **File:line anchors**: auth.py:2215 (drop-point), cognito.py:162 (static uri), oauth_state.py:220
+  (validation), main.tf:465/469 (env expressions), deploy.yml:1051-1066 (pattern) — consistent
+  spec↔plan↔tasks.
+- **Decisions**: Clarifications C1-C5 reflected in tasks (T003 defers prod per C1; T006 keeps
+  static fallback per C2; T004 add-only per C3; T002 Amplify-at-[0]+localhost per C4; T007 relies
+  on existing validation per C5). No contradiction.
+
+### Gaps / risks surfaced
+- **G1 (accepted)**: No automated CI test proves Step 2.5 idempotency/no-clobber; verification is
+  manual on preprod (T010). Acceptable — matches how the existing ENABLED_OAUTH block is verified;
+  automating a live-Lambda env test is out of proportion for this change.
+- **G2 (accepted)**: Owner question O1 (prod URL) leaves prod unconfigured. Non-blocking:
+  empty-safe Step 2.5 no-ops prod (T003). Flagged for owner.
+- **G3 (watch)**: T007 is a one-line change in a merge-hotspot file. Merge with 1380/1381 must be
+  serialized; take-both resolution expected (line-disjoint). Called out in plan + T007.
+
+### Duplication / dead scope
+- None. No duplicate tasks; no task without an artifact anchor; Out-of-Scope items (remove static
+  env, unfreeze env, GitHub provider) are not tasked.
+
+**Analyze result: CONSISTENT. 0 blocking gaps. 3 accepted/watch items (G1 manual-verify, G2 owner
+O1, G3 merge serialization).**
+
+---
+
+## Adversarial Review #3
+
+**Stance**: Final gate before implementation. Identify the highest-risk task, the most likely
+rework, and decide READY vs BLOCKED.
+
+### Highest-risk task: **T004 (extend deploy.yml Step 2.5)**
+
+Why it dominates the risk budget:
+- It edits the **critical dashboard-deploy path**. A YAML or bash error breaks EVERY dashboard
+  deploy, not just OAuth (AR1-F3).
+- It carries the **subtlest correctness trap** in the whole feature (AR2-F2): reusing a stale
+  `CUR_ENV` after the ENABLED_OAUTH block already wrote the env would silently REVERT
+  ENABLED_OAUTH_PROVIDERS on the next merge — turning a durability fix into an OAuth outage.
+- The **empty-clobber hazard** (AR1-F1) means a naive copy of the existing pattern can wipe a
+  correct value with `""` — again, the fix causing the outage it prevents.
+
+### Most likely rework
+1. **Env re-read/merge ordering (AR2-F2)** — highest-probability rework. If the implementer
+   copies the ENABLED_OAUTH block's `CUR_ENV` variable and appends, they'll likely reuse the
+   stale map. Mitigation baked into T004 acceptance criterion #1 (re-fetch or single evolving
+   map). Reviewer MUST diff-read this specifically.
+2. **Empty-skip omission (AR1-F1)** — second most likely. Easy to forget; T004 criterion #2 makes
+   it explicit; T005 case (c) tests it.
+3. **Kwarg name (AR2-F5)** — low probability now that T007 pins `redirect_uri_override`, but a
+   TypeError if missed. Caught by T008/T009 unit tests immediately.
+
+### Security re-confirmation
+- Open-redirect: neutralized — exchange uses a state-validated, allowlist-derived redirect_uri
+  (FR-011, T007/T009/T011). No raw client value reaches the exchange.
+- Secret leakage / deploy.yml injection: values pass to python3 via env vars, only non-secret
+  URLs echoed (FR-015, T004/T005). No secret touched.
+- No new AWS resources; env stays Terraform-frozen (FR-013).
+
+### Merge-serialization note (carried)
+auth.py (T007) overlaps Features 1380 and 1381. Keep to one line; serialize the merge; expect
+take-both. Do not let a 1380/1381 rebase silently drop the `redirect_uri_override` kwarg.
+
+### Gate
+- CRITICAL: 0
+- HIGH: 0 (all HIGH items from AR#1/#2 resolved or converted to enforced task criteria)
+- Blocking gaps: 0
+- Owner questions outstanding: 1 (O1, prod URL) — non-blocking for preprod delivery.
+
+**AR#3 GATE: READY for implementation.** Proceed with T004's five acceptance criteria treated as
+hard requirements and a mandatory focused review of the deploy.yml diff. Populate prod (T003→real
+value) only after owner answers O1.

--- a/src/lambdas/dashboard/auth.py
+++ b/src/lambdas/dashboard/auth.py
@@ -2211,8 +2211,16 @@ def handle_oauth_callback(
     config = CognitoConfig.from_env()
 
     # Exchange code for tokens
+    # Feature 1383: thread the request's redirect_uri (already proven equal to the
+    # stored authorize-time value by validate_oauth_state above) so the token exchange
+    # matches the authorize redirect_uri per-origin instead of the static config value.
     try:
-        tokens = exchange_code_for_tokens(config, code, code_verifier=code_verifier)
+        tokens = exchange_code_for_tokens(
+            config,
+            code,
+            code_verifier=code_verifier,
+            redirect_uri_override=redirect_uri,
+        )
     except TokenError as e:
         logger.warning(
             "OAuth token exchange failed",

--- a/src/lambdas/shared/auth/cognito.py
+++ b/src/lambdas/shared/auth/cognito.py
@@ -131,12 +131,22 @@ def exchange_code_for_tokens(
     config: CognitoConfig,
     code: str,
     code_verifier: str | None = None,
+    redirect_uri_override: str | None = None,
 ) -> CognitoTokens:
     """Exchange authorization code for tokens.
 
     Args:
         config: Cognito configuration
         code: Authorization code from OAuth callback
+        code_verifier: PKCE code verifier (FR-009)
+        redirect_uri_override: Feature 1383 — per-request redirect URI used for the
+            token exchange. When provided, it MUST equal the redirect_uri used at the
+            authorize step (OAuth requires an exact match). Mirrors the override
+            convention in ``get_authorize_url``. Falls back to the static
+            ``config.redirect_uri`` (COGNITO_REDIRECT_URI) when not provided. The caller
+            is responsible for validating this value against the stored OAuth state
+            before passing it (see ``validate_oauth_state``); do not pass a raw,
+            unvalidated client-supplied value.
 
     Returns:
         CognitoTokens with id_token, access_token, refresh_token
@@ -159,7 +169,9 @@ def exchange_code_for_tokens(
     data = {
         "grant_type": "authorization_code",
         "code": code,
-        "redirect_uri": config.redirect_uri,
+        # Feature 1383: use the per-request (state-validated) redirect_uri so the
+        # token exchange exactly matches the authorize step; fall back to static config.
+        "redirect_uri": redirect_uri_override or config.redirect_uri,
     }
 
     # Include client_id in body if no secret

--- a/tests/unit/dashboard/test_oauth_callback_federation.py
+++ b/tests/unit/dashboard/test_oauth_callback_federation.py
@@ -144,6 +144,52 @@ class TestOAuthCallbackFederationFieldsNewUser:
     @patch("src.lambdas.dashboard.auth.get_user_by_email_gsi")
     @patch("src.lambdas.dashboard.auth.exchange_code_for_tokens")
     @patch("src.lambdas.dashboard.auth.decode_id_token")
+    def test_callback_threads_request_redirect_uri_into_exchange(
+        self,
+        mock_decode_id_token: MagicMock,
+        mock_exchange: MagicMock,
+        mock_get_user: MagicMock,
+        mock_advance_role: MagicMock,
+        mock_mark_verified: MagicMock,
+        mock_link_provider: MagicMock,
+        mock_update_sub: MagicMock,
+        mock_create_user: MagicMock,
+    ) -> None:
+        """Feature 1383: the request's (state-validated) redirect_uri is passed to the token
+        exchange as redirect_uri_override, so the exchange matches the authorize step per-origin
+        instead of the static config value."""
+        table = MagicMock()
+        user = self._create_test_user(role="anonymous")
+        mock_create_user.return_value = user
+        mock_get_user.return_value = None
+        mock_exchange.return_value = self._mock_tokens()
+        mock_decode_id_token.return_value = {
+            "email": "test@example.com",
+            "sub": "google-123",
+            "email_verified": True,
+        }
+
+        handle_oauth_callback(
+            table=table,
+            code="auth-code",
+            provider="google",
+            redirect_uri="http://localhost:3000/auth/callback",
+            state="test_state_abc123",
+        )
+
+        # The exchange must receive the per-request redirect_uri as the override.
+        assert mock_exchange.call_args.kwargs.get("redirect_uri_override") == (
+            "http://localhost:3000/auth/callback"
+        )
+
+    @patch("src.lambdas.dashboard.auth._create_authenticated_user")
+    @patch("src.lambdas.dashboard.auth._update_cognito_sub")
+    @patch("src.lambdas.dashboard.auth._link_provider")
+    @patch("src.lambdas.dashboard.auth._mark_email_verified")
+    @patch("src.lambdas.dashboard.auth._advance_role")
+    @patch("src.lambdas.dashboard.auth.get_user_by_email_gsi")
+    @patch("src.lambdas.dashboard.auth.exchange_code_for_tokens")
+    @patch("src.lambdas.dashboard.auth.decode_id_token")
     def test_new_user_verification_verified_when_email_verified(
         self,
         mock_decode_id_token: MagicMock,

--- a/tests/unit/lambdas/shared/auth/test_cognito.py
+++ b/tests/unit/lambdas/shared/auth/test_cognito.py
@@ -195,6 +195,70 @@ class TestExchangeCodeForTokens:
             assert tokens.refresh_token == "refresh_token_value"
             assert tokens.expires_in == 3600
 
+    def test_exchange_uses_redirect_uri_override(self):
+        """Feature 1383: per-request redirect_uri_override is used in the token exchange."""
+        config = CognitoConfig(
+            user_pool_id="us-east-1_ABC123",
+            client_id="client123",
+            client_secret="secret456",
+            domain="myapp",
+            region="us-east-1",
+            redirect_uri="https://static.example.com/callback",
+        )
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "id_token": "id_token_value",
+            "access_token": "access_token_value",
+            "refresh_token": "refresh_token_value",
+            "expires_in": 3600,
+            "token_type": "Bearer",
+        }
+
+        with patch("httpx.Client") as mock_client:
+            post = mock_client.return_value.__enter__.return_value.post
+            post.return_value = mock_response
+
+            exchange_code_for_tokens(
+                config,
+                "auth_code_123",
+                redirect_uri_override="http://localhost:3000/auth/callback",
+            )
+
+            sent_data = post.call_args.kwargs["data"]
+            assert sent_data["redirect_uri"] == "http://localhost:3000/auth/callback"
+
+    def test_exchange_falls_back_to_config_redirect_uri(self):
+        """Feature 1383: without an override, the static config.redirect_uri is used."""
+        config = CognitoConfig(
+            user_pool_id="us-east-1_ABC123",
+            client_id="client123",
+            client_secret="secret456",
+            domain="myapp",
+            region="us-east-1",
+            redirect_uri="https://static.example.com/callback",
+        )
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "id_token": "id_token_value",
+            "access_token": "access_token_value",
+            "refresh_token": "refresh_token_value",
+            "expires_in": 3600,
+            "token_type": "Bearer",
+        }
+
+        with patch("httpx.Client") as mock_client:
+            post = mock_client.return_value.__enter__.return_value.post
+            post.return_value = mock_response
+
+            exchange_code_for_tokens(config, "auth_code_123")
+
+            sent_data = post.call_args.kwargs["data"]
+            assert sent_data["redirect_uri"] == "https://static.example.com/callback"
+
     def test_exchange_failure(self):
         """Raises TokenError on exchange failure."""
         config = CognitoConfig(


### PR DESCRIPTION
Second of the M1 auth-hardening batch. Makes the WI-6 go-live's manual env sets reproducible and fixes token-exchange redirect_uri correctness.

## A) Durability (kills the manual snowflakes)
During WI-6 go-live, `FRONTEND_URL` and `COGNITO_REDIRECT_URI` had to be set by hand on the dashboard Lambda (terraform can't manage its env — `modules/lambda` `ignore_changes=[environment]`). This adds them to `preprod.tfvars` + terraform outputs, and extends the CI dashboard-deploy **Step 2.5b** to sync them onto the Lambda env from those outputs — mirroring the existing ENABLED_OAUTH_PROVIDERS sync. Idempotent (no-ops when already correct), re-reads current env so it never reverts the ENABLED_OAUTH write, skips empty values (no clobber). Prod left as a `TODO` (prod Amplify URL unknown; empty-safe).

## B) Token-exchange redirect_uri correctness
`exchange_code_for_tokens` used a STATIC `config.redirect_uri` while the authorize step used a dynamic per-request one — the mismatch that caused `unauthorized_client` during go-live (worked around by manually setting COGNITO_REDIRECT_URI). Now threads the already-`validate_oauth_state`-validated request redirect_uri through to the exchange via a `redirect_uri_override` param (mirrors `get_authorize_url`). No new trust — the value is verified against the stored authorize-time value before use. Fixes per-origin (incl. localhost-dev-against-preprod).

## Validation
698 unit tests pass (incl. 3 new: override-used, fallback-to-static, callback threads redirect_uri). terraform fmt/validate clean, deploy.yml valid YAML, ruff clean.

## Verify (post-deploy)
Deploy log shows `Step 2.5b` syncing/no-op'ing FRONTEND_URL + COGNITO_REDIRECT_URI; `get-function-configuration` shows both correct with ENABLED_OAUTH_PROVIDERS intact. Includes full speckit trail.

Serialize note: `auth.py` touch is one kwarg (~L2213-2221), line-disjoint from 1381/1380.