### PR TITLE
fix(1163): revert email_verified from write_attributes — Cognito rejects it, unbreaks deploy

### DIFF
--- a/infrastructure/terraform/modules/cognito/main.tf
+++ b/infrastructure/terraform/modules/cognito/main.tf
@@ -137,12 +137,15 @@ resource "aws_cognito_user_pool_client" "dashboard" {
   enable_token_revocation       = true
 
   # Read/write attributes
-  read_attributes = ["email", "email_verified", "custom:anonymous_session_id"]
-  # email_verified must be writable or Cognito silently drops the mapped Google
-  # email_verified attribute at federation time (mapped IdP attributes require
-  # app-client write access) — which kept the claim out of the id_token and
-  # left every OAuth user unverified (2026-07-25 incident).
-  write_attributes = ["email", "email_verified", "custom:anonymous_session_id"]
+  # NOTE: email_verified is deliberately NOT in write_attributes — Cognito
+  # rejects it ("Invalid write attributes specified", deploy 30172429653);
+  # only admin APIs may write it. The Google IdP attribute_mapping for
+  # email_verified applied fine and federation updates run with admin
+  # privileges, so the mapping alone should carry the claim. Verify on the
+  # first post-deploy Google login; if verification stays "none", the
+  # fallback is a provider-trust decision in _mark_email_verified.
+  read_attributes  = ["email", "email_verified", "custom:anonymous_session_id"]
+  write_attributes = ["email", "custom:anonymous_session_id"]
 
   # Gap 3: Ignore callback/logout URLs to break circular dependency with Amplify
   # These URLs are patched by terraform_data after Amplify URL is known


### PR DESCRIPTION
Deploy 30172429653 failed: UpdateUserPoolClient returned
InvalidParameterException 'Invalid write attributes specified' — Cognito
does not permit email_verified in an app client's write list (admin APIs
only). The Google IdP attribute_mapping for email_verified DID apply in
that run (confirmed live via describe-identity-provider) and federation
attribute updates run with admin privileges, so the mapping alone should
carry the claim. Verify on first post-deploy Google login; fallback is a
provider-trust decision in _mark_email_verified.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
