### PR TITLE
1395 restart session on oauth

### DIFF
--- a/src/lambdas/dashboard/auth.py
+++ b/src/lambdas/dashboard/auth.py
@@ -2458,6 +2458,50 @@ def _read_rev_from_expiring_bearer(bearer: str | None) -> int | None:
 
 # T093: OAuth Callback
 @tracer.capture_method
+def _restart_session_expiry(table: Any, user: User) -> None:
+    """Restart the 30-day session window on OAuth re-authentication.
+
+    Unlike extend_session_expiry (activity-based; refuses expired sessions),
+    a completed OAuth callback is proof of identity, so an expired window is
+    restarted. Deliberately does NOT touch `revoked` — administrative
+    revocation must survive re-login. Follows the callback helpers' silent
+    failure pattern (a failed write degrades to the pre-fix behavior).
+    """
+    now = datetime.now(UTC)
+    new_expiry = now + timedelta(days=SESSION_DURATION_DAYS)
+    try:
+        table.update_item(
+            Key={"PK": user.pk, "SK": user.sk},
+            UpdateExpression=(
+                "SET session_expires_at = :expires, "
+                "last_active_at = :last_active, #ttl = :ttl"
+            ),
+            ExpressionAttributeNames={"#ttl": "ttl_timestamp"},
+            ExpressionAttributeValues={
+                ":expires": new_expiry.isoformat(),
+                ":last_active": now.isoformat(),
+                # Mirror extend_session_expiry's retention convention (90d grace)
+                ":ttl": int(new_expiry.timestamp()) + (90 * 24 * 3600),
+            },
+        )
+        # Sync the in-memory object: the callback response reports
+        # session_expires_in_seconds from this instance.
+        user.session_expires_at = new_expiry
+        user.last_active_at = now
+        logger.info(
+            "Session window restarted on OAuth re-authentication",
+            extra={"user_id_prefix": sanitize_for_log(user.user_id[:8])},
+        )
+    except Exception as e:
+        logger.warning(
+            "Failed to restart session expiry on OAuth login",
+            extra={
+                "user_id_prefix": sanitize_for_log(user.user_id[:8]),
+                **get_safe_error_info(e),
+            },
+        )
+
+
 def _email_verified_claim_is_true(claims: dict[str, Any]) -> bool:
     """Read the email_verified claim, tolerating Cognito's string form.
 
@@ -2710,6 +2754,13 @@ def handle_oauth_callback(
 
     if existing_user:
         user = existing_user
+        # A completed OAuth callback is re-authentication: restart the session
+        # window even if sign_out backdated it. Without this, sign-out then
+        # sign-in returns a valid JWT pointing at a dead session and /auth/me
+        # 404s forever (get_user returns None past session_expires_at). The
+        # bug was masked pre-1395 because every login minted a fresh duplicate
+        # user with a fresh session.
+        _restart_session_expiry(table, user)
         # Update cognito_sub if not set
         if not user.cognito_sub:
             _update_cognito_sub(table, user, cognito_sub)

--- a/tests/e2e/test_cognito_auth.py
+++ b/tests/e2e/test_cognito_auth.py
@@ -126,7 +126,19 @@ class TestPublicEndpoints:
 @pytest.mark.skipif(skip.condition, reason=skip.reason)
 @pytest.mark.preprod
 class TestCORSOnErrorResponses:
-    """US4: 401 responses include CORS headers."""
+    """US4: 401 responses include CORS headers.
+
+    Post gateway-authorizer removal (2026-07-25): 401s come from the Lambda,
+    which echoes CORS headers only for ALLOWED origins (the gateway's canned
+    401 used to reflect any origin — that behavior is gone, deliberately).
+    These tests must therefore present the real frontend origin.
+    """
+
+    @pytest.fixture
+    def frontend_origin(self) -> str:
+        return os.environ.get(
+            "PREPROD_FRONTEND_URL", "https://main.d29tlmksqcx494.amplifyapp.com"
+        ).rstrip("/")
 
     @pytest.fixture
     def api_url(self) -> str:
@@ -136,35 +148,41 @@ class TestCORSOnErrorResponses:
         return url
 
     @pytest.mark.asyncio
-    async def test_401_includes_cors_allow_origin(self, api_url: str) -> None:
+    async def test_401_includes_cors_allow_origin(
+        self, api_url: str, frontend_origin: str
+    ) -> None:
         """Scenario 15: 401 includes Access-Control-Allow-Origin."""
         async with httpx.AsyncClient() as client:
             response = await client.get(
                 f"{api_url}/api/v2/configurations",
-                headers={"Origin": "https://test.example.com"},
+                headers={"Origin": frontend_origin},
             )
         assert response.status_code == 401
-        assert "access-control-allow-origin" in {k.lower() for k in response.headers}
+        assert response.headers.get("access-control-allow-origin") == frontend_origin
 
     @pytest.mark.asyncio
-    async def test_401_includes_cors_allow_credentials(self, api_url: str) -> None:
+    async def test_401_includes_cors_allow_credentials(
+        self, api_url: str, frontend_origin: str
+    ) -> None:
         """Scenario 15: 401 includes Access-Control-Allow-Credentials: true."""
         async with httpx.AsyncClient() as client:
             response = await client.get(
                 f"{api_url}/api/v2/configurations",
-                headers={"Origin": "https://test.example.com"},
+                headers={"Origin": frontend_origin},
             )
         assert response.status_code == 401
         cred_header = response.headers.get("access-control-allow-credentials", "")
         assert cred_header == "true"
 
     @pytest.mark.asyncio
-    async def test_401_uses_explicit_allow_headers(self, api_url: str) -> None:
+    async def test_401_uses_explicit_allow_headers(
+        self, api_url: str, frontend_origin: str
+    ) -> None:
         """CORS Allow-Headers must be explicit list, not wildcard '*'."""
         async with httpx.AsyncClient() as client:
             response = await client.get(
                 f"{api_url}/api/v2/configurations",
-                headers={"Origin": "https://test.example.com"},
+                headers={"Origin": frontend_origin},
             )
         assert response.status_code == 401
         allow_headers = response.headers.get("access-control-allow-headers", "")
@@ -218,10 +236,14 @@ class TestAnonymousSessions:
                 assert response.status_code in (200, 404)  # 404 if market is closed
 
     @pytest.mark.asyncio
-    async def test_uuid_token_on_protected_endpoint_returns_401(
+    async def test_uuid_token_on_protected_endpoint_scopes_to_own_data(
         self, api_url: str
     ) -> None:
-        """Scenario 18: Anonymous UUID token on protected endpoint → 401."""
+        """Scenario 18 (rewritten 2026-07-25): anonymous sessions are valid
+        app-level auth — the Guest flow owns configurations. The old 401
+        expectation encoded the gateway Cognito authorizer, which rejected
+        anything that wasn't a Cognito JWT and thereby broke anon flows.
+        The Lambda scopes the response to the session's own (empty) data."""
         async with httpx.AsyncClient() as client:
             session_resp = await client.post(f"{api_url}/api/v2/auth/anonymous")
             if session_resp.status_code == 201:
@@ -232,4 +254,21 @@ class TestAnonymousSessions:
                     f"{api_url}/api/v2/configurations",
                     headers={"Authorization": f"Bearer {token}"},
                 )
-                assert response.status_code == 401
+                assert response.status_code == 200
+                body = response.json()
+                configs = body.get(
+                    "configurations", body if isinstance(body, list) else []
+                )
+                assert configs == []
+
+    @pytest.mark.asyncio
+    async def test_garbage_token_on_protected_endpoint_returns_401(
+        self, api_url: str
+    ) -> None:
+        """A malformed bearer must still be rejected by the Lambda middleware."""
+        async with httpx.AsyncClient() as client:
+            response = await client.get(
+                f"{api_url}/api/v2/configurations",
+                headers={"Authorization": "Bearer not.a.real-token"},
+            )
+            assert response.status_code == 401

--- a/tests/unit/dashboard/test_restart_session_expiry.py
+++ b/tests/unit/dashboard/test_restart_session_expiry.py
@@ -1,0 +1,74 @@
+"""Unit tests for _restart_session_expiry (sign-out -> sign-in 404 fix).
+
+sign_out backdates session_expires_at; the OAuth callback's reuse branch must
+restart the window on re-authentication, or /auth/me 404s forever on a valid
+JWT (get_user returns None for expired sessions). Masked pre-1395 by the
+duplicate-user-per-login bug.
+"""
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock
+
+from src.lambdas.dashboard.auth import SESSION_DURATION_DAYS, _restart_session_expiry
+from src.lambdas.shared.models.user import User
+
+
+def _expired_user() -> User:
+    return User(
+        user_id=str(uuid.uuid4()),
+        email="test@example.com",
+        auth_type="google",
+        role="free",
+        verification="verified",
+        created_at=datetime.now(UTC) - timedelta(days=2),
+        last_active_at=datetime.now(UTC) - timedelta(days=1),
+        session_expires_at=datetime.now(UTC) - timedelta(days=1),
+    )
+
+
+class TestRestartSessionExpiry:
+    def test_restarts_expired_session(self) -> None:
+        """An expired window is restarted (unlike extend_session_expiry)."""
+        table = MagicMock()
+        user = _expired_user()
+
+        _restart_session_expiry(table, user)
+
+        table.update_item.assert_called_once()
+        vals = table.update_item.call_args.kwargs["ExpressionAttributeValues"]
+        new_expiry = datetime.fromisoformat(vals[":expires"])
+        assert new_expiry > datetime.now(UTC) + timedelta(
+            days=SESSION_DURATION_DAYS - 1
+        )
+
+    def test_syncs_in_memory_user(self) -> None:
+        """Callback response reads session_expires_in_seconds from this object."""
+        table = MagicMock()
+        user = _expired_user()
+
+        _restart_session_expiry(table, user)
+
+        assert user.session_expires_at > datetime.now(UTC)
+
+    def test_failed_write_does_not_sync_or_raise(self) -> None:
+        table = MagicMock()
+        table.update_item.side_effect = RuntimeError("boom")
+        user = _expired_user()
+        old_expiry = user.session_expires_at
+
+        _restart_session_expiry(table, user)  # silent-failure pattern
+
+        assert user.session_expires_at == old_expiry
+
+    def test_does_not_touch_revoked_flag(self) -> None:
+        """Administrative revocation must survive re-login."""
+        table = MagicMock()
+        user = _expired_user()
+        user.revoked = True
+
+        _restart_session_expiry(table, user)
+
+        expr = table.update_item.call_args.kwargs["UpdateExpression"]
+        assert "revoked" not in expr
+        assert user.revoked is True


### PR DESCRIPTION
- **test(1253): update gateway-authorizer-era E2E assertions to Lambda-auth contract**
- **fix(1395): restart session window on OAuth re-authentication — sign-out then sign-in 404'd /auth/me forever**
