### PR TITLE
fix(1396): hash enable_cognito_auth into stage redeployment trigger

### DIFF
--- a/infrastructure/terraform/modules/api_gateway/main.tf
+++ b/infrastructure/terraform/modules/api_gateway/main.tf
@@ -752,6 +752,11 @@ resource "aws_api_gateway_deployment" "dashboard" {
     redeployment = sha1(jsonencode(concat(
       [
         var.lambda_invoke_arn, # Feature 1305: Force redeploy on integration URI change
+        # 2026-07-25 incident: method AUTHORIZATION values are not resource IDs,
+        # so flipping enable_cognito_auth applied green while the stage kept
+        # serving the old authorizer config (same class as the 1382 CORS gap
+        # below). Hash the flag so auth flips force a stage redeployment.
+        tostring(var.enable_cognito_auth),
         # Feature 1382: hash the CORS method/header VALUES, not just resource IDs.
         # OPTIONS integration_response .id does not change on a param-only edit, so
         # without these a verb-list change would apply green while the stage keeps


### PR DESCRIPTION
Method authorization values are not resource IDs, so flipping
enable_cognito_auth applied green while the stage kept serving the old
Cognito-authorizer config (same failure class as the 1382 CORS-values
gap documented directly below in the trigger list). A manual
create-deployment (5m1mg4) propagated the flip on preprod; this makes
terraform force its own stage redeployment on any future auth flip AND
supersede that out-of-band deployment on the next apply (without this,
the next pipeline run would revert the stage to the authorizer-era
snapshot and silently re-break auth).

Verified live post-propagation: /auth/me 200 with full profile for a
server-minted app JWT; garbage/missing bearer 401 from the Lambda
middleware. 42 gateway tests pass.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
