### PR TITLE
fix(1400): pin bc-detect-secrets (checkov fork) in CI pre-commit gate

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -212,7 +212,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           # checkov + detect-secrets are language:system / substitute-step tools.
-          pip install pre-commit==4.6.0 checkov==3.2.497 detect-secrets==1.5.45
+          # bc-detect-secrets is Bridgecrew's fork (a checkov dependency); it ships
+          # the `detect-secrets` CLI and wrote our .secrets.baseline ("version":
+          # "1.5.45"). Upstream detect-secrets stops at 1.5.0 — do not pin it.
+          pip install pre-commit==4.6.0 checkov==3.2.508 bc-detect-secrets==1.5.45
           # trivy is a language:system hook — install the pinned binary on PATH.
           curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh \
             | sh -s -- -b /usr/local/bin v0.69.3


### PR DESCRIPTION
## Summary
The Feature 1400 `Pre-commit Hooks` CI job fails at install time: `pip install detect-secrets==1.5.45` — that version doesn't exist upstream (Yelp's package stops at 1.5.0). The local `detect-secrets` CLI is actually **bc-detect-secrets** (Bridgecrew's fork, bundled with checkov), which is where 1.5.45 comes from and which wrote our `.secrets.baseline` (`"version": "1.5.45"`).

## Changes
- Pin `bc-detect-secrets==1.5.45` by its real PyPI name (fork ships the `detect-secrets` CLI, matches the baseline format).
- Bump `checkov` 3.2.497 → 3.2.508 to match the locally-proven combination (checkov is what depends on bc-detect-secrets).

## Context
PR #947 merged before this gate went green because `Pre-commit Hooks` isn't a required check yet — marking it required is the follow-up once this run passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)