### PR TITLE
fix(1392,1393): stop CloudFront WAF billing + unmask WAF integration test (zero cost)

### DIFF
--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -965,8 +965,10 @@ module "cloudfront_sse" {
   lambda_function_arn = module.sse_streaming_lambda.function_arn
 
   # FR-005: WAF WebACL (CLOUDFRONT scope). Empty string => CloudFront runs
-  # without a WAF (var.enable_waf=false). cloudfront_sse maps "" to null.
-  waf_web_acl_arn = var.enable_waf ? module.waf_cloudfront[0].web_acl_arn : ""
+  # without a WAF. Guard on enable_cloudfront_waf (the toggle that governs
+  # module.waf_cloudfront[0]); guarding on enable_waf would index a count=0
+  # module when the two toggles diverge. cloudfront_sse maps "" to null.
+  waf_web_acl_arn = var.enable_cloudfront_waf ? module.waf_cloudfront[0].web_acl_arn : ""
 
   # FR-003: 60s default max (180s requires AWS quota increase)
   origin_read_timeout = 60

--- a/infrastructure/terraform/preprod.tfvars
+++ b/infrastructure/terraform/preprod.tfvars
@@ -63,13 +63,12 @@ enable_waf = false
 # tier. Core monitoring-module alarms and the SNS topic remain.
 enable_extended_cloudwatch_alarms = false
 
-# CloudFront WAF teardown — PHASE 1 (disassociate, keep the ACL).
-# enable_waf=false already drops web_acl_id from the CloudFront distribution.
-# Keep the ACL itself alive (true) for this apply so Terraform doesn't try to
-# delete it while CloudFront is still propagating the disassociation, which
-# fails with WAFAssociatedItemException. Once this deploy reaches
-# Status=Deployed, PHASE 2 sets this to false to delete the orphaned ACL.
-enable_cloudfront_waf = true
+# CloudFront WAF teardown — PHASE 2 (delete the orphaned ACL to stop billing).
+# Phase 1 (enable_waf=false) disassociated the ACL from CloudFront. The ACL
+# (preprod-sentiment-waf) is confirmed present-but-disassociated on the
+# CLOUDFRONT scope, so deleting it now is safe (no WAFAssociatedItemException)
+# and stops the idle-ACL billing. Re-enable WAF later via enable_waf=true.
+enable_cloudfront_waf = false
 
 # M1 WI-6: enable Google as a Cognito social identity provider.
 # Google-only per Q-M1-1 (GitHub's IdP points at the GitHub Actions OIDC issuer

--- a/tests/e2e/test_waf_protection.py
+++ b/tests/e2e/test_waf_protection.py
@@ -16,9 +16,15 @@ import pytest
 from tests.e2e.conftest import SkipInfo
 
 skip = SkipInfo(
-    condition=os.getenv("AWS_ENV") != "preprod",
-    reason="Requires preprod API Gateway with WAF enabled",
-    remediation="Run with AWS_ENV=preprod and PREPROD_API_URL set to API Gateway URL",
+    condition=os.getenv("AWS_ENV") != "preprod"
+    or os.getenv("WAF_ENABLED", "false").lower() != "true",
+    reason=(
+        "Requires preprod API Gateway with WAF enabled. WAF is shelved for cost "
+        "(preprod.tfvars enable_waf=false, ~$42/mo), so these assertions skip "
+        "instead of failing the integration suite. Set WAF_ENABLED=true when "
+        "enable_waf is flipped back on."
+    ),
+    remediation="Enable WAF (preprod.tfvars enable_waf=true), run with AWS_ENV=preprod WAF_ENABLED=true",
 )
 
 


### PR DESCRIPTION
Two cost/CI fixes, **no new AWS resources** (one deletion, one test-gate).

## 1393 — stop the CloudFront WAF billing
The CloudFront-scope Web ACL `preprod-sentiment-waf` is confirmed **present-but-disassociated and still billing** (Phase-1 teardown disassociated it but kept it). This flips `enable_cloudfront_waf=false` to delete it (Phase 2), and repoints the `main.tf:969` guard to `enable_cloudfront_waf` so the teardown plans cleanly (guarding on `enable_waf` would index a `count=0` module).

⚠️ On merge/deploy, the plan should show **exactly one destroy** = `module.waf_cloudfront[0]` (the ACL + its alarm) and nothing else. Please confirm the plan before applying.

## 1392 — unmask the integration suite at zero cost
WAF is disabled for cost (`enable_waf=false`), so `test_waf_protection.py`'s 403 assertions fail every deploy and redden the whole Preprod Integration Tests job, masking other regressions. This gates those tests on a `WAF_ENABLED` flag so they **skip** (not fail) while WAF is off, and auto-reactivate when you set `WAF_ENABLED=true` after re-enabling WAF later.

Owner-gated. Do not auto-merge.