### PR TITLE
fix(1396): allow X-CSRF-Token in CORS allowlists — mid-session token refresh was CORS-blocked

### DIFF
--- a/infrastructure/terraform/modules/api_gateway/main.tf
+++ b/infrastructure/terraform/modules/api_gateway/main.tf
@@ -220,7 +220,7 @@ locals {
   # PATCH /api/v2/notifications/preferences (Settings → Save Changes). Values keep the
   # API Gateway-required single-quote wrapping ('...').
   cors_allow_methods = "'GET,POST,PUT,DELETE,PATCH,OPTIONS'"
-  cors_allow_headers = "'Content-Type,Authorization,Accept,Cache-Control,Last-Event-ID,X-Amzn-Trace-Id,X-User-ID'"
+  cors_allow_headers = "'Content-Type,Authorization,Accept,Cache-Control,Last-Event-ID,X-Amzn-Trace-Id,X-User-ID,X-CSRF-Token'"
 
   cors_headers = {
     "method.response.header.Access-Control-Allow-Headers"     = local.cors_allow_headers

--- a/src/lambdas/dashboard/handler.py
+++ b/src/lambdas/dashboard/handler.py
@@ -288,7 +288,7 @@ def _get_chaos_user_id_from_event(event: dict) -> str | None:
 _CORS_ALLOW_METHODS = "GET,POST,PUT,DELETE,PATCH,OPTIONS"
 _CORS_ALLOW_HEADERS = (
     "Content-Type,Authorization,Accept,Cache-Control,"
-    "Last-Event-ID,X-Amzn-Trace-Id,X-User-ID"
+    "Last-Event-ID,X-Amzn-Trace-Id,X-User-ID,X-CSRF-Token"
 )
 
 


### PR DESCRIPTION
The 1396 CSRF body-delivery echo shipped in the frontend, but neither
CORS allowlist (handler _CORS_ALLOW_HEADERS + api_gateway
cors_allow_headers, which must mirror) permitted the X-CSRF-Token
header. First page-load refresh has no CSRF token in memory (cookie-only,
no custom header) and succeeds; every subsequent refresh echoes the
header and its preflight is rejected — so the 15-minute app JWT can
never renew mid-session. Result: /auth/me and /auth/signout 401 after
TTL expiry, UserMenu degrades to 'User'. This was the T042 deploy-order
rider surfacing (echo before allowlist).

75 CORS unit tests pass; terraform validate clean.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
