### PR TITLE
fix(1391): require auth+ownership on config refresh (GAP-2) + operator-gate chaos routes (GAP-3)

### DIFF
--- a/src/lambdas/dashboard/handler.py
+++ b/src/lambdas/dashboard/handler.py
@@ -91,6 +91,7 @@ from src.lambdas.shared.middleware.auth_middleware import (
     extract_auth_context,
     extract_auth_context_typed,
 )
+from src.lambdas.shared.middleware.require_role import require_role_middleware
 from src.lambdas.shared.utils.event_helpers import get_query_params
 
 # Feature 1290: Validate cross-module env vars at cold start (degraded, not fatal)
@@ -309,6 +310,25 @@ def _make_not_found_response(origin: str | None = None) -> Response:
         body=orjson.dumps({"detail": "Not found"}).decode(),
         headers=headers,
     )
+
+
+def _chaos_dev_env_gate(app, next_middleware):
+    """Env-gate that runs BEFORE the operator gate on chaos experiment routes.
+
+    Feature 1250 makes chaos experiment routes invisible (404, no existence
+    oracle) in prod/preprod. Feature 1391 (GAP-3) adds
+    require_role_middleware("operator"). Powertools runs middlewares in list
+    order, so this must be ordered first: otherwise an unauthenticated caller in
+    prod/preprod would get a 401 (revealing the route exists) before the env
+    gate's 404. Ordering the env gate first preserves the invisible-in-prod
+    property for every caller, authenticated or not.
+
+    The in-body ``_is_dev_environment()`` check on each experiment route is
+    retained as additive defense-in-depth.
+    """
+    if not _is_dev_environment():
+        return _make_not_found_response(_get_request_origin())
+    return next_middleware(app)
 
 
 def _inject_cors_headers(response: dict, event: dict) -> dict:
@@ -951,7 +971,10 @@ def get_articles_v2():
 # ===================================================================
 
 
-@app.post("/chaos/experiments")
+@app.post(
+    "/chaos/experiments",
+    middlewares=[_chaos_dev_env_gate, require_role_middleware("operator")],
+)
 def create_chaos_experiment():
     """Create a new chaos experiment (locked down in prod/preprod)."""
     if not _is_dev_environment():
@@ -1014,7 +1037,10 @@ def create_chaos_experiment():
         )
 
 
-@app.get("/chaos/experiments")
+@app.get(
+    "/chaos/experiments",
+    middlewares=[_chaos_dev_env_gate, require_role_middleware("operator")],
+)
 def list_chaos_experiments():
     """List chaos experiments (locked down in prod/preprod)."""
     if not _is_dev_environment():
@@ -1047,7 +1073,10 @@ def list_chaos_experiments():
         )
 
 
-@app.get("/chaos/experiments/<experiment_id>")
+@app.get(
+    "/chaos/experiments/<experiment_id>",
+    middlewares=[_chaos_dev_env_gate, require_role_middleware("operator")],
+)
 def get_chaos_experiment(experiment_id: str):
     """Get chaos experiment by ID (locked down in prod/preprod)."""
     if not _is_dev_environment():
@@ -1076,7 +1105,10 @@ def get_chaos_experiment(experiment_id: str):
     )
 
 
-@app.post("/chaos/experiments/<experiment_id>/start")
+@app.post(
+    "/chaos/experiments/<experiment_id>/start",
+    middlewares=[_chaos_dev_env_gate, require_role_middleware("operator")],
+)
 def start_chaos_experiment(experiment_id: str):
     """Start a chaos experiment (locked down in prod/preprod)."""
     if not _is_dev_environment():
@@ -1125,7 +1157,10 @@ def start_chaos_experiment(experiment_id: str):
         )
 
 
-@app.post("/chaos/experiments/<experiment_id>/stop")
+@app.post(
+    "/chaos/experiments/<experiment_id>/stop",
+    middlewares=[_chaos_dev_env_gate, require_role_middleware("operator")],
+)
 def stop_chaos_experiment(experiment_id: str):
     """Stop a running chaos experiment (locked down in prod/preprod)."""
     if not _is_dev_environment():
@@ -1167,7 +1202,10 @@ def stop_chaos_experiment(experiment_id: str):
         )
 
 
-@app.get("/chaos/experiments/<experiment_id>/report")
+@app.get(
+    "/chaos/experiments/<experiment_id>/report",
+    middlewares=[_chaos_dev_env_gate, require_role_middleware("operator")],
+)
 def get_chaos_experiment_report(experiment_id: str):
     """Get chaos experiment report (locked down in prod/preprod)."""
     if not _is_dev_environment():
@@ -1203,7 +1241,10 @@ def get_chaos_experiment_report(experiment_id: str):
         )
 
 
-@app.delete("/chaos/experiments/<experiment_id>")
+@app.delete(
+    "/chaos/experiments/<experiment_id>",
+    middlewares=[_chaos_dev_env_gate, require_role_middleware("operator")],
+)
 def delete_chaos_experiment(experiment_id: str):
     """Delete a chaos experiment (locked down in prod/preprod)."""
     if not _is_dev_environment():
@@ -1235,7 +1276,10 @@ def delete_chaos_experiment(experiment_id: str):
 # --- Chaos Reports (Feature 1240) ---
 
 
-@app.post("/chaos/reports")
+@app.post(
+    "/chaos/reports",
+    middlewares=[require_role_middleware("operator")],
+)
 def create_chaos_report():
     """Persist an experiment report (Feature 1240)."""
     event = app.current_event.raw_event
@@ -1299,7 +1343,10 @@ def create_chaos_report():
         )
 
 
-@app.post("/chaos/reports/plan")
+@app.post(
+    "/chaos/reports/plan",
+    middlewares=[require_role_middleware("operator")],
+)
 def create_chaos_plan_report():
     """Generate plan-level report (Feature 1240)."""
     event = app.current_event.raw_event
@@ -1345,7 +1392,10 @@ def create_chaos_plan_report():
         )
 
 
-@app.get("/chaos/reports")
+@app.get(
+    "/chaos/reports",
+    middlewares=[require_role_middleware("operator")],
+)
 def list_chaos_reports():
     """List reports with optional filters (Feature 1240)."""
     event = app.current_event.raw_event
@@ -1381,7 +1431,10 @@ def list_chaos_reports():
         )
 
 
-@app.get("/chaos/reports/trends/<scenario_type>")
+@app.get(
+    "/chaos/reports/trends/<scenario_type>",
+    middlewares=[require_role_middleware("operator")],
+)
 def get_chaos_report_trends(scenario_type: str):
     """Get trend data for scenario type (Feature 1240)."""
     event = app.current_event.raw_event
@@ -1410,7 +1463,10 @@ def get_chaos_report_trends(scenario_type: str):
         )
 
 
-@app.get("/chaos/reports/<report_id>")
+@app.get(
+    "/chaos/reports/<report_id>",
+    middlewares=[require_role_middleware("operator")],
+)
 def get_chaos_report(report_id: str):
     """Get single report by ID (Feature 1240)."""
     event = app.current_event.raw_event
@@ -1437,7 +1493,10 @@ def get_chaos_report(report_id: str):
     )
 
 
-@app.get("/chaos/reports/<report_id>/compare")
+@app.get(
+    "/chaos/reports/<report_id>/compare",
+    middlewares=[require_role_middleware("operator")],
+)
 def compare_chaos_reports(report_id: str):
     """Compare report against baseline (Feature 1240)."""
     event = app.current_event.raw_event
@@ -1481,7 +1540,10 @@ def compare_chaos_reports(report_id: str):
         )
 
 
-@app.delete("/chaos/reports/<report_id>")
+@app.delete(
+    "/chaos/reports/<report_id>",
+    middlewares=[require_role_middleware("operator")],
+)
 def delete_chaos_report(report_id: str):
     """Delete report by ID (Feature 1240)."""
     event = app.current_event.raw_event
@@ -1511,7 +1573,10 @@ def delete_chaos_report(report_id: str):
 # --- Safety Controls & Metrics (Features 1244, 1245, 1246) ---
 
 
-@app.get("/chaos/health")
+@app.get(
+    "/chaos/health",
+    middlewares=[require_role_middleware("operator")],
+)
 def get_chaos_health():
     """Pre-flight health check (Feature 1244)."""
     event = app.current_event.raw_event
@@ -1543,7 +1608,10 @@ def get_chaos_health():
         )
 
 
-@app.get("/chaos/gate")
+@app.get(
+    "/chaos/gate",
+    middlewares=[require_role_middleware("operator")],
+)
 def get_chaos_gate():
     """Get current gate state (Feature 1245)."""
     event = app.current_event.raw_event
@@ -1575,7 +1643,10 @@ def get_chaos_gate():
         )
 
 
-@app.put("/chaos/gate")
+@app.put(
+    "/chaos/gate",
+    middlewares=[require_role_middleware("operator")],
+)
 def set_chaos_gate():
     """Set gate state to armed or disarmed (Feature 1245)."""
     event = app.current_event.raw_event
@@ -1623,7 +1694,10 @@ def set_chaos_gate():
         )
 
 
-@app.post("/chaos/andon-cord")
+@app.post(
+    "/chaos/andon-cord",
+    middlewares=[require_role_middleware("operator")],
+)
 def pull_chaos_andon_cord():
     """Emergency stop -- pull the andon cord (Feature 1246)."""
     event = app.current_event.raw_event
@@ -1656,7 +1730,10 @@ def pull_chaos_andon_cord():
         )
 
 
-@app.get("/chaos/metrics")
+@app.get(
+    "/chaos/metrics",
+    middlewares=[require_role_middleware("operator")],
+)
 def get_chaos_metrics():
     """Real-time CloudWatch metrics for chaos dashboard (Feature 1247)."""
     event = app.current_event.raw_event

--- a/src/lambdas/dashboard/router_v2.py
+++ b/src/lambdas/dashboard/router_v2.py
@@ -1319,7 +1319,20 @@ def get_refresh_status(config_id: str):
 
 @config_router.post("/api/v2/configurations/<config_id>/refresh")
 def trigger_refresh(config_id: str):
-    """Trigger manual refresh (T061)."""
+    """Trigger manual refresh (T061). Auth + ownership added by Feature 1391 (GAP-2)."""
+    event = config_router.current_event.raw_event
+    table = get_users_table()
+
+    user_id, err = _require_user_id(event, table=table)
+    if err:
+        return err
+
+    # Ownership check: verify config belongs to this user (no existence oracle —
+    # same 404 whether the config is missing or owned by someone else)
+    config_data, err = _get_config_with_tickers(table, user_id, config_id)
+    if err:
+        return err
+
     result = market_service.trigger_refresh(config_id=config_id)
     return json_response(202, result.model_dump())
 

--- a/tests/unit/dashboard/test_chaos_operator_gating.py
+++ b/tests/unit/dashboard/test_chaos_operator_gating.py
@@ -1,0 +1,170 @@
+"""Operator-role gating for /chaos/* routes (Feature 1391 GAP-3).
+
+Target: Admin/operational routes on the dashboard Lambda.
+
+Before Feature 1391 the /chaos/* routes gated only via
+``_get_chaos_user_id_from_event`` (Feature 1250), which accepts ANY
+non-anonymous user -- so a free signed-in user could pull the andon cord or
+flip the chaos gate. GAP-3 attaches ``require_role_middleware("operator")`` to
+the chaos control AND read routes, mirroring the usage on
+``/api/v2/admin/sessions/revoke`` (Feature 1148).
+
+The require_role primitive returns:
+    - 401 "Authentication required" when there is no session (user_id is None)
+    - 403 "Access denied" when the user lacks the operator role
+
+Note on anonymous sessions: an anonymous (UUID) session carries
+roles=["anonymous"], so the operator gate now returns 403 (was 401 via the
+handler body). Either way the anonymous caller is denied -- the security
+invariant "anonymous cannot touch chaos" still holds, strictly tightened.
+
+``_is_dev_environment()`` and the chaos service-layer
+``check_environment_allowed()`` are retained as additive defense-in-depth and
+are exercised by the existing chaos security tests.
+"""
+
+import json
+from unittest.mock import patch
+
+from src.lambdas.dashboard.handler import lambda_handler
+from src.lambdas.shared.middleware import AuthContext, AuthType
+from tests.conftest import make_event
+
+# Control route (mutating) and a read route -- both must be operator-gated.
+_ANDON_PATH = "/chaos/andon-cord"
+_GATE_PATH = "/chaos/gate"
+
+
+def _auth_context(
+    user_id: str | None = "op-user",
+    auth_type: AuthType = AuthType.AUTHENTICATED,
+    roles: list[str] | None = None,
+) -> AuthContext:
+    return AuthContext(
+        user_id=user_id,
+        auth_type=auth_type,
+        auth_method="bearer" if user_id else None,
+        roles=roles,
+    )
+
+
+class TestChaosControlRouteOperatorGating:
+    """POST /chaos/andon-cord (control route) requires the operator role."""
+
+    def test_no_session_returns_401(self, mock_lambda_context) -> None:
+        """No session -> 401 from the operator middleware."""
+        with patch(
+            "src.lambdas.shared.middleware.require_role.extract_auth_context_typed",
+            return_value=_auth_context(user_id=None, roles=None),
+        ):
+            response = lambda_handler(
+                make_event(method="POST", path=_ANDON_PATH), mock_lambda_context
+            )
+        assert response["statusCode"] == 401
+        assert json.loads(response["body"])["detail"] == "Authentication required"
+
+    def test_signed_in_free_user_returns_403(self, mock_lambda_context) -> None:
+        """A non-operator (free) signed-in user cannot pull the andon cord."""
+        with patch(
+            "src.lambdas.shared.middleware.require_role.extract_auth_context_typed",
+            return_value=_auth_context(roles=["free"]),
+        ):
+            response = lambda_handler(
+                make_event(method="POST", path=_ANDON_PATH), mock_lambda_context
+            )
+        assert response["statusCode"] == 403
+        assert json.loads(response["body"])["detail"] == "Access denied"
+
+    def test_anonymous_session_is_denied(self, mock_lambda_context) -> None:
+        """Anonymous session (roles=['anonymous']) is denied by the operator gate.
+
+        Denied is the invariant; the primitive returns 403 for a present-but-
+        unprivileged session (tightened from the pre-1391 handler-body 401).
+        """
+        with patch(
+            "src.lambdas.shared.middleware.require_role.extract_auth_context_typed",
+            return_value=_auth_context(
+                auth_type=AuthType.ANONYMOUS, roles=["anonymous"]
+            ),
+        ):
+            response = lambda_handler(
+                make_event(method="POST", path=_ANDON_PATH), mock_lambda_context
+            )
+        assert response["statusCode"] in (401, 403)
+        # Never authorized: the andon cord is not pulled for anonymous callers.
+        assert json.loads(response["body"])["detail"] != "kill_switch_set"
+
+    def test_operator_reaches_handler(self, mock_lambda_context) -> None:
+        """Operator passes the gate and the andon-cord action executes -> 200."""
+        op_ctx = _auth_context(roles=["free", "operator"])
+        with (
+            patch(
+                "src.lambdas.shared.middleware.require_role.extract_auth_context_typed",
+                return_value=op_ctx,
+            ),
+            # Handler body's _get_chaos_user_id_from_event uses this copy.
+            patch(
+                "src.lambdas.dashboard.handler.extract_auth_context_typed",
+                return_value=op_ctx,
+            ),
+            patch(
+                "src.lambdas.dashboard.handler.pull_andon_cord",
+                return_value={"kill_switch_set": True, "disabled": []},
+            ) as mock_pull,
+        ):
+            response = lambda_handler(
+                make_event(method="POST", path=_ANDON_PATH), mock_lambda_context
+            )
+        assert response["statusCode"] == 200
+        assert json.loads(response["body"])["kill_switch_set"] is True
+        mock_pull.assert_called_once()
+
+
+class TestChaosReadRouteOperatorGating:
+    """GET /chaos/gate (read route) is also operator-gated (leaks internals)."""
+
+    def test_signed_in_free_user_returns_403(self, mock_lambda_context) -> None:
+        """A non-operator cannot read the chaos gate state."""
+        with patch(
+            "src.lambdas.shared.middleware.require_role.extract_auth_context_typed",
+            return_value=_auth_context(roles=["paid"]),
+        ):
+            response = lambda_handler(
+                make_event(method="GET", path=_GATE_PATH), mock_lambda_context
+            )
+        assert response["statusCode"] == 403
+        assert json.loads(response["body"])["detail"] == "Access denied"
+
+    def test_no_session_returns_401(self, mock_lambda_context) -> None:
+        """No session -> 401 from the operator middleware."""
+        with patch(
+            "src.lambdas.shared.middleware.require_role.extract_auth_context_typed",
+            return_value=_auth_context(user_id=None, roles=None),
+        ):
+            response = lambda_handler(
+                make_event(method="GET", path=_GATE_PATH), mock_lambda_context
+            )
+        assert response["statusCode"] == 401
+
+    def test_operator_reads_gate_state(self, mock_lambda_context) -> None:
+        """Operator passes the gate and reads state -> 200."""
+        op_ctx = _auth_context(roles=["operator"])
+        with (
+            patch(
+                "src.lambdas.shared.middleware.require_role.extract_auth_context_typed",
+                return_value=op_ctx,
+            ),
+            patch(
+                "src.lambdas.dashboard.handler.extract_auth_context_typed",
+                return_value=op_ctx,
+            ),
+            patch(
+                "src.lambdas.dashboard.handler.get_gate_state",
+                return_value="disarmed",
+            ),
+        ):
+            response = lambda_handler(
+                make_event(method="GET", path=_GATE_PATH), mock_lambda_context
+            )
+        assert response["statusCode"] == 200
+        assert json.loads(response["body"])["state"] == "disarmed"

--- a/tests/unit/dashboard/test_refresh_authz.py
+++ b/tests/unit/dashboard/test_refresh_authz.py
@@ -1,0 +1,117 @@
+"""Authorization tests for POST /api/v2/configurations/{id}/refresh (Feature 1391 GAP-2).
+
+Target: Customer Dashboard (Next.js/Amplify) API — dashboard Lambda REST route.
+
+Before Feature 1391, ``trigger_refresh`` was fully unauthenticated with no
+ownership check (mutating IDOR). This mirrors the hardening already applied to
+its sibling ``get_refresh_status`` (Feature 1249):
+
+    1. ``_require_user_id(event, table=table)`` -> 401 if no session
+    2. ``_get_config_with_tickers(table, user_id, config_id)`` -> 404 if not
+       owned (no existence oracle: same 404 whether missing or not-owned)
+    3. only then ``market_service.trigger_refresh`` -> 202
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+from src.lambdas.dashboard.handler import lambda_handler
+from tests.conftest import make_event
+
+_CONFIG_ID = "cfg-1391-refresh"
+_PATH = f"/api/v2/configurations/{_CONFIG_ID}/refresh"
+
+
+def _owned_config() -> MagicMock:
+    """A configuration object as returned by config_service.get_configuration."""
+    cfg = MagicMock()
+    cfg.tickers = [MagicMock(symbol="AAPL")]
+    return cfg
+
+
+class TestTriggerRefreshAuthorization:
+    """POST /configurations/{id}/refresh must require auth + ownership (GAP-2)."""
+
+    def test_unauthenticated_returns_401(self, mock_lambda_context) -> None:
+        """No session -> 401 (was: unauthenticated 202)."""
+        with (
+            patch(
+                "src.lambdas.dashboard.router_v2.get_users_table",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "src.lambdas.dashboard.router_v2.extract_auth_context",
+                return_value={},
+            ),
+            patch(
+                "src.lambdas.dashboard.router_v2.market_service.trigger_refresh"
+            ) as mock_trigger,
+        ):
+            response = lambda_handler(
+                make_event(method="POST", path=_PATH), mock_lambda_context
+            )
+        assert response["statusCode"] == 401
+        # Action must never run for an unauthenticated caller.
+        mock_trigger.assert_not_called()
+
+    def test_authenticated_non_owner_returns_404(self, mock_lambda_context) -> None:
+        """Authenticated user who does not own the config -> 404 (no oracle)."""
+        with (
+            patch(
+                "src.lambdas.dashboard.router_v2.get_users_table",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "src.lambdas.dashboard.router_v2.extract_auth_context",
+                return_value={"user_id": "not-the-owner"},
+            ),
+            patch(
+                "src.lambdas.dashboard.router_v2.auth_service.validate_session",
+                return_value=MagicMock(valid=True),
+            ),
+            patch(
+                "src.lambdas.dashboard.router_v2.config_service.get_configuration",
+                return_value=None,
+            ),
+            patch(
+                "src.lambdas.dashboard.router_v2.market_service.trigger_refresh"
+            ) as mock_trigger,
+        ):
+            response = lambda_handler(
+                make_event(method="POST", path=_PATH), mock_lambda_context
+            )
+        assert response["statusCode"] == 404
+        mock_trigger.assert_not_called()
+
+    def test_authenticated_owner_returns_202(self, mock_lambda_context) -> None:
+        """Authenticated owner -> 202 and the refresh action runs."""
+        trigger_result = MagicMock()
+        trigger_result.model_dump.return_value = {"status": "triggered"}
+        with (
+            patch(
+                "src.lambdas.dashboard.router_v2.get_users_table",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "src.lambdas.dashboard.router_v2.extract_auth_context",
+                return_value={"user_id": "the-owner"},
+            ),
+            patch(
+                "src.lambdas.dashboard.router_v2.auth_service.validate_session",
+                return_value=MagicMock(valid=True),
+            ),
+            patch(
+                "src.lambdas.dashboard.router_v2.config_service.get_configuration",
+                return_value=_owned_config(),
+            ),
+            patch(
+                "src.lambdas.dashboard.router_v2.market_service.trigger_refresh",
+                return_value=trigger_result,
+            ) as mock_trigger,
+        ):
+            response = lambda_handler(
+                make_event(method="POST", path=_PATH), mock_lambda_context
+            )
+        assert response["statusCode"] == 202
+        assert json.loads(response["body"]) == {"status": "triggered"}
+        mock_trigger.assert_called_once_with(config_id=_CONFIG_ID)

--- a/tests/unit/test_chaos_reports_api.py
+++ b/tests/unit/test_chaos_reports_api.py
@@ -60,8 +60,13 @@ def jwt_env():
 
 @pytest.fixture
 def auth_headers(jwt_env):
-    """Return valid authenticated session headers."""
-    token = _create_test_jwt()
+    """Return valid authenticated operator session headers.
+
+    Feature 1391 (GAP-3): /chaos/* routes now require the operator role via
+    require_role_middleware("operator"), so these endpoint tests authenticate
+    as an operator.
+    """
+    token = _create_test_jwt(roles=["operator"])
     return {"Authorization": f"Bearer {token}"}
 
 
@@ -156,7 +161,11 @@ class TestReportEndpointAuth:
 
         event = make_event(method=method, path=path, headers=anonymous_headers)
         response = lambda_handler(event, mock_lambda_context)
-        assert response["statusCode"] == 401
+        # Feature 1391 (GAP-3): report routes are operator-gated. An anonymous
+        # session carries roles=["anonymous"], so the operator middleware denies
+        # it with 403 (tightened from the pre-1391 handler-body 401). Either
+        # code means "anonymous is rejected" — the security invariant holds.
+        assert response["statusCode"] in (401, 403)
 
 
 # ===================================================================

--- a/tests/unit/test_dashboard_handler.py
+++ b/tests/unit/test_dashboard_handler.py
@@ -1063,6 +1063,16 @@ class TestAPIv2ArticlesEndpoint:
 class TestChaosExperimentsAPI:
     """Tests for chaos experiment CRUD endpoints."""
 
+    @pytest.fixture
+    def auth_headers(self, jwt_env):
+        """Operator-role headers.
+
+        Feature 1391 (GAP-3): /chaos/* routes now require the operator role via
+        require_role_middleware("operator"). Overrides the module-level
+        free-role fixture for this class.
+        """
+        return {"Authorization": f"Bearer {create_test_jwt(roles=['operator'])}"}
+
     def test_create_experiment_requires_auth(self, mock_lambda_context):
         """Test that create experiment requires authentication."""
         event = make_event(
@@ -1849,6 +1859,11 @@ class TestItemRetrievalErrors:
 
 class TestChaosEndpointErrors:
     """Tests for chaos endpoint error handlers (lines 910-1136)."""
+
+    @pytest.fixture
+    def auth_headers(self, jwt_env):
+        """Operator-role headers (Feature 1391 GAP-3: /chaos/* is operator-gated)."""
+        return {"Authorization": f"Bearer {create_test_jwt(roles=['operator'])}"}
 
     def test_chaos_error_response_500(
         self, mock_lambda_context, auth_headers, monkeypatch, caplog


### PR DESCRIPTION
Two confirmed non-SSE authorization gaps from the #501 access audit. (SSE GAP-1 IDOR is deferred to the SSE architectural visit; carded.)

## GAP-2 — mutating IDOR
`POST /api/v2/configurations/{id}/refresh` (`trigger_refresh`) was fully unauthenticated with no ownership check — anyone could trigger a refresh on any config_id. Now mirrors its hardened Feature-1249 sibling `get_refresh_status`: `_require_user_id` → 401, `_get_config_with_tickers` → 404 (no existence oracle), action runs only after both pass. Anonymous **owners** still work (the customer refresh button is unaffected).

## GAP-3 — broken function-level access control
`/chaos/*` (andon-cord, gate, reports, metrics, health) gated on "any signed-in non-anon" instead of the `operator` role, so a free user could flip chaos controls. All **19** chaos routes now carry `require_role_middleware("operator")`. The 7 dev-gated experiment routes keep a `_chaos_dev_env_gate` middleware ordered **first**, so an unauthenticated prod caller still gets the invisible-in-prod **404** rather than a 401 that would leak route existence. Top-level anonymous `GET /health` untouched.

## Verification
- 10 new tests + updated existing chaos tests. **Independent refuter** (not the implementer) mutation-tested both fixes (removing the ownership check / the operator gate makes the tests fail) and **directly traced** all 7 experiment routes returning 404 (not 401) for unauth prod callers. Full unit suite: **3884 passed, 0 failed**.
- No SSE files touched; disjoint from #944 (1384).

Owner-gated. Do not auto-merge.