### PR TITLE
fix(1396): drop prevent_destroy on gateway Cognito authorizer — destroy is the intent

### DIFF
--- a/infrastructure/terraform/modules/api_gateway/main.tf
+++ b/infrastructure/terraform/modules/api_gateway/main.tf
@@ -57,9 +57,10 @@ resource "aws_api_gateway_authorizer" "cognito" {
   provider_arns   = [var.cognito_user_pool_arn]
   identity_source = "method.request.header.Authorization"
 
-  lifecycle {
-    prevent_destroy = true
-  }
+  # prevent_destroy removed 2026-07-25: enable_cognito_auth=false takes count
+  # to 0, and destroying this authorizer is the intent — it can only validate
+  # Cognito-issued JWTs, incompatible with the 1396 first-party app JWT
+  # bearer (see the gateway-authorizer board card for the replacement plan).
 }
 
 # Gateway Response: UNAUTHORIZED (FR-013)


### PR DESCRIPTION
Deploy 30175726195 failed: enable_cognito_auth=false takes the authorizer
count to 0, and lifecycle.prevent_destroy blocks the plan. The destroy is
deliberate (authorizer can only validate Cognito JWTs; bearer is now the
1396 app JWT). 42 gateway tests pass.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
