### PR TITLE
fix(1387): update E2E alert mocks to backend snake_case contract

### DIFF
--- a/frontend/tests/e2e/helpers/clean-state.ts
+++ b/frontend/tests/e2e/helpers/clean-state.ts
@@ -309,17 +309,21 @@ export async function deleteTestAlert(page: Page, index: number = 0): Promise<vo
  * Must be called BEFORE page.goto() so the initial GET is intercepted.
  */
 export async function mockAlertData(page: Page): Promise<void> {
+  // Snake_case, matching the real backend AlertResponse. The old camelCase
+  // fixture mirrored the frontend's pre-1387 casting bug, so these tests
+  // passed while production delete/toggle silently no-op'd. Keep this shape
+  // in sync with RawAlert in src/lib/api/alerts.ts.
   const mockAlert = {
-    alertId: 'mock-alert-001',
-    configId: 'mock-config-001',
+    alert_id: 'mock-alert-001',
+    config_id: 'mock-config-001',
     ticker: 'AAPL',
-    alertType: 'sentiment_threshold',
-    thresholdValue: 0.7,
-    thresholdDirection: 'above',
-    isEnabled: true,
-    lastTriggeredAt: null,
-    triggerCount: 0,
-    createdAt: new Date().toISOString(),
+    alert_type: 'sentiment_threshold',
+    threshold_value: 0.7,
+    threshold_direction: 'above',
+    is_enabled: true,
+    last_triggered_at: null,
+    trigger_count: 0,
+    created_at: new Date().toISOString(),
   };
 
   let deleted = false;
@@ -334,7 +338,7 @@ export async function mockAlertData(page: Page): Promise<void> {
           body: JSON.stringify({
             alerts: [],
             total: 0,
-            dailyEmailQuota: { used: 0, limit: 10, resetsAt: new Date().toISOString() },
+            daily_email_quota: { used: 0, limit: 10, resets_at: new Date().toISOString() },
           }),
         });
       } else {
@@ -344,7 +348,7 @@ export async function mockAlertData(page: Page): Promise<void> {
           body: JSON.stringify({
             alerts: [mockAlert],
             total: 1,
-            dailyEmailQuota: { used: 0, limit: 10, resetsAt: new Date().toISOString() },
+            daily_email_quota: { used: 0, limit: 10, resets_at: new Date().toISOString() },
           }),
         });
       }


### PR DESCRIPTION
## Summary
Fixes the 3 Playwright failures on main after #947 (alert toggle / delete tests).

`mockAlertData` in `frontend/tests/e2e/helpers/clean-state.ts` served the old camelCase shape (`alertId`, `isEnabled`, ...), the exact wrong contract the pre-1387 frontend had. That's why these tests stayed green while production delete/toggle silently no-op'd. Once 1387's snake_case mapper landed, the stale fixture mapped to all-undefined fields and the alert list never rendered.

## Changes
- Fixture now mirrors `RawAlert` / `RawAlertList` (`alert_id`, `is_enabled`, `daily_email_quota.resets_at`, ...) per the real backend `AlertResponse`.
- The mock PATCH handler's `Object.assign` now merges the frontend's snake_case update body cleanly.

## Verification
Ran locally against the same local-api webserver CI uses: `alert-crud.spec.ts` + `alerts-crud.spec.ts`, 9/9 pass on Desktop Chrome (previously 3 failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)