### PR TITLE
1395 signout kill refresh

### DIFF
--- a/src/lambdas/dashboard/auth.py
+++ b/src/lambdas/dashboard/auth.py
@@ -1223,6 +1223,54 @@ def is_token_blocklisted(table: Any, refresh_token_hash: str) -> bool:
         return True
 
 
+def blocklist_refresh_token(
+    table: Any,
+    refresh_token: str,
+    user_id: str,
+    reason: str = "sign_out",
+) -> None:
+    """Blocklist a refresh token so /refresh can never resurrect the session.
+
+    Sign-out hardening (2026-07-25 zombie-session incident): sign_out
+    backdates session_expires_at, but the refresh endpoint's Cognito branch
+    does not consult session expiry — a surviving refresh_token cookie kept
+    re-minting app JWTs after sign-out ("Signed in via Google" with /me 404).
+    refresh_access_tokens checks is_token_blocklisted FIRST for every token
+    type (Cognito JWE and anon.*), so this closes the loop server-side; the
+    route also expires the cookies client-side. Silent-failure pattern: the
+    cookie expiry still covers the common case if this write fails.
+    """
+    now = datetime.now(UTC)
+    try:
+        table.put_item(
+            Item={
+                "PK": f"BLOCK#refresh#{hash_refresh_token(refresh_token)}",
+                "SK": "BLOCK",
+                "ttl_timestamp": int(
+                    (now + timedelta(days=SESSION_DURATION_DAYS)).timestamp()
+                ),
+                "evicted_at": now.isoformat(),
+                "user_id": user_id,
+                "reason": reason,
+            }
+        )
+        logger.info(
+            "Refresh token blocklisted",
+            extra={
+                "user_id_prefix": sanitize_for_log(user_id[:8]),
+                "reason": reason,
+            },
+        )
+    except Exception as e:
+        logger.warning(
+            "Failed to blocklist refresh token on sign-out",
+            extra={
+                "user_id_prefix": sanitize_for_log(user_id[:8]),
+                **get_safe_error_info(e),
+            },
+        )
+
+
 @tracer.capture_method
 def evict_oldest_session_atomic(
     table: Any,

--- a/src/lambdas/dashboard/router_v2.py
+++ b/src/lambdas/dashboard/router_v2.py
@@ -807,7 +807,45 @@ def sign_out():
         user_id=user_id,
         access_token=access_token,
     )
-    return json_response(200, result.model_dump(), _get_no_cache_headers())
+
+    # Zombie-session fix (2026-07-25): backdating the session is not enough —
+    # the refresh endpoint doesn't consult session expiry, so a surviving
+    # refresh_token cookie kept resurrecting a half-dead identity ("Signed in
+    # via Google" with /me 404). Blocklist the presented token server-side
+    # (refresh checks the blocklist first, for all token types) AND expire
+    # both cookies client-side.
+    refresh_token = _extract_refresh_token_from_event(event)
+    if refresh_token:
+        auth_service.blocklist_refresh_token(
+            table, refresh_token, user_id, reason="sign_out"
+        )
+
+    prefix = _cookie_path_prefix(event)
+    expired_cookies = [
+        make_set_cookie(
+            REFRESH_TOKEN_COOKIE_NAME,
+            "",
+            httponly=True,
+            secure=True,
+            samesite="None",
+            max_age=0,
+            path=f"{prefix}/api/v2/auth",
+        ),
+        make_set_cookie(
+            CSRF_COOKIE_NAME,
+            "",
+            httponly=False,
+            secure=True,
+            samesite="None",
+            max_age=0,
+            path=f"{prefix}/api/v2",
+        ),
+    ]
+    return _json_response_with_cookies(
+        result.model_dump(),
+        cookies=expired_cookies,
+        extra_headers=_get_no_cache_headers(),
+    )
 
 
 @auth_router.get("/api/v2/auth/session", middlewares=[require_csrf_middleware])

--- a/tests/unit/dashboard/test_signout_blocklist.py
+++ b/tests/unit/dashboard/test_signout_blocklist.py
@@ -1,0 +1,56 @@
+"""Unit tests for blocklist_refresh_token (zombie-session fix 2026-07-25).
+
+sign_out backdated session_expires_at but the refresh endpoint never consults
+session expiry, so a surviving refresh_token cookie kept re-minting app JWTs
+after sign-out. The signout route now blocklists the presented token (checked
+FIRST by refresh_access_tokens for every token type) and expires the cookies.
+"""
+
+import uuid
+from unittest.mock import MagicMock
+
+from src.lambdas.dashboard.auth import (
+    blocklist_refresh_token,
+    hash_refresh_token,
+    is_token_blocklisted,
+)
+
+
+class TestBlocklistRefreshToken:
+    def test_puts_blocklist_row_with_1188_key_shape(self) -> None:
+        """Key must match what is_token_blocklisted reads (BLOCK#refresh#<hash>)."""
+        table = MagicMock()
+        user_id = str(uuid.uuid4())
+        token = "eyJjdHkiOiJKV1Qi.fake.jwe"
+
+        blocklist_refresh_token(table, token, user_id, reason="sign_out")
+
+        table.put_item.assert_called_once()
+        item = table.put_item.call_args.kwargs["Item"]
+        assert item["PK"] == f"BLOCK#refresh#{hash_refresh_token(token)}"
+        assert item["SK"] == "BLOCK"
+        assert item["reason"] == "sign_out"
+        assert item["user_id"] == user_id
+        assert isinstance(item["ttl_timestamp"], int)
+
+    def test_blocklisted_token_is_detected_by_reader(self) -> None:
+        """Round-trip: the row written is the row is_token_blocklisted finds."""
+        store = {}
+        table = MagicMock()
+        table.put_item.side_effect = lambda Item: store.update({Item["PK"]: Item})
+        table.get_item.side_effect = lambda Key, **kw: (
+            {"Item": store[Key["PK"]]} if Key["PK"] in store else {}
+        )
+        token = "anon.some-user.secret"
+
+        blocklist_refresh_token(table, token, "some-user", reason="sign_out")
+
+        assert is_token_blocklisted(table, hash_refresh_token(token)) is True
+        assert is_token_blocklisted(table, hash_refresh_token("other")) is False
+
+    def test_write_failure_does_not_raise(self) -> None:
+        """Silent-failure pattern: cookie expiry still covers the common case."""
+        table = MagicMock()
+        table.put_item.side_effect = RuntimeError("boom")
+
+        blocklist_refresh_token(table, "tok", str(uuid.uuid4()))  # must not raise


### PR DESCRIPTION
- **test(1253): update gateway-authorizer-era E2E assertions to Lambda-auth contract**
- **fix(1395): restart session window on OAuth re-authentication — sign-out then sign-in 404'd /auth/me forever**
- **fix(1395): sign-out blocklists the refresh token + expires cookies — kills zombie sessions**
