### PR TITLE
fix(1384): harden OAuth session persistence — single-flight init + backend no-clobber guard

### DIFF
--- a/frontend/src/hooks/use-auth.ts
+++ b/frontend/src/hooks/use-auth.ts
@@ -45,28 +45,16 @@ export function useAuth(options: UseAuthOptions = {}) {
     signOut,
     isSessionValid,
     getSessionRemainingMs,
-    setInitialized,
   } = useAuthStore();
 
-  // Initialize auth state - Feature 1165: No hydration wait needed
-  useEffect(() => {
-    if (!isInitialized) {
-      // Check if there's a valid session
-      const hasValidSession = isAuthenticated && isSessionValid();
-
-      if (!hasValidSession && requireAuth) {
-        // Try anonymous auth if no session
-        signInAnonymous().catch((error) => {
-          // Log the error for debugging - silent failures are hard to diagnose
-          console.error('[useAuth] Anonymous sign-in failed:', error);
-          // If anonymous fails and auth is required, redirect
-          router.push(redirectTo);
-        });
-      }
-
-      setInitialized(true);
-    }
-  }, [isInitialized, isAuthenticated, requireAuth, redirectTo, router, signInAnonymous, setInitialized, isSessionValid]);
+  // Feature 1384: useAuth no longer bootstraps the session. It previously ran
+  // its own init effect that minted an anonymous session independently of
+  // useSessionInit and set isInitialized. With useAuth mounted at 9 sites, that
+  // was a second, uncoordinated anon-mint path: it raced useSessionInit's
+  // restore-first flow and any anon-mint overwrites the OAuth refresh cookie,
+  // logging the user out on reload. useSessionInit (in SessionProvider, which
+  // runs on every page) is now the SOLE, single-flight owner of session
+  // bootstrap and of setInitialized. useAuth only consumes auth state here.
 
   // Schedule session refresh
   useEffect(() => {

--- a/frontend/src/hooks/use-session-init.ts
+++ b/frontend/src/hooks/use-session-init.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import { useAuthStore } from '@/stores/auth-store';
 import { SESSION_INIT_TIMEOUT_MS } from '@/lib/constants';
 
@@ -28,15 +28,11 @@ import { SESSION_INIT_TIMEOUT_MS } from '@/lib/constants';
  * ```
  */
 export function useSessionInit() {
-  // Ref guard to prevent multiple init attempts from different renders
-  const initAttempted = useRef(false);
-
   const {
     isInitialized,
     isLoading,
     error,
-    restoreSession,
-    signInAnonymous,
+    initializeSession,
     setInitialized,
     setError,
   } = useAuthStore();
@@ -44,12 +40,14 @@ export function useSessionInit() {
   // Feature 1165: Initialize immediately - no hydration wait needed
   // Session restoration happens via httpOnly cookies, not localStorage
   useEffect(() => {
-    // Only run once per app lifecycle
-    if (initAttempted.current || isInitialized) {
+    // Feature 1384: bootstrap runs exactly once. The guard against duplicate
+    // work now lives in the store's single-flight initializeSession() — shared
+    // across every SessionProvider mount — instead of a per-component ref, which
+    // could not stop two mounts from both minting an anonymous session and
+    // clobbering the OAuth refresh cookie. When already initialized, skip.
+    if (isInitialized) {
       return;
     }
-
-    initAttempted.current = true;
 
     // Clear stale OAuth sessionStorage keys from previous auth attempts.
     // CRITICAL: skip on /auth/callback. SessionProvider (root layout) runs this
@@ -62,24 +60,19 @@ export function useSessionInit() {
       sessionStorage.removeItem('oauth_state');
     }
 
-    const initializeSession = async () => {
+    const run = async () => {
       try {
-        // M1 WI-3: restore-first. The httpOnly refresh cookie (set for both
-        // guest and OAuth sessions) restores the previous session across
-        // reloads; only when nothing is restorable do we mint a NEW anonymous
-        // user. Before this, every F5 created a fresh DynamoDB user row.
+        // Feature 1384: restore-first, single-flight bootstrap owned by the
+        // store. initializeSession() restores from the httpOnly refresh cookie
+        // (guest OR OAuth) and only mints a NEW anonymous user when nothing is
+        // restorable. Raced against a timeout so a hung network call cannot
+        // leave the UI stuck on "Initializing session…".
         await Promise.race([
-          (async () => {
-            const restored = await restoreSession();
-            if (!restored) {
-              await signInAnonymous();
-            }
-          })(),
+          initializeSession(),
           new Promise<never>((_, reject) =>
             setTimeout(() => reject(new Error('timeout')), SESSION_INIT_TIMEOUT_MS)
           ),
         ]);
-        setInitialized(true);
       } catch (err) {
         if (err instanceof Error && err.message === 'timeout') {
           setError('Session initialization timed out. Please refresh.');
@@ -93,11 +86,10 @@ export function useSessionInit() {
       }
     };
 
-    initializeSession();
+    run();
   }, [
     isInitialized,
-    restoreSession,
-    signInAnonymous,
+    initializeSession,
     setInitialized,
     setError,
   ]);

--- a/frontend/src/stores/auth-store.ts
+++ b/frontend/src/stores/auth-store.ts
@@ -11,7 +11,7 @@
 import { create } from 'zustand';
 import type { User, AuthTokens, AuthState, OAuthProvider } from '@/types/auth';
 import { setUserId, setAccessToken, emitErrorEvent } from '@/lib/api/client';
-import { authApi } from '@/lib/api/auth';
+import { authApi, type RefreshTokenResponse } from '@/lib/api/auth';
 
 interface AuthStore extends AuthState {
   // Loading states
@@ -32,6 +32,7 @@ interface AuthStore extends AuthState {
   setInitialized: (initialized: boolean) => void;
 
   // Auth operations
+  initializeSession: () => Promise<void>; // Feature 1384: single-flight bootstrap owner
   restoreSession: () => Promise<boolean>; // M1 WI-3: cookie-based restore at init
   signInAnonymous: () => Promise<void>;
   signInWithMagicLink: (email: string, token: string) => Promise<void>;
@@ -68,6 +69,35 @@ const initialState: AuthState & { isLoading: boolean; isInitialized: boolean; er
   sessionDegraded: false,
 };
 
+// Feature 1384: single-flight guards (module-level so they are shared across
+// EVERY component mount, unlike a per-component useRef). See the two callers
+// below for why sharing matters.
+//
+// refreshInFlight collapses concurrent POST /refresh calls (restoreSession +
+// refreshSession + any pre-expiry timer, fired by 9 useAuth mount sites on a
+// single load) into ONE network request, so the httpOnly refresh_token cookie
+// is never rotated by two racing requests at once.
+let refreshInFlight: Promise<RefreshTokenResponse> | null = null;
+
+function singleFlightRefresh(): Promise<RefreshTokenResponse> {
+  if (!refreshInFlight) {
+    refreshInFlight = authApi.refreshToken().finally(() => {
+      refreshInFlight = null;
+    });
+  }
+  return refreshInFlight;
+}
+
+// bootstrapInFlight makes session initialization run EXACTLY ONCE. The prior
+// per-component useRef guard in useSessionInit did not prevent the race:
+// SessionProvider mounts on every page and the shared isInitialized flag is
+// only set AFTER the async restore/mint completes, so concurrent mounts all
+// passed the `!isInitialized` check and each fired its own restore + anon-mint
+// — and any anon-mint overwrites the OAuth refresh cookie (same name/path),
+// silently logging the user out on reload. A single module-level promise
+// collapses bootstrap to one restore/mint for all callers.
+let bootstrapInFlight: Promise<void> | null = null;
+
 // Feature 1165: Memory-only store - no persist() middleware
 // Session restoration relies on httpOnly cookies via /refresh endpoint
 export const useAuthStore = create<AuthStore>((set, get) => ({
@@ -99,6 +129,34 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
 
   setInitialized: (initialized) => set({ isInitialized: initialized }),
 
+  initializeSession: async () => {
+    // Feature 1384: the SOLE session-bootstrap entrypoint. Guarded by the
+    // module-level bootstrapInFlight promise so all concurrent callers await
+    // the SAME restore/mint and never trigger parallel anonymous mints (which
+    // would clobber the OAuth refresh cookie). Restore-first: only mint a new
+    // anonymous user when there is genuinely no restorable session.
+    if (get().isInitialized) {
+      return;
+    }
+    if (bootstrapInFlight) {
+      return bootstrapInFlight;
+    }
+    bootstrapInFlight = (async () => {
+      const { restoreSession, signInAnonymous, setInitialized } = get();
+      try {
+        const restored = await restoreSession();
+        if (!restored) {
+          // No valid refresh cookie → genuinely no session to restore.
+          await signInAnonymous();
+        }
+        setInitialized(true);
+      } finally {
+        bootstrapInFlight = null;
+      }
+    })();
+    return bootstrapInFlight;
+  },
+
   restoreSession: async () => {
     // M1 WI-3: restore the previous session from the httpOnly refresh cookie
     // instead of minting a new anonymous user on every reload. Returns true
@@ -107,7 +165,9 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
     const { setUser, setSession, setTokens } = get();
 
     try {
-      const data = await authApi.refreshToken();
+      // Feature 1384: single-flight — share one in-flight /refresh with any
+      // concurrent refreshSession() call so the cookie is rotated only once.
+      const data = await singleFlightRefresh();
 
       if (!data.accessToken) {
         return false;
@@ -350,7 +410,8 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
     try {
       // Use authApi to route to Lambda backend
       // Feature 1168: Refresh token now sent via httpOnly cookie, not in request body
-      const data = await authApi.refreshToken();
+      // Feature 1384: single-flight — collapse with a concurrent restoreSession().
+      const data = await singleFlightRefresh();
 
       // M1 WI-3: the unmapped client used to yield accessToken === undefined
       // here silently; a refresh without an access token is now an explicit

--- a/frontend/tests/unit/stores/auth-store-session-init.test.ts
+++ b/frontend/tests/unit/stores/auth-store-session-init.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Feature 1384: single-flight session bootstrap + no-clobber race tests.
+ *
+ * The bug: session init ran per-component. SessionProvider (useSessionInit) plus
+ * 9 useAuth mount sites each raced to bootstrap. The shared isInitialized flag
+ * was only set AFTER the async restore/mint finished, so concurrent callers all
+ * passed the `!isInitialized` check and each fired restoreSession() AND, on a
+ * miss, signInAnonymous(). Any anonymous mint issues a fresh refresh_token
+ * cookie that clobbers the OAuth refresh cookie (same name/path) → the user is
+ * logged out on reload.
+ *
+ * The fix under test: initializeSession() is a module-level single-flight that
+ * runs restore-first EXACTLY ONCE for all concurrent callers, and refreshToken()
+ * is collapsed into one in-flight request.
+ */
+
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { useAuthStore } from '@/stores/auth-store';
+
+vi.mock('@/lib/cookies', () => ({
+  setAuthCookies: vi.fn(),
+  clearAuthCookies: vi.fn(),
+}));
+
+vi.mock('@/lib/api/client', () => ({
+  setUserId: vi.fn(),
+  setAccessToken: vi.fn(),
+  emitErrorEvent: vi.fn(),
+  api: { post: vi.fn(), get: vi.fn() },
+}));
+
+const mockCreateAnonymousSession = vi.fn();
+const mockRefreshToken = vi.fn();
+const mockGetProfile = vi.fn();
+
+vi.mock('@/lib/api/auth', () => ({
+  authApi: {
+    createAnonymousSession: () => mockCreateAnonymousSession(),
+    requestMagicLink: vi.fn(),
+    verifyMagicLink: vi.fn(),
+    signOut: vi.fn(),
+    getOAuthUrls: vi.fn(),
+    exchangeOAuthCode: vi.fn(),
+    refreshToken: () => mockRefreshToken(),
+    getProfile: () => mockGetProfile(),
+  },
+}));
+
+/** A restorable OAuth (Cognito-backed) refresh response. */
+function oauthRefresh() {
+  return {
+    accessToken: 'oauth-access-token',
+    idToken: 'oauth-id-token',
+    expiresIn: 3600,
+    userId: 'oauth-user-1',
+    authType: 'email',
+    sessionExpiresAt: new Date(Date.now() + 3600_000).toISOString(),
+  };
+}
+
+/** A no-session refresh response (no restorable cookie). */
+function emptyRefresh() {
+  return {
+    accessToken: null,
+    idToken: null,
+    expiresIn: 0,
+    userId: null,
+    authType: null,
+    sessionExpiresAt: null,
+  };
+}
+
+function anonMint() {
+  return {
+    userId: 'anon-user-1',
+    token: 'anon-user-1',
+    authType: 'anonymous',
+    createdAt: new Date().toISOString(),
+    sessionExpiresAt: new Date(Date.now() + 3600_000).toISOString(),
+    storageHint: 'localStorage',
+  };
+}
+
+describe('Feature 1384: single-flight session bootstrap', () => {
+  beforeEach(() => {
+    useAuthStore.getState().reset();
+    vi.clearAllMocks();
+    mockGetProfile.mockResolvedValue({});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('collapses concurrent initializeSession() calls into ONE restore, no anon mint', async () => {
+    // Restorable OAuth session present.
+    mockRefreshToken.mockResolvedValue(oauthRefresh());
+
+    const { initializeSession } = useAuthStore.getState();
+
+    // Simulate the 9 mount sites all bootstrapping at once.
+    await Promise.all(Array.from({ length: 9 }, () => initializeSession()));
+
+    // Single-flight: exactly one /refresh, and the anon mint that would clobber
+    // the OAuth cookie is NEVER reached.
+    expect(mockRefreshToken).toHaveBeenCalledTimes(1);
+    expect(mockCreateAnonymousSession).not.toHaveBeenCalled();
+
+    const state = useAuthStore.getState();
+    expect(state.isAuthenticated).toBe(true);
+    expect(state.isAnonymous).toBe(false);
+    expect(state.isInitialized).toBe(true);
+    expect(state.user?.userId).toBe('oauth-user-1');
+  });
+
+  it('interleaved restore + anon-mint under load never double-mints (no clobber)', async () => {
+    // No restorable session → exactly one anonymous mint even with N racers.
+    mockRefreshToken.mockResolvedValue(emptyRefresh());
+    mockCreateAnonymousSession.mockResolvedValue(anonMint());
+
+    const { initializeSession } = useAuthStore.getState();
+    await Promise.all(Array.from({ length: 9 }, () => initializeSession()));
+
+    // Restore attempted once; anon minted once (not once-per-mount).
+    expect(mockRefreshToken).toHaveBeenCalledTimes(1);
+    expect(mockCreateAnonymousSession).toHaveBeenCalledTimes(1);
+
+    const state = useAuthStore.getState();
+    expect(state.isAnonymous).toBe(true);
+    expect(state.isInitialized).toBe(true);
+  });
+
+  it('does not re-bootstrap once initialized', async () => {
+    mockRefreshToken.mockResolvedValue(oauthRefresh());
+
+    const { initializeSession } = useAuthStore.getState();
+    await initializeSession();
+    expect(mockRefreshToken).toHaveBeenCalledTimes(1);
+
+    // A later mount calling initializeSession() must be a no-op.
+    await initializeSession();
+    expect(mockRefreshToken).toHaveBeenCalledTimes(1);
+    expect(mockCreateAnonymousSession).not.toHaveBeenCalled();
+  });
+
+  it('restoreSession precedence: an OAuth restore blocks the anonymous fallback', async () => {
+    // Even if a mint were queued, restore-first must win and skip it.
+    mockRefreshToken.mockResolvedValue(oauthRefresh());
+    mockCreateAnonymousSession.mockResolvedValue(anonMint());
+
+    await useAuthStore.getState().initializeSession();
+
+    expect(mockCreateAnonymousSession).not.toHaveBeenCalled();
+    expect(useAuthStore.getState().isAnonymous).toBe(false);
+  });
+});
+
+describe('Feature 1384: single-flight /refresh', () => {
+  beforeEach(() => {
+    useAuthStore.getState().reset();
+    vi.clearAllMocks();
+    mockGetProfile.mockResolvedValue({});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('collapses a concurrent restoreSession() + refreshSession() into one call', async () => {
+    // Seed an authenticated session so refreshSession() does not early-return.
+    useAuthStore.setState({
+      tokens: {
+        accessToken: 'seed',
+        refreshToken: 'has-refresh',
+        idToken: 'seed-id',
+        expiresIn: 3600,
+      },
+    });
+
+    // Never-resolving until both callers have subscribed, to prove they share
+    // the SAME in-flight promise.
+    let resolveRefresh: (v: unknown) => void = () => {};
+    mockRefreshToken.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveRefresh = resolve;
+        })
+    );
+
+    const { restoreSession, refreshSession } = useAuthStore.getState();
+    const p1 = restoreSession();
+    const p2 = refreshSession();
+
+    // Both callers issued while one request is in flight.
+    expect(mockRefreshToken).toHaveBeenCalledTimes(1);
+
+    resolveRefresh(oauthRefresh());
+    await Promise.all([p1, p2]);
+
+    expect(mockRefreshToken).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-arms the single-flight after the in-flight request settles', async () => {
+    mockRefreshToken.mockResolvedValue(oauthRefresh());
+
+    await useAuthStore.getState().restoreSession();
+    expect(mockRefreshToken).toHaveBeenCalledTimes(1);
+
+    // A brand-new restore after settle issues a fresh request.
+    await useAuthStore.getState().restoreSession();
+    expect(mockRefreshToken).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/lambdas/dashboard/router_v2.py
+++ b/src/lambdas/dashboard/router_v2.py
@@ -200,6 +200,61 @@ def _extract_refresh_token_from_event(event: dict) -> str | None:
     return cookies.get(REFRESH_TOKEN_COOKIE_NAME)
 
 
+def _noclobber_guard_response(event: dict, table) -> Response | None:
+    """Feature 1384: no-clobber guard for POST /api/v2/auth/anonymous.
+
+    Minting a new anonymous session issues a fresh refresh_token cookie under
+    the SAME name/path, so it silently overwrites (clobbers) an existing OAuth
+    (Cognito-backed) refresh cookie. When that happens the next reload can no
+    longer restore the OAuth session and the user is logged out. PR #942 fixed
+    one client trigger, but the anonymous endpoint remained reachable from other
+    paths (a second browser tab, a stray retry), so the clobber survived.
+
+    This guard closes it at the source: if the incoming request already carries
+    a VALID Cognito refresh cookie, refuse to mint and instead return the
+    existing session refreshed from that cookie — WITHOUT emitting a new
+    refresh cookie, so the OAuth cookie is preserved untouched.
+
+    Returns:
+        A 200 refresh-style Response when a valid Cognito session is present
+        (caller must NOT mint). None when there is no restorable Cognito session
+        and normal anonymous minting should proceed (no cookie, an anonymous
+        `anon.*` cookie, or an invalid/expired/revoked cookie).
+    """
+    refresh_token = _extract_refresh_token_from_event(event)
+    if not refresh_token:
+        return None
+
+    # Guest (anon.*) refresh cookies are handled by the client's restore-first
+    # flow and are safe to replace; only a Cognito-backed cookie must be
+    # protected here (that is the OAuth-persistence clobber the spec targets).
+    if refresh_token.startswith("anon."):
+        return None
+
+    result = auth_service.refresh_access_tokens(
+        refresh_token=refresh_token, table=table
+    )
+    if result.error or not result.access_token:
+        # Cookie present but invalid/expired/revoked: let the normal anonymous
+        # mint proceed. Replacing a dead Cognito cookie is correct, not a clobber.
+        return None
+
+    logger.info(
+        "anonymous.noclobber_guard",
+        extra={"auth_type": result.auth_type or "cognito"},
+    )
+
+    # Preserve the existing httpOnly Cognito refresh cookie by NOT emitting a
+    # Set-Cookie for refresh_token. Return the refreshed session so the caller
+    # still gets a usable access/id token.
+    response_data = result.model_dump(exclude={"refresh_token_for_cookie"})
+    return _json_response_with_cookies(
+        response_data,
+        extra_headers=_get_no_cache_headers(),
+        status_code=200,
+    )
+
+
 def _json_response_with_cookies(
     body: dict,
     status_code: int = 200,
@@ -390,6 +445,14 @@ def create_anonymous_session():
     """
     event = auth_router.current_event.raw_event
     table = get_users_table()
+
+    # Feature 1384: no-clobber guard — if the request already carries a valid
+    # Cognito (OAuth) refresh cookie, do NOT mint a new anonymous session that
+    # would overwrite it. Return the existing session instead. This makes the
+    # OAuth-cookie clobber unreachable from every client path (incl. multi-tab).
+    guard_response = _noclobber_guard_response(event, table)
+    if guard_response is not None:
+        return guard_response
 
     body, err = _parse_request_body(
         event, auth_service.AnonymousSessionRequest, allow_none=True

--- a/tests/unit/dashboard/test_anonymous_noclobber.py
+++ b/tests/unit/dashboard/test_anonymous_noclobber.py
@@ -1,0 +1,233 @@
+"""Unit tests for Feature 1384: no-clobber guard on POST /api/v2/auth/anonymous.
+
+Root cause the guard closes: minting a new anonymous session issues a fresh
+refresh_token cookie under the SAME name/path, which silently overwrites
+(clobbers) an existing OAuth (Cognito-backed) refresh cookie. On the next
+reload the OAuth session can no longer be restored and the user is logged out.
+
+The guard: when the incoming request already carries a VALID Cognito refresh
+cookie, the endpoint MUST refuse to mint (and MUST NOT emit a new refresh
+cookie), returning the existing session instead. With no cookie (or an
+anonymous/invalid cookie) the endpoint mints a new anonymous session as before.
+"""
+
+import json
+from unittest.mock import patch
+
+import boto3
+from moto import mock_aws
+
+from src.lambdas.dashboard.auth import RefreshTokenResponse
+from src.lambdas.dashboard.handler import lambda_handler
+from tests.conftest import make_event
+
+
+def _create_users_table():
+    dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
+    table = dynamodb.create_table(
+        TableName="test-sentiment-users",
+        KeySchema=[
+            {"AttributeName": "PK", "KeyType": "HASH"},
+            {"AttributeName": "SK", "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": "PK", "AttributeType": "S"},
+            {"AttributeName": "SK", "AttributeType": "S"},
+        ],
+        BillingMode="PAY_PER_REQUEST",
+    )
+    table.wait_until_exists()
+    return table
+
+
+def _set_cookie_values(response: dict) -> list[str]:
+    """Return every Set-Cookie header value emitted by the response."""
+    cookies: list[str] = []
+    mv = response.get("multiValueHeaders") or {}
+    for key, values in mv.items():
+        if key.lower() == "set-cookie":
+            cookies.extend(values)
+    single = response.get("headers", {}) or {}
+    for key, value in single.items():
+        if key.lower() == "set-cookie" and value not in cookies:
+            cookies.append(value)
+    return cookies
+
+
+class TestNoClobberGuardWithValidCognitoCookie:
+    """A valid Cognito refresh cookie must NOT be overwritten by an anon mint."""
+
+    @mock_aws
+    def test_valid_cognito_cookie_returns_existing_session_not_new_anon(
+        self, mock_lambda_context
+    ):
+        _create_users_table()
+
+        cognito_result = RefreshTokenResponse(
+            access_token="new-access-token",
+            id_token="new-id-token",
+            expires_in=3600,
+            user_id="oauth-user-123",
+            auth_type="google",
+        )
+
+        event = make_event(
+            method="POST",
+            path="/api/v2/auth/anonymous",
+            cookies="refresh_token=cognito-refresh-token-abc",
+        )
+
+        with patch(
+            "src.lambdas.dashboard.auth.refresh_access_tokens",
+            return_value=cognito_result,
+        ) as mock_refresh:
+            response = lambda_handler(event, mock_lambda_context)
+
+        # Guard validated the presented cookie via the refresh path.
+        mock_refresh.assert_called_once()
+        assert (
+            mock_refresh.call_args.kwargs["refresh_token"]
+            == "cognito-refresh-token-abc"
+        )
+
+        # 200 (existing session preserved), NOT 201 (new anon minted).
+        assert response["statusCode"] == 200, response["body"]
+
+        data = json.loads(response["body"])
+        # Existing OAuth session returned, not a fresh anonymous identity.
+        assert data.get("auth_type") != "anonymous"
+        assert data["access_token"] == "new-access-token"
+        assert data["user_id"] == "oauth-user-123"
+        # Refresh token must NEVER be echoed in the body.
+        assert "refresh_token_for_cookie" not in data
+        assert "refresh_token" not in data
+
+    @mock_aws
+    def test_valid_cognito_cookie_does_not_emit_new_refresh_cookie(
+        self, mock_lambda_context
+    ):
+        """The core no-clobber assertion: no Set-Cookie for refresh_token."""
+        _create_users_table()
+
+        cognito_result = RefreshTokenResponse(
+            access_token="new-access-token",
+            id_token="new-id-token",
+            expires_in=3600,
+            user_id="oauth-user-123",
+            auth_type="google",
+        )
+
+        event = make_event(
+            method="POST",
+            path="/api/v2/auth/anonymous",
+            cookies="refresh_token=cognito-refresh-token-abc",
+        )
+
+        with patch(
+            "src.lambdas.dashboard.auth.refresh_access_tokens",
+            return_value=cognito_result,
+        ):
+            response = lambda_handler(event, mock_lambda_context)
+
+        # No Set-Cookie touches refresh_token → the OAuth cookie is preserved.
+        for cookie in _set_cookie_values(response):
+            assert not cookie.startswith(
+                "refresh_token="
+            ), f"anon mint clobbered the OAuth refresh cookie: {cookie}"
+
+
+class TestNoClobberGuardFallsThroughToNormalMint:
+    """Without a valid Cognito cookie, minting proceeds as before."""
+
+    @mock_aws
+    def test_no_cookie_mints_new_anonymous_session(self, mock_lambda_context):
+        _create_users_table()
+
+        event = make_event(method="POST", path="/api/v2/auth/anonymous")
+        response = lambda_handler(event, mock_lambda_context)
+
+        assert response["statusCode"] == 201, response["body"]
+        data = json.loads(response["body"])
+        assert data["auth_type"] == "anonymous"
+        assert "user_id" in data
+        # A fresh anonymous session DOES set a refresh cookie.
+        cookies = _set_cookie_values(response)
+        assert any(c.startswith("refresh_token=") for c in cookies)
+
+    @mock_aws
+    def test_anonymous_cookie_still_mints_new_session(self, mock_lambda_context):
+        """An anon.* cookie is not a Cognito session; minting proceeds."""
+        _create_users_table()
+
+        event = make_event(
+            method="POST",
+            path="/api/v2/auth/anonymous",
+            cookies="refresh_token=anon.some-user.some-secret-value",
+        )
+        # Guard must not even invoke the Cognito refresh path for anon.* cookies.
+        with patch("src.lambdas.dashboard.auth.refresh_access_tokens") as mock_refresh:
+            response = lambda_handler(event, mock_lambda_context)
+            mock_refresh.assert_not_called()
+
+        assert response["statusCode"] == 201, response["body"]
+        assert json.loads(response["body"])["auth_type"] == "anonymous"
+
+    @mock_aws
+    def test_invalid_cognito_cookie_mints_new_session(self, mock_lambda_context):
+        """A present-but-rejected refresh cookie falls through to normal mint."""
+        _create_users_table()
+
+        rejected = RefreshTokenResponse(
+            error="invalid_grant", message="Refresh token expired or revoked"
+        )
+
+        event = make_event(
+            method="POST",
+            path="/api/v2/auth/anonymous",
+            cookies="refresh_token=stale-cognito-token",
+        )
+        with patch(
+            "src.lambdas.dashboard.auth.refresh_access_tokens",
+            return_value=rejected,
+        ):
+            response = lambda_handler(event, mock_lambda_context)
+
+        assert response["statusCode"] == 201, response["body"]
+        assert json.loads(response["body"])["auth_type"] == "anonymous"
+
+
+class TestNoClobberGuardHelperUnit:
+    """Direct unit coverage of the guard helper."""
+
+    def test_returns_none_when_no_cookie(self):
+        from src.lambdas.dashboard.router_v2 import _noclobber_guard_response
+
+        event = {"headers": {}}
+        assert _noclobber_guard_response(event, table=None) is None
+
+    def test_returns_none_for_anonymous_cookie_without_calling_refresh(self):
+        from src.lambdas.dashboard.router_v2 import _noclobber_guard_response
+
+        event = {"headers": {"cookie": "refresh_token=anon.u.secret"}}
+        with patch("src.lambdas.dashboard.auth.refresh_access_tokens") as mock_refresh:
+            assert _noclobber_guard_response(event, table=None) is None
+            mock_refresh.assert_not_called()
+
+    def test_returns_response_for_valid_cognito_cookie(self):
+        from src.lambdas.dashboard.router_v2 import _noclobber_guard_response
+
+        event = {"headers": {"cookie": "refresh_token=cognito-tok"}}
+        good = RefreshTokenResponse(
+            access_token="a", id_token="i", expires_in=3600, auth_type="github"
+        )
+        with patch(
+            "src.lambdas.dashboard.auth.refresh_access_tokens", return_value=good
+        ):
+            result = _noclobber_guard_response(event, table=None)
+        assert result is not None
+        assert result.status_code == 200
+        # No refresh cookie set on the guard response.
+        set_cookies = result.headers.get("Set-Cookie")
+        if set_cookies:
+            values = set_cookies if isinstance(set_cookies, list) else [set_cookies]
+            assert not any(v.startswith("refresh_token=") for v in values)


### PR DESCRIPTION
## Problem
OAuth login didn't survive reload: the refresh cookie got clobbered by an anonymous-session mint. PR #942 fixed one trigger, but the race **survived** — `useAuth`'s init effect (mounted at 9 sites) minted anonymous independently of `useSessionInit`, plus a TOCTOU on the shared `isInitialized` flag.

## Fix
- **Frontend:** single-flight session bootstrap in `auth-store.ts` (`initializeSession` + `singleFlightRefresh`); removed `useAuth`'s independent anon-mint so `useSessionInit` is the sole owner; concurrent `/refresh` collapses to one call.
- **Backend:** no-clobber guard on `POST /api/v2/auth/anonymous` — a *validated* Cognito refresh cookie is never overwritten by an anon mint (any client path, incl. multi-tab). Zero new AWS resources.

## Verification
- New tests: 8 backend (moto), 6 frontend (interleaved 9-way mount race). Backend slice: 582 passed, 0 regressions.
- **Independent refuter agent** (not the implementer) re-ran everything and **mutation-tested** it: deleting the single-flight guard makes the race test fail (9 mints vs 1) → not vacuous. No false-positive on the backend guard (no-cookie / `anon.*` / expired-cognito all still mint).
- Honest note: the full frontend auth suite has 5 pre-existing `user-menu.test.tsx` failures (`ResizeObserver`/floating-ui in jsdom) — verified identical on the parent commit, **not introduced here**.

## Still needs
Owner manual Google login + F5 on the Amplify site to confirm the session sticks (login can't be headless). **Do not auto-merge** — owner-gated.