### PR TITLE
fix(1380): map Google picture claim through Cognito — avatar was null at the source

### DIFF
--- a/infrastructure/terraform/modules/cognito/google.tf
+++ b/infrastructure/terraform/modules/cognito/google.tf
@@ -32,6 +32,9 @@ resource "aws_cognito_identity_provider" "google" {
     # forbidden free:none state (1163 FR-003), and every OAuth login minted
     # a duplicate user once lookups skipped the unparseable rows.
     email_verified = "email_verified"
+    # Feature 1380 renders the Google avatar; without this mapping the picture
+    # claim never reaches the id_token and _link_provider stores no avatar.
+    picture = "picture"
   }
 
   lifecycle {

--- a/infrastructure/terraform/modules/cognito/main.tf
+++ b/infrastructure/terraform/modules/cognito/main.tf
@@ -144,8 +144,8 @@ resource "aws_cognito_user_pool_client" "dashboard" {
   # privileges, so the mapping alone should carry the claim. Verify on the
   # first post-deploy Google login; if verification stays "none", the
   # fallback is a provider-trust decision in _mark_email_verified.
-  read_attributes  = ["email", "email_verified", "custom:anonymous_session_id"]
-  write_attributes = ["email", "custom:anonymous_session_id"]
+  read_attributes  = ["email", "email_verified", "picture", "custom:anonymous_session_id"]
+  write_attributes = ["email", "picture", "custom:anonymous_session_id"]
 
   # Gap 3: Ignore callback/logout URLs to break circular dependency with Amplify
   # These URLs are patched by terraform_data after Amplify URL is known


### PR DESCRIPTION
Same failure class as email_verified: the Google IdP attribute_mapping
never included picture, so the claim can't reach the id_token and
_link_provider stores no avatar (auth/me returns picture:null). The 1380
plumbing downstream is intact (validated URL in the callback response,
googleusercontent.com hot-link allowlist in the frontend). Adds the IdP
mapping + app-client read/write on picture (legal for this attribute,
unlike email_verified).

Existing signed-in users pick up the avatar on their next Google login
(federation refreshes mapped attributes at login).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
