### PR TITLE
fix(1381): persist OAuth session across reload — resolve user_id on Cognito refresh

### DIFF
--- a/specs/1381-oauth-session-persistence/contracts/auth-refresh.md
+++ b/specs/1381-oauth-session-persistence/contracts/auth-refresh.md
@@ -1,0 +1,45 @@
+# Contract: POST /api/v2/auth/refresh (OAuth session)
+
+Target: **Customer Dashboard** (Next.js/Amplify → API Gateway → dashboard Lambda). Not the HTMX admin dashboard.
+
+## Request
+
+- Method: `POST`
+- Path: `/api/v2/auth/refresh` (browser-visible path includes the API Gateway stage prefix on the deployed env)
+- Auth: httpOnly `refresh_token` cookie (cross-site from the Amplify origin; `SameSite=None; Secure`). Body fallback allowed but unused by the frontend.
+- CSRF: exempt (`csrf.py:38`) — cookie-only endpoint.
+- Origin: `https://main.d29tlmksqcx494.amplifyapp.com`
+
+## Response — success (this feature's change)
+
+`200 OK`, `Cache-Control: no-store`, plus rotated CSRF `Set-Cookie`.
+
+```json
+{
+  "id_token": "<jwt>",
+  "access_token": "<jwt>",
+  "expires_in": 3600,
+  "user_id": "<internal-user-id>",     // NEW (FR-002): required for OAuth/Cognito restore
+  "auth_type": "google"                 // NEW (FR-002/FR-003): so the client rebuilds identity
+}
+```
+
+- `user_id` MUST be derived server-side from validated id-token claims (`sub` → internal user), never from request input (SR-005).
+- `refresh_token` MUST NOT appear in the body (SR-001); it stays in the httpOnly cookie. Cognito does not rotate it, so the existing cookie persists.
+
+## Response — failure
+
+- `401` when the refresh cookie is absent/unparseable (`router_v2.py:664`) — body message distinguishes "not found".
+- `401` when Cognito rejects the token (`router_v2.py:671`, from `TokenError`) — body carries the mapped reason (e.g. `invalid_refresh_token` → "Please sign in again.").
+- `401 token_revoked` when the refresh token is blocklisted (`auth.py:2921-2924`), checked before issuance (SR-004).
+
+## Backend diagnostic requirement (FR-007)
+
+The handler MUST log, without secrets, exactly one of:
+- `refresh.cookie_absent` — `_extract_refresh_token_from_event` returned `None`.
+- `refresh.cognito_rejected` — Cognito returned non-200 (include mapped error code + refresh-token hash prefix).
+- `refresh.success` — 200 issued (include auth_type + user_id hash prefix).
+
+## Frontend consumer (no change required for core fix)
+
+`restoreSession` (`auth-store.ts:141-193`) takes the Cognito branch when `authType !== 'anonymous'` and `user_id` is present; rebuilds the user; returns `true` → `signInAnonymous()` is skipped.

--- a/specs/1381-oauth-session-persistence/plan.md
+++ b/specs/1381-oauth-session-persistence/plan.md
@@ -1,0 +1,106 @@
+# Implementation Plan: OAuth Session Persistence
+
+**Branch**: `1381-oauth-session-persistence` | **Date**: 2026-07-23 | **Spec**: `./spec.md`
+**Input**: Feature specification from `specs/1381-oauth-session-persistence/spec.md`
+
+## Summary
+
+Real Google OAuth login works on the Amplify customer frontend, but the session does not persist because `POST /api/v2/auth/refresh` fails the OAuth restore path. Root cause is a **two-defect chain**, not the originally-suspected cookie attributes (those were already unified/fixed in WI-3 #928):
+
+- **Defect A** — the Cognito refresh round-trip returns 401 (either the refresh cookie is not sent on the deployed topology, or Cognito rejects the OAuth-issued token due to app-client/secret env drift under the Feature 1290 freeze).
+- **Defect B** — even on a 200, the Cognito branch of `refresh_access_tokens` omits `user_id`, so the frontend `restoreSession` bails to `signInAnonymous()`.
+
+Technical approach: (1) add backend diagnostics to identify which sub-cause of A is live on preprod; (2) fix Defect B by returning server-derived `user_id`/`auth_type` in the Cognito refresh response (low blast radius, no frontend change); (3) remediate the identified A sub-cause — correct Cognito client/secret via the CI env-sync path (never Terraform), or correct the cookie Path if a real deployed-scope mismatch is found; (4) verify end-to-end on the real Amplify frontend via an owner-performed interactive Google login.
+
+## Technical Context
+
+**Language/Version**: Python 3.13 (backend dashboard Lambda); TypeScript 5.x / Next.js 14 / React 18 (frontend, verification only)
+**Primary Dependencies**: aws-lambda-powertools (routing/Response), httpx (Cognito token calls), PyJWT/joserfc (token decode), boto3 (DynamoDB); Zustand + React Query (frontend)
+**Storage**: DynamoDB `{env}-sentiment-users` (single-table; existing GSIs `by_provider_sub`, `by_cognito_sub`, `by_email`). No schema change.
+**Testing**: pytest (unit, `-m "not preprod"` locally); Playwright for customer E2E against the Amplify URL; owner-performed interactive Google login for real OAuth verification (Google consent cannot be automated).
+**Target Platform**: AWS Lambda (dashboard) behind API Gateway; AWS Amplify (frontend); AWS Cognito (OAuth).
+**Project Type**: Web (separate `frontend/` + `src/lambdas/dashboard/` backend).
+**Performance Goals**: `/refresh` p95 within existing auth-endpoint budget; one Cognito round-trip per restore.
+**Constraints**: Dashboard Lambda env FROZEN (Feature 1290) — env changes only via CI Step 2.5 / manual `update-function-configuration`. No new AWS resources. GPG-signed commits. Real-AWS preprod verification, no mocks for E2E. Customer dashboard only (ignore `src/dashboard/` HTMX).
+**Scale/Scope**: Small, surgical fix. Primary change is one backend response-construction site plus diagnostics; optional config remediation; verification harness.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **Security & Access Control (Constitution §3)**: Management/authenticated endpoints require auth; TLS everywhere; secrets in a managed store, not source. This feature preserves httpOnly refresh cookies, CSRF double-submit, and blocklist checks (SR-001..SR-006). Cognito client secret stays in env/secret store, never in code. **PASS.**
+- **No raw user input into logs (Constitution §3, CWE-117/312)**: Diagnostics use hash prefixes / masking via existing `sanitize_for_log` (SR-006). **PASS.**
+- **IaC / deployment (Constitution §5)**: No new infra; respects the Feature 1290 env-freeze delivery path (FR-009). **PASS.**
+- **Least privilege / no schema churn**: Reuses existing DynamoDB tables and GSIs; `user_id` derived from validated claims. **PASS.**
+- **Testing discipline**: Unit tests for the new response contract; preprod/real verification for the deployment-specific 401. **PASS.**
+
+No violations → Complexity Tracking not required.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/1381-oauth-session-persistence/
+├── plan.md              # This file
+├── research.md          # Root-cause research (R1–R7)
+├── spec.md              # Feature spec + Adversarial Review #1 + Clarifications
+├── contracts/
+│   └── auth-refresh.md  # /refresh response contract (adds user_id/auth_type)
+└── tasks.md             # Stage 7 output
+```
+
+### Source Code (repository root)
+
+```text
+src/lambdas/dashboard/
+├── auth.py              # refresh_access_tokens (Cognito branch) → populate user_id/auth_type (Defect B); diagnostics
+└── router_v2.py         # refresh_tokens handler → diagnostic logging hooks (FR-007); cookie helpers (verify only)
+
+src/lambdas/shared/auth/
+└── cognito.py           # refresh_tokens (Cognito call) — read-only reference; no change expected
+
+frontend/src/
+├── stores/auth-store.ts # restoreSession — consumer of the contract (verify; no change expected for core fix)
+└── hooks/use-session-init.ts # SessionProvider restore-first flow (verify only)
+
+tests/
+├── unit/dashboard/      # unit tests for the refresh response contract (user_id present for Cognito branch)
+└── (preprod verification is manual/owner-driven; documented in quickstart)
+
+infrastructure / ops (no Terraform env change):
+└── .github/workflows/deploy.yml  # CI Step 2.5 env-sync is the ONLY path to correct Cognito client/secret (FR-009)
+```
+
+**Structure Decision**: Web app. The core fix is backend-only in `src/lambdas/dashboard/auth.py` (response construction) plus diagnostics in `router_v2.py`. Frontend is verification-only because the existing `restoreSession` contract is already satisfied once the backend returns `user_id`. Any Cognito config remediation is an ops action through the CI env-sync, not code/Terraform.
+
+## Phased Approach
+
+- **Phase 0 — Diagnose (blocking)**: Ship FR-007 diagnostics; on preprod, capture which 401 sub-cause is live (cookie-absent vs Cognito-reject) and whether the cookie is being sent. This decides whether Phase 2 is a Cognito-config action or a cookie-Path correction.
+- **Phase 1 — Backend contract fix (Defect B)**: Populate `user_id`/`auth_type` in the Cognito refresh response, derived from validated id-token claims → internal user lookup. Unit-test it. This is required regardless of the Phase 0 outcome.
+- **Phase 2 — Remediate Defect A (gated by Phase 0)**: If Cognito-reject → correct client/secret via CI Step 2.5 and verify against live function config (FR-009). If cookie-absent → correct the deployed cookie Path/scope (FR-008).
+- **Phase 3 — Verify (real, no mocks)**: Owner-performed interactive Google login on the Amplify frontend; confirm 200 refresh, persisted identity, responsive left-nav, and no security regression (SC-001..SC-006).
+
+## Complexity Tracking
+
+No constitution violations; table intentionally empty.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| — | — | — |
+
+---
+
+## Adversarial Review #2
+
+Re-read spec.md (incl. AR#1 + Clarifications), research.md, contracts/auth-refresh.md, and plan.md for drift introduced by the Stage 4 clarifications and for cross-artifact inconsistency.
+
+| # | Sev | Drift / inconsistency | Resolution |
+|---|-----|------------------------|------------|
+| 1 | HIGH | **Non-existent function cited.** Q2 and research R5 referenced `get_user_by_cognito_sub`, which does not exist in `auth.py` (only `get_user_by_id:411`, `get_user_by_email_gsi:476`, `get_user_by_provider_sub:527`). An implementer would call a phantom symbol. | Corrected Q2 (spec) and R5 (research) to reuse `get_user_by_provider_sub(table, provider, sub)` (+ optional `by_cognito_sub` GSI helper). Verified names via grep. |
+| 2 | MED | **`table` availability for the new lookup.** Adding a DB lookup in `refresh_access_tokens` assumes `table` is present; the signature defaults it to `None`. | Confirmed the live router path passes `table` (`router_v2.py:667-668`); noted in Q2. Tasks include a guard: if `table is None`, fall back to deriving identity from claims without a hard failure. |
+| 3 | MED | **Provider unknown at refresh.** `get_user_by_provider_sub` needs `provider`; a bare Cognito refresh id-token may not carry the OAuth provider directly. | Tasks specify: read provider from the id-token `identities`/`cognito:username` claim, else use the `by_cognito_sub` GSI. Kept as a concrete implementation decision, not left ambiguous. |
+| 4 | MED | **Phase 0 diagnostics vs "no frontend change" claim.** If Phase 0 shows the cookie is genuinely not sent (Path/scope), the fix is backend cookie-Path, still no frontend change — consistent. But the spec's US2 left-nav symptom could, in a worst case, be a separate UI bug. | Clarification Q5 already scopes a residual UI-only lockup as a deferred follow-up; plan Phase 3 verifies it. Consistent; no edit needed. |
+| 5 | LOW | **Contract lists `auth_type: "google"` example** but FR-003 allows other providers. | Acceptable — example is illustrative; contract text says "so the client rebuilds identity." No change. |
+
+**Gate: 0 CRITICAL, 0 HIGH remaining.** The one HIGH (phantom function) is fixed and grep-verified. Remaining MEDs are converted into explicit task-level implementation decisions, not open ambiguities. Cross-artifact references (spec ↔ research ↔ contract ↔ plan) are now consistent on: backend-first fix, `user_id` from validated claims via `get_user_by_provider_sub`, env-freeze delivery path, and no-frontend-change scope.

--- a/specs/1381-oauth-session-persistence/research.md
+++ b/specs/1381-oauth-session-persistence/research.md
@@ -1,0 +1,58 @@
+# Research: OAuth Session Persistence (1381)
+
+## R1 — Where the 401 is actually emitted
+
+`refresh_tokens()` (`src/lambdas/dashboard/router_v2.py:639-688`) returns 401 in exactly two places:
+- `router_v2.py:663-664`: no refresh token found in cookie or body → `error_response(401, "Refresh token not found ...")`.
+- `router_v2.py:670-671`: `result.error` truthy → `error_response(401, result.message or result.error)`.
+
+`/refresh` is CSRF-exempt (`src/lambdas/shared/auth/csrf.py:38`), so CSRF (403) is ruled out. Therefore the console 401 is one of the two above.
+
+## R2 — Guest vs OAuth refresh divergence
+
+`refresh_access_tokens` (`src/lambdas/dashboard/auth.py:2898-2944`):
+- Blocklist check first (FR-007 of Feature 1188): `auth.py:2913-2924`.
+- Anonymous branch: `refresh_token.startswith("anon.")` → `_refresh_anonymous_session` (`auth.py:2928-2929`). Fully local, self-describing token. **No external call → reliable.**
+- Cognito branch: `cognito_refresh_tokens(config, refresh_token)` (`auth.py:2931-2944`) → HTTP POST to Cognito token endpoint (`cognito.py:213-284`). Non-200 → `TokenError` (`cognito.py:257-265`) → router 401.
+
+This is the OAuth-specific failure surface. The guest path can't hit it.
+
+## R3 — Cognito token call mechanics
+
+`cognito.py:213-284`:
+- Basic auth header from `client_id:client_secret` when `config.client_secret` is set (`cognito.py:236-239`); else `client_id` in the body (`cognito.py:246-247`).
+- `CognitoConfig.from_env` reads `COGNITO_CLIENT_ID` (required) and `COGNITO_CLIENT_SECRET` (optional) (`cognito.py:51-56`).
+- Cognito refresh does NOT rotate the refresh token: returns `refresh_token=None` (`cognito.py:273`). Router leaves the existing cookie untouched (`router_v2.py:678`).
+
+**Failure modes that yield 401 here:** app-client mismatch (token issued under Hosted-UI client X, refreshed under client Y), missing/incorrect client secret, or a confidential-vs-public client mismatch → Cognito `invalid_grant`/`invalid_client`.
+
+## R4 — Feature 1290 env freeze (critical operational constraint)
+
+`infrastructure/terraform/modules/lambda` carries `lifecycle { ignore_changes = [image_uri, environment] }`. Terraform CANNOT set the dashboard Lambda env. Env changes flow through the CI "Step 2.5" sync in `.github/workflows/deploy.yml` or a manual `aws lambda update-function-configuration`. Consequence: the live `COGNITO_CLIENT_ID`/`COGNITO_CLIENT_SECRET` can diverge from Terraform. Any config correction must be verified against `aws lambda get-function-configuration`.
+
+## R5 — Defect B: missing `user_id` in the Cognito refresh response
+
+`RefreshTokenResponse` (`auth.py:1504-1520`) defaults `user_id=None`, `auth_type=None`. The Cognito branch (`auth.py:2934-2939`) never sets them. The frontend `restoreSession` (`frontend/src/stores/auth-store.ts:157-161`) returns `false` when `!data.userId`, forcing `signInAnonymous()`. So the persistence chain breaks at the response contract even when the Cognito call succeeds.
+
+**Server-side source of `user_id`:** `decode_id_token(tokens.id_token)` yields `sub` (cognito_sub); map that to the internal `user_id` via the existing `get_user_by_provider_sub(table, provider, sub)` helper (`auth.py:527`) and/or the `by_cognito_sub` GSI (Feature 1222). ACCURACY NOTE: `get_user_by_cognito_sub` does **not** exist in `auth.py` (only `get_user_by_id:411`, `get_user_by_email_gsi:476`, `get_user_by_provider_sub:527`); implementation reuses `get_user_by_provider_sub` (provider from the id-token identity claim), adding a small `by_cognito_sub` GSI query helper only if provider is unavailable at refresh. This keeps `user_id` derived from validated token claims (SR-005), not client input.
+
+## R6 — Frontend restore contract
+
+`restoreSession` branches:
+- Anonymous: `data.authType === 'anonymous' && data.userId` → rebuild guest (`auth-store.ts:116-139`).
+- Cognito/OAuth: needs `data.userId`; then `getProfile()` for the rest, best-effort (`auth-store.ts:141-193`).
+- Catch/`!accessToken`/`!userId` → `false` → caller runs `signInAnonymous()` (`use-session-init.ts`).
+
+Fixing FR-002 (backend returns `user_id` + `auth_type` for OAuth) satisfies the existing frontend contract with **no frontend change required** for the core fix — a strong argument for a backend-first, low-blast-radius fix.
+
+## R7 — Cookie scope on the deployed topology (to verify, not assume)
+
+`_cookie_path_prefix` (`router_v2.py:150-163`) derives the Path prefix from `requestContext.stage`. For API Gateway REST with an explicit stage, the browser-visible path includes `/{stage}`; the helper matches it. If a custom domain / base-path mapping fronts the API, the stage-derived Path may not match the browser path, and the cookie would not be sent → the `router_v2.py:664` 401. This is the only cookie-side item left to confirm at runtime and is covered by FR-008 and the US1 diagnostic task.
+
+## Decision Summary
+
+- **Primary fix (backend, low risk)**: FR-002/FR-003 — populate `user_id`/`auth_type` in the Cognito refresh response, sourced from validated id-token claims. Unblocks persistence the moment `/refresh` returns 200.
+- **Enabling diagnostic (backend, first)**: FR-007 — logging to split absent-cookie vs Cognito-reject, so the 401 cause is identified on the live deployment before touching Cognito config.
+- **Config remediation (ops, gated by diagnosis)**: FR-009 — correct Cognito client/secret via CI Step 2.5 / manual update if the diagnostic shows a Cognito reject; verify against live config.
+- **Cookie confirmation (verify-only unless mismatch found)**: FR-008.
+- **No frontend code change expected** for the core fix; US2 verification confirms the nav/identity symptoms clear once restore succeeds.

--- a/specs/1381-oauth-session-persistence/spec.md
+++ b/specs/1381-oauth-session-persistence/spec.md
@@ -1,0 +1,205 @@
+# Feature Specification: OAuth Session Persistence
+
+**Feature Branch**: `1381-oauth-session-persistence`
+**Created**: 2026-07-23
+**Status**: Draft (planning only — no implementation in this pipeline)
+**Input**: Real Google OAuth login succeeds on the customer frontend (Next.js on AWS Amplify, `https://main.d29tlmksqcx494.amplifyapp.com`), but the OAuth session does not persist. `POST /api/v2/auth/refresh` returns 401 for an authenticated OAuth session on page load; session-init falls back to `signInAnonymous()`; Settings shows "Anonymous/Guest (limited features)" while the top-nav UserMenu still shows the Google user, and the left-nav becomes unresponsive after entering Settings.
+
+---
+
+## Root-Cause Investigation (verified against current code)
+
+The task-provided prime suspect ("the OAuth-callback refresh cookie has wrong SameSite/Path/Domain attributes so the browser won't send it cross-site") was **investigated and found to already be resolved in current code**. It is NOT the live root cause. Evidence:
+
+- The OAuth callback path (`src/lambdas/dashboard/router_v2.py:587-628`), the magic-link path (`router_v2.py:507-561`), and the guest path (`router_v2.py:405-416`) all build the refresh cookie through the **same** unified helper `_make_refresh_token_cookie` (`router_v2.py:179-194`) and the CSRF cookie through `_make_csrf_set_cookie` (`router_v2.py:166-176`). Both emit `SameSite=None; Secure; HttpOnly` (refresh) with a **stage-aware Path** `{/stage}/api/v2/auth` via `_cookie_path_prefix` (`router_v2.py:150-163`), `Max-Age=30 days`.
+- This unification was the fix delivered by commit `0849559` (M1 WI-3, PR #928): *"stage-prefix cookie Path + stale SameSite broke deployed session restore"*. The helper's own docstring records that the inline OAuth/magic-link blocks were already updated to `SameSite=None` and the stale `Strict` was removed (`router_v2.py:182-184`).
+- Because the guest path uses the **identical** cookie helper and guest restore works, cookie attributes cannot be the OAuth-specific differentiator.
+
+The **actual** OAuth-specific breakage is in the token-refresh code path, which differs by session type. There are **two backend defects in one persistence chain**:
+
+### Defect A — Cognito refresh round-trip returns 401 (the observed console error)
+
+- `/api/v2/auth/refresh` is CSRF-exempt (`src/lambdas/shared/auth/csrf.py:38`), so CSRF (403) is not the cause. The 401 is emitted by `refresh_tokens()` at `router_v2.py:663-664` (no refresh token found) or `router_v2.py:670-671` (`result.error` set).
+- Guest sessions carry an **opaque, self-contained** refresh token (`anon.{user_id}.{secret}`) refreshed **locally** with no external call — `refresh_access_tokens` branches to `_refresh_anonymous_session` (`auth.py:2928-2929`). This never fails on identity round-trips, which is why guest restore is reliable.
+- OAuth sessions carry a **real Cognito refresh token** (`auth.py:2437`, `refresh_token_for_cookie=tokens.refresh_token`). On refresh they take the Cognito branch (`auth.py:2931-2944`) → `cognito_refresh_tokens` (`src/lambdas/shared/auth/cognito.py:213-284`), which POSTs `grant_type=refresh_token` to the Cognito token endpoint with Basic auth built from `config.client_id` / `config.client_secret` (`cognito.py:236-247`). A non-200 raises `TokenError` (`cognito.py:257-265`), surfaced as a 401 at `router_v2.py:671`.
+- Prime configuration suspect: a **Cognito app-client / client-secret mismatch** between the Hosted-UI app client that ISSUED the OAuth refresh token and the `COGNITO_CLIENT_ID`/`COGNITO_CLIENT_SECRET` the dashboard Lambda uses at refresh time (`CognitoConfig.from_env`, `cognito.py:51-56`). Cognito returns `invalid_grant`/`invalid_client`, producing the 401. **This is not confirmable from source alone** — the dashboard Lambda's live env is FROZEN (Feature 1290: `modules/lambda` `lifecycle { ignore_changes = [environment] }`), so the running values can drift from Terraform. It must be discriminated at runtime (see US1 / instrumentation task).
+- Alternate (less likely) sub-cause still in scope: the refresh cookie is genuinely not sent because the DEPLOYED browser-visible API path prefix differs from what `_cookie_path_prefix` computes (custom domain / base-path mapping vs raw stage). This produces the 401 at `router_v2.py:664` and is distinguishable from the Cognito-reject case by whether `_extract_refresh_token_from_event` returned a token.
+
+### Defect B — Cognito refresh response omits `user_id` (latent; blocks persistence even after A is fixed)
+
+- The Cognito branch of `refresh_access_tokens` returns `RefreshTokenResponse(id_token, access_token, expires_in)` only (`auth.py:2934-2939`); `user_id` and `auth_type` default to `None` (`RefreshTokenResponse`, `auth.py:1507-1517` — the model comments confirm these are "None for Cognito-backed refreshes").
+- The frontend `restoreSession` (`frontend/src/stores/auth-store.ts:102-198`) requires `data.userId` for the non-anonymous branch: when `!data.userId` it returns `false` (`auth-store.ts:157-161`), and `use-session-init.ts` then calls `signInAnonymous()`.
+- **Consequence**: even if Defect A is fixed and `/refresh` returns 200, an OAuth session still cannot rebuild its user object and still falls back to guest. Fixing A without B leaves every reported symptom intact.
+
+### Why three symptoms, one chain
+
+`restoreSession` fails → `signInAnonymous()` runs → Zustand user is overwritten with a guest identity that Settings reads ("Guest, limited features"), while the top-nav UserMenu is showing a stale pre-fallback render of the Google user, and the guest identity mismatch/aborted async work leaves the left-nav in an inconsistent, unresponsive state. One failed restore, three visible faults.
+
+---
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - OAuth session survives a full-page reload (Priority: P1) 🎯 MVP
+
+A user signs in with Google on the Amplify frontend, then reloads the page (F5). The app restores the same Google-authenticated session instead of dropping to guest.
+
+**Why this priority**: This is the headline defect and the MVP. Without reload persistence, OAuth login is effectively single-use per tab and the product looks broken immediately after the marquee "Sign in with Google" flow.
+
+**Independent Test**: On the real Amplify frontend, sign in with Google (owner-performed interactive login), reload, and confirm `POST /api/v2/auth/refresh` returns 200 with a body carrying the OAuth `user_id`, and that the app remains signed in as the Google user. No mocks.
+
+**Acceptance Scenarios**:
+
+1. **Given** a live Google OAuth session (valid refresh cookie present), **When** the page reloads and `SessionProvider` runs `restoreSession()`, **Then** `POST /api/v2/auth/refresh` returns 200 with `access_token`, `id_token`, and a non-null `user_id` for the OAuth user.
+2. **Given** the 200 refresh response, **When** `restoreSession()` processes it, **Then** it takes the Cognito-restore branch, rebuilds the user with the OAuth identity, returns `true`, and `signInAnonymous()` is NOT called.
+3. **Given** the restored session, **When** the Settings page renders, **Then** it shows the signed-in Google user (email/role `free` or higher), NOT "Anonymous/Guest".
+4. **Given** an expired or revoked OAuth refresh token, **When** `/refresh` is called, **Then** the backend returns 401 with a clear reason and the frontend falls back to guest *gracefully* (no unresponsive UI).
+
+---
+
+### User Story 2 - OAuth session survives client-side navigation and the left-nav stays responsive (Priority: P1)
+
+After signing in with Google, the user navigates to Settings and around the app via the left-nav. The nav stays responsive and every view reflects the Google user, not guest.
+
+**Why this priority**: The left-nav lockup and the Settings/UserMenu identity mismatch are the other two reported symptoms of the same failed restore. Ties with US1 as P1 because they share the root cause and must both be verified to call the bug fixed.
+
+**Independent Test**: With a restored OAuth session, click into Settings and back out through the left-nav; confirm no lockup and consistent Google identity across UserMenu, Settings, and the left-nav.
+
+**Acceptance Scenarios**:
+
+1. **Given** a restored OAuth session, **When** the user navigates to `/settings` and back via the left-nav, **Then** the left-nav remains interactive (no dead clicks) and no unhandled rejection/timeout fires.
+2. **Given** a restored OAuth session, **When** any authenticated view renders, **Then** the identity shown by the top-nav UserMenu and by Settings is the same Google user (no guest/Google split-brain).
+3. **Given** a transient `/refresh` failure during navigation, **When** the store degrades, **Then** the UI surfaces a recoverable state rather than a hung nav.
+
+---
+
+### User Story 3 - Security posture is preserved under cross-site cookies (Priority: P2)
+
+The persistence fix keeps the existing auth/session/cookie security guarantees intact: httpOnly refresh cookie, CSRF double-submit protection, single-use guest tokens, and no widening of exploitable surface from `SameSite=None`.
+
+**Why this priority**: This is auth/session/cookie work on a cross-origin (Amplify → API Gateway) deployment. `SameSite=None` is already in place and required, but any change to the refresh path must not regress CSRF, session fixation, or cookie-scope protections. P2 because it gates merge, not the demo.
+
+**Independent Test**: Re-run the CSRF and refresh-path security checks; confirm `/refresh` still rejects forged/absent cookies, CSRF middleware still guards non-exempt state-changing routes, and no refresh token or user_id leaks into a response body beyond what the frontend requires.
+
+**Acceptance Scenarios**:
+
+1. **Given** the fix, **When** `/refresh` receives no valid refresh cookie, **Then** it returns 401 and issues no tokens.
+2. **Given** the fix, **When** a request presents a blocklisted (evicted) refresh token, **Then** `/refresh` returns 401 `token_revoked` (`auth.py:2913-2924`) — blocklist check still runs before issuance.
+3. **Given** the fix, **When** the refresh response is serialized, **Then** the rotated refresh token is never in the body (`exclude={"refresh_token_for_cookie"}`, `router_v2.py:674`) and only the minimal `user_id` needed for restore is present.
+4. **Given** the fix, **When** a state-changing non-exempt route is called cross-site without a matching CSRF header/cookie, **Then** `require_csrf_middleware` still returns 403 (`csrf_middleware.py:66-73`).
+
+---
+
+### Edge Cases
+
+- **Cookie sent but Cognito rejects** (Defect A, Cognito sub-case): `/refresh` returns 401 with a Cognito error; frontend must fall back to guest without UI lockup, and the backend must log enough to distinguish this from "cookie not sent."
+- **Cookie NOT sent** (Defect A, path/scope sub-case): `_extract_refresh_token_from_event` returns `None`; `/refresh` returns 401 "not found." Instrumentation must make this case unambiguous.
+- **Refresh succeeds but `/auth/me` fails**: `restoreSession` already best-effort registers the identity with conservative role (`auth-store.ts:177-192`); confirm this path still yields a usable OAuth session once `user_id` is present.
+- **Cognito does not rotate the refresh token**: `cognito_refresh_tokens` returns `refresh_token=None` (`cognito.py:273`); the router correctly leaves the existing cookie in place (`router_v2.py:678`). Ensure this does not accidentally clear the cookie.
+- **Guest → OAuth upgrade in the same tab**: after upgrade, the refresh cookie now holds a Cognito token; the next reload must restore OAuth, not the pre-upgrade guest.
+- **Stage vs custom-domain path**: if a custom domain / base-path mapping is in front of API Gateway, the cookie `Path` computed from `requestContext.stage` may not match the browser path. Must be verified on the real deployment.
+- **Env drift under Feature 1290 freeze**: any Cognito client/secret correction lands via the CI "Step 2.5" env sync or a manual `update-function-configuration`, NOT Terraform. A "fixed" Terraform value that never reaches the live Lambda is a trap.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: `POST /api/v2/auth/refresh` MUST return HTTP 200 for a live, valid Google OAuth session on the real Amplify → API Gateway deployment.
+- **FR-002**: The 200 refresh response for a Cognito-backed (OAuth) session MUST include the session's `user_id` (and `auth_type`) so the frontend can rebuild the user object. (Fixes Defect B: `auth.py:2934-2939` must populate `user_id`.)
+- **FR-003**: The system MUST resolve `user_id` for a Cognito refresh from a trustworthy source — the validated token claims (`cognito_sub` → user lookup) or an existing session/user record — NOT from client-supplied data.
+- **FR-004**: `restoreSession()` MUST take the Cognito-restore branch for OAuth sessions and MUST NOT fall back to `signInAnonymous()` when a valid OAuth session is restorable.
+- **FR-005**: After restore, the OAuth identity MUST be consistent across the top-nav UserMenu, the Settings page, and the left-nav (no guest/OAuth split-brain).
+- **FR-006**: The left-nav MUST remain responsive after navigating into and out of Settings with a restored OAuth session.
+- **FR-007**: The backend refresh path MUST emit diagnostic logging that unambiguously distinguishes (a) refresh cookie absent, (b) refresh cookie present but Cognito rejected, (c) success — without logging secret token values (use existing `sanitize_for_log` / hash-prefix conventions).
+- **FR-008**: The refresh cookie for OAuth sessions MUST continue to be sent by the browser on cross-site `/refresh` calls from the Amplify origin (verify the deployed cookie `Path`/`Domain`/`SameSite=None`/`Secure` against the real request path; correct only if a real mismatch is observed).
+- **FR-009**: Any Cognito client/secret configuration correction MUST be delivered through the CI env-sync ("Step 2.5") or a manual live `update-function-configuration`, since Terraform cannot mutate the frozen dashboard Lambda env (Feature 1290). The change MUST be documented and verified against the live function config.
+- **FR-010**: On an unrecoverable refresh (expired/revoked/invalid), the frontend MUST fall back to guest gracefully with no unresponsive UI and no console-visible unhandled rejection.
+- **FR-011**: No new AWS resources may be introduced; the fix reuses the existing Cognito user pool, app client(s), dashboard Lambda, and DynamoDB tables.
+
+### Security Requirements
+
+- **SR-001**: The refresh token MUST remain httpOnly and MUST NEVER appear in a response body (preserve `exclude={"refresh_token_for_cookie"}`).
+- **SR-002**: CSRF protection MUST remain intact: `require_csrf_middleware` still guards non-exempt state-changing routes; `/refresh` stays cookie-only and CSRF-exempt by design (`csrf.py:38`), and the CSRF cookie continues to rotate on refresh (`router_v2.py:684`).
+- **SR-003**: `SameSite=None` MUST NOT be broadened beyond what cross-origin requires; the CSRF double-submit token remains the CSRF control that compensates for `SameSite=None`.
+- **SR-004**: The refresh-token blocklist / eviction check MUST run BEFORE issuing new tokens (preserve `auth.py:2913-2924`), so revoked sessions cannot be resurrected via reload.
+- **SR-005**: The `user_id` added to the refresh response (FR-002) MUST be the minimum identity needed for restore and MUST be derived server-side from validated tokens/session, never echoed from request input (guards against session fixation / identity spoofing).
+- **SR-006**: Diagnostic logging (FR-007) MUST NOT log raw refresh tokens, id/access tokens, or full user identifiers; use hash prefixes and masking consistent with repo SAST rules (CWE-117/CWE-312).
+
+### Key Entities
+
+- **Refresh token (OAuth)**: real Cognito refresh token; lives only in the httpOnly `refresh_token` cookie; scoped to `{/stage}/api/v2/auth`.
+- **RefreshTokenResponse**: backend response model (`auth.py:1504-1520`); must carry `user_id`/`auth_type` for the Cognito branch after this feature.
+- **CognitoConfig**: `client_id`/`client_secret`/URLs from env (`cognito.py:44-56`); the suspected misconfiguration surface for Defect A.
+- **Auth store (frontend)**: Zustand store; `restoreSession` (`auth-store.ts:102-198`) is the consumer that gates on `user_id`.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: On the real Amplify frontend, after an owner-performed interactive Google login, `POST /api/v2/auth/refresh` returns **200** on page reload (was 401) — verified in the browser network panel / preprod, no mocks.
+- **SC-002**: The reload keeps the session signed in as the Google user in **100%** of trials across at least 3 consecutive reloads.
+- **SC-003**: Settings and the top-nav UserMenu show the **same** Google identity (0 guest/OAuth mismatches) after reload and after Settings navigation.
+- **SC-004**: The left-nav remains responsive (all links clickable) after entering and leaving Settings, across at least 3 navigation cycles.
+- **SC-005**: OAuth session persists across client-side navigation with no re-drop to guest for the token's validity window (≥ the Cognito access-token lifetime, e.g. 1 hour, on a single refresh cycle).
+- **SC-006**: No security regression: existing CSRF, blocklist, and cookie-scope checks still pass; `/refresh` still 401s on absent/forged cookies and on blocklisted tokens.
+
+## Assumptions
+
+- The Google OAuth *login* itself works (task-confirmed): code exchange, user provisioning, and cookie SET on callback all succeed. Only *persistence via refresh* is broken.
+- The refresh cookie is being SET correctly on the OAuth callback (unified helper), matching the working guest path. Whether it is being SENT on `/refresh` in the deployed topology is the one cookie-side item still to confirm at runtime (FR-008).
+- The dashboard Lambda live env is authoritative and may differ from Terraform due to the Feature 1290 freeze.
+- Owner performs the interactive Google login for verification; automated E2E cannot complete Google's consent screen.
+
+## Out of Scope
+
+- The HTMX admin dashboard (`src/dashboard/`) — this is the customer dashboard only.
+- OAuth *login* flow changes (provider config, redirect URI, code exchange) beyond what refresh persistence needs.
+- GitHub OAuth provider behavior (only incidentally covered; primary target is Google).
+- Prod rollout (tracked separately, e.g. 1372); this feature targets fix + preprod verification.
+
+---
+
+## Adversarial Review #1
+
+Attacked the spec as a pentester, a skeptical staff engineer, and a 3am on-call. Findings and resolutions below; all CRITICAL/HIGH self-resolved by editing the spec above.
+
+| # | Sev | Finding | Resolution |
+|---|-----|---------|------------|
+| 1 | CRITICAL | Original prime suspect (cookie attributes) would have sent the whole feature down a dead end — cookies are already unified/fixed (WI-3 #928). Building the spec around a non-bug wastes the fix. | Rewrote the root-cause section to prove the cookie hypothesis is already resolved (cited `router_v2.py:179-194`, commit `0849559`) and re-anchored on the real chain (Defects A + B). |
+| 2 | CRITICAL | Even a "fix the 401" spec would leave the bug live: the Cognito refresh response omits `user_id`, so `restoreSession` bails to guest on a 200. Single-defect framing fails the success criteria. | Added **Defect B** and **FR-002/FR-003**; made SC-002/SC-003 depend on both defects being fixed. |
+| 3 | HIGH | "The cookie is not sent" vs "Cognito rejects the token" are different fixes with the same 401. Without disambiguation, implementers guess and thrash at 3am. | Added FR-007 (diagnostic logging that separates absent-cookie / Cognito-reject / success) and made it the first implementation task (see plan/tasks). |
+| 4 | HIGH | `SameSite=None` widens CSRF surface; a naive fix could relax CSRF on `/refresh` "to make it work." | Added SR-002/SR-003: `/refresh` stays CSRF-exempt by design (cookie-only), CSRF double-submit remains the compensating control; forbid relaxing it. |
+| 5 | HIGH | Session fixation / identity spoof: if `user_id` in the refresh response were sourced from client input, an attacker could pin another identity. | FR-003 + SR-005: `user_id` MUST be derived server-side from validated token claims / session, never from request input. |
+| 6 | HIGH | Feature 1290 env freeze trap: a Cognito client/secret "fix" applied via Terraform silently never reaches the live Lambda; verification passes locally, prod stays broken. | FR-009 + Edge Case + Assumption: config corrections go via CI Step 2.5 / manual `update-function-configuration`, verified against live config. |
+| 7 | MED | Revoked-session resurrection: reload could revive an evicted session if blocklist check is bypassed. | SR-004: preserve pre-issuance blocklist check (`auth.py:2913-2924`); added AC US3-2. |
+| 8 | MED | Logging a refresh token while adding diagnostics (FR-007) would create a CWE-312 leak. | SR-006: hash-prefix/masking only, per repo SAST rules. |
+| 9 | MED | Left-nav "unresponsive" is asserted but not mechanistically tied to the root cause — risk of treating it as a separate UI bug and mis-scoping. | Explained the one-chain mechanism ("Why three symptoms, one chain") and kept US2 acceptance focused on the shared restore failure, with a fallback-graceful requirement (FR-010). |
+| 10 | LOW | Cognito not rotating the refresh token could be misread as "cookie lost," causing a spurious cookie-clear. | Edge case added; noted router already handles `refresh_token=None` (`router_v2.py:678`). |
+
+**Post-resolution gate: 0 CRITICAL, 0 HIGH remaining.** Residual MED/LOW items are captured as requirements/edge cases and carried into the plan and tasks. The one genuinely runtime-only unknown (is the 401 cookie-absent or Cognito-reject?) is converted into a required first diagnostic step rather than left as an open question.
+
+---
+
+## Clarifications
+
+Self-answered from the codebase/context (no human asked, per pipeline rules). Each records the question, the chosen answer, and the evidence source. Genuinely-unanswerable items are deferred to the final report.
+
+### Session 2026-07-23
+
+- **Q1: Should the core fix live in the backend (return `user_id`) or the frontend (`restoreSession` accept a `user_id`-less OAuth restore)?**
+  **A: Backend.** `restoreSession` already implements the correct, secure contract — it needs a server-authoritative `user_id` and refuses to invent one (`frontend/src/stores/auth-store.ts:157-161`). The backend Cognito branch is the side that violates the contract by returning `None` (`src/lambdas/dashboard/auth.py:2934-2939`, model `auth.py:1515`). Fixing the backend keeps identity server-derived (SR-005) and requires no frontend change. Evidence: auth-store.ts:141-193; auth.py:1504-1520, 2934-2939.
+
+- **Q2: Where does the OAuth `user_id` come from server-side so it is never client-supplied?**
+  **A: From the refreshed id-token claims → internal user lookup.** `cognito_refresh_tokens` returns a fresh `id_token` (`cognito.py:270-274`); `decode_id_token` extracts `sub` (used at `auth.py:2228-2230` for the callback). Map `sub` → internal `user_id` via the existing `get_user_by_provider_sub(table, provider, sub)` helper (`auth.py:527`), using the provider from the id-token identity claim, and/or the `by_cognito_sub` GSI introduced by Feature 1222. NOTE (accuracy correction from AR#2): there is **no** `get_user_by_cognito_sub` function in `auth.py` today — the only sub-based lookup helper is `get_user_by_provider_sub` (`auth.py:527`); implementation must reuse it (adding a thin `by_cognito_sub` GSI query helper only if the provider is not recoverable at refresh time). This keeps identity server-authoritative (SR-005). Evidence: auth.py:527, 2228-2245; cognito.py:270-274. `refresh_access_tokens` already receives `table` on the live path (`router_v2.py:667-668`), so the lookup is available.
+
+- **Q3: Is the 401 a CSRF rejection (403) misreported, or a genuine 401?**
+  **A: Genuine 401 from the refresh handler.** `/api/v2/auth/refresh` is in `CSRF_EXEMPT_PATHS` (`src/lambdas/shared/auth/csrf.py:38`), and `require_csrf_middleware` returns 403 (not 401) on failure (`csrf_middleware.py:66-73`). So the observed 401 must come from `refresh_tokens()` at `router_v2.py:664` (cookie absent) or `:671` (Cognito error). Evidence: csrf.py:38; csrf_middleware.py:66-73; router_v2.py:663-671.
+
+- **Q4: Does the fix require any Terraform/infra change, and how is a Cognito config correction delivered given the env freeze?**
+  **A: No Terraform env change is possible; corrections go through the CI "Step 2.5" env-sync or a manual `update-function-configuration`.** The dashboard Lambda module carries `lifecycle { ignore_changes = [image_uri, environment] }` (Feature 1290), so Terraform cannot mutate `COGNITO_CLIENT_ID`/`COGNITO_CLIENT_SECRET`. Any correction must be applied via the deploy workflow env-sync and verified against `aws lambda get-function-configuration`. Evidence: research.md R4; task-provided ground truth (Feature 1290); FR-009.
+
+- **Q5: Is a frontend change in scope for the MVP (US1/US2), or backend-only?**
+  **A: Backend-only for the core fix; frontend is verification-only.** Once the backend returns `user_id`+`auth_type` for the Cognito branch, the existing `restoreSession` Cognito branch (`auth-store.ts:141-193`) completes without modification, and the guest-fallback that produced all three symptoms stops firing. The left-nav/UserMenu/Settings symptoms are downstream of the restore result, so they clear when restore succeeds. If preprod verification reveals a residual UI-only lockup after restore succeeds, that becomes a follow-up (deferred), not part of this MVP. Evidence: auth-store.ts:141-198; use-session-init.ts restore-first flow; spec "Why three symptoms, one chain".
+
+**Deferred to owner (not codebase-answerable):**
+- **D1**: The live value of `COGNITO_CLIENT_SECRET`/`COGNITO_CLIENT_ID` on the deployed dashboard Lambda and the app-client that Cognito Hosted UI used to issue the OAuth refresh token — required to confirm the Cognito-reject sub-cause of Defect A. Runtime-only.
+- **D2**: Whether a custom domain / base-path mapping fronts the API Gateway on preprod (affects whether the stage-derived cookie `Path` matches the browser path, FR-008). Deployment-topology fact, runtime-only.

--- a/specs/1381-oauth-session-persistence/tasks.md
+++ b/specs/1381-oauth-session-persistence/tasks.md
@@ -1,0 +1,174 @@
+---
+description: "Task list for OAuth Session Persistence (1381)"
+---
+
+# Tasks: OAuth Session Persistence
+
+**Input**: Design documents from `specs/1381-oauth-session-persistence/`
+**Prerequisites**: plan.md, spec.md (US1–US3, FR-001..FR-011, SR-001..SR-006), research.md (R1–R7), contracts/auth-refresh.md
+
+**Tests**: Unit tests are included for the backend response contract (repo convention: no mocks for E2E; real verification is owner-driven and manual). Preprod verification tasks are explicit and gated on an owner-performed interactive Google login.
+
+**Two-dashboard guard**: All work targets the **Customer Dashboard** (`frontend/` + `src/lambdas/dashboard/`). Do NOT touch `src/dashboard/` (HTMX admin).
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: US1 / US2 / US3 (or SETUP/FOUND/POLISH)
+
+---
+
+## Phase 1: Setup
+
+- [ ] T001 [SETUP] Confirm worktree is on the customer-dashboard code paths; open `src/lambdas/dashboard/auth.py`, `src/lambdas/dashboard/router_v2.py`, `frontend/src/stores/auth-store.ts` and re-read the cited line ranges (spec Root-Cause). Activate the Python 3.13 venv (`source .venv/bin/activate`).
+- [ ] T002 [SETUP] Capture a baseline: record current `POST /api/v2/auth/refresh` behavior for an OAuth session on preprod (401) and the response body, so the fix is provably a change. (Owner may need to supply a live session for the capture.)
+
+---
+
+## Phase 2: Foundational (Blocking) — Diagnose the live 401 (Defect A discriminator)
+
+**⚠️ CRITICAL**: Phase 0 of the plan. This decides whether Defect A remediation is a Cognito-config action or a cookie-Path correction. Blocks the Phase 2-remediation tasks (T012/T013) but NOT the Defect B fix (US1 core).
+
+- [ ] T003 [FOUND] (FR-007, SR-006) In `src/lambdas/dashboard/router_v2.py` `refresh_tokens()`, add non-secret diagnostic logging that emits exactly one of `refresh.cookie_absent` / `refresh.cognito_rejected` / `refresh.success`, using hash-prefix/masking (`sanitize_for_log`). Distinguish `_extract_refresh_token_from_event` returning `None` (absent) from `result.error` (Cognito reject). No raw tokens (CWE-312).
+- [ ] T004 [FOUND] (FR-007) In `src/lambdas/dashboard/auth.py` Cognito branch of `refresh_access_tokens`, surface the mapped Cognito error code (from `TokenError`) into the log context (not the body) so `invalid_grant` vs `invalid_client` vs `network_error` is visible.
+- [ ] T005 [FOUND] Unit test in `tests/unit/dashboard/` asserting the three diagnostic branches fire on: (a) event with no cookie, (b) Cognito 4xx (mock httpx via `responses`), (c) success. Assert no token material is logged.
+- [ ] T006 [FOUND] Deploy diagnostics to preprod via the normal pipeline; owner performs an interactive Google login + reload; collect CloudWatch logs to classify the live 401 as cookie-absent (→ FR-008 path) or Cognito-reject (→ FR-009 path). **Record the verdict in the PR/spec before remediation.**
+
+**Checkpoint**: The live 401 sub-cause is known and recorded.
+
+---
+
+## Phase 3: User Story 1 — OAuth session survives reload (P1) 🎯 MVP
+
+**Goal**: `/refresh` returns 200 with `user_id` for an OAuth session, and `restoreSession` rebuilds the Google identity instead of dropping to guest.
+
+**Independent Test**: Owner interactive Google login on Amplify → reload → 200 refresh carrying `user_id` → stays signed in as Google user.
+
+### Tests for User Story 1
+
+- [ ] T007 [P] [US1] Unit test in `tests/unit/dashboard/test_auth_refresh.py`: Cognito-branch `refresh_access_tokens` returns a `RefreshTokenResponse` with non-null `user_id` and `auth_type` for a valid OAuth refresh (mock `cognito_refresh_tokens` to return a fresh id-token; mock the user lookup). Covers FR-002/FR-003.
+- [ ] T008 [P] [US1] Contract test asserting the `/refresh` 200 body matches `contracts/auth-refresh.md` (has `access_token`, `id_token`, `expires_in`, `user_id`, `auth_type`; does NOT contain `refresh_token`). Covers SR-001.
+
+### Implementation for User Story 1 (Defect B — backend)
+
+- [ ] T009 [US1] (FR-002, FR-003, SR-005) In `src/lambdas/dashboard/auth.py` Cognito branch (`~2934-2939`): after a successful `cognito_refresh_tokens`, `decode_id_token(tokens.id_token)` to get `sub` (+ provider from identity claim), resolve internal `user_id` via `get_user_by_provider_sub(table, provider, sub)` (`auth.py:527`) — reuse it; add a `by_cognito_sub` GSI query helper ONLY if provider is not recoverable. Populate `RefreshTokenResponse(user_id=..., auth_type=...)`. `user_id` MUST come from validated claims/DB, never request input.
+- [ ] T010 [US1] (AR#2 #2) Guard the lookup: if `table is None` or the user is not found, do NOT 500 — return the tokens without `user_id` (existing behavior) and log a `refresh.identity_unresolved` diagnostic, so the endpoint degrades to today's behavior rather than regressing.
+- [ ] T011 [US1] Run `pytest tests/unit/dashboard/ -v` and `ruff format`/`ruff check`; ensure no SAST (bandit/semgrep) findings on the new logging/lookup.
+
+**Checkpoint**: `/refresh` returns `user_id` for OAuth on a 200 — `restoreSession` can complete without frontend changes.
+
+---
+
+## Phase 4: User Story 1 (cont.) — Remediate Defect A (gated by T006)
+
+**Only one of T012 / T013 applies, per the T006 verdict.**
+
+- [ ] T012 [US1] (FR-009) IF Cognito-reject: correct `COGNITO_CLIENT_ID`/`COGNITO_CLIENT_SECRET` (or app-client) on the dashboard Lambda **via the CI "Step 2.5" env-sync in `.github/workflows/deploy.yml`** (Terraform cannot — Feature 1290 freeze). Verify with `aws lambda get-function-configuration` that the live env matches the Hosted-UI app client that issues OAuth tokens. Do NOT commit secrets; reference the secret store.
+- [ ] T013 [US1] (FR-008) IF cookie-absent: correct the deployed refresh-cookie `Path`/scope so it is sent on the real `/refresh` request path (reconcile `_cookie_path_prefix` `router_v2.py:150-163` against the actual browser path — custom domain / base-path mapping vs stage). Add a unit test pinning the computed Path for the deployed topology.
+
+**Checkpoint**: `/refresh` returns 200 for a live OAuth session on preprod.
+
+---
+
+## Phase 5: User Story 2 — Navigation persistence + responsive left-nav (P1)
+
+**Goal**: Restored OAuth identity is consistent across UserMenu/Settings/left-nav; nav stays responsive.
+
+**Independent Test**: With a restored OAuth session, navigate into/out of Settings via the left-nav; identity consistent, no lockup.
+
+- [ ] T014 [US2] (FR-005, FR-006) Verify on the real Amplify frontend (owner session): after reload-restore, navigate `/` ↔ `/settings` via left-nav ≥3 cycles; confirm UserMenu + Settings show the same Google user and every left-nav link stays clickable. Capture screenshots/network trace.
+- [ ] T015 [US2] (FR-010) Verify graceful fallback: with a deliberately expired/absent refresh cookie, reload → guest fallback occurs with no unresponsive nav and no console unhandled rejection. If a residual UI-only lockup persists AFTER restore succeeds, file a scoped follow-up (per Clarification Q5) — do not expand this feature.
+- [ ] T016 [P] [US2] (Regression) Run the customer Playwright suite (`cd frontend && npx playwright test`) against the Amplify URL for the auth/session specs to confirm no guest-flow regression. (Google consent step remains owner-manual.)
+
+**Checkpoint**: All three reported symptoms clear on the real frontend.
+
+---
+
+## Phase 6: User Story 3 — Security posture preserved (P2)
+
+**Goal**: No regression to CSRF, blocklist, cookie-scope, or token-body hygiene.
+
+- [ ] T017 [P] [US3] (SR-002) Test/verify `require_csrf_middleware` still returns 403 for a non-exempt state-changing route called cross-site without a matching CSRF header/cookie; `/refresh` stays CSRF-exempt and rotates the CSRF cookie on success (`router_v2.py:684`).
+- [ ] T018 [P] [US3] (SR-004) Test that a blocklisted refresh token yields 401 `token_revoked` BEFORE any token issuance (`auth.py:2913-2924`) — reload cannot resurrect an evicted session.
+- [ ] T019 [P] [US3] (SR-001, SR-003) Assert the refresh token never appears in any `/refresh` body and `SameSite=None` scope is unchanged (no broadening); the added `user_id` is the minimal identity only.
+- [ ] T020 [US3] (SR-006) Re-run `make sast` (semgrep) + bandit on `auth.py`/`router_v2.py`; confirm the new logging has no CWE-117/CWE-312 findings.
+
+**Checkpoint**: Security gates green.
+
+---
+
+## Phase 7: Polish & Verification Seal
+
+- [ ] T021 (SC-001..SC-006) Produce a verification record: preprod `/refresh` 200 (was 401), 3× reload persistence, UserMenu/Settings identity match, responsive left-nav, security checks — attach network traces / log excerpts. Real frontend, no mocks.
+- [ ] T022 [P] Update `specs/1381-oauth-session-persistence/` with the T006 verdict and the final applied remediation (T012 or T013) for traceability.
+- [ ] T023 Run `make validate` + full `pytest tests/unit/ -m "not preprod"`; GPG-sign commits (`git commit -S`). Do NOT push/open PR (pipeline stops at planning; implementation/commit is a separate gated step).
+
+---
+
+## Dependencies & Execution Order
+
+- **Setup (T001–T002)**: first.
+- **Foundational / Diagnose (T003–T006)**: blocks Defect A remediation (T012/T013) and the final verification seal. Does NOT block the Defect B code fix (T007–T011), which can proceed in parallel since it's required regardless.
+- **US1 (T007–T013)**: T009 is the core; T012/T013 are mutually exclusive and gated on T006.
+- **US2 (T014–T016)**: requires US1 fix deployed to preprod.
+- **US3 (T017–T020)**: can run in parallel with US2 verification (different concern), but before the seal.
+- **Polish (T021–T023)**: last.
+
+### Parallel Opportunities
+
+- T007, T008 (different test files) in parallel.
+- T017, T018, T019 (independent security checks) in parallel.
+- T016 (Playwright regression) parallel with T014/T015 manual verification.
+
+---
+
+## Requirement → Task Coverage (traceability)
+
+| Requirement | Task(s) |
+|-------------|---------|
+| FR-001 (200 for OAuth) | T009, T012/T013, T006, T021 |
+| FR-002 (user_id in response) | T007, T008, T009 |
+| FR-003 (server-derived user_id) | T009 |
+| FR-004 (restoreSession takes Cognito branch, no guest fallback) | T009, T014 |
+| FR-005 (consistent identity) | T014 |
+| FR-006 (responsive left-nav) | T014 |
+| FR-007 (diagnostics) | T003, T004, T005 |
+| FR-008 (cookie sent cross-site) | T006, T013 |
+| FR-009 (env-freeze delivery) | T012 |
+| FR-010 (graceful guest fallback) | T015 |
+| FR-011 (no new AWS resources) | T012, T013 (reuse existing), plan Constitution Check |
+| SR-001 (refresh token never in body) | T008, T019 |
+| SR-002 (CSRF intact) | T017 |
+| SR-003 (SameSite=None not broadened) | T019 |
+| SR-004 (blocklist before issuance) | T018 |
+| SR-005 (server-side identity, no spoof) | T009 |
+| SR-006 (no secret logging) | T003, T005, T020 |
+| SC-001..SC-006 | T021 |
+
+Every FR/SR maps to ≥1 task. Every task traces to a requirement or an explicit setup/verification purpose.
+
+---
+
+## Adversarial Review #3
+
+Final readiness review across spec.md, plan.md, tasks.md, research.md, contracts/.
+
+### Highest-risk task
+**T012 — correcting Cognito client/secret on the frozen Lambda env (Feature 1290).** Risk: an implementer applies the change via Terraform (the obvious place), it silently no-ops on the live env, preprod stays 401, and the team concludes "the fix didn't work" and rips out the correct Defect B fix. Mitigation baked in: T012 mandates the CI Step 2.5 path + a `get-function-configuration` verification; FR-009, research R4, and Clarification Q4 all reinforce it. Second-order risk: leaking a secret into git during the correction — T012 forbids committing secrets.
+
+### Most-likely rework
+**T009's user_id resolution** — provider may not be directly present on a bare Cognito refresh id-token, so `get_user_by_provider_sub` could miss and the code falls to T010's degrade path, leaving OAuth still un-restored despite a 200. If T006 shows the 401 is purely Cognito-reject, the team could ship T012 alone, verify a 200, and MISS that Defect B still blocks restore. Mitigation: T007/T008 unit-gate `user_id` presence, and the traceability table forces FR-002 (T009) to ship even when FR-001 (T012) is the visible win. AR#2 #3 pre-specified the provider-claim / `by_cognito_sub` GSI fallback so this is a known decision, not a surprise.
+
+### Readiness checks
+- Root cause verified against source with file:line (not re-derived from the task's hypothesis; the cookie hypothesis was disproven and the real two-defect chain proven). ✅
+- Both defects have tasks; fixing only the visible 401 is explicitly guarded against. ✅
+- Security requirements each have a task; no CSRF/blocklist/cookie-scope regression path is unowned. ✅
+- Env-freeze operational trap is called out in spec, plan, research, clarifications, and the highest-risk task. ✅
+- Verification is real-frontend / owner-interactive, no mocks, per constraints. ✅
+- Two deferred owner items (D1 live Cognito config, D2 deployment topology) are runtime-only and are exactly what T006 resolves. ✅
+
+### Gate
+
+**READY FOR IMPLEMENTATION.**
+
+Rationale: the plan is executable by a fresh agent, every requirement is task-covered and traceable, the two most dangerous failure modes (env-freeze no-op, single-defect tunnel vision) are explicitly mitigated, and the only remaining unknowns are runtime facts that the first foundational task (T006) is designed to resolve on preprod. No open CRITICAL/HIGH. Pipeline stops here (no `/speckit.implement`, no push).

--- a/src/lambdas/dashboard/auth.py
+++ b/src/lambdas/dashboard/auth.py
@@ -2903,6 +2903,48 @@ def _refresh_anonymous_session(
     )
 
 
+def get_user_by_cognito_sub(table: Any, cognito_sub: str) -> User | None:
+    """Get a user by their Cognito user-pool sub via the by_cognito_sub GSI.
+
+    Feature 1381 (Defect B): the OAuth (Cognito) refresh path needs the internal
+    user_id so the frontend can rebuild its session instead of dropping to guest.
+    The stable Cognito `sub` from the freshly-issued id_token maps to exactly one
+    user record. Server-authoritative — sub comes from a validated token, never
+    from client input.
+
+    Args:
+        table: DynamoDB Table resource
+        cognito_sub: Cognito user-pool subject claim (stable across refreshes)
+
+    Returns:
+        User if found, None otherwise
+    """
+    if not cognito_sub:
+        return None
+
+    try:
+        response = table.query(
+            IndexName="by_cognito_sub",
+            KeyConditionExpression="cognito_sub = :sub",
+            FilterExpression="entity_type = :type",
+            ExpressionAttributeValues={
+                ":sub": cognito_sub,
+                ":type": "USER",
+            },
+            Limit=1,  # one cognito_sub maps to at most one user
+        )
+        items = response.get("Items", [])
+        if not items:
+            return None
+        return User.from_dynamodb_item(items[0])
+    except Exception as e:
+        logger.error(
+            "Failed GSI cognito_sub lookup",
+            extra=get_safe_error_info(e),
+        )
+        return None
+
+
 def refresh_access_tokens(
     refresh_token: str,
     table: Any | None = None,
@@ -2940,10 +2982,33 @@ def refresh_access_tokens(
 
     try:
         tokens = cognito_refresh_tokens(config, refresh_token)
+        # Feature 1381 (Defect B): resolve the OAuth user_id so the frontend's
+        # restoreSession() takes the Cognito branch instead of bailing to guest
+        # on a missing user_id. Identity is derived from the freshly-issued
+        # id_token's stable Cognito sub (server-authoritative, not client input).
+        user_id: str | None = None
+        auth_type: str | None = None
+        if table is not None and tokens.id_token:
+            try:
+                cognito_sub = decode_id_token(tokens.id_token).get("sub")
+                if cognito_sub:
+                    user = get_user_by_cognito_sub(table, cognito_sub)
+                    if user:
+                        user_id = user.user_id
+                        auth_type = user.auth_type
+            except Exception as e:
+                # Degrade to today's behavior (tokens without identity) rather
+                # than failing the refresh; frontend falls back gracefully.
+                logger.warning(
+                    "OAuth refresh identity resolution failed",
+                    extra=get_safe_error_info(e),
+                )
         return RefreshTokenResponse(
             id_token=tokens.id_token,
             access_token=tokens.access_token,
             expires_in=tokens.expires_in,
+            user_id=user_id,
+            auth_type=auth_type,
         )
     except TokenError as e:
         return RefreshTokenResponse(

--- a/src/lambdas/dashboard/router_v2.py
+++ b/src/lambdas/dashboard/router_v2.py
@@ -661,6 +661,10 @@ def refresh_tokens():
             refresh_token = body.refresh_token
 
     if not refresh_token:
+        # Feature 1381 (FR-007): distinguish the cookie-absent 401 from a
+        # Cognito-reject 401 in CloudWatch so the OAuth-persistence failure mode
+        # is unambiguous on the live deployment. No token material logged.
+        logger.info("refresh.cookie_absent")
         return error_response(401, "Refresh token not found in cookie or request body")
 
     # Feature 1188: Pass table for blocklist check (FR-007)
@@ -668,7 +672,20 @@ def refresh_tokens():
         refresh_token=refresh_token, table=table
     )
     if result.error:
+        # Feature 1381 (FR-007): cookie WAS present but the refresh was rejected
+        # (e.g. Cognito invalid_grant / revoked). Distinct from cookie_absent.
+        logger.info("refresh.rejected", extra={"error": result.error})
         return error_response(401, result.message or result.error)
+
+    # Feature 1381 (FR-007): successful refresh; record whether an OAuth identity
+    # was resolved (Defect B). auth_type is non-sensitive; no tokens logged.
+    logger.info(
+        "refresh.success",
+        extra={
+            "auth_type": result.auth_type or "unknown",
+            "identity_resolved": bool(result.user_id),
+        },
+    )
 
     # M1 WI-3: the rotated refresh token travels ONLY in the httpOnly cookie
     response_data = result.model_dump(exclude={"refresh_token_for_cookie"})

--- a/tests/unit/dashboard/test_oauth_refresh_identity.py
+++ b/tests/unit/dashboard/test_oauth_refresh_identity.py
@@ -1,0 +1,137 @@
+"""Unit tests for OAuth (Cognito) refresh identity resolution.
+
+Feature 1381 (Defect B): the Cognito refresh branch of refresh_access_tokens
+previously returned user_id=None, so the frontend restoreSession() bailed to
+signInAnonymous() and every OAuth session dropped to guest on reload. The fix
+resolves the internal user_id from the freshly-issued id_token's stable Cognito
+sub via the by_cognito_sub GSI (server-authoritative, never client input).
+"""
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
+from src.lambdas.dashboard.auth import (
+    get_user_by_cognito_sub,
+    refresh_access_tokens,
+)
+from src.lambdas.shared.auth.cognito import CognitoTokens, TokenError
+
+
+def _user_item(user_id: str, cognito_sub: str, auth_type: str = "google") -> dict:
+    now = datetime.now(UTC).isoformat()
+    return {
+        "PK": f"USER#{user_id}",
+        "SK": "PROFILE",
+        "user_id": user_id,
+        "auth_type": auth_type,
+        "cognito_sub": cognito_sub,
+        "entity_type": "USER",
+        "role": "free",
+        "verification": "verified",
+        "created_at": now,
+        "last_active_at": now,
+        "session_expires_at": now,
+    }
+
+
+def _cognito_tokens() -> CognitoTokens:
+    return CognitoTokens(
+        id_token="header.payload.sig",  # decoded via patched decode_id_token
+        access_token="access-xyz",
+        refresh_token=None,  # Cognito does not rotate on refresh
+        expires_in=3600,
+    )
+
+
+class TestGetUserByCognitoSub:
+    def test_queries_by_cognito_sub_gsi_and_returns_user(self):
+        table = MagicMock()
+        table.query.return_value = {"Items": [_user_item("u-1", "sub-abc")]}
+
+        user = get_user_by_cognito_sub(table, "sub-abc")
+
+        assert user is not None
+        assert user.user_id == "u-1"
+        kwargs = table.query.call_args.kwargs
+        assert kwargs["IndexName"] == "by_cognito_sub"
+        assert kwargs["ExpressionAttributeValues"][":sub"] == "sub-abc"
+
+    def test_empty_sub_returns_none_without_query(self):
+        table = MagicMock()
+        assert get_user_by_cognito_sub(table, "") is None
+        table.query.assert_not_called()
+
+    def test_no_match_returns_none(self):
+        table = MagicMock()
+        table.query.return_value = {"Items": []}
+        assert get_user_by_cognito_sub(table, "missing") is None
+
+
+class TestCognitoRefreshResolvesUserId:
+    @patch("src.lambdas.dashboard.auth.CognitoConfig")
+    @patch("src.lambdas.dashboard.auth.decode_id_token")
+    @patch("src.lambdas.dashboard.auth.cognito_refresh_tokens")
+    def test_populates_user_id_and_auth_type(
+        self, mock_refresh, mock_decode, mock_config
+    ):
+        mock_refresh.return_value = _cognito_tokens()
+        mock_decode.return_value = {"sub": "sub-abc"}
+        table = MagicMock()
+        # blocklist check + GSI query both go through table; blocklist -> get_item
+        table.get_item.return_value = {}
+        table.query.return_value = {"Items": [_user_item("u-1", "sub-abc", "google")]}
+
+        result = refresh_access_tokens(refresh_token="cognito-rt", table=table)
+
+        assert result.error is None
+        assert result.access_token == "access-xyz"
+        assert result.user_id == "u-1"
+        assert result.auth_type == "google"
+
+    @patch("src.lambdas.dashboard.auth.CognitoConfig")
+    @patch("src.lambdas.dashboard.auth.decode_id_token")
+    @patch("src.lambdas.dashboard.auth.cognito_refresh_tokens")
+    def test_degrades_when_user_not_found(self, mock_refresh, mock_decode, mock_config):
+        mock_refresh.return_value = _cognito_tokens()
+        mock_decode.return_value = {"sub": "unknown-sub"}
+        table = MagicMock()
+        table.get_item.return_value = {}
+        table.query.return_value = {"Items": []}
+
+        result = refresh_access_tokens(refresh_token="cognito-rt", table=table)
+
+        # tokens still returned; identity simply unresolved (today's behavior)
+        assert result.error is None
+        assert result.access_token == "access-xyz"
+        assert result.user_id is None
+
+    @patch("src.lambdas.dashboard.auth.CognitoConfig")
+    @patch("src.lambdas.dashboard.auth.decode_id_token")
+    @patch("src.lambdas.dashboard.auth.cognito_refresh_tokens")
+    def test_identity_resolution_error_does_not_fail_refresh(
+        self, mock_refresh, mock_decode, mock_config
+    ):
+        mock_refresh.return_value = _cognito_tokens()
+        mock_decode.side_effect = ValueError("bad token")
+        table = MagicMock()
+        table.get_item.return_value = {}
+
+        result = refresh_access_tokens(refresh_token="cognito-rt", table=table)
+
+        assert result.error is None
+        assert result.access_token == "access-xyz"
+        assert result.user_id is None
+
+    @patch("src.lambdas.dashboard.auth.CognitoConfig")
+    @patch("src.lambdas.dashboard.auth.cognito_refresh_tokens")
+    def test_cognito_reject_still_returns_error(self, mock_refresh, mock_config):
+        mock_refresh.side_effect = TokenError(
+            "invalid_refresh_token", "Please sign in again."
+        )
+        table = MagicMock()
+        table.get_item.return_value = {}
+
+        result = refresh_access_tokens(refresh_token="bad-rt", table=table)
+
+        assert result.error == "invalid_refresh_token"
+        assert result.user_id is None


### PR DESCRIPTION
Third of the M1 auth-hardening batch. Fixes the post-login defect where a Google session reverts to guest (Settings shows Anonymous, dead nav).

## Diagnosis corrected the assumed cause (evidence-backed, read-only on preprod)
The plan suspected wrong cookie attributes or a Cognito client/secret mismatch. **Both ruled out:** the Lambda's `COGNITO_CLIENT_ID` matches the token-issuing public client, an empirical `/oauth2/token` probe shows a valid refresh token would succeed, and the refresh cookie `Path=/v1/api/v2/auth` matches the request path.

## Root cause = Defect B (code-certain)
The Cognito refresh branch of `refresh_access_tokens` returned `user_id=None`, so the frontend (`auth-store.ts:157-161`) re-guested **even on a successful refresh** — reproducing all three symptoms.

## Fix
- New `get_user_by_cognito_sub()` (auth.py) using the existing `by_cognito_sub` GSI (verified live).
- Cognito refresh branch decodes the freshly-issued id-token's stable `sub` → internal user → returns real `user_id`/`auth_type`. Server-authoritative; identity-resolution failure degrades to prior behavior (never a 500).
- FR-007 diagnostics (`refresh.cookie_absent`/`rejected`/`success{identity_resolved}`, no token material) so any residual 401 self-classifies post-deploy.

## Tests
7 new cases; 561 pass (dashboard + auth + cognito), 0 regressions. ruff + bandit clean.

## Verify (needs owner interactive Google login after deploy)
Sign in → reload 3× → `POST /v1/api/v2/auth/refresh` returns 200 with non-null `user_id` + `auth_type:"google"`; stays signed in (not guest); Settings + nav show the Google identity; left-nav responsive. If a 401 survives, its response body names the cause.

Full speckit trail included. Serialized after 1383 (auth.py line-disjoint).