### PR TITLE
feat(001): Lambda log visibility — surface INFO logs in CloudWatch across all six functions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -343,10 +343,13 @@ jobs:
             --disable-pip-version-check \
             --quiet
 
-          # Build canary package (standalone — no shared modules needed)
-          mkdir -p packages/canary-build
+          # Build canary package (feature 001: bundles src/lambdas/shared for
+          # logging_config — same recipe as notification/metrics packages)
+          mkdir -p packages/canary-build/src/lambdas/canary
           cp -r packages/canary-deps/* packages/canary-build/
-          cp -r src/lambdas/canary/* packages/canary-build/
+          cp -r src/lambdas/canary/* packages/canary-build/          # handler.py at ROOT
+          cp -r src/lambdas/canary/* packages/canary-build/src/lambdas/canary/  # also in src/ for imports
+          cp -r src/lambdas/shared packages/canary-build/src/lambdas/
           cd packages/canary-build
           zip -r ../canary-${SHA}.zip . \
             -x "*.pyc" "__pycache__/*" "*.pytest_cache/*" "tests/*" -q

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -232,7 +232,7 @@ jobs:
           # Metrics Lambda - Minimal dependencies (TD-011)
           # ============================================================
           echo ""
-          echo "📦 Packaging Metrics Lambda (minimal - boto3 only)..."
+          echo "📦 Packaging Metrics Lambda (boto3, aws-lambda-powertools)..."
 
           # Install minimal metrics dependencies
           # Note: Metrics Lambda doesn't use pydantic, but we include platform flags
@@ -240,6 +240,7 @@ jobs:
           pip install \
             boto3==1.41.0 \
             python-json-logger==4.0.0 \
+            aws-lambda-powertools==3.7.0 \
             -t packages/metrics-deps/ \
             --platform manylinux2014_x86_64 \
             --implementation cp \

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -125,7 +125,7 @@
         "filename": ".github/workflows/deploy.yml",
         "hashed_secret": "dc724af18fbdd4e59189f5fe768a5f8311527050",
         "is_verified": false,
-        "line_number": 445,
+        "line_number": 448,
         "is_added": false,
         "is_removed": false
       }
@@ -2506,5 +2506,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-25T21:13:55Z"
+  "generated_at": "2026-07-26T03:54:23Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -125,7 +125,7 @@
         "filename": ".github/workflows/deploy.yml",
         "hashed_secret": "dc724af18fbdd4e59189f5fe768a5f8311527050",
         "is_verified": false,
-        "line_number": 448,
+        "line_number": 449,
         "is_added": false,
         "is_removed": false
       }
@@ -2506,5 +2506,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-26T03:54:23Z"
+  "generated_at": "2026-07-26T03:58:25Z"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,6 +137,8 @@ The Lambda is named `dashboard Lambda`, the handler is `src/lambdas/dashboard/`,
 - HCL (Terraform 1.5+, AWS Provider ~> 5.0) + AWS API Gateway (REST API), AWS Cognito, AWS Amplify, AWS Lambda (1253-api-gateway-cognito-auth)
 - HCL (Terraform 1.5+, AWS Provider ~> 5.0) + AWS WAF v2, AWS API Gateway (existing) (1254-api-gateway-waf)
 - HCL (Terraform 1.5+, AWS Provider ~> 5.0) + AWS CloudFront, AWS WAF v2, existing SSE Lambda (1255-cloudfront-sse-waf)
+- Python 3.13 (Lambda base image `public.ecr.aws/lambda/python:3.13` for image Lambdas; managed python3.13 runtime for ZIP Lambdas) + stdlib `logging` only for the mechanism; aws-lambda-powertools 3.23.0 already present (dashboard handler) and untouched (001-lambda-log-visibility)
+- N/A (observability-only; no data-store changes) (001-lambda-log-visibility)
 
 - **Python 3.13** with aws-lambda-powertools, boto3, pydantic, httpx, orjson
 - **AWS Services**: DynamoDB (single-table design), S3, Lambda, SNS, EventBridge, Cognito, Amplify
@@ -934,12 +936,9 @@ aws cloudwatch get-metric-data --metric-data-queries '[...]' --start-time ... --
 ```
 
 ## Recent Changes
+- 001-lambda-log-visibility: Added Python 3.13 (Lambda base image `public.ecr.aws/lambda/python:3.13` for image Lambdas; managed python3.13 runtime for ZIP Lambdas) + stdlib `logging` only for the mechanism; aws-lambda-powertools 3.23.0 already present (dashboard handler) and untouched
 - 1256-restrict-function-urls: Added HCL (Terraform 1.5+, AWS Provider ~> 5.0)
 - 1255-cloudfront-sse-waf: Added HCL (Terraform 1.5+, AWS Provider ~> 5.0) + AWS CloudFront, AWS WAF v2, existing SSE Lambda
-- 1254-api-gateway-waf: Added HCL (Terraform 1.5+, AWS Provider ~> 5.0) + AWS WAF v2, AWS API Gateway (existing)
-- 1227-real-sentiment-pipeline: Added Python 3.13 (existing project standard) + aws_lambda_powertools 3.7.0 (missing from ingestion ZIP), boto3 (existing), pydantic (existing)
-- 1226-frontend-error-visibility: Added TypeScript ^5 / Next.js 14.2.21 / React ^18 + @tanstack/react-query ^5.90.11, zustand ^5.0.8, sonner ^2.0.7
-- 001-cache-architecture-audit: Added Python 3.13 + boto3 (AWS SDK), pydantic (validation), functools (current caching)
 
 <!-- MANUAL ADDITIONS START -->
 

--- a/scripts/verify-log-visibility.py
+++ b/scripts/verify-log-visibility.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+# Target: backend Lambda CloudWatch log groups (not either dashboard UI)
+"""On-demand FR-008 verifier + SC-006 refresh-classification drill (feature 001).
+
+Drives the dashboard Lambda (alias-qualified, direct invoke) through all
+three session-refresh outcomes, then asserts the classification INFO lines
+and the C-8 self-test line are queryable in CloudWatch. Exits non-zero on
+any missing line — run pre-deploy it MUST fail (lines are dark), post-deploy
+it MUST pass; that asymmetry is the discrimination proof.
+
+Usage:
+    AWS_REGION=us-east-1 .venv/bin/python scripts/verify-log-visibility.py
+
+The refresh.success probe needs NO secret and NO real login (AR#3): an
+anonymous session mint returns an `anon.` refresh cookie; replaying it to
+/refresh takes the anonymous branch to the refresh.success log line.
+"""
+
+import json
+import os
+import re
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+os.environ.setdefault("AWS_REGION", "us-east-1")
+
+import boto3
+
+from tests.e2e.helpers.lambda_invoke_transport import (
+    LambdaInvokeTransport,
+    _build_apigw_rest_event,
+)
+
+LOG_GROUP = "/aws/lambda/preprod-sentiment-dashboard"
+SELF_TEST_MESSAGE = "logging configured: root INFO visibility active (feature 001)"
+EXPECTED_LINES = (
+    "refresh.cookie_absent",
+    "refresh.rejected",
+    "refresh.success",
+    SELF_TEST_MESSAGE,
+)
+POLL_TIMEOUT_S = 120
+POLL_INTERVAL_S = 10
+
+
+def _mint_anon_refresh_cookie(transport: LambdaInvokeTransport) -> str:
+    """POST /auth/anonymous and pull the anon refresh cookie from the raw payload.
+
+    Raw invoke (not transport.invoke): the flattened header dict keeps only
+    the FIRST Set-Cookie value and the response sets several cookies.
+    """
+    event = _build_apigw_rest_event("POST", "/api/v2/auth/anonymous", None, None, None)
+    raw = transport._client.invoke(
+        FunctionName=transport.function_name,
+        Qualifier=transport.qualifier,
+        Payload=json.dumps(event).encode(),
+    )
+    payload = json.loads(raw["Payload"].read())
+    set_cookies: list[str] = []
+    for key, values in (payload.get("multiValueHeaders") or {}).items():
+        if key.lower() == "set-cookie" and isinstance(values, list):
+            set_cookies.extend(str(v) for v in values)
+    for cookie in set_cookies:
+        match = re.match(r"refresh_token=([^;]+)", cookie)
+        if match and match.group(1).startswith("anon."):
+            return match.group(1)
+    print(
+        f"FATAL: no anon refresh_token cookie in /auth/anonymous response "
+        f"(status {payload.get('statusCode')}, cookies seen: {len(set_cookies)})"
+    )
+    sys.exit(2)
+
+
+def main() -> int:
+    transport = LambdaInvokeTransport()
+    window_start_ms = int(time.time() * 1000) - 30_000
+
+    print("probe (a): POST /refresh, no cookie -> expect refresh.cookie_absent")
+    r_absent = transport.invoke("POST", "/api/v2/auth/refresh")
+    print(f"  -> {r_absent.status_code}")
+
+    print("probe (b): POST /refresh, garbage cookie -> expect refresh.rejected")
+    r_rejected = transport.invoke(
+        "POST",
+        "/api/v2/auth/refresh",
+        headers={"Cookie": "refresh_token=garbage-not-a-real-token"},
+    )
+    print(f"  -> {r_rejected.status_code}")
+
+    print("probe (c): anon mint -> replay cookie -> expect refresh.success")
+    anon_cookie = _mint_anon_refresh_cookie(transport)
+    r_success = transport.invoke(
+        "POST",
+        "/api/v2/auth/refresh",
+        headers={"Cookie": f"refresh_token={anon_cookie}"},
+    )
+    print(f"  -> {r_success.status_code} (must be 2xx for the branch to log success)")
+
+    logs = boto3.client("logs", region_name=os.environ["AWS_REGION"])
+    missing = set(EXPECTED_LINES)
+    deadline = time.time() + POLL_TIMEOUT_S
+    while missing and time.time() < deadline:
+        time.sleep(POLL_INTERVAL_S)
+        for line in list(missing):
+            resp = logs.filter_log_events(
+                logGroupName=LOG_GROUP,
+                startTime=window_start_ms,
+                filterPattern=f'"{line}"',
+                limit=1,
+            )
+            if resp.get("events"):
+                print(f"  FOUND: {line}")
+                missing.discard(line)
+
+    if missing:
+        print("\nFAIL — lines not found in CloudWatch (dark or not deployed):")
+        for line in sorted(missing):
+            print(f"  MISSING: {line}")
+        return 1
+    print(
+        "\nPASS — all three refresh classifications + C-8 self-test visible (SC-006)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/specs/001-lambda-log-visibility/checklists/requirements.md
+++ b/specs/001-lambda-log-visibility/checklists/requirements.md
@@ -1,0 +1,45 @@
+# Specification Quality Checklist: Lambda Log Visibility
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-26
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- "CloudWatch", "log group", and "X-Ray" appear in the spec by name. Judgment
+  call: for an observability feature the log platform IS the user-facing
+  surface (the operator's UI), not an implementation choice — the spec would
+  be less testable if it said "the log system" abstractly. Mechanism choices
+  (delivery-config vs code-config vs structured-logging adoption, and the
+  format question) are explicitly deferred to planning (see Assumptions).
+- Zero [NEEDS CLARIFICATION] markers: the two genuinely open decisions
+  (mechanism option, log format change) are planning-level trade-offs with
+  the spec constraining their outcomes via FR-003/FR-004/FR-009/FR-010; no
+  scope-level ambiguity requires user input at spec stage.
+- SC-005's budget envelope (~$60/month) comes from the project's standing
+  budget validation feature (1020) rather than this spec inventing a number.

--- a/specs/001-lambda-log-visibility/contracts/logging-config.md
+++ b/specs/001-lambda-log-visibility/contracts/logging-config.md
@@ -8,12 +8,12 @@ analysis, metrics, notification, canary handler modules)
 
 ```python
 def configure_lambda_logging(*, default_level: int = logging.INFO) -> None:
-    """Set root logger level and pin noisy third-party loggers.
+    """Set root logger level, pin noisy third-party loggers, emit self-test.
 
     Level-setter ONLY: never creates/attaches handlers, never sets
-    formatters, never touches propagation. Idempotent per process.
-    Honors LOG_LEVEL env (name or int); values below INFO are applied
-    only when explicitly set (deliberate DEBUG), default floor is INFO.
+    formatters, never touches propagation. Honors LOG_LEVEL env (name or
+    int); unset -> INFO. Re-asserts levels on every call; emits its
+    self-test line once per process.
     """
 ```
 
@@ -21,26 +21,35 @@ def configure_lambda_logging(*, default_level: int = logging.INFO) -> None:
 
 | # | Guarantee | Verifying test |
 |---|---|---|
-| C-1 | After call, `logging.getLogger().level == INFO` (or explicit LOG_LEVEL) | unit |
-| C-2 | `httpx` and `httpcore` loggers at WARNING after call, regardless of LOG_LEVEL | unit |
+| C-1 | After EVERY call, `logging.getLogger().level` == INFO (or explicit LOG_LEVEL) — the level set RE-ASSERTS on each call (idempotent by same-outcome, not by latch) | unit |
+| C-2 | `httpx` and `httpcore` loggers at WARNING after every call, regardless of LOG_LEVEL (pins hold even under deliberate DEBUG) | unit |
 | C-3 | Zero handlers added/removed anywhere (root handler count unchanged pre/post) | unit |
-| C-4 | Idempotent: second call changes nothing (incl. after level mutation between calls — latch, not re-assert) | unit |
-| C-5 | No import-time side effects: importing the module does NOT configure anything; only the call does (SSE safety, FR-006) | unit |
-| C-6 | Existing module-logger levels untouched (e.g., a logger pre-set to INFO stays INFO; none made stricter) | unit (FR-011) |
-| C-7 | Every deployed non-SSE entrypoint calls it at module import top-level, before request handling | coverage-guard unit test walking the six handler files |
+| C-4 | Self-test line (C-8) emits at most ONCE per process — the once-latch applies ONLY to the emission, never to the level assertions of C-1/C-2 | unit |
+| C-5 | Importing `logging_config` itself is side-effect-free; configuration happens only on call. (The six ENTRYPOINT modules invoke the function at their own import top-level — that is C-7's requirement, not a violation of this one.) SSE importing shared modules therefore stays untouched (FR-006) | unit |
+| C-6 | Levels of loggers OTHER THAN root/httpx/httpcore are untouched (e.g., an entrypoint logger pre-set to INFO stays INFO; none made stricter) | unit (FR-011) |
+| C-7 | Every deployed non-SSE entrypoint calls it at module import top-level, before request handling. Coverage-guard derives the entrypoint set by GLOBBING `src/lambdas/*/handler.py` minus the documented exclusion list `{sse_streaming, chaos_restore}` — a new Lambda directory enters the walked set automatically (AR#2 F4: no hardcoded six-name list) | coverage-guard unit test |
+| C-8 | Self-test probe: on first call per process, emits exactly one INFO line via `logging.getLogger("src.lambdas.shared.logging_config")` (an un-leveled child logger that inherits root). Its presence in a function's log group PROVES the root-level fix is live in that function — the universal FR-008 evidence line, and the ONLY possible evidence for canary/metrics, which have no other dark INFO site (AR#2 F1/F2). Message is static (no dynamic values → no injection/PII surface) | unit + preprod E2E |
 
 ## Emitted log-shape contract (unchanged — the point of O2+)
 
-- Format stays runtime Text: `[LEVEL]\t<ts>\t<request-id>\t<message>`.
-- The `dashboard_import_errors` metric filter pattern continues to match.
+- Format stays the runtime Text application-line format. NOTE (AR#2 F8): the
+  observed line shape (`[LEVEL]` first) disagrees with the field order the
+  `dashboard_import_errors` metric filter pattern assumes (`[time,
+  request_id, level=ERROR*, ...]`) — meaning the filter may NEVER have
+  matched an application line even pre-change. SC-003's comparison therefore
+  includes a positive control (see plan); if the filter proves
+  dead-on-arrival, that is a PRE-EXISTING defect carded separately, not a
+  regression of this feature.
 - powertools JSON request lines and StructuredLogger/log_structured JSON
   lines are byte-identical to pre-change (no wrapper, no nesting).
-- Delta is strictly additive: `[INFO]` lines from first-party modules.
+- Delta is strictly additive: `[INFO]` lines from first-party modules plus
+  one C-8 self-test line per cold start.
 
 ## Out-of-contract (explicitly not provided)
 
 - No correlation-ID injection on module lines (signposted O3 migration).
 - No JSON structuring of stdlib lines (signposted O1/O3 migration).
-- No coverage of a hypothetical future Lambda whose handler omits the call —
-  the coverage-guard test fails CI when the deployed-entrypoint set grows
-  without a corresponding call, which is detection, not prevention.
+- Prevention (vs detection) of a future Lambda omitting the call: the C-7
+  glob catches any new `src/lambdas/<name>/handler.py` in CI, which is
+  detection at PR time — accepted as the strongest guard available without
+  the platform-level mechanism (signposted O1).

--- a/specs/001-lambda-log-visibility/contracts/logging-config.md
+++ b/specs/001-lambda-log-visibility/contracts/logging-config.md
@@ -1,0 +1,46 @@
+# Contract: configure_lambda_logging()
+
+**Module**: `src/lambdas/shared/logging_config.py` (NEW)
+**Consumers**: the six deployed non-SSE entrypoints (dashboard, ingestion,
+analysis, metrics, notification, canary handler modules)
+
+## Signature
+
+```python
+def configure_lambda_logging(*, default_level: int = logging.INFO) -> None:
+    """Set root logger level and pin noisy third-party loggers.
+
+    Level-setter ONLY: never creates/attaches handlers, never sets
+    formatters, never touches propagation. Idempotent per process.
+    Honors LOG_LEVEL env (name or int); values below INFO are applied
+    only when explicitly set (deliberate DEBUG), default floor is INFO.
+    """
+```
+
+## Behavioral contract
+
+| # | Guarantee | Verifying test |
+|---|---|---|
+| C-1 | After call, `logging.getLogger().level == INFO` (or explicit LOG_LEVEL) | unit |
+| C-2 | `httpx` and `httpcore` loggers at WARNING after call, regardless of LOG_LEVEL | unit |
+| C-3 | Zero handlers added/removed anywhere (root handler count unchanged pre/post) | unit |
+| C-4 | Idempotent: second call changes nothing (incl. after level mutation between calls — latch, not re-assert) | unit |
+| C-5 | No import-time side effects: importing the module does NOT configure anything; only the call does (SSE safety, FR-006) | unit |
+| C-6 | Existing module-logger levels untouched (e.g., a logger pre-set to INFO stays INFO; none made stricter) | unit (FR-011) |
+| C-7 | Every deployed non-SSE entrypoint calls it at module import top-level, before request handling | coverage-guard unit test walking the six handler files |
+
+## Emitted log-shape contract (unchanged — the point of O2+)
+
+- Format stays runtime Text: `[LEVEL]\t<ts>\t<request-id>\t<message>`.
+- The `dashboard_import_errors` metric filter pattern continues to match.
+- powertools JSON request lines and StructuredLogger/log_structured JSON
+  lines are byte-identical to pre-change (no wrapper, no nesting).
+- Delta is strictly additive: `[INFO]` lines from first-party modules.
+
+## Out-of-contract (explicitly not provided)
+
+- No correlation-ID injection on module lines (signposted O3 migration).
+- No JSON structuring of stdlib lines (signposted O1/O3 migration).
+- No coverage of a hypothetical future Lambda whose handler omits the call —
+  the coverage-guard test fails CI when the deployed-entrypoint set grows
+  without a corresponding call, which is detection, not prevention.

--- a/specs/001-lambda-log-visibility/data-model.md
+++ b/specs/001-lambda-log-visibility/data-model.md
@@ -10,8 +10,8 @@ logging configuration state machine per process.
 | Field | Type | Rules |
 |---|---|---|
 | root_level | int | INFO (20) after helper runs; overridable via LOG_LEVEL env, floor INFO for prod-normal ops (DEBUG requires explicit deliberate value; FR-002 default holds) |
-| pinned_loggers | map[str,int] | `httpx`→WARNING, `httpcore`→WARNING (FR-010); applied after root level so pins always win |
-| configured | bool | idempotency latch — second call is a no-op (module-level flag), safe under Lambda re-import and unit-test re-entry |
+| pinned_loggers | map[str,int] | `httpx`→WARNING, `httpcore`→WARNING (FR-010); pins win because those loggers get their OWN explicit level (application order is not load-bearing — AR#2 F14) |
+| selftest_emitted | bool | once-per-process latch for the C-8 self-test line ONLY; level assertions (C-1/C-2) re-assert on every call (AR#2 F5); unit tests reset via the module's documented reset hook |
 
 State transition: `unconfigured → configured` exactly once per process, at
 entrypoint import time, before first request. No reverse transition.

--- a/specs/001-lambda-log-visibility/data-model.md
+++ b/specs/001-lambda-log-visibility/data-model.md
@@ -1,0 +1,38 @@
+# Data Model: Lambda Log Visibility
+
+No persistent data entities — observability-only feature. The "model" is the
+logging configuration state machine per process.
+
+## Entities
+
+### LoggingConfiguration (per Lambda process, in-memory)
+
+| Field | Type | Rules |
+|---|---|---|
+| root_level | int | INFO (20) after helper runs; overridable via LOG_LEVEL env, floor INFO for prod-normal ops (DEBUG requires explicit deliberate value; FR-002 default holds) |
+| pinned_loggers | map[str,int] | `httpx`→WARNING, `httpcore`→WARNING (FR-010); applied after root level so pins always win |
+| configured | bool | idempotency latch — second call is a no-op (module-level flag), safe under Lambda re-import and unit-test re-entry |
+
+State transition: `unconfigured → configured` exactly once per process, at
+entrypoint import time, before first request. No reverse transition.
+
+### LogLine (emitted; contract with consumers — unchanged by this feature)
+
+| Field | Source | Invariant |
+|---|---|---|
+| severity tag | runtime Text formatter (`[INFO]`/`[WARNING]`/…) | FR-009 distinguishable; FR-003 semantics unchanged |
+| request id | runtime formatter | unchanged |
+| message | application | FR-012: no secrets/credentials; masked PII in newly visible lines |
+
+### VerificationBaseline (recorded artifact, evidence directory)
+
+| Field | Rules |
+|---|---|
+| metrics_dup_count | StructuredLogger events per logical event over 24h pre-deploy window (FR-004); post-deploy must be ≤ baseline |
+| consumer_inventory_snapshot | the 4-consumer inventory from spec US2; each verified matching post-deploy |
+
+## Relationships
+
+- One LoggingConfiguration per Lambda process; created by the shared helper;
+  six entrypoints depend on it (coverage-guard test enforces the edge).
+- SSE process explicitly has NO relationship to the helper (FR-006).

--- a/specs/001-lambda-log-visibility/evidence/cards.md
+++ b/specs/001-lambda-log-visibility/evidence/cards.md
@@ -31,3 +31,20 @@ to the owner board follow-up queue alongside the existing cards from the
 Status: recorded here per T018; to be added to CLEANUP-BOARD.html riders at
 the next board update (board edits batch with the next board PR per session
 convention).
+
+## Card C — dashboard_import_errors metric filter is dead-on-arrival (found by T005)
+
+- Filter pattern (modules/monitoring/main.tf:30-41) assumes field order
+  `[time, request_id, level=ERROR*, ...]`; real runtime lines lead with
+  `[LEVEL]`. Metric namespace `SentimentAnalyzer/Packaging` has been EMPTY
+  since the filter's creation (2025-12-06) — it has never matched anything.
+- Proven consequence: the metrics Lambda crash-looped with
+  Runtime.ImportModuleError for 7+ days (26,036 errors/24h) and the CRITICAL
+  alarm built for exactly that failure never fired.
+- Fix shape: correct the filter pattern to match real line shapes (both
+  `[ERROR]`-prefixed app lines AND bare `Runtime.ImportModuleError` platform
+  lines), then a positive control proving the metric increments.
+- NOTE: the metrics-Lambda crash-loop ITSELF (missing aws-lambda-powertools
+  in the ZIP) is fixed IN feature 001's PR (deploy.yml one-line pin, same as
+  Feature 1227's ingestion fix) because FR-008/SC-002 are unachievable while
+  the function cannot import its handler. The filter fix remains carded.

--- a/specs/001-lambda-log-visibility/evidence/cards.md
+++ b/specs/001-lambda-log-visibility/evidence/cards.md
@@ -1,0 +1,33 @@
+# T018: Out-of-scope defects carded (feature 001-lambda-log-visibility)
+
+Both defects are ALREADY VISIBLE today (not caused by this feature) and are
+deliberately NOT fixed here (AR#1 F2 / AR#3 over-masking guardrail). They go
+to the owner board follow-up queue alongside the existing cards from the
+2026-07-25 incident close.
+
+## Card A — notification entrypoint logs raw event incl. live magic-link token
+
+- `src/lambdas/notification/handler.py:56` — `logger.info(f"Notification
+  Lambda invoked: {json.dumps(event)[:500]}")`; magic-link events carry
+  recipient email AND the live sign-in token (a bearer credential:
+  handler.py:204 builds the link from it). Pre-existing CWE-312.
+- Same class, same module logger (INFO since :33, visible today):
+  handler.py:170 "Alert email sent to {email}…", :220 "Magic link email sent
+  to {email}", error-path lines :173/:197-199/:224 with full email.
+- Fix shape (one card): mask emails via the `_mask_email` helper landed by
+  feature 001; replace the raw-event dump with a redacted summary
+  (notification_type + keys present, never values).
+
+## Card B — Finnhub adapter passes API key as URL query parameter
+
+- `src/lambdas/shared/adapters/finnhub.py:127` — `params={"token":
+  self.api_key}`. Key lands in any URL-logging path (httpx INFO — pinned to
+  WARNING by feature 001, which closes the ACTIVE path — plus proxies,
+  traces, error messages that echo URLs). Tiingo already uses headers
+  (tiingo.py:121-122) — same change here.
+- Feature 001's httpx pin is a mitigation, not a fix; the key-in-URL pattern
+  itself is the defect.
+
+Status: recorded here per T018; to be added to CLEANUP-BOARD.html riders at
+the next board update (board edits batch with the next board PR per session
+convention).

--- a/specs/001-lambda-log-visibility/evidence/pre-deploy/dashboard-p50-baseline.md
+++ b/specs/001-lambda-log-visibility/evidence/pre-deploy/dashboard-p50-baseline.md
@@ -1,0 +1,33 @@
+# T004 SC-005 p50 Baseline: INFO events per dashboard invocation (pre-deploy)
+
+Collected: 2026-07-26T03:54:23.848717+00:00
+Function: `preprod-sentiment-dashboard` qualifier `live` (direct boto3 `lambda.invoke`,
+RequestResponse, API Gateway REST v1 event built by
+`tests/e2e/helpers/lambda_invoke_transport._build_apigw_rest_event`).
+Route: `GET /health` (cheap read-only; DynamoDB table_status check only).
+Invocations: 20 identical requests, serial.
+
+## Methodology
+
+Each invoke's Lambda request id was taken from `ResponseMetadata.RequestId`
+(equals the function's `aws_request_id`). 45s after the last invoke, all events in
+`/aws/lambda/preprod-sentiment-dashboard` for the window [start-10s, end+60s] were pulled
+(83 events) and every non-platform line containing the request id was
+classified: stdlib `[INFO]`-prefixed vs powertools single-line JSON with
+`"level":"INFO"` vs other.
+
+## Results (per invocation)
+
+| metric | p50 | min | max | mean |
+|---|---|---|---|---|
+| stdlib `[INFO]` lines | 0.0 | 0 | 0 | 0.00 |
+| powertools JSON INFO lines | 1.0 | 1 | 1 | 1.00 |
+| invoke wall latency (ms) | 154 | 127 | 3321 | 311.1 |
+
+Status codes: [200];
+FunctionError: ['None'].
+
+**SC-005 baseline p50 (stdlib INFO events per invocation): 0.0**
+**Powertools JSON INFO events per invocation (p50): 1.0**
+
+Raw per-invocation data: `dashboard-p50-raw.json`.

--- a/specs/001-lambda-log-visibility/evidence/pre-deploy/dashboard-p50-raw.json
+++ b/specs/001-lambda-log-visibility/evidence/pre-deploy/dashboard-p50-raw.json
@@ -1,0 +1,229 @@
+{
+  "collectedAt": "2026-07-26T03:54:23.848494+00:00",
+  "function": "preprod-sentiment-dashboard",
+  "qualifier": "live",
+  "path": "/health",
+  "invocations": [
+    {
+      "i": 0,
+      "request_id": "2632b1b3-97b4-492f-8c0c-643a080d165a",
+      "status_code": 200,
+      "function_error": null,
+      "latency_ms": 3320.8,
+      "ts": 1785038011.7787523,
+      "stdlib_info": 0,
+      "powertools_json_info": 1,
+      "other_app_lines": 0
+    },
+    {
+      "i": 1,
+      "request_id": "f3cad494-73ee-4fd6-aa92-5564a87d4c78",
+      "status_code": 200,
+      "function_error": null,
+      "latency_ms": 149.4,
+      "ts": 1785038015.099617,
+      "stdlib_info": 0,
+      "powertools_json_info": 1,
+      "other_app_lines": 0
+    },
+    {
+      "i": 2,
+      "request_id": "a422dbb2-b99f-4e77-901e-ff3a061f1cf2",
+      "status_code": 200,
+      "function_error": null,
+      "latency_ms": 146.5,
+      "ts": 1785038015.2491207,
+      "stdlib_info": 0,
+      "powertools_json_info": 1,
+      "other_app_lines": 0
+    },
+    {
+      "i": 3,
+      "request_id": "5dcd4849-1b90-4c27-9447-22dc84e0473b",
+      "status_code": 200,
+      "function_error": null,
+      "latency_ms": 157.2,
+      "ts": 1785038015.3956409,
+      "stdlib_info": 0,
+      "powertools_json_info": 1,
+      "other_app_lines": 0
+    },
+    {
+      "i": 4,
+      "request_id": "af3dcabb-0fe7-4ab9-aea4-f09e473c7ba1",
+      "status_code": 200,
+      "function_error": null,
+      "latency_ms": 149.0,
+      "ts": 1785038015.5528803,
+      "stdlib_info": 0,
+      "powertools_json_info": 1,
+      "other_app_lines": 0
+    },
+    {
+      "i": 5,
+      "request_id": "82ce2992-811c-4529-a414-9f7ae64e70f4",
+      "status_code": 200,
+      "function_error": null,
+      "latency_ms": 179.8,
+      "ts": 1785038015.7019653,
+      "stdlib_info": 0,
+      "powertools_json_info": 1,
+      "other_app_lines": 0
+    },
+    {
+      "i": 6,
+      "request_id": "ad5d3a23-786b-4f8a-adf2-11907030ecf4",
+      "status_code": 200,
+      "function_error": null,
+      "latency_ms": 177.3,
+      "ts": 1785038015.8819537,
+      "stdlib_info": 0,
+      "powertools_json_info": 1,
+      "other_app_lines": 0
+    },
+    {
+      "i": 7,
+      "request_id": "80810077-031b-45f3-bfe6-29b5d24fd60f",
+      "status_code": 200,
+      "function_error": null,
+      "latency_ms": 155.4,
+      "ts": 1785038016.0594015,
+      "stdlib_info": 0,
+      "powertools_json_info": 1,
+      "other_app_lines": 0
+    },
+    {
+      "i": 8,
+      "request_id": "2a997091-af65-4036-aa30-89dd8d414d2c",
+      "status_code": 200,
+      "function_error": null,
+      "latency_ms": 159.4,
+      "ts": 1785038016.2148166,
+      "stdlib_info": 0,
+      "powertools_json_info": 1,
+      "other_app_lines": 0
+    },
+    {
+      "i": 9,
+      "request_id": "b04893ab-b167-4a78-9931-00b28c3d8e57",
+      "status_code": 200,
+      "function_error": null,
+      "latency_ms": 146.4,
+      "ts": 1785038016.3743224,
+      "stdlib_info": 0,
+      "powertools_json_info": 1,
+      "other_app_lines": 0
+    },
+    {
+      "i": 10,
+      "request_id": "c54cb328-3005-427a-ba56-709928b52c67",
+      "status_code": 200,
+      "function_error": null,
+      "latency_ms": 150.5,
+      "ts": 1785038016.5207803,
+      "stdlib_info": 0,
+      "powertools_json_info": 1,
+      "other_app_lines": 0
+    },
+    {
+      "i": 11,
+      "request_id": "af467b73-3574-48f1-a6b4-05dba1828371",
+      "status_code": 200,
+      "function_error": null,
+      "latency_ms": 145.6,
+      "ts": 1785038016.6713421,
+      "stdlib_info": 0,
+      "powertools_json_info": 1,
+      "other_app_lines": 0
+    },
+    {
+      "i": 12,
+      "request_id": "c41138cd-fce5-4e8f-bd67-f1f292ed70c0",
+      "status_code": 200,
+      "function_error": null,
+      "latency_ms": 154.0,
+      "ts": 1785038016.8170705,
+      "stdlib_info": 0,
+      "powertools_json_info": 1,
+      "other_app_lines": 0
+    },
+    {
+      "i": 13,
+      "request_id": "5e7523d1-32f7-4b90-b896-c0c102ce8471",
+      "status_code": 200,
+      "function_error": null,
+      "latency_ms": 159.3,
+      "ts": 1785038016.9711158,
+      "stdlib_info": 0,
+      "powertools_json_info": 1,
+      "other_app_lines": 0
+    },
+    {
+      "i": 14,
+      "request_id": "eebae5fa-10af-472d-8d05-5baba2637410",
+      "status_code": 200,
+      "function_error": null,
+      "latency_ms": 137.8,
+      "ts": 1785038017.1305277,
+      "stdlib_info": 0,
+      "powertools_json_info": 1,
+      "other_app_lines": 0
+    },
+    {
+      "i": 15,
+      "request_id": "ef6a1ea5-483b-4bee-946c-cafa1d8cdbd8",
+      "status_code": 200,
+      "function_error": null,
+      "latency_ms": 140.8,
+      "ts": 1785038017.2686582,
+      "stdlib_info": 0,
+      "powertools_json_info": 1,
+      "other_app_lines": 0
+    },
+    {
+      "i": 16,
+      "request_id": "fd6fc95c-a9ca-423e-bbc4-8fcc531337a9",
+      "status_code": 200,
+      "function_error": null,
+      "latency_ms": 126.6,
+      "ts": 1785038017.4098125,
+      "stdlib_info": 0,
+      "powertools_json_info": 1,
+      "other_app_lines": 0
+    },
+    {
+      "i": 17,
+      "request_id": "090f7f51-55d7-4272-9968-af3cc9fc2c6d",
+      "status_code": 200,
+      "function_error": null,
+      "latency_ms": 154.3,
+      "ts": 1785038017.5365603,
+      "stdlib_info": 0,
+      "powertools_json_info": 1,
+      "other_app_lines": 0
+    },
+    {
+      "i": 18,
+      "request_id": "5c5fced1-030d-4807-8c6d-ed428319ab9f",
+      "status_code": 200,
+      "function_error": null,
+      "latency_ms": 158.5,
+      "ts": 1785038017.6909575,
+      "stdlib_info": 0,
+      "powertools_json_info": 1,
+      "other_app_lines": 0
+    },
+    {
+      "i": 19,
+      "request_id": "f9be7f38-b7f0-4628-9d7e-dd272d8a38e0",
+      "status_code": 200,
+      "function_error": null,
+      "latency_ms": 153.3,
+      "ts": 1785038017.8495917,
+      "stdlib_info": 0,
+      "powertools_json_info": 1,
+      "other_app_lines": 0
+    }
+  ],
+  "log_events_in_window": 83
+}

--- a/specs/001-lambda-log-visibility/evidence/pre-deploy/filter-control.md
+++ b/specs/001-lambda-log-visibility/evidence/pre-deploy/filter-control.md
@@ -1,0 +1,88 @@
+# T005 Metric-Filter Positive Control (R-9) — BLOCKED by IAM, partial read-only evidence
+
+Collected: 2026-07-26 (UTC), pre-deploy. AWS identity:
+`arn:aws:iam::218795110243:user/sentiment-analyzer-preprod-deployer` (us-east-1).
+
+## Planned control
+
+Create log stream `feature-001-filter-control-test` in
+`/aws/lambda/preprod-sentiment-dashboard`, put three ERROR-shaped messages with
+event timestamps in distinct 60s buckets, then read
+`SentimentAnalyzer/Packaging / DashboardImportErrors` at period=60 to attribute any
+increment to a specific shape. Messages prepared:
+
+1. Task-prescribed runtime-guess shape:
+   `[ERROR] 2026-07-26T02:00:00.000Z 00000000-0000-0000-0000-000000000000 Runtime.ImportModuleError: Unable to import module 'handler'`
+2. Filter-assumed field order (time first):
+   `2026-07-26T02:00:01.000Z 00000000-0000-0000-0000-000000000000 ERROR Runtime.ImportModuleError: test`
+3. Actual runtime shape as observed live in `/aws/lambda/preprod-sentiment-metrics`
+   during T003 (added because ground truth became available):
+   `[ERROR] Runtime.ImportModuleError: Unable to import module 'handler': No module named 'aws_lambda_powertools'`
+
+## Denials (verbatim)
+
+`logs:CreateLogStream`:
+
+```
+AccessDeniedException: User: arn:aws:iam::218795110243:user/sentiment-analyzer-preprod-deployer
+is not authorized to perform: logs:CreateLogStream on resource:
+arn:aws:logs:us-east-1:218795110243:log-group:/aws/lambda/preprod-sentiment-dashboard:log-stream:feature-001-filter-control-test
+because no identity-based policy allows the logs:CreateLogStream action
+```
+
+Fallback attempt via the read-only `logs:TestMetricFilter` API (evaluates a pattern
+against sample messages, touches no resources) — also denied:
+
+```
+AccessDeniedException: User: arn:aws:iam::218795110243:user/sentiment-analyzer-preprod-deployer
+is not authorized to perform: logs:TestMetricFilter ... because no identity-based
+policy allows the logs:TestMetricFilter action
+```
+
+No privilege escalation attempted. No test stream was created; nothing to clean up.
+
+## Read-only evidence gathered instead
+
+1. Filter is deployed exactly as coded (`describe-metric-filters` on the dashboard
+   group): name `preprod-sentiment-dashboard-import-errors`, pattern
+   `[time, request_id, level=ERROR*, msg="*ImportModuleError*" || msg="*No module named*" || msg="*cannot import name*"]`,
+   created 2025-12-06T07:48:01Z, `applyOnTransformedLogs: false`.
+2. `list-metrics --namespace SentimentAnalyzer/Packaging` returns **empty** — the
+   `DashboardImportErrors` metric has never been created, i.e. the filter has never
+   matched a single event since deployment. 14-day `get-metric-statistics` (Sum,
+   daily): no datapoints.
+3. Caveat that keeps (2) from being conclusive on its own: the dashboard log group
+   contains zero `ImportModuleError` / `No module named` / ERROR-token lines in the
+   last 7 days (dashboard Lambda is healthy), so "no metric" could also mean
+   "no error ever offered to the filter" over that window at least.
+4. Ground-truth error shape (live, from the metrics-Lambda crash loop, see
+   `metrics-dup-baseline.md`): the runtime emits
+   `[ERROR] Runtime.ImportModuleError: <msg>` — **`[ERROR]` is the first
+   space-delimited token; there is no leading timestamp or request-id**.
+
+## Static field-alignment analysis (pattern vs shapes)
+
+Space-delimited pattern fields: `time` (1st), `request_id` (2nd), `level=ERROR*`
+(3rd), `msg=...` (4th).
+
+| shape | field 3 content | matches `level=ERROR*` in field 3? |
+|---|---|---|
+| real runtime (`[ERROR] Runtime.ImportModuleError: Unable ...`) | `Unable` | no |
+| task msg 1 (`[ERROR] <time> <rid> Runtime.ImportModuleError...`) | `<rid>` | no |
+| task msg 2 (`<time> <rid> ERROR Runtime.ImportModuleError: test`) | `ERROR` | field 3 aligns, but per AWS docs a space-delimited pattern with 4 terms requires a 4-term event unless `...` is used; msg 2 has 5 tokens — match is uncertain without a live test |
+
+The runtime never emits shape 2; shapes 1 and 3 (the only real ones) cannot satisfy
+`level=ERROR*` in field position 3.
+
+## Verdict
+
+**R-9: filter is dead-on-arrival with high confidence, but the live positive control
+is UNPROVEN — blocked by IAM.** Evidence: (a) the pattern's field positions cannot
+align with the runtime's actual `[ERROR] Runtime.ImportModuleError: ...` shape,
+(b) the metric has never existed in 7+ months of the filter being deployed, and
+(c) a real, week-old ImportModuleError crash loop in the metrics Lambda raised no
+alarm (though that group isn't watched by this filter — the coverage gap is itself a
+finding). To close R-9 conclusively, re-run this control at/after T024 with either
+`logs:CreateLogStream`+`logs:PutLogEvents` or `logs:TestMetricFilter` granted, or
+have the orchestrator run the three prepared messages above from a principal that
+has those permissions.

--- a/specs/001-lambda-log-visibility/evidence/pre-deploy/logshape-analysis.json
+++ b/specs/001-lambda-log-visibility/evidence/pre-deploy/logshape-analysis.json
@@ -1,0 +1,359 @@
+{
+  "logGroupName": "/aws/lambda/preprod-sentiment-analysis",
+  "collectedAt": "2026-07-26T03:50:34.613762+00:00",
+  "windowUsed": "6h",
+  "error": null,
+  "eventCount": 50,
+  "events": [
+    {
+      "logStreamName": "2026/07/26/[$LATEST]edf1457fd86b4bc79031e87243cd7b5b",
+      "timestamp": 1785033514087,
+      "message": "[WARNING]\t2026-07-26T02:38:34.087Z\td3814ed7-df04-430c-bc1c-99efd5c8e7f6\tItem already analyzed, skipping\n",
+      "ingestionTime": 1785033522642,
+      "eventId": "39807577568491910697375359872452714102912783637258043394"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]57e6f3069d8e40d283a08fb863d32d1b",
+      "timestamp": 1785033514093,
+      "message": "[WARNING]\t2026-07-26T02:38:34.093Z\t19165ec0-92a2-4373-aedb-b4066ed528cb\tItem already analyzed, skipping\n",
+      "ingestionTime": 1785033522640,
+      "eventId": "39807577568625715168566543611299616035755486023841939458"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]17fc3c3251e840e88d369751d9a992f0",
+      "timestamp": 1785033514103,
+      "message": "{\"timestamp\": \"2026-07-26T02:38:34.103451+00:00\", \"level\": \"INFO\", \"message\": \"Inference complete\", \"source_id\": \"dedup:a08dfe267e72314470348ac127950492\", \"sentiment\": \"negative\", \"score\": 0.9765, \"inference_time_ms\": 105.8}\n",
+      "ingestionTime": 1785033522985,
+      "eventId": "39807577568848722620551849843132293651422217519087288322"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]7c3db65770284fc9998abe999d525398",
+      "timestamp": 1785033514142,
+      "message": "{\"timestamp\": \"2026-07-26T02:38:34.142395+00:00\", \"level\": \"INFO\", \"message\": \"Inference complete\", \"source_id\": \"dedup:a08dfe267e72314470348ac127950492\", \"sentiment\": \"negative\", \"score\": 0.9765, \"inference_time_ms\": 318.81}\n",
+      "ingestionTime": 1785033522796,
+      "eventId": "39807577569718451683294544145423365448932710271689687041"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]edf1457fd86b4bc79031e87243cd7b5b",
+      "timestamp": 1785033514145,
+      "message": "{\"timestamp\": \"2026-07-26T02:38:34.145047+00:00\", \"level\": \"INFO\", \"message\": \"Analysis completed\", \"source_id\": \"dedup:480d191be91a79c82776f1538a270bd0\", \"sentiment\": \"negative\", \"score\": 0.9991, \"model_version\": \"a4b88c6\", \"inference_time_ms\": 300.74, \"execution_time_ms\": 32939.06, \"updated\": false}\n",
+      "ingestionTime": 1785033522642,
+      "eventId": "39807577569785353918890136014661785762726388604604907523"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]edf1457fd86b4bc79031e87243cd7b5b",
+      "timestamp": 1785033514147,
+      "message": "END RequestId: d3814ed7-df04-430c-bc1c-99efd5c8e7f6\n",
+      "ingestionTime": 1785033522642,
+      "eventId": "39807577569829955409287197260944857199271685327616868356"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]edf1457fd86b4bc79031e87243cd7b5b",
+      "timestamp": 1785033514147,
+      "message": "REPORT RequestId: d3814ed7-df04-430c-bc1c-99efd5c8e7f6\tDuration: 32974.08 ms\tBilled Duration: 33779 ms\tMemory Size: 2048 MB\tMax Memory Used: 850 MB\tInit Duration: 804.50 ms\t\nXRAY TraceId: 1-6a6572f4-74632e5e2a4b2f4646cd9e02\tSegmentId: 0c20fb548cf3153a\tSampled: true\t\n",
+      "ingestionTime": 1785033522642,
+      "eventId": "39807577569829955409287197260944857199271685327616868357"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]57e6f3069d8e40d283a08fb863d32d1b",
+      "timestamp": 1785033514155,
+      "message": "{\"timestamp\": \"2026-07-26T02:38:34.155805+00:00\", \"level\": \"INFO\", \"message\": \"Analysis completed\", \"source_id\": \"dedup:8c22ebbe86163e50e94c5e1e3fecde29\", \"sentiment\": \"positive\", \"score\": 0.9943, \"model_version\": \"a4b88c6\", \"inference_time_ms\": 329.04, \"execution_time_ms\": 32984.99, \"updated\": false}\n",
+      "ingestionTime": 1785033522640,
+      "eventId": "39807577570008361370875442246074830568659684437212725251"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]57e6f3069d8e40d283a08fb863d32d1b",
+      "timestamp": 1785033514158,
+      "message": "END RequestId: 19165ec0-92a2-4373-aedb-b4066ed528cb\n",
+      "ingestionTime": 1785033522640,
+      "eventId": "39807577570075263606471034115499437723477629521730666500"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]57e6f3069d8e40d283a08fb863d32d1b",
+      "timestamp": 1785033514158,
+      "message": "REPORT RequestId: 19165ec0-92a2-4373-aedb-b4066ed528cb\tDuration: 33022.18 ms\tBilled Duration: 33781 ms\tMemory Size: 2048 MB\tMax Memory Used: 837 MB\tInit Duration: 758.34 ms\t\nXRAY TraceId: 1-6a6572f4-74632e5e2a4b2f4646cd9e02\tSegmentId: 4457f0e5fcbad0a7\tSampled: true\t\n",
+      "ingestionTime": 1785033522640,
+      "eventId": "39807577570075263606471034115499437723477629521730666501"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]17fc3c3251e840e88d369751d9a992f0",
+      "timestamp": 1785033514200,
+      "message": "{\"timestamp\": \"2026-07-26T02:38:34.200784+00:00\", \"level\": \"INFO\", \"message\": \"Time-series fanout complete\", \"tickers_written\": 1, \"tickers_failed\": 0}\n",
+      "ingestionTime": 1785033522985,
+      "eventId": "39807577571011894904809320287861258323869108585167388675"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]17fc3c3251e840e88d369751d9a992f0",
+      "timestamp": 1785033514227,
+      "message": "{\"timestamp\": \"2026-07-26T02:38:34.227265+00:00\", \"level\": \"INFO\", \"message\": \"Analysis completed\", \"source_id\": \"dedup:a08dfe267e72314470348ac127950492\", \"sentiment\": \"negative\", \"score\": 0.9765, \"model_version\": \"a4b88c6\", \"inference_time_ms\": 105.8, \"execution_time_ms\": 231.16, \"updated\": true}\n",
+      "ingestionTime": 1785033522985,
+      "eventId": "39807577571614015025169647112682722717230614345828859908"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]17fc3c3251e840e88d369751d9a992f0",
+      "timestamp": 1785033514230,
+      "message": "END RequestId: 91cf344e-f895-490d-85ea-615055bc51bd\n",
+      "ingestionTime": 1785033522985,
+      "eventId": "39807577571680917260765238982107329872048559430346801157"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]17fc3c3251e840e88d369751d9a992f0",
+      "timestamp": 1785033514230,
+      "message": "REPORT RequestId: 91cf344e-f895-490d-85ea-615055bc51bd\tDuration: 261.78 ms\tBilled Duration: 262 ms\tMemory Size: 2048 MB\tMax Memory Used: 848 MB\t\nXRAY TraceId: 1-6a6572f4-74632e5e2a4b2f4646cd9e02\tSegmentId: ba3291924130c773\tSampled: true\t\n",
+      "ingestionTime": 1785033522985,
+      "eventId": "39807577571680917260765238982107329872048559430346801158"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]7c3db65770284fc9998abe999d525398",
+      "timestamp": 1785033514246,
+      "message": "[WARNING]\t2026-07-26T02:38:34.246Z\t7ac550c4-e3c1-416a-878b-6922be9f6e93\tItem already analyzed, skipping\n",
+      "ingestionTime": 1785033522796,
+      "eventId": "39807577572037729183941728952143080149288139868311650306"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]7c3db65770284fc9998abe999d525398",
+      "timestamp": 1785033514307,
+      "message": "{\"timestamp\": \"2026-07-26T02:38:34.307645+00:00\", \"level\": \"INFO\", \"message\": \"Analysis completed\", \"source_id\": \"dedup:a08dfe267e72314470348ac127950492\", \"sentiment\": \"negative\", \"score\": 0.9765, \"model_version\": \"a4b88c6\", \"inference_time_ms\": 318.81, \"execution_time_ms\": 33182.13, \"updated\": false}\n",
+      "ingestionTime": 1785033522796,
+      "eventId": "39807577573398074641052096963776758963919689920176455683"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]7c3db65770284fc9998abe999d525398",
+      "timestamp": 1785033514310,
+      "message": "END RequestId: 7ac550c4-e3c1-416a-878b-6922be9f6e93\n",
+      "ingestionTime": 1785033522796,
+      "eventId": "39807577573464976876647688833201366118737635004694396932"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]7c3db65770284fc9998abe999d525398",
+      "timestamp": 1785033514310,
+      "message": "REPORT RequestId: 7ac550c4-e3c1-416a-878b-6922be9f6e93\tDuration: 33217.46 ms\tBilled Duration: 33931 ms\tMemory Size: 2048 MB\tMax Memory Used: 842 MB\tInit Duration: 713.46 ms\t\nXRAY TraceId: 1-6a6572f4-74632e5e2a4b2f4646cd9e02\tSegmentId: c7dbb500bc12cf4f\tSampled: true\t\n",
+      "ingestionTime": 1785033522796,
+      "eventId": "39807577573464976876647688833201366118737635004694396933"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]7ba8a465af474d0a97cfebeaf8460cbd",
+      "timestamp": 1785034974376,
+      "message": "START RequestId: da7afb60-7d75-4a3d-a148-27add1486ca9 Version: $LATEST\n",
+      "ingestionTime": 1785034975201,
+      "eventId": "39807610134024815914460498358541436070533405013177860096"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]7ba8a465af474d0a97cfebeaf8460cbd",
+      "timestamp": 1785034974377,
+      "message": "{\"timestamp\": \"2026-07-26T03:02:54.377228+00:00\", \"level\": \"INFO\", \"message\": \"Analysis started\", \"request_id\": \"da7afb60-7d75-4a3d-a148-27add1486ca9\", \"source_id\": \"dedup:a0e95d9b3b3d0c36173d7bccaca02a81\", \"ticker_count\": 1}\n",
+      "ingestionTime": 1785034975201,
+      "eventId": "39807610134047116659659028981682971788806053374683840513"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]65d221a293c143829854afce2854a507",
+      "timestamp": 1785034974632,
+      "message": "START RequestId: c8d9d0ad-407d-4ac8-aada-56e26e1b7f9d Version: $LATEST\n",
+      "ingestionTime": 1785034978339,
+      "eventId": "39807610139733806685284337886568051206885196097690140672"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]65d221a293c143829854afce2854a507",
+      "timestamp": 1785034974633,
+      "message": "{\"timestamp\": \"2026-07-26T03:02:54.632910+00:00\", \"level\": \"INFO\", \"message\": \"Analysis started\", \"request_id\": \"c8d9d0ad-407d-4ac8-aada-56e26e1b7f9d\", \"source_id\": \"dedup:a0e95d9b3b3d0c36173d7bccaca02a81\", \"ticker_count\": 1}\n",
+      "ingestionTime": 1785034978339,
+      "eventId": "39807610139756107430482868509709586925157844459196121089"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]7ba8a465af474d0a97cfebeaf8460cbd",
+      "timestamp": 1785034982248,
+      "message": "Device set to use cpu\n",
+      "ingestionTime": 1785034991264,
+      "eventId": "39807610309576282117293563748129813940311625713262395392"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]7ba8a465af474d0a97cfebeaf8460cbd",
+      "timestamp": 1785034982426,
+      "message": "{\"timestamp\": \"2026-07-26T03:03:02.426522+00:00\", \"level\": \"INFO\", \"message\": \"Inference complete\", \"source_id\": \"dedup:a0e95d9b3b3d0c36173d7bccaca02a81\", \"sentiment\": \"negative\", \"score\": 0.9919, \"inference_time_ms\": 132.36}\n",
+      "ingestionTime": 1785034991264,
+      "eventId": "39807610313545814762632014667323171792843034061326909441"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]7ba8a465af474d0a97cfebeaf8460cbd",
+      "timestamp": 1785034982669,
+      "message": "{\"timestamp\": \"2026-07-26T03:03:02.669511+00:00\", \"level\": \"INFO\", \"message\": \"Time-series fanout complete\", \"tickers_written\": 1, \"tickers_failed\": 0}\n",
+      "ingestionTime": 1785034991264,
+      "eventId": "39807610318964895845874956090716351333096585907280150530"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]7ba8a465af474d0a97cfebeaf8460cbd",
+      "timestamp": 1785034982696,
+      "message": "{\"timestamp\": \"2026-07-26T03:03:02.695916+00:00\", \"level\": \"INFO\", \"message\": \"Analysis completed\", \"source_id\": \"dedup:a0e95d9b3b3d0c36173d7bccaca02a81\", \"sentiment\": \"negative\", \"score\": 0.9919, \"model_version\": \"a4b88c6\", \"inference_time_ms\": 132.36, \"execution_time_ms\": 8292.57, \"updated\": true}\n",
+      "ingestionTime": 1785034991264,
+      "eventId": "39807610319567015966235282915537815726458091667941621763"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]7ba8a465af474d0a97cfebeaf8460cbd",
+      "timestamp": 1785034982700,
+      "message": "END RequestId: da7afb60-7d75-4a3d-a148-27add1486ca9\n",
+      "ingestionTime": 1785034991264,
+      "eventId": "39807610319656218947029405408103958599548685113965543428"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]7ba8a465af474d0a97cfebeaf8460cbd",
+      "timestamp": 1785034982700,
+      "message": "REPORT RequestId: da7afb60-7d75-4a3d-a148-27add1486ca9\tDuration: 8323.78 ms\tBilled Duration: 9134 ms\tMemory Size: 2048 MB\tMax Memory Used: 855 MB\tInit Duration: 809.68 ms\t\nXRAY TraceId: 1-6a6578d0-0b8d7a4612beaaf972a340e9\tSegmentId: 8d02f99b15d9afa9\tSampled: true\t\n",
+      "ingestionTime": 1785034991264,
+      "eventId": "39807610319656218947029405408103958599548685113965543429"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]65d221a293c143829854afce2854a507",
+      "timestamp": 1785034982767,
+      "message": "Device set to use cpu\n",
+      "ingestionTime": 1785034991784,
+      "eventId": "39807610321150368875330957159215521639412076868958552064"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]65d221a293c143829854afce2854a507",
+      "timestamp": 1785034982950,
+      "message": "{\"timestamp\": \"2026-07-26T03:03:02.950792+00:00\", \"level\": \"INFO\", \"message\": \"Inference complete\", \"source_id\": \"dedup:a0e95d9b3b3d0c36173d7bccaca02a81\", \"sentiment\": \"negative\", \"score\": 0.9919, \"inference_time_ms\": 140.8}\n",
+      "ingestionTime": 1785034991784,
+      "eventId": "39807610325231405246662061194116558083306727024552968193"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]65d221a293c143829854afce2854a507",
+      "timestamp": 1785034983048,
+      "message": "[WARNING]\t2026-07-26T03:03:03.048Z\tc8d9d0ad-407d-4ac8-aada-56e26e1b7f9d\tItem already analyzed, skipping\n",
+      "ingestionTime": 1785034991784,
+      "eventId": "39807610327416878276118062261987058474026266452139048962"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]65d221a293c143829854afce2854a507",
+      "timestamp": 1785034983120,
+      "message": "{\"timestamp\": \"2026-07-26T03:03:03.120795+00:00\", \"level\": \"INFO\", \"message\": \"Analysis completed\", \"source_id\": \"dedup:a0e95d9b3b3d0c36173d7bccaca02a81\", \"sentiment\": \"negative\", \"score\": 0.9919, \"model_version\": \"a4b88c6\", \"inference_time_ms\": 140.8, \"execution_time_ms\": 8446.06, \"updated\": false}\n",
+      "ingestionTime": 1785034991784,
+      "eventId": "39807610329022531930412267128177630189656948480569638915"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]65d221a293c143829854afce2854a507",
+      "timestamp": 1785034983123,
+      "message": "END RequestId: c8d9d0ad-407d-4ac8-aada-56e26e1b7f9d\n",
+      "ingestionTime": 1785034991784,
+      "eventId": "39807610329089434166007858997602237344474893565087580164"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]65d221a293c143829854afce2854a507",
+      "timestamp": 1785034983123,
+      "message": "REPORT RequestId: c8d9d0ad-407d-4ac8-aada-56e26e1b7f9d\tDuration: 8491.06 ms\tBilled Duration: 9621 ms\tMemory Size: 2048 MB\tMax Memory Used: 845 MB\tInit Duration: 1129.49 ms\t\nXRAY TraceId: 1-6a6578d0-0b8d7a4612beaaf972a340e9\tSegmentId: 63afe225a357accb\tSampled: true\t\n",
+      "ingestionTime": 1785034991784,
+      "eventId": "39807610329089434166007858997602237344474893565087580165"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]2aa2b2645def4f299b56803ed8e49c45",
+      "timestamp": 1785037386089,
+      "message": "START RequestId: 039ccb10-b47f-4fcd-9f1d-fe7dc99234ce Version: $LATEST\n",
+      "ingestionTime": 1785037389921,
+      "eventId": "39807663917021920898345229820290892802044251177199730688"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]2aa2b2645def4f299b56803ed8e49c45",
+      "timestamp": 1785037386089,
+      "message": "{\"timestamp\": \"2026-07-26T03:43:06.089764+00:00\", \"level\": \"INFO\", \"message\": \"Analysis started\", \"request_id\": \"039ccb10-b47f-4fcd-9f1d-fe7dc99234ce\", \"source_id\": \"dedup:11d34698f0eb6941bfe3ab8e6abd8780\", \"ticker_count\": 1}\n",
+      "ingestionTime": 1785037389921,
+      "eventId": "39807663917021920898345229820290892802044251177199730689"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]cc4eb9db81284c02a90dc8e66b4dac7d",
+      "timestamp": 1785037386198,
+      "message": "START RequestId: 1a7c3202-3806-4837-b84a-1f2634f37941 Version: $LATEST\n",
+      "ingestionTime": 1785037389242,
+      "eventId": "39807663919452702124985067741897147342275971882798219264"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]cc4eb9db81284c02a90dc8e66b4dac7d",
+      "timestamp": 1785037386199,
+      "message": "{\"timestamp\": \"2026-07-26T03:43:06.198907+00:00\", \"level\": \"INFO\", \"message\": \"Analysis started\", \"request_id\": \"1a7c3202-3806-4837-b84a-1f2634f37941\", \"source_id\": \"dedup:11d34698f0eb6941bfe3ab8e6abd8780\", \"ticker_count\": 1}\n",
+      "ingestionTime": 1785037389242,
+      "eventId": "39807663919475002870183598365038683060548620244304199681"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]2aa2b2645def4f299b56803ed8e49c45",
+      "timestamp": 1785037394506,
+      "message": "Device set to use cpu\n",
+      "ingestionTime": 1785037403521,
+      "eventId": "39807664104727293234377484819038270690710137278417403904"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]2aa2b2645def4f299b56803ed8e49c45",
+      "timestamp": 1785037394667,
+      "message": "{\"timestamp\": \"2026-07-26T03:43:14.667673+00:00\", \"level\": \"INFO\", \"message\": \"Inference complete\", \"source_id\": \"dedup:11d34698f0eb6941bfe3ab8e6abd8780\", \"sentiment\": \"positive\", \"score\": 0.9991, \"inference_time_ms\": 117.25}\n",
+      "ingestionTime": 1785037403521,
+      "eventId": "39807664108317713211340915144825521332606523480880250881"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]2aa2b2645def4f299b56803ed8e49c45",
+      "timestamp": 1785037394847,
+      "message": "{\"timestamp\": \"2026-07-26T03:43:14.847852+00:00\", \"level\": \"INFO\", \"message\": \"Time-series fanout complete\", \"tickers_written\": 1, \"tickers_failed\": 0}\n",
+      "ingestionTime": 1785037403521,
+      "eventId": "39807664112331847347076427310301950621683228551956725762"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]2aa2b2645def4f299b56803ed8e49c45",
+      "timestamp": 1785037394880,
+      "message": "{\"timestamp\": \"2026-07-26T03:43:14.880691+00:00\", \"level\": \"INFO\", \"message\": \"Analysis completed\", \"source_id\": \"dedup:11d34698f0eb6941bfe3ab8e6abd8780\", \"sentiment\": \"positive\", \"score\": 0.9991, \"model_version\": \"a4b88c6\", \"inference_time_ms\": 117.25, \"execution_time_ms\": 8758.4, \"updated\": true}\n",
+      "ingestionTime": 1785037403521,
+      "eventId": "39807664113067771938627937873972629324680624481654079491"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]2aa2b2645def4f299b56803ed8e49c45",
+      "timestamp": 1785037394884,
+      "message": "END RequestId: 039ccb10-b47f-4fcd-9f1d-fe7dc99234ce\n",
+      "ingestionTime": 1785037403521,
+      "eventId": "39807664113156974919422060366538772197771217927678001156"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]2aa2b2645def4f299b56803ed8e49c45",
+      "timestamp": 1785037394885,
+      "message": "REPORT RequestId: 039ccb10-b47f-4fcd-9f1d-fe7dc99234ce\tDuration: 8795.49 ms\tBilled Duration: 9622 ms\tMemory Size: 2048 MB\tMax Memory Used: 849 MB\tInit Duration: 825.57 ms\t\nXRAY TraceId: 1-6a658230-5051985d74f95a4c3c814b1d\tSegmentId: d751d1b6faf277c2\tSampled: true\t\n",
+      "ingestionTime": 1785037403521,
+      "eventId": "39807664113179275664620590989680307916043866289183981573"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]cc4eb9db81284c02a90dc8e66b4dac7d",
+      "timestamp": 1785037394900,
+      "message": "Device set to use cpu\n",
+      "ingestionTime": 1785037403914,
+      "eventId": "39807664113513786842598550337278292997736361182765187072"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]cc4eb9db81284c02a90dc8e66b4dac7d",
+      "timestamp": 1785037395064,
+      "message": "{\"timestamp\": \"2026-07-26T03:43:15.064335+00:00\", \"level\": \"INFO\", \"message\": \"Inference complete\", \"source_id\": \"dedup:11d34698f0eb6941bfe3ab8e6abd8780\", \"sentiment\": \"positive\", \"score\": 0.9991, \"inference_time_ms\": 122.98}\n",
+      "ingestionTime": 1785037403914,
+      "eventId": "39807664117171109055157572532490150794450692469745975297"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]cc4eb9db81284c02a90dc8e66b4dac7d",
+      "timestamp": 1785037395160,
+      "message": "[WARNING]\t2026-07-26T03:43:15.160Z\t1a7c3202-3806-4837-b84a-1f2634f37941\tItem already analyzed, skipping\n",
+      "ingestionTime": 1785037403914,
+      "eventId": "39807664119311980594216512354077579748624935174320095234"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]cc4eb9db81284c02a90dc8e66b4dac7d",
+      "timestamp": 1785037395223,
+      "message": "{\"timestamp\": \"2026-07-26T03:43:15.222969+00:00\", \"level\": \"INFO\", \"message\": \"Analysis completed\", \"source_id\": \"dedup:11d34698f0eb6941bfe3ab8e6abd8780\", \"sentiment\": \"positive\", \"score\": 0.9991, \"model_version\": \"a4b88c6\", \"inference_time_ms\": 122.98, \"execution_time_ms\": 8987.61, \"updated\": false}\n",
+      "ingestionTime": 1785037403914,
+      "eventId": "39807664120716927541723941611994329999801781949196861443"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]cc4eb9db81284c02a90dc8e66b4dac7d",
+      "timestamp": 1785037395225,
+      "message": "END RequestId: 1a7c3202-3806-4837-b84a-1f2634f37941\n",
+      "ingestionTime": 1785037403914,
+      "eventId": "39807664120761529032121002858277401436347078672208822276"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]cc4eb9db81284c02a90dc8e66b4dac7d",
+      "timestamp": 1785037395225,
+      "message": "REPORT RequestId: 1a7c3202-3806-4837-b84a-1f2634f37941\tDuration: 9027.18 ms\tBilled Duration: 10008 ms\tMemory Size: 2048 MB\tMax Memory Used: 857 MB\tInit Duration: 980.06 ms\t\nXRAY TraceId: 1-6a658230-5051985d74f95a4c3c814b1d\tSegmentId: c102bf5e191e57b7\tSampled: true\t\n",
+      "ingestionTime": 1785037403914,
+      "eventId": "39807664120761529032121002858277401436347078672208822277"
+    }
+  ]
+}

--- a/specs/001-lambda-log-visibility/evidence/pre-deploy/logshape-canary.json
+++ b/specs/001-lambda-log-visibility/evidence/pre-deploy/logshape-canary.json
@@ -1,0 +1,359 @@
+{
+  "logGroupName": "/aws/lambda/preprod-sentiment-canary",
+  "collectedAt": "2026-07-26T03:50:39.614027+00:00",
+  "windowUsed": "1h",
+  "error": null,
+  "eventCount": 50,
+  "events": [
+    {
+      "logStreamName": "2026/07/26/[$LATEST]1091310250734a2c80fea86f19117d5a",
+      "timestamp": 1785036429926,
+      "message": "[INFO]\t2026-07-26T03:27:09.926Z\tb533e31a-8fbb-4ce0-a7e1-53a501b8b9c1\tCanary invocation started\n",
+      "ingestionTime": 1785036438938,
+      "eventId": "39807642593874489635709013790405712341312125382492487681"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]1091310250734a2c80fea86f19117d5a",
+      "timestamp": 1785036430126,
+      "message": "[INFO]\t2026-07-26T03:27:10.126Z\tb533e31a-8fbb-4ce0-a7e1-53a501b8b9c1\tSubmitted synthetic trace\n",
+      "ingestionTime": 1785036438938,
+      "eventId": "39807642598334638675415138418712855995841797683688570882"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]1091310250734a2c80fea86f19117d5a",
+      "timestamp": 1785036430342,
+      "message": "[WARNING]\t2026-07-26T03:27:10.342Z\tb533e31a-8fbb-4ce0-a7e1-53a501b8b9c1\tNo canary traces found\n",
+      "ingestionTime": 1785036438938,
+      "eventId": "39807642603151599638297753017284571142733843768980340739"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]1091310250734a2c80fea86f19117d5a",
+      "timestamp": 1785036460389,
+      "message": "[WARNING]\t2026-07-26T03:27:40.389Z\tb533e31a-8fbb-4ce0-a7e1-53a501b8b9c1\tNo canary traces found\n",
+      "ingestionTime": 1785036469403,
+      "eventId": "39807643273222090618547386587838372511714795455392579584"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]1091310250734a2c80fea86f19117d5a",
+      "timestamp": 1785036520586,
+      "message": "[WARNING]\t2026-07-26T03:28:40.586Z\tb533e31a-8fbb-4ce0-a7e1-53a501b8b9c1\tNo canary traces found\n",
+      "ingestionTime": 1785036529602,
+      "eventId": "39807644615660049334495307911639859071660186771334365184"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]1091310250734a2c80fea86f19117d5a",
+      "timestamp": 1785036520773,
+      "message": "[INFO]\t2026-07-26T03:28:40.773Z\tb533e31a-8fbb-4ce0-a7e1-53a501b8b9c1\tMetrics emitted\n",
+      "ingestionTime": 1785036529602,
+      "eventId": "39807644619830288686620534439107038388645430372952702977"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]1091310250734a2c80fea86f19117d5a",
+      "timestamp": 1785036520773,
+      "message": "[INFO]\t2026-07-26T03:28:40.773Z\tb533e31a-8fbb-4ce0-a7e1-53a501b8b9c1\tCanary complete\n",
+      "ingestionTime": 1785036529602,
+      "eventId": "39807644619830288686620534439107038388645430372952702978"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]1091310250734a2c80fea86f19117d5a",
+      "timestamp": 1785036520847,
+      "message": "END RequestId: b533e31a-8fbb-4ce0-a7e1-53a501b8b9c1\n",
+      "ingestionTime": 1785036529602,
+      "eventId": "39807644621480543831311800551580681540821409124395253763"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]1091310250734a2c80fea86f19117d5a",
+      "timestamp": 1785036520847,
+      "message": "REPORT RequestId: b533e31a-8fbb-4ce0-a7e1-53a501b8b9c1\tDuration: 90929.92 ms\tBilled Duration: 90930 ms\tMemory Size: 128 MB\tMax Memory Used: 92 MB\t\n",
+      "ingestionTime": 1785036529602,
+      "eventId": "39807644621480543831311800551580681540821409124395253764"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]1091310250734a2c80fea86f19117d5a",
+      "timestamp": 1785036729944,
+      "message": "START RequestId: 2f9dea49-c8ec-4722-907f-cb24f2ed967e Version: $LATEST\n",
+      "ingestionTime": 1785036738963,
+      "eventId": "39807649284499462608469507830376728733352593942590914560"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]1091310250734a2c80fea86f19117d5a",
+      "timestamp": 1785036729948,
+      "message": "[INFO]\t2026-07-26T03:32:09.948Z\t2f9dea49-c8ec-4722-907f-cb24f2ed967e\tCanary invocation started\n",
+      "ingestionTime": 1785036738963,
+      "eventId": "39807649284588665589263630322942871606443187388614836225"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]1091310250734a2c80fea86f19117d5a",
+      "timestamp": 1785036730068,
+      "message": "[INFO]\t2026-07-26T03:32:10.068Z\t2f9dea49-c8ec-4722-907f-cb24f2ed967e\tSubmitted synthetic trace\n",
+      "ingestionTime": 1785036738963,
+      "eventId": "39807649287264755013087305099927157799160990769332486146"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]1091310250734a2c80fea86f19117d5a",
+      "timestamp": 1785036730276,
+      "message": "[WARNING]\t2026-07-26T03:32:10.276Z\t2f9dea49-c8ec-4722-907f-cb24f2ed967e\tNo canary traces found\n",
+      "ingestionTime": 1785036738963,
+      "eventId": "39807649291903310014381674713366587199871849962576412675"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]1091310250734a2c80fea86f19117d5a",
+      "timestamp": 1785036760307,
+      "message": "[WARNING]\t2026-07-26T03:32:40.307Z\t2f9dea49-c8ec-4722-907f-cb24f2ed967e\tNo canary traces found\n",
+      "ingestionTime": 1785036769323,
+      "eventId": "39807649961616989071454818313528754057990279335253835776"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]1091310250734a2c80fea86f19117d5a",
+      "timestamp": 1785036820508,
+      "message": "[WARNING]\t2026-07-26T03:33:40.508Z\t2f9dea49-c8ec-4722-907f-cb24f2ed967e\tNo canary traces found\n",
+      "ingestionTime": 1785036829523,
+      "eventId": "39807651304144150768196862129898167505699585045121073152"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]1091310250734a2c80fea86f19117d5a",
+      "timestamp": 1785036820708,
+      "message": "[INFO]\t2026-07-26T03:33:40.708Z\t2f9dea49-c8ec-4722-907f-cb24f2ed967e\tMetrics emitted\n",
+      "ingestionTime": 1785036829523,
+      "eventId": "39807651308604299807902986758205311160229257346317156353"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]1091310250734a2c80fea86f19117d5a",
+      "timestamp": 1785036820708,
+      "message": "[INFO]\t2026-07-26T03:33:40.708Z\t2f9dea49-c8ec-4722-907f-cb24f2ed967e\tCanary complete\n",
+      "ingestionTime": 1785036829523,
+      "eventId": "39807651308604299807902986758205311160229257346317156354"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]1091310250734a2c80fea86f19117d5a",
+      "timestamp": 1785036820788,
+      "message": "END RequestId: 2f9dea49-c8ec-4722-907f-cb24f2ed967e\n",
+      "ingestionTime": 1785036829523,
+      "eventId": "39807651310388359423785436609528168622041126266795589635"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]1091310250734a2c80fea86f19117d5a",
+      "timestamp": 1785036820788,
+      "message": "REPORT RequestId: 2f9dea49-c8ec-4722-907f-cb24f2ed967e\tDuration: 90844.35 ms\tBilled Duration: 90845 ms\tMemory Size: 128 MB\tMax Memory Used: 92 MB\t\n",
+      "ingestionTime": 1785036829523,
+      "eventId": "39807651310388359423785436609528168622041126266795589636"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]1091310250734a2c80fea86f19117d5a",
+      "timestamp": 1785037030068,
+      "message": "START RequestId: 9514f67a-9457-4384-a281-8b263b19f80d Version: $LATEST\n",
+      "ingestionTime": 1785037039089,
+      "eventId": "39807655977488314572274247923472986727915453604176658432"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]1091310250734a2c80fea86f19117d5a",
+      "timestamp": 1785037030069,
+      "message": "[INFO]\t2026-07-26T03:37:10.069Z\t9514f67a-9457-4384-a281-8b263b19f80d\tCanary invocation started\n",
+      "ingestionTime": 1785037039089,
+      "eventId": "39807655977510615317472778546614522446188101965682638849"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]1091310250734a2c80fea86f19117d5a",
+      "timestamp": 1785037030169,
+      "message": "[INFO]\t2026-07-26T03:37:10.169Z\t9514f67a-9457-4384-a281-8b263b19f80d\tSubmitted synthetic trace\n",
+      "ingestionTime": 1785037039089,
+      "eventId": "39807655979740689837325840860768094273452938116280680450"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]1091310250734a2c80fea86f19117d5a",
+      "timestamp": 1785037030465,
+      "message": "[WARNING]\t2026-07-26T03:37:10.465Z\t9514f67a-9457-4384-a281-8b263b19f80d\tNo canary traces found\n",
+      "ingestionTime": 1785037039089,
+      "eventId": "39807655986341710416090905310662666882156853122050883587"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]1091310250734a2c80fea86f19117d5a",
+      "timestamp": 1785037060530,
+      "message": "[WARNING]\t2026-07-26T03:37:40.530Z\t9514f67a-9457-4384-a281-8b263b19f80d\tNo canary traces found\n",
+      "ingestionTime": 1785037069547,
+      "eventId": "39807656656813614809914090097755357638729683751189938176"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]1091310250734a2c80fea86f19117d5a",
+      "timestamp": 1785037120726,
+      "message": "[WARNING]\t2026-07-26T03:38:40.726Z\t9514f67a-9457-4384-a281-8b263b19f80d\tNo canary traces found\n",
+      "ingestionTime": 1785037129747,
+      "eventId": "39807657999229272780663480798416662080645321299100434432"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]1091310250734a2c80fea86f19117d5a",
+      "timestamp": 1785037120929,
+      "message": "[INFO]\t2026-07-26T03:38:40.929Z\t9514f67a-9457-4384-a281-8b263b19f80d\tMetrics emitted\n",
+      "ingestionTime": 1785037129747,
+      "eventId": "39807658003756324055965197296148412889992938684814458881"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]1091310250734a2c80fea86f19117d5a",
+      "timestamp": 1785037120930,
+      "message": "[INFO]\t2026-07-26T03:38:40.930Z\t9514f67a-9457-4384-a281-8b263b19f80d\tCanary complete\n",
+      "ingestionTime": 1785037129747,
+      "eventId": "39807658003778624801163727919289948608265587046320439298"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]1091310250734a2c80fea86f19117d5a",
+      "timestamp": 1785037120990,
+      "message": "END RequestId: 9514f67a-9457-4384-a281-8b263b19f80d\n",
+      "ingestionTime": 1785037129747,
+      "eventId": "39807658005116669513075565307782091704624488736679264259"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]1091310250734a2c80fea86f19117d5a",
+      "timestamp": 1785037120990,
+      "message": "REPORT RequestId: 9514f67a-9457-4384-a281-8b263b19f80d\tDuration: 90921.09 ms\tBilled Duration: 90922 ms\tMemory Size: 128 MB\tMax Memory Used: 92 MB\t\n",
+      "ingestionTime": 1785037129747,
+      "eventId": "39807658005116669513075565307782091704624488736679264260"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]1091310250734a2c80fea86f19117d5a",
+      "timestamp": 1785037329992,
+      "message": "START RequestId: 15bc2321-899d-4cc6-b126-5bc83ebfaf90 Version: $LATEST\n",
+      "ingestionTime": 1785037339012,
+      "eventId": "39807662666017017496372863388016318135104758512959029248"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]1091310250734a2c80fea86f19117d5a",
+      "timestamp": 1785037330011,
+      "message": "[INFO]\t2026-07-26T03:42:10.011Z\t15bc2321-899d-4cc6-b126-5bc83ebfaf90\tCanary invocation started\n",
+      "ingestionTime": 1785037339012,
+      "eventId": "39807662666440731655144945227705496782285077381572657153"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]1091310250734a2c80fea86f19117d5a",
+      "timestamp": 1785037330150,
+      "message": "[INFO]\t2026-07-26T03:42:10.074Z\t15bc2321-899d-4cc6-b126-5bc83ebfaf90\tSubmitted synthetic trace\n",
+      "ingestionTime": 1785037339012,
+      "eventId": "39807662669540535237740701844378961622183199630903934978"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]1091310250734a2c80fea86f19117d5a",
+      "timestamp": 1785037330378,
+      "message": "[WARNING]\t2026-07-26T03:42:10.378Z\t15bc2321-899d-4cc6-b126-5bc83ebfaf90\tNo canary traces found\n",
+      "ingestionTime": 1785037339012,
+      "eventId": "39807662674625105143005683920649105388347026054267469827"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]1091310250734a2c80fea86f19117d5a",
+      "timestamp": 1785037360415,
+      "message": "[WARNING]\t2026-07-26T03:42:40.414Z\t15bc2321-899d-4cc6-b126-5bc83ebfaf90\tNo canary traces found\n",
+      "ingestionTime": 1785037369433,
+      "eventId": "39807663344472588671270011259734132801653692728913100800"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]1091310250734a2c80fea86f19117d5a",
+      "timestamp": 1785037420597,
+      "message": "[WARNING]\t2026-07-26T03:43:40.597Z\t15bc2321-899d-4cc6-b126-5bc83ebfaf90\tNo canary traces found\n",
+      "ingestionTime": 1785037429615,
+      "eventId": "39807664686576036209239973236392295686016734604140347392"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]1091310250734a2c80fea86f19117d5a",
+      "timestamp": 1785037420791,
+      "message": "[INFO]\t2026-07-26T03:43:40.791Z\t15bc2321-899d-4cc6-b126-5bc83ebfaf90\tMetrics emitted\n",
+      "ingestionTime": 1785037429615,
+      "eventId": "39807664690902380777754914125850225030910516736300548097"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]1091310250734a2c80fea86f19117d5a",
+      "timestamp": 1785037420791,
+      "message": "[INFO]\t2026-07-26T03:43:40.791Z\t15bc2321-899d-4cc6-b126-5bc83ebfaf90\tCanary complete\n",
+      "ingestionTime": 1785037429615,
+      "eventId": "39807664690902380777754914125850225030910516736300548098"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]1091310250734a2c80fea86f19117d5a",
+      "timestamp": 1785037420871,
+      "message": "END RequestId: 15bc2321-899d-4cc6-b126-5bc83ebfaf90\n",
+      "ingestionTime": 1785037429615,
+      "eventId": "39807664692686440393637363977173082492722385656778981379"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]1091310250734a2c80fea86f19117d5a",
+      "timestamp": 1785037420871,
+      "message": "REPORT RequestId: 15bc2321-899d-4cc6-b126-5bc83ebfaf90\tDuration: 90878.64 ms\tBilled Duration: 90879 ms\tMemory Size: 128 MB\tMax Memory Used: 92 MB\t\n",
+      "ingestionTime": 1785037429615,
+      "eventId": "39807664692686440393637363977173082492722385656778981380"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]1091310250734a2c80fea86f19117d5a",
+      "timestamp": 1785037629931,
+      "message": "START RequestId: 7af2b2e8-0699-4647-92c0-fd2f78203a4d Version: $LATEST\n",
+      "ingestionTime": 1785037638949,
+      "eventId": "39807669354880231598449438199699665336941846380542558208"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]1091310250734a2c80fea86f19117d5a",
+      "timestamp": 1785037629953,
+      "message": "[INFO]\t2026-07-26T03:47:09.953Z\t7af2b2e8-0699-4647-92c0-fd2f78203a4d\tCanary invocation started\n",
+      "ingestionTime": 1785037638949,
+      "eventId": "39807669355370847992817111908813451138940110333674127361"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]1091310250734a2c80fea86f19117d5a",
+      "timestamp": 1785037630093,
+      "message": "[INFO]\t2026-07-26T03:47:10.093Z\t7af2b2e8-0699-4647-92c0-fd2f78203a4d\tSubmitted synthetic trace\n",
+      "ingestionTime": 1785037638949,
+      "eventId": "39807669358492952320611399148628451697110880944511385602"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]1091310250734a2c80fea86f19117d5a",
+      "timestamp": 1785037630301,
+      "message": "[WARNING]\t2026-07-26T03:47:10.301Z\t7af2b2e8-0699-4647-92c0-fd2f78203a4d\tNo canary traces found\n",
+      "ingestionTime": 1785037638949,
+      "eventId": "39807669363131507321905768762067881097821740137755312131"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]1091310250734a2c80fea86f19117d5a",
+      "timestamp": 1785037660328,
+      "message": "[WARNING]\t2026-07-26T03:47:40.328Z\t7af2b2e8-0699-4647-92c0-fd2f78203a4d\tNo canary traces found\n",
+      "ingestionTime": 1785037669340,
+      "eventId": "39807670032755983398184789869701124749025256101027250176"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]1091310250734a2c80fea86f19117d5a",
+      "timestamp": 1785037720498,
+      "message": "[WARNING]\t2026-07-26T03:48:40.498Z\t7af2b2e8-0699-4647-92c0-fd2f78203a4d\tNo canary traces found\n",
+      "ingestionTime": 1785037729518,
+      "eventId": "39807671374591821993772384368656183870212868743428571136"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]1091310250734a2c80fea86f19117d5a",
+      "timestamp": 1785037720712,
+      "message": "[INFO]\t2026-07-26T03:48:40.699Z\t7af2b2e8-0699-4647-92c0-fd2f78203a4d\tMetrics emitted\n",
+      "ingestionTime": 1785037729518,
+      "eventId": "39807671379364181466257937720944827580559618105708380161"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]1091310250734a2c80fea86f19117d5a",
+      "timestamp": 1785037720712,
+      "message": "[INFO]\t2026-07-26T03:48:40.712Z\t7af2b2e8-0699-4647-92c0-fd2f78203a4d\tCanary complete\n",
+      "ingestionTime": 1785037729518,
+      "eventId": "39807671379364181466257937720944827580559618105708380162"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]1091310250734a2c80fea86f19117d5a",
+      "timestamp": 1785037720773,
+      "message": "END RequestId: 7af2b2e8-0699-4647-92c0-fd2f78203a4d\n",
+      "ingestionTime": 1785037729518,
+      "eventId": "39807671380724526923368305732578506395191168157573185539"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]1091310250734a2c80fea86f19117d5a",
+      "timestamp": 1785037720773,
+      "message": "REPORT RequestId: 7af2b2e8-0699-4647-92c0-fd2f78203a4d\tDuration: 90841.56 ms\tBilled Duration: 90842 ms\tMemory Size: 128 MB\tMax Memory Used: 92 MB\t\n",
+      "ingestionTime": 1785037729518,
+      "eventId": "39807671380724526923368305732578506395191168157573185540"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]f5fe6670be5d4e3d9d4c37cb06720409",
+      "timestamp": 1785037825016,
+      "message": "INIT_START Runtime Version: python:3.13.mainlinev2.v18\tRuntime Version ARN: arn:aws:lambda:us-east-1::runtime:85016a02049aea54df8f85632acb695fe6e1c8623b63b4ed1d582917e22e8e4d\n",
+      "ingestionTime": 1785037827415,
+      "eventId": "39807673705421108653796053994036762458642125794393653248"
+    }
+  ]
+}

--- a/specs/001-lambda-log-visibility/evidence/pre-deploy/logshape-dashboard.json
+++ b/specs/001-lambda-log-visibility/evidence/pre-deploy/logshape-dashboard.json
@@ -1,0 +1,359 @@
+{
+  "logGroupName": "/aws/lambda/preprod-sentiment-dashboard",
+  "collectedAt": "2026-07-26T03:50:28.959325+00:00",
+  "windowUsed": "6h",
+  "error": null,
+  "eventCount": 50,
+  "events": [
+    {
+      "logStreamName": "2026/07/26/[134]778907c660394325b4d8b9f1baba8e34",
+      "timestamp": 1785030834873,
+      "message": "REPORT RequestId: f6762773-4488-424f-ab5d-9f12b215ba4d\tDuration: 2.04 ms\tBilled Duration: 3 ms\tMemory Size: 1024 MB\tMax Memory Used: 178 MB\t\nXRAY TraceId: 1-6a6568b2-32735e1f4635bece02412276\tSegmentId: 77f1e035d9e81f20\tSampled: true\t\n",
+      "ingestionTime": 1785030840421,
+      "eventId": "39807517820023164361350407103368772821693779984943743011"
+    },
+    {
+      "logStreamName": "2026/07/26/[134]778907c660394325b4d8b9f1baba8e34",
+      "timestamp": 1785030834879,
+      "message": "START RequestId: 2ba25fb5-c5e1-4eaa-abe7-ffca9881ae6c Version: 134\n",
+      "ingestionTime": 1785030840421,
+      "eventId": "39807517820156968832541590842217987131329670153979625508"
+    },
+    {
+      "logStreamName": "2026/07/26/[134]778907c660394325b4d8b9f1baba8e34",
+      "timestamp": 1785030834879,
+      "message": "{\"level\":\"INFO\",\"location\":\"lambda_handler:1871\",\"message\":\"Dashboard Lambda invoked\",\"timestamp\":\"2026-07-26 01:53:54,879+0000\",\"service\":\"dashboard\",\"cold_start\":false,\"function_name\":\"preprod-sentiment-dashboard\",\"function_memory_size\":\"1024\",\"function_arn\":\"arn:aws:lambda:us-east-1:218795110243:function:preprod-sentiment-dashboard:live\",\"function_request_id\":\"2ba25fb5-c5e1-4eaa-abe7-ffca9881ae6c\",\"path\":\"/api/v2/runtime\",\"method\":\"GET\",\"xray_trace_id\":\"1-6a6568b2-3e4033a90d16c70e2e414af3\"}\n",
+      "ingestionTime": 1785030840421,
+      "eventId": "39807517820156968832541590842217987131329670153979625509"
+    },
+    {
+      "logStreamName": "2026/07/26/[134]778907c660394325b4d8b9f1baba8e34",
+      "timestamp": 1785030834881,
+      "message": "END RequestId: 2ba25fb5-c5e1-4eaa-abe7-ffca9881ae6c\n",
+      "ingestionTime": 1785030840421,
+      "eventId": "39807517820201570322938652088501058567874966876991586342"
+    },
+    {
+      "logStreamName": "2026/07/26/[134]778907c660394325b4d8b9f1baba8e34",
+      "timestamp": 1785030834881,
+      "message": "REPORT RequestId: 2ba25fb5-c5e1-4eaa-abe7-ffca9881ae6c\tDuration: 1.87 ms\tBilled Duration: 2 ms\tMemory Size: 1024 MB\tMax Memory Used: 178 MB\t\nXRAY TraceId: 1-6a6568b2-3e4033a90d16c70e2e414af3\tSegmentId: 04d18820711d7ed7\tSampled: true\t\n",
+      "ingestionTime": 1785030840421,
+      "eventId": "39807517820201570322938652088501058567874966876991586343"
+    },
+    {
+      "logStreamName": "2026/07/26/[134]778907c660394325b4d8b9f1baba8e34",
+      "timestamp": 1785030834892,
+      "message": "START RequestId: 3b50d362-c19a-464c-ada6-be5c0fc64fb3 Version: 134\n",
+      "ingestionTime": 1785030840421,
+      "eventId": "39807517820446878520122488943057951468874098853557370920"
+    },
+    {
+      "logStreamName": "2026/07/26/[134]778907c660394325b4d8b9f1baba8e34",
+      "timestamp": 1785030834893,
+      "message": "{\"level\":\"INFO\",\"location\":\"lambda_handler:1871\",\"message\":\"Dashboard Lambda invoked\",\"timestamp\":\"2026-07-26 01:53:54,893+0000\",\"service\":\"dashboard\",\"cold_start\":false,\"function_name\":\"preprod-sentiment-dashboard\",\"function_memory_size\":\"1024\",\"function_arn\":\"arn:aws:lambda:us-east-1:218795110243:function:preprod-sentiment-dashboard:live\",\"function_request_id\":\"3b50d362-c19a-464c-ada6-be5c0fc64fb3\",\"path\":\"/api/v2/auth/oauth/urls\",\"method\":\"GET\",\"xray_trace_id\":\"1-6a6568b2-099f9dff1f488bc25f6ee716\"}\n",
+      "ingestionTime": 1785030840421,
+      "eventId": "39807517820469179265321019566199487187146747215063351337"
+    },
+    {
+      "logStreamName": "2026/07/26/[134]778907c660394325b4d8b9f1baba8e34",
+      "timestamp": 1785030834901,
+      "message": "END RequestId: 3b50d362-c19a-464c-ada6-be5c0fc64fb3\n",
+      "ingestionTime": 1785030840421,
+      "eventId": "39807517820647585226909264551331772933327934107111194666"
+    },
+    {
+      "logStreamName": "2026/07/26/[134]778907c660394325b4d8b9f1baba8e34",
+      "timestamp": 1785030834901,
+      "message": "REPORT RequestId: 3b50d362-c19a-464c-ada6-be5c0fc64fb3\tDuration: 8.51 ms\tBilled Duration: 9 ms\tMemory Size: 1024 MB\tMax Memory Used: 178 MB\t\nXRAY TraceId: 1-6a6568b2-099f9dff1f488bc25f6ee716\tSegmentId: 43a55fbcf6afb231\tSampled: true\t\n",
+      "ingestionTime": 1785030840421,
+      "eventId": "39807517820647585226909264551331772933327934107111194667"
+    },
+    {
+      "logStreamName": "2026/07/26/[134]778907c660394325b4d8b9f1baba8e34",
+      "timestamp": 1785030834958,
+      "message": "START RequestId: 40ff4e5a-0f85-4eb3-a27f-4d6fefd26f8f Version: 134\n",
+      "ingestionTime": 1785030840421,
+      "eventId": "39807517821918727703225510070399308874868890712952078380"
+    },
+    {
+      "logStreamName": "2026/07/26/[134]778907c660394325b4d8b9f1baba8e34",
+      "timestamp": 1785030834959,
+      "message": "{\"level\":\"INFO\",\"location\":\"lambda_handler:1871\",\"message\":\"Dashboard Lambda invoked\",\"timestamp\":\"2026-07-26 01:53:54,959+0000\",\"service\":\"dashboard\",\"cold_start\":false,\"function_name\":\"preprod-sentiment-dashboard\",\"function_memory_size\":\"1024\",\"function_arn\":\"arn:aws:lambda:us-east-1:218795110243:function:preprod-sentiment-dashboard:live\",\"function_request_id\":\"40ff4e5a-0f85-4eb3-a27f-4d6fefd26f8f\",\"path\":\"/api/v2/auth/anonymous\",\"method\":\"POST\",\"xray_trace_id\":\"1-6a6568b2-39479fc630fe71207a283ad4\"}\n",
+      "ingestionTime": 1785030840421,
+      "eventId": "39807517821941028448424040693540844593141539074458058797"
+    },
+    {
+      "logStreamName": "2026/07/26/[134]778907c660394325b4d8b9f1baba8e34",
+      "timestamp": 1785030834966,
+      "message": "END RequestId: 40ff4e5a-0f85-4eb3-a27f-4d6fefd26f8f\n",
+      "ingestionTime": 1785030840421,
+      "eventId": "39807517822097133664813755055531594621050077604999921710"
+    },
+    {
+      "logStreamName": "2026/07/26/[134]778907c660394325b4d8b9f1baba8e34",
+      "timestamp": 1785030834966,
+      "message": "REPORT RequestId: 40ff4e5a-0f85-4eb3-a27f-4d6fefd26f8f\tDuration: 7.57 ms\tBilled Duration: 8 ms\tMemory Size: 1024 MB\tMax Memory Used: 178 MB\t\nXRAY TraceId: 1-6a6568b2-39479fc630fe71207a283ad4\tSegmentId: e153327476f404b3\tSampled: true\t\n",
+      "ingestionTime": 1785030840421,
+      "eventId": "39807517822097133664813755055531594621050077604999921711"
+    },
+    {
+      "logStreamName": "2026/07/26/[134]778907c660394325b4d8b9f1baba8e34",
+      "timestamp": 1785030835147,
+      "message": "START RequestId: 3260cba2-8a33-44d2-9292-cce1c72e1ed1 Version: 134\n",
+      "ingestionTime": 1785030840421,
+      "eventId": "39807517826133568545747797844149559628399431037582377008"
+    },
+    {
+      "logStreamName": "2026/07/26/[134]778907c660394325b4d8b9f1baba8e34",
+      "timestamp": 1785030835148,
+      "message": "{\"level\":\"INFO\",\"location\":\"lambda_handler:1871\",\"message\":\"Dashboard Lambda invoked\",\"timestamp\":\"2026-07-26 01:53:55,148+0000\",\"service\":\"dashboard\",\"cold_start\":false,\"function_name\":\"preprod-sentiment-dashboard\",\"function_memory_size\":\"1024\",\"function_arn\":\"arn:aws:lambda:us-east-1:218795110243:function:preprod-sentiment-dashboard:live\",\"function_request_id\":\"3260cba2-8a33-44d2-9292-cce1c72e1ed1\",\"path\":\"/api/v2/auth/oauth/urls\",\"method\":\"GET\",\"xray_trace_id\":\"1-6a6568b3-4613e5ab226378b245e046f0\"}\n",
+      "ingestionTime": 1785030840421,
+      "eventId": "39807517826155869290946328467291095346672079399088357425"
+    },
+    {
+      "logStreamName": "2026/07/26/[134]778907c660394325b4d8b9f1baba8e34",
+      "timestamp": 1785030835156,
+      "message": "END RequestId: 3260cba2-8a33-44d2-9292-cce1c72e1ed1\n",
+      "ingestionTime": 1785030840421,
+      "eventId": "39807517826334275252534573452423381092853266291136200754"
+    },
+    {
+      "logStreamName": "2026/07/26/[134]778907c660394325b4d8b9f1baba8e34",
+      "timestamp": 1785030835156,
+      "message": "REPORT RequestId: 3260cba2-8a33-44d2-9292-cce1c72e1ed1\tDuration: 8.33 ms\tBilled Duration: 9 ms\tMemory Size: 1024 MB\tMax Memory Used: 178 MB\t\nXRAY TraceId: 1-6a6568b3-4613e5ab226378b245e046f0\tSegmentId: b06881cdd43d1e1b\tSampled: true\t\n",
+      "ingestionTime": 1785030840421,
+      "eventId": "39807517826334275252534573452423381092853266291136200755"
+    },
+    {
+      "logStreamName": "2026/07/26/[134]778907c660394325b4d8b9f1baba8e34",
+      "timestamp": 1785030841855,
+      "message": "START RequestId: 70e7f4c8-7c14-46ae-b5cf-ec5de94a10c6 Version: 134\n",
+      "ingestionTime": 1785030850871,
+      "eventId": "39807517975726967337491217890204583328936232941436338176"
+    },
+    {
+      "logStreamName": "2026/07/26/[134]778907c660394325b4d8b9f1baba8e34",
+      "timestamp": 1785030841856,
+      "message": "{\"level\":\"INFO\",\"location\":\"lambda_handler:1871\",\"message\":\"Dashboard Lambda invoked\",\"timestamp\":\"2026-07-26 01:54:01,856+0000\",\"service\":\"dashboard\",\"cold_start\":false,\"function_name\":\"preprod-sentiment-dashboard\",\"function_memory_size\":\"1024\",\"function_arn\":\"arn:aws:lambda:us-east-1:218795110243:function:preprod-sentiment-dashboard:live\",\"function_request_id\":\"70e7f4c8-7c14-46ae-b5cf-ec5de94a10c6\",\"path\":\"/api/v2/runtime\",\"method\":\"GET\",\"xray_trace_id\":\"1-6a6568b9-7c46279a1d5843741ca57ac1\"}\n",
+      "ingestionTime": 1785030850871,
+      "eventId": "39807517975749268082689748513346119047208881302942318593"
+    },
+    {
+      "logStreamName": "2026/07/26/[134]778907c660394325b4d8b9f1baba8e34",
+      "timestamp": 1785030841858,
+      "message": "END RequestId: 70e7f4c8-7c14-46ae-b5cf-ec5de94a10c6\n",
+      "ingestionTime": 1785030850871,
+      "eventId": "39807517975793869573086809759629190483754178025954279426"
+    },
+    {
+      "logStreamName": "2026/07/26/[134]778907c660394325b4d8b9f1baba8e34",
+      "timestamp": 1785030841858,
+      "message": "REPORT RequestId: 70e7f4c8-7c14-46ae-b5cf-ec5de94a10c6\tDuration: 2.01 ms\tBilled Duration: 3 ms\tMemory Size: 1024 MB\tMax Memory Used: 178 MB\t\nXRAY TraceId: 1-6a6568b9-7c46279a1d5843741ca57ac1\tSegmentId: ac103c2ebd8cba07\tSampled: true\t\n",
+      "ingestionTime": 1785030850871,
+      "eventId": "39807517975793869573086809759629190483754178025954279427"
+    },
+    {
+      "logStreamName": "2026/07/26/[134]778907c660394325b4d8b9f1baba8e34",
+      "timestamp": 1785030841864,
+      "message": "START RequestId: 8172cd39-cd0a-4173-b498-53484d5138d4 Version: 134\n",
+      "ingestionTime": 1785030850871,
+      "eventId": "39807517975927674044277993498478404793390068194990161924"
+    },
+    {
+      "logStreamName": "2026/07/26/[134]778907c660394325b4d8b9f1baba8e34",
+      "timestamp": 1785030841865,
+      "message": "{\"level\":\"INFO\",\"location\":\"lambda_handler:1871\",\"message\":\"Dashboard Lambda invoked\",\"timestamp\":\"2026-07-26 01:54:01,865+0000\",\"service\":\"dashboard\",\"cold_start\":false,\"function_name\":\"preprod-sentiment-dashboard\",\"function_memory_size\":\"1024\",\"function_arn\":\"arn:aws:lambda:us-east-1:218795110243:function:preprod-sentiment-dashboard:live\",\"function_request_id\":\"8172cd39-cd0a-4173-b498-53484d5138d4\",\"path\":\"/api/v2/auth/refresh\",\"method\":\"POST\",\"xray_trace_id\":\"1-6a6568b9-045abf6e362ad2d377b8297c\"}\n",
+      "ingestionTime": 1785030850871,
+      "eventId": "39807517975949974789476524121619940511662716556496142341"
+    },
+    {
+      "logStreamName": "2026/07/26/[134]778907c660394325b4d8b9f1baba8e34",
+      "timestamp": 1785030841866,
+      "message": "END RequestId: 8172cd39-cd0a-4173-b498-53484d5138d4\n",
+      "ingestionTime": 1785030850871,
+      "eventId": "39807517975972275534675054744761476229935364918002122758"
+    },
+    {
+      "logStreamName": "2026/07/26/[134]778907c660394325b4d8b9f1baba8e34",
+      "timestamp": 1785030841866,
+      "message": "REPORT RequestId: 8172cd39-cd0a-4173-b498-53484d5138d4\tDuration: 1.79 ms\tBilled Duration: 2 ms\tMemory Size: 1024 MB\tMax Memory Used: 178 MB\t\nXRAY TraceId: 1-6a6568b9-045abf6e362ad2d377b8297c\tSegmentId: 772ae76dc0d3a3e1\tSampled: true\t\n",
+      "ingestionTime": 1785030850871,
+      "eventId": "39807517975972275534675054744761476229935364918002122759"
+    },
+    {
+      "logStreamName": "2026/07/26/[134]778907c660394325b4d8b9f1baba8e34",
+      "timestamp": 1785030841958,
+      "message": "START RequestId: 5c8e49a4-7802-4552-828d-9558d06bcd79 Version: 134\n",
+      "ingestionTime": 1785030850871,
+      "eventId": "39807517978023944092939872073782762311019014176552321032"
+    },
+    {
+      "logStreamName": "2026/07/26/[134]778907c660394325b4d8b9f1baba8e34",
+      "timestamp": 1785030841959,
+      "message": "{\"level\":\"INFO\",\"location\":\"lambda_handler:1871\",\"message\":\"Dashboard Lambda invoked\",\"timestamp\":\"2026-07-26 01:54:01,958+0000\",\"service\":\"dashboard\",\"cold_start\":false,\"function_name\":\"preprod-sentiment-dashboard\",\"function_memory_size\":\"1024\",\"function_arn\":\"arn:aws:lambda:us-east-1:218795110243:function:preprod-sentiment-dashboard:live\",\"function_request_id\":\"5c8e49a4-7802-4552-828d-9558d06bcd79\",\"path\":\"/api/v2/auth/anonymous\",\"method\":\"POST\",\"xray_trace_id\":\"1-6a6568b9-02711d9322b9de59690e81e7\"}\n",
+      "ingestionTime": 1785030850871,
+      "eventId": "39807517978046244838138402696924298029291662538058301449"
+    },
+    {
+      "logStreamName": "2026/07/26/[134]778907c660394325b4d8b9f1baba8e34",
+      "timestamp": 1785030841966,
+      "message": "END RequestId: 5c8e49a4-7802-4552-828d-9558d06bcd79\n",
+      "ingestionTime": 1785030850871,
+      "eventId": "39807517978202350054528117058915048057200201068600164362"
+    },
+    {
+      "logStreamName": "2026/07/26/[134]778907c660394325b4d8b9f1baba8e34",
+      "timestamp": 1785030841966,
+      "message": "REPORT RequestId: 5c8e49a4-7802-4552-828d-9558d06bcd79\tDuration: 7.51 ms\tBilled Duration: 8 ms\tMemory Size: 1024 MB\tMax Memory Used: 178 MB\t\nXRAY TraceId: 1-6a6568b9-02711d9322b9de59690e81e7\tSegmentId: cad425a2b0a79aee\tSampled: true\t\n",
+      "ingestionTime": 1785030850871,
+      "eventId": "39807517978202350054528117058915048057200201068600164363"
+    },
+    {
+      "logStreamName": "2026/07/26/[134]778907c660394325b4d8b9f1baba8e34",
+      "timestamp": 1785030842147,
+      "message": "START RequestId: a3b960c6-6c6c-49de-b7f0-275357ca090e Version: 134\n",
+      "ingestionTime": 1785030850871,
+      "eventId": "39807517982238784935462159847533013064549554501182619660"
+    },
+    {
+      "logStreamName": "2026/07/26/[134]778907c660394325b4d8b9f1baba8e34",
+      "timestamp": 1785030842148,
+      "message": "{\"level\":\"INFO\",\"location\":\"lambda_handler:1871\",\"message\":\"Dashboard Lambda invoked\",\"timestamp\":\"2026-07-26 01:54:02,148+0000\",\"service\":\"dashboard\",\"cold_start\":false,\"function_name\":\"preprod-sentiment-dashboard\",\"function_memory_size\":\"1024\",\"function_arn\":\"arn:aws:lambda:us-east-1:218795110243:function:preprod-sentiment-dashboard:live\",\"function_request_id\":\"a3b960c6-6c6c-49de-b7f0-275357ca090e\",\"path\":\"/api/v2/auth/oauth/urls\",\"method\":\"GET\",\"xray_trace_id\":\"1-6a6568ba-46ed921552b2d15135fd9155\"}\n",
+      "ingestionTime": 1785030850871,
+      "eventId": "39807517982261085680660690470674548782822202862688600077"
+    },
+    {
+      "logStreamName": "2026/07/26/[134]778907c660394325b4d8b9f1baba8e34",
+      "timestamp": 1785030842156,
+      "message": "END RequestId: a3b960c6-6c6c-49de-b7f0-275357ca090e\n",
+      "ingestionTime": 1785030850871,
+      "eventId": "39807517982439491642248935455806834529003389754736443406"
+    },
+    {
+      "logStreamName": "2026/07/26/[134]778907c660394325b4d8b9f1baba8e34",
+      "timestamp": 1785030842156,
+      "message": "REPORT RequestId: a3b960c6-6c6c-49de-b7f0-275357ca090e\tDuration: 7.78 ms\tBilled Duration: 8 ms\tMemory Size: 1024 MB\tMax Memory Used: 178 MB\t\nXRAY TraceId: 1-6a6568ba-46ed921552b2d15135fd9155\tSegmentId: 4d03be589d238406\tSampled: true\t\n",
+      "ingestionTime": 1785030850871,
+      "eventId": "39807517982439491642248935455806834529003389754736443407"
+    },
+    {
+      "logStreamName": "2026/07/26/[134]778907c660394325b4d8b9f1baba8e34",
+      "timestamp": 1785031000038,
+      "message": "START RequestId: d13b124b-6ddf-4f30-87b3-23d5aaeeb224 Version: 134\n",
+      "ingestionTime": 1785031009053,
+      "eventId": "39807521503325745076660778478979659528965954345543335936"
+    },
+    {
+      "logStreamName": "2026/07/26/[134]778907c660394325b4d8b9f1baba8e34",
+      "timestamp": 1785031000040,
+      "message": "{\"level\":\"INFO\",\"location\":\"lambda_handler:1871\",\"message\":\"Dashboard Lambda invoked\",\"timestamp\":\"2026-07-26 01:56:40,039+0000\",\"service\":\"dashboard\",\"cold_start\":false,\"function_name\":\"preprod-sentiment-dashboard\",\"function_memory_size\":\"1024\",\"function_arn\":\"arn:aws:lambda:us-east-1:218795110243:function:preprod-sentiment-dashboard:live\",\"function_request_id\":\"d13b124b-6ddf-4f30-87b3-23d5aaeeb224\",\"path\":\"/api/v2/auth/me\",\"method\":\"GET\",\"xray_trace_id\":\"1-6a656958-1d56cef153f023bc7ad46867\"}\n",
+      "ingestionTime": 1785031009053,
+      "eventId": "39807521503370346567057839725262730965511251068555296769"
+    },
+    {
+      "logStreamName": "2026/07/26/[134]778907c660394325b4d8b9f1baba8e34",
+      "timestamp": 1785031000041,
+      "message": "[WARNING]\t2026-07-26T01:56:40.041Z\td13b124b-6ddf-4f30-87b3-23d5aaeeb224\tJWT audience mismatch detected\n",
+      "ingestionTime": 1785031009053,
+      "eventId": "39807521503392647312256370348404266683783899430061277186"
+    },
+    {
+      "logStreamName": "2026/07/26/[134]778907c660394325b4d8b9f1baba8e34",
+      "timestamp": 1785031000043,
+      "message": "END RequestId: d13b124b-6ddf-4f30-87b3-23d5aaeeb224\n",
+      "ingestionTime": 1785031009053,
+      "eventId": "39807521503437248802653431594687338120329196153073238019"
+    },
+    {
+      "logStreamName": "2026/07/26/[134]778907c660394325b4d8b9f1baba8e34",
+      "timestamp": 1785031000043,
+      "message": "REPORT RequestId: d13b124b-6ddf-4f30-87b3-23d5aaeeb224\tDuration: 4.80 ms\tBilled Duration: 5 ms\tMemory Size: 1024 MB\tMax Memory Used: 178 MB\t\nXRAY TraceId: 1-6a656958-1d56cef153f023bc7ad46867\tSegmentId: 9a78d6f62e517f49\tSampled: true\t\n",
+      "ingestionTime": 1785031009053,
+      "eventId": "39807521503437248802653431594687338120329196153073238020"
+    },
+    {
+      "logStreamName": "2026/07/26/[134]778907c660394325b4d8b9f1baba8e34",
+      "timestamp": 1785031000163,
+      "message": "START RequestId: b12a21db-7824-404f-bf83-5800d797f5d6 Version: 134\n",
+      "ingestionTime": 1785031009053,
+      "eventId": "39807521506113338226477106371671624313046999533790887941"
+    },
+    {
+      "logStreamName": "2026/07/26/[134]778907c660394325b4d8b9f1baba8e34",
+      "timestamp": 1785031000164,
+      "message": "{\"level\":\"INFO\",\"location\":\"lambda_handler:1871\",\"message\":\"Dashboard Lambda invoked\",\"timestamp\":\"2026-07-26 01:56:40,163+0000\",\"service\":\"dashboard\",\"cold_start\":false,\"function_name\":\"preprod-sentiment-dashboard\",\"function_memory_size\":\"1024\",\"function_arn\":\"arn:aws:lambda:us-east-1:218795110243:function:preprod-sentiment-dashboard:live\",\"function_request_id\":\"b12a21db-7824-404f-bf83-5800d797f5d6\",\"path\":\"/api/v2/auth/me\",\"method\":\"GET\",\"xray_trace_id\":\"1-6a656958-7d0fc1fe17ef3e283a9f441e\"}\n",
+      "ingestionTime": 1785031009053,
+      "eventId": "39807521506135638971675636994813160031319647895296868358"
+    },
+    {
+      "logStreamName": "2026/07/26/[134]778907c660394325b4d8b9f1baba8e34",
+      "timestamp": 1785031000165,
+      "message": "END RequestId: b12a21db-7824-404f-bf83-5800d797f5d6\n",
+      "ingestionTime": 1785031009053,
+      "eventId": "39807521506157939716874167617954695749592296256802848775"
+    },
+    {
+      "logStreamName": "2026/07/26/[134]778907c660394325b4d8b9f1baba8e34",
+      "timestamp": 1785031000165,
+      "message": "REPORT RequestId: b12a21db-7824-404f-bf83-5800d797f5d6\tDuration: 2.19 ms\tBilled Duration: 3 ms\tMemory Size: 1024 MB\tMax Memory Used: 178 MB\t\nXRAY TraceId: 1-6a656958-7d0fc1fe17ef3e283a9f441e\tSegmentId: 778c4184857e8512\tSampled: true\t\n",
+      "ingestionTime": 1785031009053,
+      "eventId": "39807521506157939716874167617954695749592296256802848776"
+    },
+    {
+      "logStreamName": "2026/07/26/[134]778907c660394325b4d8b9f1baba8e34",
+      "timestamp": 1785031000266,
+      "message": "START RequestId: 33a81a25-886d-4d70-ba24-c4c581272845 Version: 134\n",
+      "ingestionTime": 1785031009053,
+      "eventId": "39807521508410314981925760555249803295129780768906870793"
+    },
+    {
+      "logStreamName": "2026/07/26/[134]778907c660394325b4d8b9f1baba8e34",
+      "timestamp": 1785031000267,
+      "message": "{\"level\":\"INFO\",\"location\":\"lambda_handler:1871\",\"message\":\"Dashboard Lambda invoked\",\"timestamp\":\"2026-07-26 01:56:40,267+0000\",\"service\":\"dashboard\",\"cold_start\":false,\"function_name\":\"preprod-sentiment-dashboard\",\"function_memory_size\":\"1024\",\"function_arn\":\"arn:aws:lambda:us-east-1:218795110243:function:preprod-sentiment-dashboard:live\",\"function_request_id\":\"33a81a25-886d-4d70-ba24-c4c581272845\",\"path\":\"/api/v2/auth/me\",\"method\":\"GET\",\"xray_trace_id\":\"1-6a656958-26d1ac40359746cb2e64568d\"}\n",
+      "ingestionTime": 1785031009053,
+      "eventId": "39807521508432615727124291178391339013402429130412851210"
+    },
+    {
+      "logStreamName": "2026/07/26/[134]778907c660394325b4d8b9f1baba8e34",
+      "timestamp": 1785031000269,
+      "message": "END RequestId: 33a81a25-886d-4d70-ba24-c4c581272845\n",
+      "ingestionTime": 1785031009053,
+      "eventId": "39807521508477217217521352424674410449947725853424812043"
+    },
+    {
+      "logStreamName": "2026/07/26/[134]778907c660394325b4d8b9f1baba8e34",
+      "timestamp": 1785031000269,
+      "message": "REPORT RequestId: 33a81a25-886d-4d70-ba24-c4c581272845\tDuration: 2.26 ms\tBilled Duration: 3 ms\tMemory Size: 1024 MB\tMax Memory Used: 178 MB\t\nXRAY TraceId: 1-6a656958-26d1ac40359746cb2e64568d\tSegmentId: 5b5f0f1ed622b75d\tSampled: true\t\n",
+      "ingestionTime": 1785031009053,
+      "eventId": "39807521508477217217521352424674410449947725853424812044"
+    },
+    {
+      "logStreamName": "2026/07/26/[134]22543b3ecf6c468b97918156da5b7cb7",
+      "timestamp": 1785031152222,
+      "message": "START RequestId: b5a4eb16-cb31-467c-80e8-05b76e7ebdf0 Version: 134\n",
+      "ingestionTime": 1785031161244,
+      "eventId": "39807524897142352369845130834438533267505090536369094656"
+    },
+    {
+      "logStreamName": "2026/07/26/[134]22543b3ecf6c468b97918156da5b7cb7",
+      "timestamp": 1785031152225,
+      "message": "{\"level\":\"INFO\",\"location\":\"lambda_handler:1871\",\"message\":\"Dashboard Lambda invoked\",\"timestamp\":\"2026-07-26 01:59:12,223+0000\",\"service\":\"dashboard\",\"cold_start\":false,\"function_name\":\"preprod-sentiment-dashboard\",\"function_memory_size\":\"1024\",\"function_arn\":\"arn:aws:lambda:us-east-1:218795110243:function:preprod-sentiment-dashboard:live\",\"function_request_id\":\"b5a4eb16-cb31-467c-80e8-05b76e7ebdf0\",\"path\":\"/api/v2/auth/oauth/urls\",\"method\":\"GET\",\"xray_trace_id\":\"1-6a6569f0-35484db6621dddd148df7dcf\"}\n",
+      "ingestionTime": 1785031161244,
+      "eventId": "39807524897209254605440722703863140422323035620887035905"
+    },
+    {
+      "logStreamName": "2026/07/26/[134]22543b3ecf6c468b97918156da5b7cb7",
+      "timestamp": 1785031152290,
+      "message": "END RequestId: b5a4eb16-cb31-467c-80e8-05b76e7ebdf0\n",
+      "ingestionTime": 1785031161244,
+      "eventId": "39807524898658803043345213208062962110045179118775762946"
+    },
+    {
+      "logStreamName": "2026/07/26/[134]22543b3ecf6c468b97918156da5b7cb7",
+      "timestamp": 1785031152290,
+      "message": "REPORT RequestId: b5a4eb16-cb31-467c-80e8-05b76e7ebdf0\tDuration: 66.98 ms\tBilled Duration: 67 ms\tMemory Size: 1024 MB\tMax Memory Used: 178 MB\t\nXRAY TraceId: 1-6a6569f0-35484db6621dddd148df7dcf\tSegmentId: 7b2080d88a5f9173\tSampled: true\t\n",
+      "ingestionTime": 1785031161244,
+      "eventId": "39807524898658803043345213208062962110045179118775762947"
+    }
+  ]
+}

--- a/specs/001-lambda-log-visibility/evidence/pre-deploy/logshape-ingestion.json
+++ b/specs/001-lambda-log-visibility/evidence/pre-deploy/logshape-ingestion.json
@@ -1,0 +1,359 @@
+{
+  "logGroupName": "/aws/lambda/preprod-sentiment-ingestion",
+  "collectedAt": "2026-07-26T03:50:30.409850+00:00",
+  "windowUsed": "1h",
+  "error": null,
+  "eventCount": 50,
+  "events": [
+    {
+      "logStreamName": "2026/07/26/[$LATEST]874f7416b1df49539b530a357efc0652",
+      "timestamp": 1785036780340,
+      "message": "[INFO]\t2026-07-26T03:33:00.340Z\t2a157ddc-3ca2-4610-86bd-b60cafaf58eb\tIngestion metrics\n",
+      "ingestionTime": 1785036789353,
+      "eventId": "39807650408367817633618791732128721681387481946901315584"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]874f7416b1df49539b530a357efc0652",
+      "timestamp": 1785036780411,
+      "message": "[ERROR]\t2026-07-26T03:33:00.411Z\t2a157ddc-3ca2-4610-86bd-b60cafaf58eb\tFailed to publish CloudWatch metrics: An error occurred (AccessDenied) when calling the PutMetricData operation: User: arn:aws:sts::218795110243:assumed-role/preprod-ingestion-lambda-role/preprod-sentiment-ingestion is not authorized to perform: cloudwatch:PutMetricData because no identity-based policy allows the cloudwatch:PutMetricData action\n",
+      "ingestionTime": 1785036789353,
+      "eventId": "39807650409951170542714465975177757678745515613825925121"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]874f7416b1df49539b530a357efc0652",
+      "timestamp": 1785036780672,
+      "message": "[INFO]\t2026-07-26T03:33:00.671Z\t2a157ddc-3ca2-4610-86bd-b60cafaf58eb\tFinancial ingestion completed\n",
+      "ingestionTime": 1785036789353,
+      "eventId": "39807650415771665039530958615118580147906737966886813698"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]874f7416b1df49539b530a357efc0652",
+      "timestamp": 1785036780680,
+      "message": "END RequestId: 2a157ddc-3ca2-4610-86bd-b60cafaf58eb\n",
+      "ingestionTime": 1785036789353,
+      "eventId": "39807650415950071001119203600250865894087924858934657027"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]874f7416b1df49539b530a357efc0652",
+      "timestamp": 1785036780680,
+      "message": "REPORT RequestId: 2a157ddc-3ca2-4610-86bd-b60cafaf58eb\tDuration: 20350.12 ms\tBilled Duration: 20351 ms\tMemory Size: 512 MB\tMax Memory Used: 147 MB\t\nXRAY TraceId: 1-6a657fd8-6dc606636154bf736482711f\tSegmentId: 7efba0e6736fb8ca\tSampled: true\t\n",
+      "ingestionTime": 1785036789353,
+      "eventId": "39807650415950071001119203600250865894087924858934657028"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]874f7416b1df49539b530a357efc0652",
+      "timestamp": 1785037060268,
+      "message": "START RequestId: 2a2df489-2064-4ab4-9025-5c1850ea5fb8 Version: $LATEST\n",
+      "ingestionTime": 1785037069515,
+      "eventId": "39807656650970819567899066834634435423329647023285600256"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]874f7416b1df49539b530a357efc0652",
+      "timestamp": 1785037060281,
+      "message": "[INFO]\t2026-07-26T03:37:40.281Z\t2a2df489-2064-4ab4-9025-5c1850ea5fb8\tFinancial ingestion started\n",
+      "ingestionTime": 1785037069515,
+      "eventId": "39807656651260729255479964935474399760874075722863345665"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]874f7416b1df49539b530a357efc0652",
+      "timestamp": 1785037060321,
+      "message": "[INFO]\t2026-07-26T03:37:40.321Z\t2a2df489-2064-4ab4-9025-5c1850ea5fb8\tFound active tickers\n",
+      "ingestionTime": 1785037069515,
+      "eventId": "39807656652152759063421189861135828491780010183102562306"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]874f7416b1df49539b530a357efc0652",
+      "timestamp": 1785037060601,
+      "message": "[WARNING]\t2026-07-26T03:37:40.601Z\t2a2df489-2064-4ab4-9025-5c1850ea5fb8\tALERT_TOPIC_ARN not configured, failure alerts will not be sent\n",
+      "ingestionTime": 1785037069515,
+      "eventId": "39807656658396967719009764340765829608121551404777078787"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]874f7416b1df49539b530a357efc0652",
+      "timestamp": 1785037060601,
+      "message": "[INFO]\t2026-07-26T03:37:40.601Z\t2a2df489-2064-4ab4-9025-5c1850ea5fb8\tUsing parallel ingestion mode\n",
+      "ingestionTime": 1785037069515,
+      "eventId": "39807656658396967719009764340765829608121551404777078788"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]874f7416b1df49539b530a357efc0652",
+      "timestamp": 1785037060719,
+      "message": "[WARNING]\t2026-07-26T03:37:40.719Z\t2a2df489-2064-4ab4-9025-5c1850ea5fb8\tParallel fetch failed\n",
+      "ingestionTime": 1785037069515,
+      "eventId": "39807656661028455652436377871467044364294058062482767877"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]874f7416b1df49539b530a357efc0652",
+      "timestamp": 1785037060809,
+      "message": "[ERROR]\t2026-07-26T03:37:40.809Z\t2a2df489-2064-4ab4-9025-5c1850ea5fb8\tFailed to emit metric: An error occurred (AccessDenied) when calling the PutMetricData operation: User: arn:aws:sts::218795110243:assumed-role/preprod-ingestion-lambda-role/preprod-sentiment-ingestion is not authorized to perform: cloudwatch:PutMetricData because no identity-based policy allows the cloudwatch:PutMetricData action\n",
+      "ingestionTime": 1785037069515,
+      "eventId": "39807656663035522720304133954205259008832410598021005318"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]874f7416b1df49539b530a357efc0652",
+      "timestamp": 1785037060810,
+      "message": "[INFO]\t2026-07-26T03:37:40.810Z\t2a2df489-2064-4ab4-9025-5c1850ea5fb8\tParallel fetch complete\n",
+      "ingestionTime": 1785037069515,
+      "eventId": "39807656663057823465502664577346794727105058959526985735"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]874f7416b1df49539b530a357efc0652",
+      "timestamp": 1785037060810,
+      "message": "[WARNING]\t2026-07-26T03:37:40.810Z\t2a2df489-2064-4ab4-9025-5c1850ea5fb8\tCollection failure recorded\n",
+      "ingestionTime": 1785037069515,
+      "eventId": "39807656663057823465502664577346794727105058959526985736"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]874f7416b1df49539b530a357efc0652",
+      "timestamp": 1785037073365,
+      "message": "[INFO]\t2026-07-26T03:37:53.365Z\t2a2df489-2064-4ab4-9025-5c1850ea5fb8\tIngestion metrics\n",
+      "ingestionTime": 1785037082380,
+      "eventId": "39807656943043679433054638134880332536751780443301216256"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]874f7416b1df49539b530a357efc0652",
+      "timestamp": 1785037073430,
+      "message": "[ERROR]\t2026-07-26T03:37:53.430Z\t2a2df489-2064-4ab4-9025-5c1850ea5fb8\tFailed to publish CloudWatch metrics: An error occurred (AccessDenied) when calling the PutMetricData operation: User: arn:aws:sts::218795110243:assumed-role/preprod-ingestion-lambda-role/preprod-sentiment-ingestion is not authorized to perform: cloudwatch:PutMetricData because no identity-based policy allows the cloudwatch:PutMetricData action\n",
+      "ingestionTime": 1785037082380,
+      "eventId": "39807656944493227870959128639080154224473923941189943297"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]874f7416b1df49539b530a357efc0652",
+      "timestamp": 1785037073702,
+      "message": "[INFO]\t2026-07-26T03:37:53.701Z\t2a2df489-2064-4ab4-9025-5c1850ea5fb8\tFinancial ingestion completed\n",
+      "ingestionTime": 1785037082380,
+      "eventId": "39807656950559030564959458133577869594634278270816616450"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]874f7416b1df49539b530a357efc0652",
+      "timestamp": 1785037073704,
+      "message": "END RequestId: 2a2df489-2064-4ab4-9025-5c1850ea5fb8\n",
+      "ingestionTime": 1785037082380,
+      "eventId": "39807656950603632055356519379860941031179574993828577283"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]874f7416b1df49539b530a357efc0652",
+      "timestamp": 1785037073704,
+      "message": "REPORT RequestId: 2a2df489-2064-4ab4-9025-5c1850ea5fb8\tDuration: 13435.38 ms\tBilled Duration: 13436 ms\tMemory Size: 512 MB\tMax Memory Used: 147 MB\t\nXRAY TraceId: 1-6a658104-15a369527edc883441d0e95e\tSegmentId: 6568bdee3ddf3ce6\tSampled: true\t\n",
+      "ingestionTime": 1785037082380,
+      "eventId": "39807656950603632055356519379860941031179574993828577284"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]ba9822b943164262ad127ca4e0bdbb9a",
+      "timestamp": 1785037263355,
+      "message": "INIT_START Runtime Version: python:3.13.mainlinev2.v18\tRuntime Version ARN: arn:aws:lambda:us-east-1::runtime:85016a02049aea54df8f85632acb695fe6e1c8623b63b4ed1d582917e22e8e4d\n",
+      "ingestionTime": 1785037263895,
+      "eventId": "39807661179962259701887729014689985232613701355652972544"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]113c22287261471d8c6e851185725d82",
+      "timestamp": 1785037360628,
+      "message": "INIT_START Runtime Version: python:3.13.mainlinev2.v18\tRuntime Version ARN: arn:aws:lambda:us-east-1::runtime:85016a02049aea54df8f85632acb695fe6e1c8623b63b4ed1d582917e22e8e4d\n",
+      "ingestionTime": 1785037364696,
+      "eventId": "39807663349222647398557033983154708715136227465900785664"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]113c22287261471d8c6e851185725d82",
+      "timestamp": 1785037362058,
+      "message": "START RequestId: 9a755fad-c24f-43b0-b1b6-18d0abffbedc Version: $LATEST\n",
+      "ingestionTime": 1785037364696,
+      "eventId": "39807663381112713032455825075550785845023384419452780545"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]113c22287261471d8c6e851185725d82",
+      "timestamp": 1785037362059,
+      "message": "[INFO]\t2026-07-26T03:42:42.059Z\t9a755fad-c24f-43b0-b1b6-18d0abffbedc\tFinancial ingestion started\n",
+      "ingestionTime": 1785037364696,
+      "eventId": "39807663381135013777654355698692321563296032780958760962"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]113c22287261471d8c6e851185725d82",
+      "timestamp": 1785037369301,
+      "message": "[INFO]\t2026-07-26T03:42:49.301Z\t9a755fad-c24f-43b0-b1b6-18d0abffbedc\tFound active tickers\n",
+      "ingestionTime": 1785037378317,
+      "eventId": "39807663542637010505413128506160383505344264491596447744"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]113c22287261471d8c6e851185725d82",
+      "timestamp": 1785037369596,
+      "message": "[WARNING]\t2026-07-26T03:42:49.596Z\t9a755fad-c24f-43b0-b1b6-18d0abffbedc\tALERT_TOPIC_ARN not configured, failure alerts will not be sent\n",
+      "ingestionTime": 1785037378317,
+      "eventId": "39807663549215730338979662332913420395775531135860670465"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]113c22287261471d8c6e851185725d82",
+      "timestamp": 1785037369596,
+      "message": "[INFO]\t2026-07-26T03:42:49.596Z\t9a755fad-c24f-43b0-b1b6-18d0abffbedc\tUsing parallel ingestion mode\n",
+      "ingestionTime": 1785037378317,
+      "eventId": "39807663549215730338979662332913420395775531135860670466"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]113c22287261471d8c6e851185725d82",
+      "timestamp": 1785037370393,
+      "message": "[WARNING]\t2026-07-26T03:42:50.393Z\t9a755fad-c24f-43b0-b1b6-18d0abffbedc\tParallel fetch failed\n",
+      "ingestionTime": 1785037378317,
+      "eventId": "39807663566989424262208568976717387859076275256127062019"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]113c22287261471d8c6e851185725d82",
+      "timestamp": 1785037370556,
+      "message": "[ERROR]\t2026-07-26T03:42:50.556Z\t9a755fad-c24f-43b0-b1b6-18d0abffbedc\tFailed to emit metric: An error occurred (AccessDenied) when calling the PutMetricData operation: User: arn:aws:sts::218795110243:assumed-role/preprod-ingestion-lambda-role/preprod-sentiment-ingestion is not authorized to perform: cloudwatch:PutMetricData because no identity-based policy allows the cloudwatch:PutMetricData action\n",
+      "ingestionTime": 1785037378317,
+      "eventId": "39807663570624445729569060548787709937517958181601869828"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]113c22287261471d8c6e851185725d82",
+      "timestamp": 1785037370868,
+      "message": "[INFO]\t2026-07-26T03:42:50.868Z\t9a755fad-c24f-43b0-b1b6-18d0abffbedc\tParallel fetch complete\n",
+      "ingestionTime": 1785037378317,
+      "eventId": "39807663577582278231510614968946854038584246971467759621"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]113c22287261471d8c6e851185725d82",
+      "timestamp": 1785037370868,
+      "message": "[WARNING]\t2026-07-26T03:42:50.868Z\t9a755fad-c24f-43b0-b1b6-18d0abffbedc\tCollection failure recorded\n",
+      "ingestionTime": 1785037378317,
+      "eventId": "39807663577582278231510614968946854038584246971467759622"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]113c22287261471d8c6e851185725d82",
+      "timestamp": 1785037384538,
+      "message": "[INFO]\t2026-07-26T03:43:04.538Z\t9a755fad-c24f-43b0-b1b6-18d0abffbedc\tIngestion metrics\n",
+      "ingestionTime": 1785037393553,
+      "eventId": "39807663882433465095424233332159685825991538203130003456"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]113c22287261471d8c6e851185725d82",
+      "timestamp": 1785037384615,
+      "message": "[ERROR]\t2026-07-26T03:43:04.615Z\t9a755fad-c24f-43b0-b1b6-18d0abffbedc\tFailed to publish CloudWatch metrics: An error occurred (AccessDenied) when calling the PutMetricData operation: User: arn:aws:sts::218795110243:assumed-role/preprod-ingestion-lambda-role/preprod-sentiment-ingestion is not authorized to perform: cloudwatch:PutMetricData because no identity-based policy allows the cloudwatch:PutMetricData action\n",
+      "ingestionTime": 1785037393553,
+      "eventId": "39807663884150622475711091314057936132985462039090495489"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]113c22287261471d8c6e851185725d82",
+      "timestamp": 1785037384731,
+      "message": "[INFO]\t2026-07-26T03:43:04.731Z\t9a755fad-c24f-43b0-b1b6-18d0abffbedc\tSNS batch publish complete\n",
+      "ingestionTime": 1785037393553,
+      "eventId": "39807663886737508918740643598476079452612671973784223746"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]113c22287261471d8c6e851185725d82",
+      "timestamp": 1785037385112,
+      "message": "[INFO]\t2026-07-26T03:43:05.111Z\t9a755fad-c24f-43b0-b1b6-18d0abffbedc\tFinancial ingestion completed\n",
+      "ingestionTime": 1785037393553,
+      "eventId": "39807663895234092839380811015401188114491697707562762243"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]113c22287261471d8c6e851185725d82",
+      "timestamp": 1785037385115,
+      "message": "END RequestId: 9a755fad-c24f-43b0-b1b6-18d0abffbedc\n",
+      "ingestionTime": 1785037393553,
+      "eventId": "39807663895300995074976402884825795269309642792080703492"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]113c22287261471d8c6e851185725d82",
+      "timestamp": 1785037385115,
+      "message": "REPORT RequestId: 9a755fad-c24f-43b0-b1b6-18d0abffbedc\tDuration: 23056.93 ms\tBilled Duration: 24484 ms\tMemory Size: 512 MB\tMax Memory Used: 130 MB\tInit Duration: 1426.08 ms\t\nXRAY TraceId: 1-6a658230-5051985d74f95a4c3c814b1d\tSegmentId: 3dd5d004bdb55067\tSampled: true\t\n",
+      "ingestionTime": 1785037393553,
+      "eventId": "39807663895300995074976402884825795269309642792080703493"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]113c22287261471d8c6e851185725d82",
+      "timestamp": 1785037660322,
+      "message": "START RequestId: 48c8a430-b64e-4d94-875c-1f2518bc6d02 Version: $LATEST\n",
+      "ingestionTime": 1785037669339,
+      "eventId": "39807670032622178926993606130851007800048471090228232192"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]113c22287261471d8c6e851185725d82",
+      "timestamp": 1785037660324,
+      "message": "[INFO]\t2026-07-26T03:47:40.324Z\t48c8a430-b64e-4d94-875c-1f2518bc6d02\tFinancial ingestion started\n",
+      "ingestionTime": 1785037669339,
+      "eventId": "39807670032666780417390667377134079236593767813240193025"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]113c22287261471d8c6e851185725d82",
+      "timestamp": 1785037660362,
+      "message": "[INFO]\t2026-07-26T03:47:40.362Z\t48c8a430-b64e-4d94-875c-1f2518bc6d02\tFound active tickers\n",
+      "ingestionTime": 1785037669339,
+      "eventId": "39807670033514208734934831056512436530954405550467448834"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]113c22287261471d8c6e851185725d82",
+      "timestamp": 1785037660572,
+      "message": "[WARNING]\t2026-07-26T03:47:40.572Z\t48c8a430-b64e-4d94-875c-1f2518bc6d02\tALERT_TOPIC_ARN not configured, failure alerts will not be sent\n",
+      "ingestionTime": 1785037669339,
+      "eventId": "39807670038197365226626261916234937368210561466723336195"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]113c22287261471d8c6e851185725d82",
+      "timestamp": 1785037660573,
+      "message": "[INFO]\t2026-07-26T03:47:40.573Z\t48c8a430-b64e-4d94-875c-1f2518bc6d02\tUsing parallel ingestion mode\n",
+      "ingestionTime": 1785037669339,
+      "eventId": "39807670038219665971824792539376473086483209828229316612"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]113c22287261471d8c6e851185725d82",
+      "timestamp": 1785037660651,
+      "message": "[WARNING]\t2026-07-26T03:47:40.651Z\t48c8a430-b64e-4d94-875c-1f2518bc6d02\tParallel fetch failed\n",
+      "ingestionTime": 1785037669339,
+      "eventId": "39807670039959124097310181144416259111749782025695789061"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]113c22287261471d8c6e851185725d82",
+      "timestamp": 1785037660715,
+      "message": "[ERROR]\t2026-07-26T03:47:40.709Z\t48c8a430-b64e-4d94-875c-1f2518bc6d02\tFailed to emit metric: An error occurred (AccessDenied) when calling the PutMetricData operation: User: arn:aws:sts::218795110243:assumed-role/preprod-ingestion-lambda-role/preprod-sentiment-ingestion is not authorized to perform: cloudwatch:PutMetricData because no identity-based policy allows the cloudwatch:PutMetricData action\n",
+      "ingestionTime": 1785037669339,
+      "eventId": "39807670041386371790016141025474545081199277162078535686"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]113c22287261471d8c6e851185725d82",
+      "timestamp": 1785037660715,
+      "message": "[INFO]\t2026-07-26T03:47:40.715Z\t48c8a430-b64e-4d94-875c-1f2518bc6d02\tParallel fetch complete\n",
+      "ingestionTime": 1785037669339,
+      "eventId": "39807670041386371790016141025474545081199277162078535687"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]113c22287261471d8c6e851185725d82",
+      "timestamp": 1785037660715,
+      "message": "[WARNING]\t2026-07-26T03:47:40.715Z\t48c8a430-b64e-4d94-875c-1f2518bc6d02\tCollection failure recorded\n",
+      "ingestionTime": 1785037669339,
+      "eventId": "39807670041386371790016141025474545081199277162078535688"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]113c22287261471d8c6e851185725d82",
+      "timestamp": 1785037674036,
+      "message": "[INFO]\t2026-07-26T03:47:54.036Z\t48c8a430-b64e-4d94-875c-1f2518bc6d02\tIngestion metrics\n",
+      "ingestionTime": 1785037683050,
+      "eventId": "39807670338454598579642571910447320121795497133245464576"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]113c22287261471d8c6e851185725d82",
+      "timestamp": 1785037674102,
+      "message": "[ERROR]\t2026-07-26T03:47:54.102Z\t48c8a430-b64e-4d94-875c-1f2518bc6d02\tFailed to publish CloudWatch metrics: An error occurred (AccessDenied) when calling the PutMetricData operation: User: arn:aws:sts::218795110243:assumed-role/preprod-ingestion-lambda-role/preprod-sentiment-ingestion is not authorized to perform: cloudwatch:PutMetricData because no identity-based policy allows the cloudwatch:PutMetricData action\n",
+      "ingestionTime": 1785037683050,
+      "eventId": "39807670339926447762745593037788677527790288992640172033"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]113c22287261471d8c6e851185725d82",
+      "timestamp": 1785037674395,
+      "message": "[INFO]\t2026-07-26T03:47:54.395Z\t48c8a430-b64e-4d94-875c-1f2518bc6d02\tFinancial ingestion completed\n",
+      "ingestionTime": 1785037683050,
+      "eventId": "39807670346460566105915065618258642981676258913892433922"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]113c22287261471d8c6e851185725d82",
+      "timestamp": 1785037674398,
+      "message": "END RequestId: 48c8a430-b64e-4d94-875c-1f2518bc6d02\n",
+      "ingestionTime": 1785037683050,
+      "eventId": "39807670346527468341510657487683250136494203998410375171"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]113c22287261471d8c6e851185725d82",
+      "timestamp": 1785037674398,
+      "message": "REPORT RequestId: 48c8a430-b64e-4d94-875c-1f2518bc6d02\tDuration: 14075.09 ms\tBilled Duration: 14076 ms\tMemory Size: 512 MB\tMax Memory Used: 131 MB\t\nXRAY TraceId: 1-6a65835c-79ba6ed74504e4c213bf8093\tSegmentId: 50818ef0ea90fa73\tSampled: true\t\n",
+      "ingestionTime": 1785037683050,
+      "eventId": "39807670346527468341510657487683250136494203998410375172"
+    }
+  ]
+}

--- a/specs/001-lambda-log-visibility/evidence/pre-deploy/logshape-metrics.json
+++ b/specs/001-lambda-log-visibility/evidence/pre-deploy/logshape-metrics.json
@@ -1,0 +1,359 @@
+{
+  "logGroupName": "/aws/lambda/preprod-sentiment-metrics",
+  "collectedAt": "2026-07-26T03:50:36.888455+00:00",
+  "windowUsed": "1h",
+  "error": null,
+  "eventCount": 50,
+  "events": [
+    {
+      "logStreamName": "2026/07/26/[$LATEST]d38c0c49edf04c87ae9ccfdbced20fdc",
+      "timestamp": 1785037683246,
+      "message": "END RequestId: 54265b85-fc8d-4a53-b4e5-144f2fdf6ca6\n",
+      "ingestionTime": 1785037685295,
+      "eventId": "39807670543844461858109611046705184378364454478590115842"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]d38c0c49edf04c87ae9ccfdbced20fdc",
+      "timestamp": 1785037683247,
+      "message": "REPORT RequestId: 54265b85-fc8d-4a53-b4e5-144f2fdf6ca6\tDuration: 633.34 ms\tBilled Duration: 634 ms\tMemory Size: 128 MB\tMax Memory Used: 71 MB\tStatus: error\tError Type: Runtime.ImportModuleError\nXRAY TraceId: 1-6a658338-6fd015a80f9288ae24614956\tSegmentId: b609c7fd81d6cac2\tSampled: true\t\n",
+      "ingestionTime": 1785037685295,
+      "eventId": "39807670543866762603308141669846720096637102840096096259"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]d38c0c49edf04c87ae9ccfdbced20fdc",
+      "timestamp": 1785037685291,
+      "message": "[WARNING]\t2026-07-26T03:48:05.291Z\t\tLAMBDA_WARNING: Unhandled exception. The most likely cause is an issue in the function code. However, in rare cases, a Lambda runtime update can cause unexpected function behavior. For functions using managed runtimes, runtime updates can be triggered by a function change, or can be applied automatically. To determine if the runtime has been updated, check the runtime version in the INIT_START log entry. If this error correlates with a change in the runtime version, you may be able to mitigate this error by temporarily rolling back to the previous runtime version. For more information, see https://docs.aws.amazon.com/lambda/latest/dg/runtimes-update.html\r\n",
+      "ingestionTime": 1785037685295,
+      "eventId": "39807670589449485789104735371145728245930353758320066564"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]d38c0c49edf04c87ae9ccfdbced20fdc",
+      "timestamp": 1785037685291,
+      "message": "[ERROR] Runtime.ImportModuleError: Unable to import module 'handler': No module named 'aws_lambda_powertools'\nTraceback (most recent call last):",
+      "ingestionTime": 1785037685295,
+      "eventId": "39807670589449485789104735371145728245930353758320066565"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]d38c0c49edf04c87ae9ccfdbced20fdc",
+      "timestamp": 1785037685333,
+      "message": "INIT_REPORT Init Duration: 610.17 ms\tPhase: invoke\tStatus: error\tError Type: Runtime.ImportModuleError\n",
+      "ingestionTime": 1785037694351,
+      "eventId": "39807670590386117087443021554038209478725937279095734272"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]d38c0c49edf04c87ae9ccfdbced20fdc",
+      "timestamp": 1785037685333,
+      "message": "START RequestId: 36771c7a-f71a-46e3-98d2-c0a4412b5400 Version: $LATEST\n",
+      "ingestionTime": 1785037694351,
+      "eventId": "39807670590386117087443021554038209478725937279095734273"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]d38c0c49edf04c87ae9ccfdbced20fdc",
+      "timestamp": 1785037685337,
+      "message": "END RequestId: 36771c7a-f71a-46e3-98d2-c0a4412b5400\n",
+      "ingestionTime": 1785037694351,
+      "eventId": "39807670590475320068237144046604352351816530725119655938"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]d38c0c49edf04c87ae9ccfdbced20fdc",
+      "timestamp": 1785037685337,
+      "message": "REPORT RequestId: 36771c7a-f71a-46e3-98d2-c0a4412b5400\tDuration: 619.55 ms\tBilled Duration: 620 ms\tMemory Size: 128 MB\tMax Memory Used: 71 MB\tStatus: error\tError Type: Runtime.ImportModuleError\nXRAY TraceId: 1-6a658374-622c8d5c314474ba6aba891a\tSegmentId: f035f6d97bc26219\tSampled: true\t\n",
+      "ingestionTime": 1785037694351,
+      "eventId": "39807670590475320068237144046604352351816530725119655939"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]d38c0c49edf04c87ae9ccfdbced20fdc",
+      "timestamp": 1785037696879,
+      "message": "[WARNING]\t2026-07-26T03:48:16.879Z\t\tLAMBDA_WARNING: Unhandled exception. The most likely cause is an issue in the function code. However, in rare cases, a Lambda runtime update can cause unexpected function behavior. For functions using managed runtimes, runtime updates can be triggered by a function change, or can be applied automatically. To determine if the runtime has been updated, check the runtime version in the INIT_START log entry. If this error correlates with a change in the runtime version, you may be able to mitigate this error by temporarily rolling back to the previous runtime version. For more information, see https://docs.aws.amazon.com/lambda/latest/dg/runtimes-update.html\r\n",
+      "ingestionTime": 1785037696885,
+      "eventId": "39807670847870521149677596349273287223386165211551563776"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]d38c0c49edf04c87ae9ccfdbced20fdc",
+      "timestamp": 1785037696879,
+      "message": "[ERROR] Runtime.ImportModuleError: Unable to import module 'handler': No module named 'aws_lambda_powertools'\nTraceback (most recent call last):",
+      "ingestionTime": 1785037696885,
+      "eventId": "39807670847870521149677596349273287223386165211551563777"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]d38c0c49edf04c87ae9ccfdbced20fdc",
+      "timestamp": 1785037696917,
+      "message": "INIT_REPORT Init Duration: 608.04 ms\tPhase: invoke\tStatus: error\tError Type: Runtime.ImportModuleError\n",
+      "ingestionTime": 1785037705930,
+      "eventId": "39807670848717949467221760039586105978231853058888695808"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]d38c0c49edf04c87ae9ccfdbced20fdc",
+      "timestamp": 1785037696917,
+      "message": "START RequestId: 501c6069-886b-46f3-aee4-53c1246287e2 Version: $LATEST\n",
+      "ingestionTime": 1785037705930,
+      "eventId": "39807670848717949467221760039586105978231853058888695809"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]d38c0c49edf04c87ae9ccfdbced20fdc",
+      "timestamp": 1785037696920,
+      "message": "END RequestId: 501c6069-886b-46f3-aee4-53c1246287e2\n",
+      "ingestionTime": 1785037705930,
+      "eventId": "39807670848784851702817351909010713133049798143406637058"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]d38c0c49edf04c87ae9ccfdbced20fdc",
+      "timestamp": 1785037696920,
+      "message": "REPORT RequestId: 501c6069-886b-46f3-aee4-53c1246287e2\tDuration: 616.33 ms\tBilled Duration: 617 ms\tMemory Size: 128 MB\tMax Memory Used: 70 MB\tStatus: error\tError Type: Runtime.ImportModuleError\nXRAY TraceId: 1-6a6582c0-5ec4cc1a2fb41e9c048e3649\tSegmentId: 037954508d06bdfb\tSampled: true\t\n",
+      "ingestionTime": 1785037705930,
+      "eventId": "39807670848784851702817351909010713133049798143406637059"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]d38c0c49edf04c87ae9ccfdbced20fdc",
+      "timestamp": 1785037745387,
+      "message": "[WARNING]\t2026-07-26T03:49:05.387Z\t\tLAMBDA_WARNING: Unhandled exception. The most likely cause is an issue in the function code. However, in rare cases, a Lambda runtime update can cause unexpected function behavior. For functions using managed runtimes, runtime updates can be triggered by a function change, or can be applied automatically. To determine if the runtime has been updated, check the runtime version in the INIT_START log entry. If this error correlates with a change in the runtime version, you may be able to mitigate this error by temporarily rolling back to the previous runtime version. For more information, see https://docs.aws.amazon.com/lambda/latest/dg/runtimes-update.html\r\n",
+      "ingestionTime": 1785037745470,
+      "eventId": "39807671929635069240001063757623350632109927592771911680"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]d38c0c49edf04c87ae9ccfdbced20fdc",
+      "timestamp": 1785037745387,
+      "message": "[ERROR] Runtime.ImportModuleError: Unable to import module 'handler': No module named 'aws_lambda_powertools'\nTraceback (most recent call last):",
+      "ingestionTime": 1785037745470,
+      "eventId": "39807671929635069240001063757623350632109927592771911681"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]d38c0c49edf04c87ae9ccfdbced20fdc",
+      "timestamp": 1785037745432,
+      "message": "INIT_REPORT Init Duration: 636.16 ms\tPhase: invoke\tStatus: error\tError Type: Runtime.ImportModuleError\n",
+      "ingestionTime": 1785037745489,
+      "eventId": "39807671930638602773934941799015510550509045052705275904"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]d38c0c49edf04c87ae9ccfdbced20fdc",
+      "timestamp": 1785037745432,
+      "message": "START RequestId: d2298232-2650-42a4-a2ae-b1b0437ae14d Version: $LATEST\n",
+      "ingestionTime": 1785037745489,
+      "eventId": "39807671930638602773934941799015510550509045052705275905"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]d38c0c49edf04c87ae9ccfdbced20fdc",
+      "timestamp": 1785037745437,
+      "message": "END RequestId: d2298232-2650-42a4-a2ae-b1b0437ae14d\n",
+      "ingestionTime": 1785037745489,
+      "eventId": "39807671930750106499927594914723189141872286860235177986"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]d38c0c49edf04c87ae9ccfdbced20fdc",
+      "timestamp": 1785037745437,
+      "message": "REPORT RequestId: d2298232-2650-42a4-a2ae-b1b0437ae14d\tDuration: 647.20 ms\tBilled Duration: 648 ms\tMemory Size: 128 MB\tMax Memory Used: 71 MB\tStatus: error\tError Type: Runtime.ImportModuleError\nXRAY TraceId: 1-6a6583b0-30364c1d1ef4beea3ad133fa\tSegmentId: 2e5cb040a6198cd6\tSampled: true\t\n",
+      "ingestionTime": 1785037745489,
+      "eventId": "39807671930750106499927594914723189141872286860235177987"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]d38c0c49edf04c87ae9ccfdbced20fdc",
+      "timestamp": 1785037752090,
+      "message": "[WARNING]\t2026-07-26T03:49:12.090Z\t\tLAMBDA_WARNING: Unhandled exception. The most likely cause is an issue in the function code. However, in rare cases, a Lambda runtime update can cause unexpected function behavior. For functions using managed runtimes, runtime updates can be triggered by a function change, or can be applied automatically. To determine if the runtime has been updated, check the runtime version in the INIT_START log entry. If this error correlates with a change in the runtime version, you may be able to mitigate this error by temporarily rolling back to the previous runtime version. For more information, see https://docs.aws.amazon.com/lambda/latest/dg/runtimes-update.html\r\n",
+      "ingestionTime": 1785037752111,
+      "eventId": "39807672079116964305751830683365773889673623558500581376"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]d38c0c49edf04c87ae9ccfdbced20fdc",
+      "timestamp": 1785037752090,
+      "message": "[ERROR] Runtime.ImportModuleError: Unable to import module 'handler': No module named 'aws_lambda_powertools'\nTraceback (most recent call last):",
+      "ingestionTime": 1785037752111,
+      "eventId": "39807672079116964305751830683365773889673623558500581377"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]d38c0c49edf04c87ae9ccfdbced20fdc",
+      "timestamp": 1785037752132,
+      "message": "INIT_REPORT Init Duration: 634.78 ms\tPhase: invoke\tStatus: error\tError Type: Runtime.ImportModuleError\n",
+      "ingestionTime": 1785037761147,
+      "eventId": "39807672080053595604090116866234313313975851380569800704"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]d38c0c49edf04c87ae9ccfdbced20fdc",
+      "timestamp": 1785037752132,
+      "message": "START RequestId: 36771c7a-f71a-46e3-98d2-c0a4412b5400 Version: $LATEST\n",
+      "ingestionTime": 1785037761147,
+      "eventId": "39807672080053595604090116866234313313975851380569800705"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]d38c0c49edf04c87ae9ccfdbced20fdc",
+      "timestamp": 1785037752136,
+      "message": "END RequestId: 36771c7a-f71a-46e3-98d2-c0a4412b5400\n",
+      "ingestionTime": 1785037761147,
+      "eventId": "39807672080142798584884239358800456187066444826593722370"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]d38c0c49edf04c87ae9ccfdbced20fdc",
+      "timestamp": 1785037752136,
+      "message": "REPORT RequestId: 36771c7a-f71a-46e3-98d2-c0a4412b5400\tDuration: 644.39 ms\tBilled Duration: 645 ms\tMemory Size: 128 MB\tMax Memory Used: 71 MB\tStatus: error\tError Type: Runtime.ImportModuleError\nXRAY TraceId: 1-6a658374-622c8d5c314474ba6aba891a\tSegmentId: b3d78e52d78ead56\tSampled: true\t\n",
+      "ingestionTime": 1785037761147,
+      "eventId": "39807672080142798584884239358800456187066444826593722371"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]d38c0c49edf04c87ae9ccfdbced20fdc",
+      "timestamp": 1785037762217,
+      "message": "[WARNING]\t2026-07-26T03:49:22.217Z\t\tLAMBDA_WARNING: Unhandled exception. The most likely cause is an issue in the function code. However, in rare cases, a Lambda runtime update can cause unexpected function behavior. For functions using managed runtimes, runtime updates can be triggered by a function change, or can be applied automatically. To determine if the runtime has been updated, check the runtime version in the INIT_START log entry. If this error correlates with a change in the runtime version, you may be able to mitigate this error by temporarily rolling back to the previous runtime version. For more information, see https://docs.aws.amazon.com/lambda/latest/dg/runtimes-update.html\r\n",
+      "ingestionTime": 1785037762221,
+      "eventId": "39807672304956610931271451249920651114339272458992484352"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]d38c0c49edf04c87ae9ccfdbced20fdc",
+      "timestamp": 1785037762217,
+      "message": "[ERROR] Runtime.ImportModuleError: Unable to import module 'handler': No module named 'aws_lambda_powertools'\nTraceback (most recent call last):",
+      "ingestionTime": 1785037762221,
+      "eventId": "39807672304956610931271451249920651114339272458992484353"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]d38c0c49edf04c87ae9ccfdbced20fdc",
+      "timestamp": 1785037762257,
+      "message": "INIT_REPORT Init Duration: 650.70 ms\tPhase: invoke\tStatus: error\tError Type: Runtime.ImportModuleError\n",
+      "ingestionTime": 1785037771270,
+      "eventId": "39807672305848640739212676186521223897012947787901239296"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]d38c0c49edf04c87ae9ccfdbced20fdc",
+      "timestamp": 1785037762257,
+      "message": "START RequestId: cfa775f7-07e7-4b97-b311-5eea166777b9 Version: $LATEST\n",
+      "ingestionTime": 1785037771270,
+      "eventId": "39807672305848640739212676186521223897012947787901239297"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]d38c0c49edf04c87ae9ccfdbced20fdc",
+      "timestamp": 1785037762260,
+      "message": "END RequestId: cfa775f7-07e7-4b97-b311-5eea166777b9\n",
+      "ingestionTime": 1785037771270,
+      "eventId": "39807672305915542974808268055945831051830892872419180546"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]d38c0c49edf04c87ae9ccfdbced20fdc",
+      "timestamp": 1785037762260,
+      "message": "REPORT RequestId: cfa775f7-07e7-4b97-b311-5eea166777b9\tDuration: 659.67 ms\tBilled Duration: 660 ms\tMemory Size: 128 MB\tMax Memory Used: 70 MB\tStatus: error\tError Type: Runtime.ImportModuleError\nXRAY TraceId: 1-6a6582fc-7e11b4a3557a73661fd9a4a1\tSegmentId: fa6191c5eacc5d5e\tSampled: true\t\n",
+      "ingestionTime": 1785037771270,
+      "eventId": "39807672305915542974808268055945831051830892872419180547"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]d38c0c49edf04c87ae9ccfdbced20fdc",
+      "timestamp": 1785037803997,
+      "message": "[WARNING]\t2026-07-26T03:50:03.997Z\t\tLAMBDA_WARNING: Unhandled exception. The most likely cause is an issue in the function code. However, in rare cases, a Lambda runtime update can cause unexpected function behavior. For functions using managed runtimes, runtime updates can be triggered by a function change, or can be applied automatically. To determine if the runtime has been updated, check the runtime version in the INIT_START log entry. If this error correlates with a change in the runtime version, you may be able to mitigate this error by temporarily rolling back to the previous runtime version. For more information, see https://docs.aws.amazon.com/lambda/latest/dg/runtimes-update.html\r\n",
+      "ingestionTime": 1785037804016,
+      "eventId": "39807673236681745325880886153809477526531630709958574080"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]d38c0c49edf04c87ae9ccfdbced20fdc",
+      "timestamp": 1785037803997,
+      "message": "[ERROR] Runtime.ImportModuleError: Unable to import module 'handler': No module named 'aws_lambda_powertools'\nTraceback (most recent call last):",
+      "ingestionTime": 1785037804016,
+      "eventId": "39807673236681745325880886153809477526531630709958574081"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]d38c0c49edf04c87ae9ccfdbced20fdc",
+      "timestamp": 1785037804036,
+      "message": "INIT_REPORT Init Duration: 618.07 ms\tPhase: invoke\tStatus: error\tError Type: Runtime.ImportModuleError\n",
+      "ingestionTime": 1785037805211,
+      "eventId": "39807673237551474388623580457774430531444985994111090688"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]d38c0c49edf04c87ae9ccfdbced20fdc",
+      "timestamp": 1785037804036,
+      "message": "START RequestId: 54265b85-fc8d-4a53-b4e5-144f2fdf6ca6 Version: $LATEST\n",
+      "ingestionTime": 1785037805211,
+      "eventId": "39807673237551474388623580457774430531444985994111090689"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]d38c0c49edf04c87ae9ccfdbced20fdc",
+      "timestamp": 1785037804040,
+      "message": "END RequestId: 54265b85-fc8d-4a53-b4e5-144f2fdf6ca6\n",
+      "ingestionTime": 1785037805211,
+      "eventId": "39807673237640677369417702950340573404535579440135012354"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]d38c0c49edf04c87ae9ccfdbced20fdc",
+      "timestamp": 1785037804040,
+      "message": "REPORT RequestId: 54265b85-fc8d-4a53-b4e5-144f2fdf6ca6\tDuration: 629.05 ms\tBilled Duration: 630 ms\tMemory Size: 128 MB\tMax Memory Used: 71 MB\tStatus: error\tError Type: Runtime.ImportModuleError\nXRAY TraceId: 1-6a658338-6fd015a80f9288ae24614956\tSegmentId: fc9a46c9e5d24394\tSampled: true\t\n",
+      "ingestionTime": 1785037805211,
+      "eventId": "39807673237640677369417702950340573404535579440135012355"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]d38c0c49edf04c87ae9ccfdbced20fdc",
+      "timestamp": 1785037805206,
+      "message": "[WARNING]\t2026-07-26T03:50:05.206Z\t\tLAMBDA_WARNING: Unhandled exception. The most likely cause is an issue in the function code. However, in rare cases, a Lambda runtime update can cause unexpected function behavior. For functions using managed runtimes, runtime updates can be triggered by a function change, or can be applied automatically. To determine if the runtime has been updated, check the runtime version in the INIT_START log entry. If this error correlates with a change in the runtime version, you may be able to mitigate this error by temporarily rolling back to the previous runtime version. For more information, see https://docs.aws.amazon.com/lambda/latest/dg/runtimes-update.html\r\n",
+      "ingestionTime": 1785037805211,
+      "eventId": "39807673263643346270904409533371220910443568956108177412"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]d38c0c49edf04c87ae9ccfdbced20fdc",
+      "timestamp": 1785037805206,
+      "message": "[ERROR] Runtime.ImportModuleError: Unable to import module 'handler': No module named 'aws_lambda_powertools'\nTraceback (most recent call last):",
+      "ingestionTime": 1785037805211,
+      "eventId": "39807673263643346270904409533371220910443568956108177413"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]d38c0c49edf04c87ae9ccfdbced20fdc",
+      "timestamp": 1785037805249,
+      "message": "INIT_REPORT Init Duration: 628.99 ms\tPhase: invoke\tStatus: error\tError Type: Runtime.ImportModuleError\n",
+      "ingestionTime": 1785037806648,
+      "eventId": "39807673264602278314441226330194649426676383050645176320"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]d38c0c49edf04c87ae9ccfdbced20fdc",
+      "timestamp": 1785037805249,
+      "message": "START RequestId: d2298232-2650-42a4-a2ae-b1b0437ae14d Version: $LATEST\n",
+      "ingestionTime": 1785037806648,
+      "eventId": "39807673264602278314441226330194649426676383050645176321"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]d38c0c49edf04c87ae9ccfdbced20fdc",
+      "timestamp": 1785037805253,
+      "message": "END RequestId: d2298232-2650-42a4-a2ae-b1b0437ae14d\n",
+      "ingestionTime": 1785037806648,
+      "eventId": "39807673264691481295235348822760792299766976496669097986"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]d38c0c49edf04c87ae9ccfdbced20fdc",
+      "timestamp": 1785037805253,
+      "message": "REPORT RequestId: d2298232-2650-42a4-a2ae-b1b0437ae14d\tDuration: 639.28 ms\tBilled Duration: 640 ms\tMemory Size: 128 MB\tMax Memory Used: 71 MB\tStatus: error\tError Type: Runtime.ImportModuleError\nXRAY TraceId: 1-6a6583b0-30364c1d1ef4beea3ad133fa\tSegmentId: 6727d7a26c473730\tSampled: true\t\n",
+      "ingestionTime": 1785037806648,
+      "eventId": "39807673264691481295235348822760792299766976496669097987"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]d38c0c49edf04c87ae9ccfdbced20fdc",
+      "timestamp": 1785037806640,
+      "message": "[WARNING]\t2026-07-26T03:50:06.640Z\t\tLAMBDA_WARNING: Unhandled exception. The most likely cause is an issue in the function code. However, in rare cases, a Lambda runtime update can cause unexpected function behavior. For functions using managed runtimes, runtime updates can be triggered by a function change, or can be applied automatically. To determine if the runtime has been updated, check the runtime version in the INIT_START log entry. If this error correlates with a change in the runtime version, you may be able to mitigate this error by temporarily rolling back to the previous runtime version. For more information, see https://docs.aws.amazon.com/lambda/latest/dg/runtimes-update.html\r\n",
+      "ingestionTime": 1785037806648,
+      "eventId": "39807673295622614885597323120070833543930253905463934980"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]d38c0c49edf04c87ae9ccfdbced20fdc",
+      "timestamp": 1785037806640,
+      "message": "[ERROR] Runtime.ImportModuleError: Unable to import module 'handler': No module named 'aws_lambda_powertools'\nTraceback (most recent call last):",
+      "ingestionTime": 1785037806648,
+      "eventId": "39807673295622614885597323120070833543930253905463934981"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]d38c0c49edf04c87ae9ccfdbced20fdc",
+      "timestamp": 1785037806684,
+      "message": "INIT_REPORT Init Duration: 625.13 ms\tPhase: invoke\tStatus: error\tError Type: Runtime.ImportModuleError\n",
+      "ingestionTime": 1785037815701,
+      "eventId": "39807673296603847674332670549242692769200959929368838144"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]d38c0c49edf04c87ae9ccfdbced20fdc",
+      "timestamp": 1785037806684,
+      "message": "START RequestId: a501b050-eab0-4139-867f-aa4e5a929a52 Version: $LATEST\n",
+      "ingestionTime": 1785037815701,
+      "eventId": "39807673296603847674332670549242692769200959929368838145"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]d38c0c49edf04c87ae9ccfdbced20fdc",
+      "timestamp": 1785037806688,
+      "message": "END RequestId: a501b050-eab0-4139-867f-aa4e5a929a52\n",
+      "ingestionTime": 1785037815701,
+      "eventId": "39807673296693050655126793041808835642291553375392759810"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]d38c0c49edf04c87ae9ccfdbced20fdc",
+      "timestamp": 1785037806688,
+      "message": "REPORT RequestId: a501b050-eab0-4139-867f-aa4e5a929a52\tDuration: 634.48 ms\tBilled Duration: 635 ms\tMemory Size: 128 MB\tMax Memory Used: 71 MB\tStatus: error\tError Type: Runtime.ImportModuleError\nXRAY TraceId: 1-6a6583ec-14c99c6f0cac176379bdb195\tSegmentId: 18787ef08efee900\tSampled: true\t\n",
+      "ingestionTime": 1785037815701,
+      "eventId": "39807673296693050655126793041808835642291553375392759811"
+    }
+  ]
+}

--- a/specs/001-lambda-log-visibility/evidence/pre-deploy/logshape-notification.json
+++ b/specs/001-lambda-log-visibility/evidence/pre-deploy/logshape-notification.json
@@ -1,0 +1,8 @@
+{
+  "logGroupName": "/aws/lambda/preprod-sentiment-notification",
+  "collectedAt": "2026-07-26T03:50:38.149835+00:00",
+  "windowUsed": "168h",
+  "error": null,
+  "eventCount": 0,
+  "events": []
+}

--- a/specs/001-lambda-log-visibility/evidence/pre-deploy/logshape-summary.md
+++ b/specs/001-lambda-log-visibility/evidence/pre-deploy/logshape-summary.md
@@ -1,0 +1,34 @@
+# T002 Log-Shape Baseline Summary (pre-deploy)
+
+Collected: 2026-07-26T03:50:21.730314+00:00
+Method: `aws logs filter-log-events --log-group-name /aws/lambda/preprod-sentiment-<fn>`
+(boto3 equivalent), starting at now-1h and widening through 6h/24h/72h/168h until
+>=50 events or the 7-day window was exhausted; kept the most recent 50 events.
+
+Shape classes: platform (START/END/REPORT/INIT), powertools/structured JSON
+(single-line JSON with `level` key), stdlib `[LEVEL]` prefix, tab-separated
+LEVEL (Lambda text-format wrapper), print/other.
+
+| function | window used | events | platform | structured JSON | stdlib [LEVEL] | stdlib tab-LEVEL | print/other |
+|---|---|---|---|---|---|---|---|
+| dashboard | 6h | 50 | 37 | 12 | 1 | 0 | 0 |
+| ingestion | 1h | 50 | 13 | 0 | 37 | 0 | 0 |
+| analysis | 6h | 50 | 20 | 21 | 5 | 0 | 4 |
+| metrics | 1h | 50 | 34 | 0 | 16 | 0 | 0 |
+| notification | 168h | 0 | 0 | 0 | 0 | 0 | 0 |
+| canary | 1h | 50 | 15 | 0 | 35 | 0 | 0 |
+
+## Notes
+
+- **metrics**: the 16 stdlib `[LEVEL]` lines are NOT healthy app logging — they are a
+  crash loop (`LAMBDA_WARNING: Unhandled exception` + `[ERROR] Runtime.ImportModuleError:
+  Unable to import module 'handler': No module named 'aws_lambda_powertools'`). Every
+  invocation has failed at import for at least 7 days. See `metrics-dup-baseline.md`.
+- **notification**: zero events in the full 7-day window — the function has not been
+  invoked (or logs nothing). `logshape-notification.json` records the empty result.
+- **dashboard**: structured JSON lines are aws-lambda-powertools Logger output
+  (`"level"`, `"service"`, `"timestamp"` keys). The single stdlib line was a `[WARNING]`.
+- **ingestion / canary**: no structured JSON at all; application output is entirely
+  stdlib `[LEVEL]` text format.
+- Raw samples: `logshape-<fn>.json` (each contains `windowUsed`, `eventCount`, and the
+  raw `filter_log_events` events, most recent <=50).

--- a/specs/001-lambda-log-visibility/evidence/pre-deploy/metrics-dup-baseline.md
+++ b/specs/001-lambda-log-visibility/evidence/pre-deploy/metrics-dup-baseline.md
@@ -1,0 +1,56 @@
+# T003 FR-004 StructuredLogger Duplication Baseline (pre-deploy)
+
+Collected: 2026-07-26T03:50:39Z (UTC), pre-deploy — log-visibility fix NOT yet deployed.
+Log group: `/aws/lambda/preprod-sentiment-metrics`
+
+## Query
+
+boto3 `filter_log_events(logGroupName="/aws/lambda/preprod-sentiment-metrics",
+startTime=now-24h)`, full pagination, no filter pattern.
+Window: last 24h, **26,036 total events** (8,696 non-platform application/text lines,
+0 single-line JSON lines).
+
+Classification: single-line JSON with a `level` key = StructuredLogger/powertools-shaped;
+`[LEVEL]`-prefixed = stdlib/runtime text. Planned duplication tests:
+(a) identical JSON payload emitted 2+ times, (b) a JSON event's `message` re-emitted
+as a stdlib-wrapped text line within +/-2s of the JSON line.
+
+## Result: baseline VACUOUS — but not for lack of traffic
+
+The metrics Lambda has plenty of traffic, but **every invocation fails at import**:
+
+```
+[ERROR] Runtime.ImportModuleError: Unable to import module 'handler': No module named 'aws_lambda_powertools'
+```
+
+- All application-shaped events in the 24h window are the crash pair
+  (`LAMBDA_WARNING: Unhandled exception` + `Runtime.ImportModuleError`), repeating
+  continuously.
+- Structured JSON lines (CloudWatch pattern `{ $.level = "*" }`) in the last
+  **7 days: 0**.
+- Earliest `Runtime.ImportModuleError` in the 7-day window: 2026-07-19T03:52:01Z —
+  that is the window boundary, so the crash loop is at least 7 days old, likely older.
+
+`src/lib/metrics.py` StructuredLogger never executes because the handler never
+imports. There are no logical events to count, so no ONCE/TWICE verdict is possible.
+
+## Verdict
+
+**Vacuous — re-measure at T024 (after deploy).** Duplication count: N/A
+(0 StructuredLogger events in 7d). The code-path duplication risk is still real on
+paper — StructuredLogger attaches its own JsonFormatter StreamHandler AND propagates
+to the root logger (which in a working Lambda runtime carries the platform text
+handler) — but it cannot be observed until the packaging failure is fixed.
+
+## Side findings (feed R-9 / T005 and the feature premise)
+
+1. The real runtime ImportModuleError line shape is
+   `[ERROR] Runtime.ImportModuleError: <msg>` — no timestamp and no request-id fields
+   between `[ERROR]` and the message. The metric filter in
+   `infrastructure/terraform/modules/monitoring/main.tf:30-41` expects
+   `[time, request_id, level=ERROR*, msg=...]` (level in field 3). Neither shape
+   lines up with the filter.
+2. This live, week-old ImportModuleError is in the **metrics** log group; the only
+   import-error metric filter that exists watches the **dashboard** log group. No
+   alarm has fired for a Lambda that has been 100% failing for 7+ days — consistent
+   with this feature's premise.

--- a/specs/001-lambda-log-visibility/plan.md
+++ b/specs/001-lambda-log-visibility/plan.md
@@ -1,0 +1,172 @@
+# Implementation Plan: Lambda Log Visibility
+
+**Branch**: `001-lambda-log-visibility` | **Date**: 2026-07-25 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/001-lambda-log-visibility/spec.md`
+
+## Summary
+
+Surface INFO-level logs from all first-party modules in the six deployed
+non-SSE Lambdas by raising the root logger level once per entrypoint via a
+shared helper, while pinning third-party HTTP-client loggers to WARNING and
+masking the PII in currently-dark notification lines. Mechanism O2+ (code-level
+root wire with hardening riders) was selected over the platform-level route
+(O1) and the powertools-propagation route (O3) because it is the only option
+whose blast radius is exactly "new INFO lines appear" — every existing log
+line, consumer, and format survives byte-identical by construction. Full
+rationale and the rejected alternatives are in [research.md](research.md).
+
+## Technical Context
+
+**Language/Version**: Python 3.13 (Lambda base image `public.ecr.aws/lambda/python:3.13` for image Lambdas; managed python3.13 runtime for ZIP Lambdas)
+**Primary Dependencies**: stdlib `logging` only for the mechanism; aws-lambda-powertools 3.23.0 already present (dashboard handler) and untouched
+**Storage**: N/A (observability-only; no data-store changes)
+**Testing**: pytest (unit: helper semantics + entrypoint-coverage guard; preprod E2E: log-group assertions via boto3 `filter_log_events`)
+**Target Platform**: AWS Lambda — 6 functions: dashboard (image), analysis (image), ingestion (ZIP), metrics (ZIP), notification (ZIP), canary (ZIP)
+**Project Type**: single (backend Lambdas + shared library)
+**Performance Goals**: zero measurable request-latency impact (level check is an integer compare; handler I/O already async-buffered by runtime)
+**Constraints**: no new AWS resources; SSE untouched (incl. via shared imports); Text log format preserved; existing consumers byte-compatible; INFO floor (never DEBUG)
+**Scale/Scope**: 6 entrypoint files + 1 new shared helper + ~4 masking edits in notification module + 1 coverage-guard unit test + preprod verification additions
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Constitution requirement | Status |
+|---|---|
+| Observability: structured logs for requests (request id, latency, outcome) without raw input text | PASS — powertools JSON request lines (dashboard) unchanged; this feature adds module-level INFO without touching them; FR-012 masks PII before new lines become visible |
+| Security & IAM: least privilege; no new secrets handling | PASS — no IAM change, no new resources (FR-005) |
+| SAST/IaC checks in CI | PASS — code-only change rides existing gates (ruff, bandit, semgrep) |
+| Git workflow: GPG-signed, feature branch, lint/format pre-push | PASS — standing practice on this branch |
+| Rollback: quick rollback support | PASS — single revertable code commit; no config/schema migration |
+| Dashboard/metrics contracts | PASS — no metric shape changes; the one log metric filter untouched (Text preserved) |
+
+No violations. Complexity Tracking section not needed.
+
+**Post-Phase-1 re-check (2026-07-25)**: design artifacts introduce no new
+projects, resources, or patterns beyond one shared helper module; gates
+unchanged — PASS.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/001-lambda-log-visibility/
+├── plan.md              # This file
+├── research.md          # Phase 0: mechanism decision + verified facts
+├── data-model.md        # Phase 1: logging-configuration entities
+├── quickstart.md        # Phase 1: verify-INFO-visibility procedure
+├── contracts/
+│   └── logging-config.md  # Phase 1: helper API + log-shape contract
+├── checklists/
+│   └── requirements.md  # Stage 1 spec-quality checklist
+└── tasks.md             # Stage 7 (/speckit.tasks — not this command)
+```
+
+### Source Code (repository root)
+
+```text
+src/lambdas/shared/
+└── logging_config.py            # NEW: configure_lambda_logging() helper
+
+src/lambdas/dashboard/handler.py     # + configure_lambda_logging() call
+src/lambdas/ingestion/handler.py     # + call (keeps its own setLevel(INFO))
+src/lambdas/analysis/handler.py      # + call (keeps its own setLevel(INFO))
+src/lambdas/metrics/handler.py       # + call (currently configures nothing)
+src/lambdas/notification/handler.py  # + call (keeps LOG_LEVEL env read)
+src/lambdas/canary/handler.py        # + call (keeps its own setLevel)
+
+src/lambdas/notification/sendgrid_service.py  # FR-012: mask recipient email
+src/lambdas/notification/handler.py           # FR-012: stop raw-event dump widening (see research R-7)
+
+tests/unit/shared/test_logging_config.py       # helper semantics
+tests/unit/test_entrypoint_logging_coverage.py # guard: every deployed handler calls helper
+tests/e2e/test_log_visibility.py               # preprod: INFO line per function (FR-008)
+```
+
+**Structure Decision**: single-project layout; the only new module is
+`src/lambdas/shared/logging_config.py`. SSE (`src/lambdas/sse_streaming/`)
+deliberately absent from the change set (FR-006); the helper has no
+import-time side effects, so SSE importing other shared modules is unaffected.
+
+## Mechanism Decision (core of this plan)
+
+**Chosen: O2+ — shared root-wire helper with hardening riders.**
+
+`configure_lambda_logging()` in `src/lambdas/shared/logging_config.py`:
+
+1. `logging.getLogger().setLevel(logging.INFO)` — the one-line cure for the
+   diagnosed mechanism (root handler exists on every awslambdaric Lambda;
+   only the level is missing).
+2. Pin noisy/dangerous third-party loggers: `httpx`, `httpcore` →
+   `logging.WARNING` (FR-010; blocks the finnhub key-in-URL exposure path).
+3. Explicitly NO handler creation, NO format change, NO powertools coupling —
+   the function is a level-setter only, idempotent, callable at import time
+   of each entrypoint.
+4. Respects an optional `LOG_LEVEL` env override (existing notification
+   pattern generalized), floor-clamped so DEBUG requires an explicit
+   deliberate value and defaults remain INFO (FR-002).
+
+Riders in the same change:
+
+- FR-012 masking edits in the notification module (currently-dark lines that
+  would newly expose recipient emails).
+- Coverage-guard unit test: walks the six deployed entrypoints and fails if
+  any does not call the helper — this is the testable form of the
+  "future Lambda inherits the fix" design note (a new handler copied from an
+  existing one carries the call; a new handler written from scratch fails
+  the guard the moment it's added to the deployed set).
+- Preprod E2E additions asserting an INFO line from a non-entrypoint module
+  per function (FR-008), alias-qualified invocation for dashboard.
+
+**Why not O1 (terraform `logging_config`, ApplicationLogLevel=INFO)**:
+hard-coupled to JSON format → obligates in-change migration of the
+`dashboard_import_errors` Text-pattern metric filter, re-validation of the
+deploy-pipeline grep, and acceptance of runtime-JSON-wrapping around the
+existing powertools/StructuredLogger JSON lines (nested-JSON consumers).
+It is also NOT actually zero-code: FR-010's httpx pin is code regardless of
+mechanism, because ALC raises the floor for every logger including
+third-party. Post-incident risk appetite (7 defects closed 48h ago) argues
+against the largest observable-shape change. Kept as the signposted future
+migration (see research R-6) since it is the only mechanism that also
+covers a hypothetical 8th Lambda with zero code.
+
+**Why not O3 (powertools + `copy_config_to_registered_loggers`)**: changes
+every stdlib line to JSON (same consumer migration as O1) and adds a
+propagation-rewiring step across 71 registered loggers whose interaction
+with the metrics module's self-handled logger and the five self-leveling
+entrypoints multiplies the FR-004/FR-011 verification surface. The benefits
+(correlation IDs on module lines) are real but belong in the signposted
+structured-logging migration, not in the incident-follow-up visibility fix.
+
+**Why not O4 (67-file sweep)**: maximal diff for the same observable outcome
+as O3; rejected on scale alone.
+
+## Verification Design (FR-008 / SC-001..007)
+
+- **Dashboard (on demand)**: direct alias-qualified invoke of a request that
+  crosses a known INFO site (session refresh → `refresh.*` classification
+  lines, router_v2.py:742/757/762) then `filter_log_events` for the line —
+  this simultaneously executes the SC-006 drill.
+- **Canary**: fires every 5 minutes; assert any non-entrypoint INFO within
+  15 minutes of deploy.
+- **Ingestion/analysis**: next scheduled collection cycle (both emit
+  non-entrypoint INFO on every real run: storage/parallel-fetcher modules).
+- **Metrics**: scheduled run; baseline measurement doubles as its check.
+- **Notification**: synthetic digest trigger (EventBridge test event
+  `{"notification_type": "digest"}`) — empty-digest runs exercise
+  entrypoint INFO only, so the E2E asserts on a masked sendgrid_service
+  line via a test-mode send or accepts the entrypoint line plus the
+  coverage-guard as the evidence pair (decision recorded in tasks).
+- **FR-004 baseline**: before deploy, capture 24h of metrics-Lambda log
+  events and count StructuredLogger duplicates (the propagate=True question);
+  re-run after deploy; assert no additional duplication.
+- **SC-007 content safety**: targeted queries for `token=`, `@`-bearing
+  addresses in new INFO lines across all six groups during the first week.
+
+## Rollback
+
+Single revert of the feature commit restores the status quo (root level
+returns to WARNING). No infrastructure state, no data migration, no consumer
+migration to unwind. This is the smallest-rollback option of the four — a
+deliberate selection criterion 48 hours after a 7-defect incident.

--- a/specs/001-lambda-log-visibility/plan.md
+++ b/specs/001-lambda-log-visibility/plan.md
@@ -79,9 +79,10 @@ src/lambdas/canary/handler.py        # + call (keeps its own setLevel)
 src/lambdas/notification/sendgrid_service.py  # FR-012: mask recipient email
 src/lambdas/notification/handler.py           # FR-012: stop raw-event dump widening (see research R-7)
 
-tests/unit/shared/test_logging_config.py       # helper semantics
-tests/unit/test_entrypoint_logging_coverage.py # guard: every deployed handler calls helper
-tests/e2e/test_log_visibility.py               # preprod: INFO line per function (FR-008)
+tests/unit/shared/test_logging_config.py       # helper semantics (C-1..C-6, C-8)
+tests/unit/test_entrypoint_logging_coverage.py # C-7 guard: GLOB src/lambdas/*/handler.py minus {sse_streaming, chaos_restore}
+tests/e2e/test_log_visibility.py               # preprod: dark-line evidence per function (FR-008)
+scripts/verify-log-visibility.py               # on-demand dashboard probe + SC-006 drill (AR#2 F6)
 ```
 
 **Structure Decision**: single-project layout; the only new module is
@@ -144,25 +145,45 @@ as O3; rejected on scale alone.
 
 ## Verification Design (FR-008 / SC-001..007)
 
-- **Dashboard (on demand)**: direct alias-qualified invoke of a request that
-  crosses a known INFO site (session refresh → `refresh.*` classification
-  lines, router_v2.py:742/757/762) then `filter_log_events` for the line —
-  this simultaneously executes the SC-006 drill.
-- **Canary**: fires every 5 minutes; assert any non-entrypoint INFO within
-  15 minutes of deploy.
-- **Ingestion/analysis**: next scheduled collection cycle (both emit
-  non-entrypoint INFO on every real run: storage/parallel-fetcher modules).
-- **Metrics**: scheduled run; baseline measurement doubles as its check.
-- **Notification**: synthetic digest trigger (EventBridge test event
-  `{"notification_type": "digest"}`) — empty-digest runs exercise
-  entrypoint INFO only, so the E2E asserts on a masked sendgrid_service
-  line via a test-mode send or accepts the entrypoint line plus the
-  coverage-guard as the evidence pair (decision recorded in tasks).
+Universal evidence line (AR#2): the helper's C-8 self-test probe — one
+static INFO line per cold start on the helper's own un-leveled child logger
+— can only appear when root=INFO is live, in every function. Per-function
+checks assert it PLUS the strongest function-specific dark line:
+
+- **Dashboard (on demand)**: `scripts/verify-log-visibility.py` (owned by
+  this feature) performs an alias-qualified invoke of the three session-
+  refresh outcomes (no cookie / garbage cookie / valid session) then
+  `filter_log_events` for `refresh.cookie_absent` / `refresh.rejected` /
+  `refresh.success` (router_v2.py:742/757/762 — verified logger.info on the
+  stdlib logger) — this IS the SC-006 drill.
+- **Canary**: fires every 5 minutes; assert the C-8 self-test line within
+  15 minutes of deploy (AR#2 F1: canary has NO first-party imports — any
+  `[INFO]` grep is a false-positive verifier since its entrypoint self-
+  levels today; only the probe line discriminates).
+- **Ingestion/analysis**: next scheduled cycle; assert SPECIFIC dark module
+  lines (ingestion: storage.py:184 "Storage operation complete"; analysis:
+  sentiment.py INFO sites), not any-`[INFO]`.
+- **Metrics**: C-8 self-test line only (AR#2 F2: no other dark INFO exists
+  in this function; its StructuredLogger lines are visible pre-fix).
+- **Notification**: synthetic empty-digest invoke (flat payload
+  `{"notification_type": "digest"}`, handler accepts it directly); assert
+  the DARK digest_service lines ("Found users due for digest" /
+  "Digest processing complete") — AR#2 F3 established these exist and
+  cannot appear pre-deploy. No email is sent; no test-mode path needed.
 - **FR-004 baseline**: before deploy, capture 24h of metrics-Lambda log
   events and count StructuredLogger duplicates (the propagate=True question);
   re-run after deploy; assert no additional duplication.
-- **SC-007 content safety**: targeted queries for `token=`, `@`-bearing
-  addresses in new INFO lines across all six groups during the first week.
+- **SC-005 p50 procedure (AR#2 F7)**: fixed workload of 20 identical
+  dashboard requests pre- and post-deploy; count INFO events per request-id;
+  compare p50; assert delta ≤10.
+- **SC-003 positive control (AR#2 F8)**: the metric filter's field order may
+  never have matched application lines (pre-existing question, research
+  R-9). Fire one synthetic ImportModuleError-shaped line pre- and
+  post-deploy; identical filter behavior in both = no regression regardless
+  of whether the filter was ever alive.
+- **SC-007 content safety**: targeted queries for `token=` AND `@`-bearing
+  address patterns in new INFO lines across all six groups during the first
+  week (both patterns, per spec).
 
 ## Rollback
 
@@ -170,3 +191,41 @@ Single revert of the feature commit restores the status quo (root level
 returns to WARNING). No infrastructure state, no data migration, no consumer
 migration to unwind. This is the smallest-rollback option of the four — a
 deliberate selection criterion 48 hours after a 7-defect incident.
+
+## Adversarial Review #2
+
+Independent cross-artifact reviewer (post-Clarifications): 14 findings —
+0 CRITICAL, 3 HIGH, 5 MEDIUM, 6 LOW. All resolved in this revision.
+
+**Drift found (Stage 1 → Stage 5)**: the Clarifications pass introduced a
+factually wrong premise (notification empty-digest "exercises only
+entrypoint INFO" — digest_service actually has dark INFO lines that fire on
+every run), and the plan contradicted the settled no-test-mode-send decision.
+Both corrected.
+
+| # | Sev | Finding (compressed) | Resolution |
+|---|-----|----------------------|------------|
+| 1 | HIGH | Canary FR-008 unsatisfiable: no first-party imports exist; quickstart any-INFO grep passes PRE-deploy (false-positive verifier) | C-8 self-test probe line added to helper contract — the only line that discriminates; quickstart + FR-008 rewritten |
+| 2 | HIGH | Metrics function has zero currently-dark INFO (StructuredLogger self-handled, visible today) — its check was circular, SC-002 vacuous for it | Same C-8 probe is its evidence; spec FR-008 amended honestly |
+| 3 | HIGH | Notification Clarification premise false — empty digest DOES emit dark digest_service INFO (count=0 + completion lines, PII-safe); plan reopened settled decision with nonexistent "test-mode send" | Clarification rewritten to use digest_service lines as evidence; plan verification bullet corrected; stronger check than the compromise it replaces |
+| 4 | MEDIUM | Coverage-guard set undefined — hardcoded list would make regression-resistance circular | C-7 now mandates glob src/lambdas/*/handler.py minus documented exclusions {sse_streaming, chaos_restore} |
+| 5 | MEDIUM | C-4 latch contradicted C-1 (external mutation between calls) | Levels re-assert every call; latch scoped to self-test emission only; data-model updated |
+| 6 | MEDIUM | quickstart invoked scripts/verify-log-visibility.py — absent from plan file list; FR-008 on-demand check had no owning artifact | Script added to Project Structure + tasks |
+| 7 | MEDIUM | SC-005 p50 had no defined procedure (FR-004 comparison never touches dashboard) | 20-request fixed-workload p50 procedure added to Verification Design |
+| 8 | MEDIUM | Contract line-shape vs metric-filter field order disagree — filter may never have matched (SC-003 vacuously true) | research R-9 records the pre-existing question; SC-003 gains a positive control; filter fix (if dead) carded separately |
+| 9 | MEDIUM | FR-012 review record incomplete (digest_service, secrets.py, cognito.py unreviewed in R-8) | R-8 completed with reviewed-no-exposure verdicts; repo-wide PII-in-INFO grep recorded clean |
+| 10 | LOW | notification handler:170/220 (+error paths) same already-visible email class as :56, unrecorded | Spec FR-012 recorded-not-endorsed bullet now covers the full set, one card |
+| 11 | LOW | C-6 vs C-2 theoretical conflict if httpx ever deliberately configured | C-6 scoped to "other than root/httpx/httpcore" |
+| 12 | LOW | C-5 wording could be misread vs call-at-entrypoint-import | Clarifying sentence added to C-5 |
+| 13 | LOW | quickstart SC-007 grep missed @-pattern; SC-004 conflicts with deliberate DEBUG window | Both queries in quickstart; SC-004 caveat noted there |
+| 14 | LOW | data-model "applied after root so pins win" — wrong rationale (order not load-bearing) | Rationale corrected (pins win via own explicit level) |
+
+**Cross-artifact consistency**: verified post-edit — spec FR-008/Clarifications,
+plan Verification Design, contract C-1..C-8, data-model, research R-8/R-9, and
+quickstart all describe the same design (probe line + specific dark lines +
+glob-based guard). Verified accurate by AR#2's independent reads:
+router_v2.py:742/757/762 classification set matches the drill exactly; 7
+terraform lambda instantiations confirm the six-function scope; exactly one
+log metric filter repo-wide.
+
+**Gate: 0 CRITICAL, 0 HIGH remaining.**

--- a/specs/001-lambda-log-visibility/quickstart.md
+++ b/specs/001-lambda-log-visibility/quickstart.md
@@ -1,0 +1,47 @@
+# Quickstart: verifying Lambda log visibility
+
+# Target: backend Lambdas (CloudWatch log groups) — not either dashboard UI
+
+## Local (before deploy)
+
+```bash
+source .venv/bin/activate
+pytest tests/unit/shared/test_logging_config.py -v          # helper contract C-1..C-6
+pytest tests/unit/test_entrypoint_logging_coverage.py -v    # C-7 guard
+```
+
+## Preprod (after deploy)
+
+1. Dashboard on-demand probe (also the SC-006 drill — three refresh outcomes):
+
+```bash
+AWS_REGION=us-east-1 .venv/bin/python scripts/verify-log-visibility.py --function dashboard
+# exercises refresh with: no cookie / garbage cookie / valid session
+# then filter_log_events for refresh.cookie_absent, refresh.rejected, refresh.success
+```
+
+2. Canary (fires every 5 min — just wait and query):
+
+```bash
+aws logs filter-log-events --log-group-name /aws/lambda/preprod-sentiment-canary \
+  --start-time $(($(date +%s -d '-20 min')*1000)) --filter-pattern '"[INFO]"' --max-items 5
+```
+
+3. Content-safety spot check (SC-007; expect ZERO hits):
+
+```bash
+for fn in dashboard ingestion analysis metrics notification canary; do
+  aws logs filter-log-events --log-group-name /aws/lambda/preprod-sentiment-$fn \
+    --start-time $(($(date +%s -d '-24 hours')*1000)) \
+    --filter-pattern '"token="' --max-items 3
+done
+```
+
+4. FR-004 baseline comparison: see tasks — captured pre-deploy, re-run
+   post-deploy on the metrics log group; assert no additional duplication.
+
+## Rollback
+
+```bash
+git revert <feature-commit> && git push  # root returns to WARNING on next deploy
+```

--- a/specs/001-lambda-log-visibility/research.md
+++ b/specs/001-lambda-log-visibility/research.md
@@ -1,0 +1,140 @@
+# Research: Lambda Log Visibility
+
+**Date**: 2026-07-25 (diagnosis executed 2026-07-26 UTC)
+**Inputs**: live-account diagnosis agent (CloudWatch + terraform + awslambdaric
+source), Context7 powertools docs pull, local verification against installed
+aws-lambda-powertools 3.23.0, AR#1 code inspection.
+
+## R-1: Darkness mechanism (SETTLED — evidence, not theory)
+
+**Decision basis**: `awslambdaric/bootstrap.py::_setup_logging` ALWAYS attaches
+`LambdaLoggerHandler` to the root logger but calls `setLevel` ONLY when
+`AWS_LAMBDA_LOG_LEVEL` holds a valid level name — which Lambda sets only when
+the function's LoggingConfig has an `ApplicationLogLevel`. All deployed
+functions have `LoggingConfig: {LogFormat: Text}` with no ApplicationLogLevel
+and no LOG_LEVEL/POWERTOOLS_* env. Root therefore sits at Python default
+WARNING; every un-leveled module logger inherits it.
+
+**Live evidence**: 48h window on `/aws/lambda/preprod-sentiment-dashboard`:
+488 stdlib `[WARNING]` events, 0 stdlib `[INFO]` events; 400-event sample =
+282 platform, 104 powertools JSON, 14 stdlib WARNING. The incident's
+"missing" lines were all `logger.info` (router_v2.py:742/757/762,
+auth.py:197); the incident's visible "Token exchange failed" was
+`logger.warning` (cognito.py:198) — consistent, no contradiction.
+
+**Consequence**: the fix is a LEVEL problem, not a handler problem. Any
+mechanism that sets the root level to INFO cures all first-party modules at
+once; no handler/formatter work is needed or wanted.
+
+## R-2: Per-function facts
+
+| Function | Packaging | Startup logging config today | In scope |
+|---|---|---|---|
+| dashboard | image (lambda/python:3.13) | powertools Logger("dashboard") for request lines only; root untouched | YES |
+| analysis | image | own module logger setLevel(INFO) at handler.py:78; log_structured() print-JSON channel | YES |
+| ingestion | ZIP | own module logger setLevel(INFO) at handler.py:116 | YES |
+| metrics | ZIP | NOTHING (no setLevel/basicConfig in handler) | YES (AR#1 add) |
+| notification | ZIP | module logger from LOG_LEVEL env (unset→INFO) at handler.py:33 | YES |
+| canary | ZIP | own module logger setLevel at handler.py:25 | YES (AR#1 add) |
+| sse_streaming | image (python:3.13-slim, custom bootstrap, NO awslambdaric) | basicConfig(INFO) at handler.py:44-47 | NO (owner defer; already INFO) |
+| chaos_restore | code only — NOT deployed (terraform TODO TD-2) | setLevel at handler.py:32 | NO (not deployed) |
+
+Key subtlety: the five existing `setLevel` sites configure each handler's OWN
+module logger, not root — which is why their entrypoint INFO appears while
+their imported modules' INFO stays dark (verified live: ingestion handler
+INFO visible + storage.py:184 INFO absent in the same invocation).
+
+## R-3: ALC coupling (kills O1's "free lunch")
+
+AWS constraint (powertools ALC docs + Lambda platform): `ApplicationLogLevel`
+is only settable with `LogFormat=JSON`. JSON format re-shapes every emitted
+line and wraps stdout free-text (powertools JSON, StructuredLogger JSON,
+prints) in runtime JSON envelopes. Downstream: breaks the repo's single
+Text-pattern metric filter `dashboard_import_errors`
+(modules/monitoring/main.tf:30-41, feeding a CRITICAL alarm), and turns the
+existing structured-JSON lines into nested JSON for their consumers.
+Additionally `AWS_LAMBDA_LOG_LEVEL` outranks POWERTOOLS_LOG_LEVEL (documented
+precedence), a coupling we'd carry forever after.
+
+## R-4: powertools facts (verified against installed 3.23.0)
+
+`aws_lambda_powertools.logging.utils.copy_config_to_registered_loggers(
+source_logger, log_level=None, ignore_log_level=False, exclude=None,
+include=None)` — exists at the canonical path (a Context7-indexed doc page
+showed a different path; local import check settled it). It propagates the
+powertools handler/level across `loggerDict`-registered loggers — the
+sanctioned O3 building block. Powertools Logger does not touch root by
+default. Log-buffering exists in 3.x but is opt-in (`logger_buffer=`);
+irrelevant unless O3 chosen.
+
+## R-5: Third-party logger reality check
+
+botocore/urllib3: chatty at DEBUG, near-silent at INFO — NOT a risk.
+httpx: logs one INFO line per request INCLUDING THE FULL URL; used by
+finnhub.py, tiingo.py, cognito.py, hcaptcha.py. finnhub.py:127 passes the
+API key as a URL query param (`params={"token": self.api_key}`) — root at
+INFO without an httpx pin publishes the key to CloudWatch on every
+ingestion poll. tiingo passes its key via headers (safe from URL logging).
+→ FR-010 pins `httpx` and `httpcore` to WARNING inside the helper,
+mechanism-independent.
+
+## R-6: Mechanism decision
+
+**Decision**: O2+ — shared `configure_lambda_logging()` helper (root
+setLevel(INFO) + third-party pins + LOG_LEVEL override with INFO floor),
+called by the six deployed entrypoints; FR-012 masking riders; coverage-guard
+unit test.
+
+**Rationale**: only option where the entire observable delta is "new INFO
+lines appear" — Text format, every existing line, the metric filter, the
+deploy grep, and the structured-JSON consumers survive byte-identical by
+construction rather than by migration. Fewest moving parts 48h after a
+7-defect incident; single-commit rollback. The helper centralizes what O2
+naively scatters, and the coverage-guard test converts the "new Lambda
+regresses" weakness into a CI-enforced invariant.
+
+**Alternatives considered**:
+- O1 terraform logging_config: rejected for the R-3 coupling; NOT zero-code
+  anyway (httpx pin is code under every option). Signposted as the future
+  migration if/when the project wants platform-level JSON + level control
+  (also the only mechanism covering a Lambda that never calls the helper);
+  revisit alongside any structured-logging initiative. (Per standing owner
+  preference, this architecture decision is deferred as a signpost, not
+  decided now.)
+- O3 powertools propagation: correlation IDs are attractive but it inherits
+  R-3's consumer migration PLUS a 71-logger propagation rewiring whose
+  interaction with the metrics module's self-handled logger (R-7) and five
+  self-leveling entrypoints multiplies verification surface. Deferred to the
+  same signpost.
+- O4 sweep: strictly dominated by O3.
+
+**LoggingConfig version-scoping question** (was flagged for verification):
+moot under O2 — no LoggingConfig change ships. Recorded for the signpost:
+LoggingConfig is a function-level attribute (not version-pinned), so O1
+would not be alias-trapped; the env-var trap (ignore_changes) is also
+avoided by O2 since the helper needs no env var.
+
+## R-7: FR-004 baseline unknown (must measure, not assume)
+
+`src/lib/metrics.py` StructuredLogger attaches its own handler, sets INFO,
+never sets `propagate=False`. Python logging dispatches a created record to
+ALL ancestor handlers regardless of ancestor LOGGER levels — so its records
+plausibly already emit twice (own handler + root LambdaLoggerHandler).
+Whether they do is invisible in code (depends on runtime handler config) and
+MUST be measured pre-deploy on the metrics log group. O2 does not change
+record creation for this logger (its level is already INFO), so the correct
+assertion is "no ADDITIONAL duplication vs baseline" (FR-004 as amended).
+
+## R-8: Content-safety review targets (FR-012)
+
+Newly-visible-line review is scoped to modules handling credentials/PII:
+- notification/sendgrid_service.py:136,141 — full recipient email in
+  currently-dark INFO → mask (e.g., `s***@domain`) in-change.
+- shared/adapters/finnhub.py — covered by httpx pin; key-in-URL itself
+  carded separately (hygiene, out of scope).
+- Already-visible defect recorded not endorsed: notification/handler.py:56
+  raw-event INFO dump (email + live magic-link token) — separate card;
+  this feature must not widen it (it's entrypoint-level, already at INFO;
+  root-level change does not affect it).
+- dashboard/auth.py discipline confirmed good (8-char prefixes,
+  sanitize_for_log, domain-only emails) — no edits needed.

--- a/specs/001-lambda-log-visibility/research.md
+++ b/specs/001-lambda-log-visibility/research.md
@@ -138,3 +138,28 @@ Newly-visible-line review is scoped to modules handling credentials/PII:
   root-level change does not affect it).
 - dashboard/auth.py discipline confirmed good (8-char prefixes,
   sanitize_for_log, domain-only emails) — no edits needed.
+
+AR#2 completion of the review record (FR-012/SC-007 require it recorded;
+each verified REVIEWED, NO EXPOSURE):
+- notification/digest_service.py:153,635,656 — dark INFO, logs counts and
+  sanitized 8-char user ids only; PII-safe (and now notification's FR-008
+  evidence line).
+- shared/secrets.py:244 — "Secret retrieved from Secrets Manager", name-only,
+  no value.
+- shared/auth/cognito.py:157,312 — INFO lines, no values.
+- Cross-repo grep for interpolated PII in INFO lines outside notification:
+  no hits. Content verdict: clean beyond the already-recorded notification
+  entrypoint defects (spec FR-012 records the full set incl. lines 170/220
+  and error-path counterparts).
+
+## R-9: Metric filter field-order discrepancy (AR#2 F8 — pre-existing)
+
+The `dashboard_import_errors` filter pattern assumes field order `[time,
+request_id, level=ERROR*, msg...]` but observed application lines lead with
+`[LEVEL]`. If the filter never matched an application line, it has been dead
+since authoring — a PRE-EXISTING defect, not a regression risk of this
+feature. SC-003 verification includes a positive control (fire a synthetic
+ImportModuleError-shaped line, watch the metric); outcome either proves the
+filter alive (then Text preservation keeps it alive) or proves it
+dead-on-arrival (then card its fix separately; this feature changes nothing
+about it either way).

--- a/specs/001-lambda-log-visibility/spec.md
+++ b/specs/001-lambda-log-visibility/spec.md
@@ -38,6 +38,43 @@ already enables informational logging; deferred by owner constraint; zero
 invocations in 30+ days) and the chaos-restore handler (code exists but the
 function is not deployed — terraform TODO TD-2).
 
+## Clarifications
+
+### Session 2026-07-25 (battleplan autonomy mode — self-answered from evidence; none deferred)
+
+- Q: Which third-party loggers get pinned to WARNING (exact list vs open-ended
+  policy)? → A: Exactly `httpx` and `httpcore` now. Evidence: research R-5 —
+  httpx is the only third-party logger that emits at INFO per request (with
+  full URL, the credential vector); botocore/urllib3 are DEBUG-chatty but
+  INFO-quiet; the analysis Lambda's ML stack writes via stderr prints, not
+  INFO logging. Policy: pin-on-evidence — the SC-004/SC-007 first-week
+  queries are the detection mechanism for any logger that proves this wrong,
+  and adding a pin is a one-line change to the helper.
+- Q: What counts as the notification function's FR-008 evidence, given a
+  synthetic empty-digest run exercises only entrypoint-level INFO and a real
+  send would consume SendGrid quota (100/day) against a real recipient? →
+  A: Accepted evidence pair: (1) synthetic digest trigger produces the
+  entrypoint INFO line in the log group (proves the function's runtime level
+  config), plus (2) the coverage-guard test proves the helper call, plus
+  (3) the masked sendgrid_service line is unit-tested for shape. No real
+  email is sent for verification. Evidence: eventbridge digest test event
+  exists (modules/eventbridge input template); no sandbox-mode send path is
+  wired in sendgrid_service.py; quota constraint is real.
+- Q: SC-005's "bounded, reviewed amount" — what bound? → A: Guardrail: a
+  representative dashboard request adds ≤10 new INFO lines (p50), and
+  projected CloudWatch ingestion delta at current traffic is <$1/month.
+  Evidence: the 48h diagnosis sample (400 events on the busiest group)
+  puts absolute volumes so low that even a 3× multiplier is cents; the
+  ≤10-line figure is verified during the FR-004 before/after comparison.
+- Q: Does a deliberately set LOG_LEVEL=DEBUG env violate FR-002 ("DEBUG
+  suppressed by default")? → A: No. Precedence: explicitly-set LOG_LEVEL
+  (including DEBUG for temporary diagnostics) wins; unset → INFO floor.
+  "By default" in FR-002 means the unset state. Evidence: this generalizes
+  the existing notification pattern (handler.py:33 reads LOG_LEVEL, defaults
+  INFO); contract C-1/C-2 already encode it, and the httpx/httpcore pins
+  hold at WARNING regardless of LOG_LEVEL so the credential path stays
+  closed even under DEBUG.
+
 ## User Scenarios & Testing *(mandatory)*
 
 ### User Story 1 - Operator debugs a production incident from logs (Priority: P1)
@@ -230,16 +267,22 @@ in the enabled output.
   check demonstrating an informational line from a non-entrypoint module
   reaching its log group. The dashboard check MUST be executable on demand;
   the other five MAY use scheduled runs (canary fires every 5 minutes) or a
-  synthetic trigger (e.g., the notification digest's documented test event) —
-  "wait for organic traffic" is not an acceptable verification plan for a
-  function that may not organically emit for a week.
+  synthetic trigger — "wait for organic traffic" is not an acceptable
+  verification plan for a function that may not organically emit for a week.
+  Notification's accepted evidence is the three-part pair from
+  Clarifications (synthetic-digest entrypoint INFO line + coverage-guard
+  test + unit-tested masked line); no real email is sent for verification.
 - **FR-009**: Log severity MUST remain distinguishable per line after the
   change (an operator can filter informational vs warning vs error).
 - **FR-010**: Informational visibility MUST be scoped to first-party module
-  loggers. Third-party HTTP-client loggers (httpx and its dependencies) MUST
-  be pinned to warning-or-stricter as part of this feature. (AR#1 removed the
-  former "or demonstrate no material volume increase" branch: it was
-  satisfiable while leaking a credential at low volume.)
+  loggers. The third-party loggers `httpx` and `httpcore` MUST be pinned to
+  warning-or-stricter as part of this feature, and the pins MUST hold even
+  under an explicit debug-level override (the credential path stays closed
+  in every configuration). Pin list is exact per Clarifications (pin-on-
+  evidence policy; first-week SC-004/SC-007 queries detect any needed
+  additions). (AR#1 removed the former "or demonstrate no material volume
+  increase" branch: it was satisfiable while leaking a credential at low
+  volume.)
 - **FR-011**: Modules and entrypoints that already configure their own
   logging LEVELS retain their current effective levels (no regression to
   stricter levels, no duplicate emission). This preservation covers level
@@ -299,9 +342,10 @@ in the enabled output.
 - **SC-004**: Debug-level lines remain absent from all six log groups
   post-deploy (spot-checked over one week of normal traffic).
 - **SC-005**: Per-invocation log event count on a representative dashboard
-  request increases by a bounded, reviewed amount, and monthly CloudWatch
-  ingestion cost projection stays within the project's existing budget
-  envelope (~$60/month total project spend).
+  request increases by ≤10 new informational lines (p50, measured in the
+  FR-004 before/after comparison), and projected CloudWatch ingestion delta
+  at current traffic is <$1/month — comfortably inside the project's
+  ~$60/month budget envelope.
 - **SC-006** (refresh-classification drill, replaces the former unfalsifiable
   "next incident" criterion): exercising all three session-refresh outcomes
   against preprod (cookie absent; cookie rejected; cookie valid) yields all

--- a/specs/001-lambda-log-visibility/spec.md
+++ b/specs/001-lambda-log-visibility/spec.md
@@ -1,0 +1,239 @@
+# Feature Specification: Lambda Log Visibility
+
+**Feature Branch**: `001-lambda-log-visibility`
+**Created**: 2026-07-26
+**Status**: Draft
+**Input**: User description: "Surface INFO-level application logs in CloudWatch across sentiment-analyzer Lambdas. All five preprod Lambdas have LoggingConfig LogFormat=Text with no ApplicationLogLevel, so the runtime attaches a root handler but never sets the root logger level; Python default WARNING applies and logger.info/debug from ~66 of 67 stdlib-logging modules under src/lambdas is silently dropped (WARNING+ was always visible). Three OAuth-incident bugs were debugged blind via X-Ray because the diagnostics were logger.info calls. Goal: INFO logs from all src/lambdas modules reach CloudWatch on dashboard, ingestion, analysis, notification Lambdas. SSE Lambda out of scope."
+
+## Problem Statement
+
+Application code across the backend emits informational diagnostics that never
+reach the log system. The logging pipeline is configured so that only warnings
+and errors survive; informational messages are silently discarded before they
+are recorded. This is not hypothetical cost: during the 2026-07-25 OAuth
+incident, the exact diagnostic lines written to classify session-refresh
+failures (`refresh.cookie_absent` / `refresh.rejected` / `refresh.success`)
+and session creation events were informational-level and therefore invisible,
+forcing three separate defects to be diagnosed blind through request tracing
+instead of logs.
+
+The failure is silent in both directions: developers writing `logger.info(...)`
+believe they are adding observability, and operators reading CloudWatch believe
+the absence of those lines means the code path did not run. Both beliefs are
+wrong today.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Operator debugs a production incident from logs (Priority: P1)
+
+An operator investigating a misbehaving backend function opens its CloudWatch
+log group and sees the informational diagnostics the code emits (session
+classification lines, state transitions, request outcomes) alongside the
+warnings and errors that were already visible — enough to reconstruct what a
+request did without resorting to X-Ray trace archaeology.
+
+**Why this priority**: This is the incident-response gap that motivated the
+feature. Every hour of blind debugging during an incident is directly
+attributable to this story being unmet.
+
+**Independent Test**: Trigger a known code path in the dashboard function that
+emits an informational diagnostic (e.g., a session refresh), then confirm the
+line appears in the function's CloudWatch log group within the normal log
+delivery delay.
+
+**Acceptance Scenarios**:
+
+1. **Given** the deployed dashboard function, **When** a request executes a
+   code path containing an informational log call in any backend module,
+   **Then** that log line appears in the function's CloudWatch log group.
+2. **Given** the deployed ingestion, analysis, and notification functions,
+   **When** their scheduled or triggered work runs, **Then** informational
+   log lines from their internal modules appear in their respective log groups.
+3. **Given** an operator viewing logs during an incident, **When** they filter
+   the log group for a request's identifier, **Then** informational and
+   warning/error lines for that request are both present and distinguishable
+   by severity.
+
+---
+
+### User Story 2 - Existing log consumers keep working (Priority: P2)
+
+Anyone or anything that already consumes these logs — operators' saved
+queries, the deploy pipeline's checks, alerting/metric rules, and the
+already-visible warning/error lines — continues to work unchanged after the
+fix ships.
+
+**Why this priority**: A visibility fix that breaks existing alarms, breaks
+warning-line greps, or floods the logs would trade one observability failure
+for another. Compatibility is the guardrail on Story 1, not an optional
+nicety.
+
+**Independent Test**: Compare the set and shape of warning/error log lines,
+structured JSON lines from the existing structured-logging paths, and any
+metric-filter matches for a fixed workload before and after the change.
+
+**Acceptance Scenarios**:
+
+1. **Given** the pre-existing warning/error log output, **When** the fix is
+   deployed, **Then** those lines still appear with unchanged severity
+   semantics (no warnings lost, none demoted).
+2. **Given** the existing structured JSON log lines (the dashboard service
+   logger and the metrics module's structured output), **When** the fix is
+   deployed, **Then** those lines continue to appear exactly once per event
+   (no duplication, no wrapping that breaks their parseability).
+3. **Given** any CloudWatch metric filters or alarms defined on these log
+   groups, **When** the fix is deployed, **Then** they continue to match the
+   events they matched before.
+
+---
+
+### User Story 3 - Log volume and cost stay bounded (Priority: P3)
+
+The platform team can predict and bound the log volume increase: the
+visibility floor is informational level (not debug), per-request log storms do
+not appear, and the noisiest known emitters are reviewed so that turning on
+informational logging does not multiply CloudWatch ingestion cost unexpectedly.
+
+**Why this priority**: Cost and noise are real but secondary — a bounded
+increase in log volume is an acceptable price for incident debuggability, and
+the budget guardrail (~$60/month project-wide) has headroom for it only if the
+increase is deliberate.
+
+**Independent Test**: Measure log events per invocation for a representative
+request on the dashboard function before and after; confirm debug-level lines
+remain suppressed and the per-request increase is a bounded, reviewed number.
+
+**Acceptance Scenarios**:
+
+1. **Given** the fix is deployed, **When** a code path containing debug-level
+   log calls executes, **Then** debug lines do NOT appear in the log group.
+2. **Given** a representative dashboard request, **When** logs are counted
+   per invocation after the change, **Then** the increase is attributable to
+   intentional informational diagnostics, not accidental per-item loops.
+
+---
+
+### Edge Cases
+
+- A module that already sets its own logger level explicitly (five handler
+  entrypoints do today) must not be double-affected: its effective level must
+  not become stricter, and its lines must not duplicate.
+- The metrics module's structured logger attaches its own handler; the fix
+  must not cause its events to emit twice (once via its handler, once via the
+  root handler).
+- Third-party library loggers (AWS SDK, HTTP clients, ML libraries) become
+  visible at informational level too; the noisiest (e.g., HTTP request logs
+  per call) could dominate volume — the fix must bound which loggers gain
+  visibility or verify the noisy ones stay quiet.
+- The streaming (SSE) function is explicitly out of scope: it uses a separate
+  startup path that already enables informational logging, it has had zero
+  invocations in over 30 days, and touching it is deferred by owner
+  constraint. The fix must not require changes to it, and must not accidentally
+  alter its behavior via shared modules.
+- A future new Lambda added to the project should inherit the visibility fix
+  by default rather than silently reverting to the dark-logger state
+  (regression resistance).
+- If log delivery configuration and code-level configuration disagree (one
+  says informational, the other warning), the stricter one silently wins —
+  the deployed combination must be verified end-to-end, not assumed from
+  either half.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Informational-level log messages emitted by any backend module
+  in the four batch/request Lambdas (dashboard, ingestion, analysis,
+  notification) MUST be recorded in that function's CloudWatch log group.
+- **FR-002**: Debug-level log messages MUST remain suppressed by default in
+  all deployed environments.
+- **FR-003**: Warning- and error-level log output that is visible today MUST
+  remain visible with unchanged severity semantics.
+- **FR-004**: Existing structured log lines (the dashboard service logger's
+  JSON output and the metrics module's structured JSON output) MUST continue
+  to be emitted exactly once per event and remain machine-parseable as they
+  are today.
+- **FR-005**: The change MUST NOT create new cloud resources; it may only
+  modify configuration or code of existing functions and their delivery
+  settings. (Standing owner constraint.)
+- **FR-006**: The streaming (SSE) function MUST NOT require changes and MUST
+  NOT change observable behavior as a result of this feature, including via
+  modules it shares with other functions.
+- **FR-007**: The visibility configuration MUST be applied through the
+  project's normal delivery pipeline (infrastructure code and/or application
+  code in git), not via console or one-off CLI mutation, so it survives
+  redeploys and is visible in review. (Lesson from the frozen-env
+  incidents: out-of-band configuration is a defect class in this project.)
+- **FR-008**: Each of the four functions MUST have a verifiable post-deploy
+  check demonstrating an informational line from a non-entrypoint module
+  reaching its log group; the check for the dashboard function MUST be
+  executable on demand (the other three may rely on their scheduled/triggered
+  runs).
+- **FR-009**: Log severity MUST remain distinguishable per line after the
+  change (an operator can filter informational vs warning vs error).
+- **FR-010**: Third-party library loggers MUST NOT gain unbounded
+  informational verbosity: the change either scopes visibility to
+  first-party modules or demonstrates that affected third-party loggers do
+  not materially increase per-invocation log volume.
+- **FR-011**: Modules and entrypoints that already configure their own
+  logging levels MUST retain at least their current visibility (no
+  regression to stricter levels, no duplicate emission).
+
+### Key Entities
+
+- **Log line**: A single recorded event with severity, timestamp, request
+  correlation, and message; the unit operators filter and alarms match on.
+- **Log group**: The per-function CloudWatch destination; the boundary at
+  which visibility is verified.
+- **Logger**: A named per-module emitter whose effective severity threshold
+  decides whether a line is recorded; ~67 first-party module loggers exist,
+  plus third-party library loggers.
+- **Delivery configuration**: The function-level settings (format, level
+  floor) that the platform applies before code-level configuration is
+  consulted.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: An informational diagnostic emitted by a non-entrypoint backend
+  module appears in the dashboard function's log group within one deploy
+  cycle of the fix landing (the original incident gap, closed).
+- **SC-002**: 100% of the four in-scope functions show at least one
+  informational line from a non-entrypoint module in their log group within
+  one week of deploy (all four verified, not just dashboard).
+- **SC-003**: Zero regressions in existing log consumers: no lost
+  warning/error lines, no duplicated or malformed structured JSON events, no
+  metric filter/alarm that stops matching (verified by before/after
+  comparison on a fixed workload).
+- **SC-004**: Debug-level lines remain absent from all four log groups
+  post-deploy (spot-checked over one week of normal traffic).
+- **SC-005**: Per-invocation log event count on a representative dashboard
+  request increases by a bounded, reviewed amount, and monthly CloudWatch
+  ingestion cost projection stays within the project's existing budget
+  envelope (~$60/month total project spend).
+- **SC-006**: The next incident's responder can classify a session-refresh
+  failure from CloudWatch logs alone (the specific capability whose absence
+  defined the 2026-07-25 incident experience).
+
+## Assumptions
+
+- The diagnosis of record (2026-07-26, live-evidence-backed): the darkness
+  mechanism is the root logger's default WARNING threshold — the platform
+  attaches a log handler but nothing sets the level, because the functions'
+  delivery configuration specifies no application log level. Warning+ lines
+  were always visible (488 stdlib warning events in a 48h window on the
+  dashboard group; zero stdlib informational events). The fix design may rely
+  on this mechanism.
+- "Informational visibility" is defined at the log-group boundary: a line
+  counts as visible only when it is queryable in CloudWatch, not when it is
+  merely written by code.
+- The five entrypoints that already self-configure levels (analysis,
+  ingestion, notification, canary, chaos-restore handlers) and the metrics
+  module's self-handled structured logger are existing behavior to preserve,
+  not defects to fix here.
+- Choosing between delivery-level configuration, code-level configuration, or
+  structured-logging adoption (and any combination) is a planning decision;
+  this spec constrains outcomes (FR-001..FR-011), not mechanism.
+- Production functions follow the same fix through the normal pipeline;
+  preprod is the verification environment.

--- a/specs/001-lambda-log-visibility/spec.md
+++ b/specs/001-lambda-log-visibility/spec.md
@@ -1,9 +1,13 @@
 # Feature Specification: Lambda Log Visibility
 
 **Feature Branch**: `001-lambda-log-visibility`
-**Created**: 2026-07-26
+**Created**: 2026-07-25
 **Status**: Draft
 **Input**: User description: "Surface INFO-level application logs in CloudWatch across sentiment-analyzer Lambdas. All five preprod Lambdas have LoggingConfig LogFormat=Text with no ApplicationLogLevel, so the runtime attaches a root handler but never sets the root logger level; Python default WARNING applies and logger.info/debug from ~66 of 67 stdlib-logging modules under src/lambdas is silently dropped (WARNING+ was always visible). Three OAuth-incident bugs were debugged blind via X-Ray because the diagnostics were logger.info calls. Goal: INFO logs from all src/lambdas modules reach CloudWatch on dashboard, ingestion, analysis, notification Lambdas. SSE Lambda out of scope."
+
+> Inventory correction (AR#1): the input's "five Lambdas / four in scope" was
+> wrong. Terraform deploys SEVEN lambda modules; six are live non-SSE
+> functions and all six are in scope. See Scope below.
 
 ## Problem Statement
 
@@ -21,6 +25,18 @@ The failure is silent in both directions: developers writing `logger.info(...)`
 believe they are adding observability, and operators reading CloudWatch believe
 the absence of those lines means the code path did not run. Both beliefs are
 wrong today.
+
+## Scope
+
+**In scope — the six deployed non-streaming functions** (all instantiate the
+shared lambda terraform module; all use the standard runtime whose root-level
+default causes the darkness): dashboard, ingestion, analysis, **metrics**,
+notification, canary.
+
+**Out of scope**: the streaming (SSE) function (separate startup path that
+already enables informational logging; deferred by owner constraint; zero
+invocations in 30+ days) and the chaos-restore handler (code exists but the
+function is not deployed — terraform TODO TD-2).
 
 ## User Scenarios & Testing *(mandatory)*
 
@@ -46,9 +62,9 @@ delivery delay.
 1. **Given** the deployed dashboard function, **When** a request executes a
    code path containing an informational log call in any backend module,
    **Then** that log line appears in the function's CloudWatch log group.
-2. **Given** the deployed ingestion, analysis, and notification functions,
-   **When** their scheduled or triggered work runs, **Then** informational
-   log lines from their internal modules appear in their respective log groups.
+2. **Given** the other five in-scope functions, **When** their scheduled,
+   triggered, or synthetically invoked work runs, **Then** informational log
+   lines from their internal modules appear in their respective log groups.
 3. **Given** an operator viewing logs during an incident, **When** they filter
    the log group for a request's identifier, **Then** informational and
    warning/error lines for that request are both present and distinguishable
@@ -69,39 +85,59 @@ for another. Compatibility is the guardrail on Story 1, not an optional
 nicety.
 
 **Independent Test**: Compare the set and shape of warning/error log lines,
-structured JSON lines from the existing structured-logging paths, and any
-metric-filter matches for a fixed workload before and after the change.
+structured JSON lines from the existing structured-logging paths, and the
+known log-consumer inventory (below) for a fixed workload before and after
+the change.
+
+**Known log-consumer inventory** (established by AR#1 code inspection — this
+is the complete acceptance set for compatibility):
+
+1. The single log metric filter `dashboard_import_errors` on the dashboard
+   log group — a Text-format, space-delimited pattern feeding a CRITICAL
+   alarm. (The only artifact that structurally breaks if the log format
+   flips to JSON.)
+2. The deploy pipeline's post-deploy smoke grep of dashboard logs for
+   import-error strings (case-insensitive substring match; format-tolerant).
+3. Per-function error/duration alarms — metric-based, not log-pattern-based;
+   unaffected by line shape.
+4. The dashboard service logger's JSON lines and the metrics module's
+   structured JSON output (machine-parsed by operators).
 
 **Acceptance Scenarios**:
 
 1. **Given** the pre-existing warning/error log output, **When** the fix is
    deployed, **Then** those lines still appear with unchanged severity
    semantics (no warnings lost, none demoted).
-2. **Given** the existing structured JSON log lines (the dashboard service
-   logger and the metrics module's structured output), **When** the fix is
-   deployed, **Then** those lines continue to appear exactly once per event
-   (no duplication, no wrapping that breaks their parseability).
-3. **Given** any CloudWatch metric filters or alarms defined on these log
-   groups, **When** the fix is deployed, **Then** they continue to match the
-   events they matched before.
+2. **Given** the existing structured JSON log lines, **When** the fix is
+   deployed, **Then** those lines show no ADDITIONAL duplication or wrapping
+   relative to the measured pre-deploy baseline (see FR-004 — the baseline
+   itself must be measured, not assumed).
+3. **Given** the log-consumer inventory above, **When** the fix is deployed,
+   **Then** each consumer continues to match/parse the events it did before,
+   or (if the chosen mechanism changes line format) has been migrated in the
+   same change with before/after proof.
 
 ---
 
-### User Story 3 - Log volume and cost stay bounded (Priority: P3)
+### User Story 3 - Log volume and content stay bounded and safe (Priority: P3)
 
-The platform team can predict and bound the log volume increase: the
-visibility floor is informational level (not debug), per-request log storms do
-not appear, and the noisiest known emitters are reviewed so that turning on
-informational logging does not multiply CloudWatch ingestion cost unexpectedly.
+The platform team can predict and bound the log volume increase, and — more
+importantly — turning on informational visibility does not start recording
+secrets or personal data that today's suppression was accidentally hiding.
+The visibility floor is informational level (not debug), per-request log
+storms do not appear, and every newly visible log call site in modules that
+handle credentials or personal data is reviewed before enablement.
 
-**Why this priority**: Cost and noise are real but secondary — a bounded
-increase in log volume is an acceptable price for incident debuggability, and
-the budget guardrail (~$60/month project-wide) has headroom for it only if the
-increase is deliberate.
+**Why this priority**: Cost and noise are real but secondary. Content safety
+is not: this feature's entire effect is to make previously-invisible lines
+visible, so any credential or PII sitting in a dark `logger.info` call
+becomes a CloudWatch exposure the moment the feature ships. The review is the
+feature's safety gate, not an optional audit.
 
 **Independent Test**: Measure log events per invocation for a representative
-request on the dashboard function before and after; confirm debug-level lines
-remain suppressed and the per-request increase is a bounded, reviewed number.
+request before and after; confirm debug-level lines remain suppressed; run
+the newly-visible-call-site review and confirm zero credential/PII exposures
+in the enabled output.
 
 **Acceptance Scenarios**:
 
@@ -110,74 +146,124 @@ remain suppressed and the per-request increase is a bounded, reviewed number.
 2. **Given** a representative dashboard request, **When** logs are counted
    per invocation after the change, **Then** the increase is attributable to
    intentional informational diagnostics, not accidental per-item loops.
+3. **Given** the third-party HTTP client's per-request informational logging
+   and the external-API adapter that passes its credential in the request
+   URL, **When** the fix is enabled, **Then** no credential appears in any
+   log group (the HTTP client's logger is pinned to warning-or-stricter, and
+   the enablement review confirms it).
+4. **Given** the notification module's currently-dark informational lines
+   that include recipient email addresses, **When** the fix is enabled,
+   **Then** those lines are masked or redacted before they become visible
+   (personal data must not be newly exposed by this feature).
 
 ---
 
 ### Edge Cases
 
-- A module that already sets its own logger level explicitly (five handler
-  entrypoints do today) must not be double-affected: its effective level must
-  not become stricter, and its lines must not duplicate.
-- The metrics module's structured logger attaches its own handler; the fix
-  must not cause its events to emit twice (once via its handler, once via the
-  root handler).
-- Third-party library loggers (AWS SDK, HTTP clients, ML libraries) become
-  visible at informational level too; the noisiest (e.g., HTTP request logs
-  per call) could dominate volume — the fix must bound which loggers gain
-  visibility or verify the noisy ones stay quiet.
+- A module that already sets its own logger level explicitly (analysis,
+  ingestion, notification, canary entrypoints today; chaos-restore in code
+  only) must not be double-affected: its effective level must not become
+  stricter, and its lines must not duplicate.
+- The metrics module's structured logger attaches its own handler and does
+  not disable propagation — records plausibly reach both its handler and the
+  root handler. Whether that already double-emits today is UNKNOWN; the
+  pre-deploy baseline measurement (FR-004) must settle it before the
+  after-state can be judged.
+- The specific noisy third-party logger is the HTTP client (httpx), which
+  logs one informational line per request including the full request URL —
+  this is both the volume risk and the credential risk (one adapter passes
+  its API key as a URL parameter). The AWS SDK and its transport are quiet at
+  informational level (chatty only at debug) and are not the concern.
 - The streaming (SSE) function is explicitly out of scope: it uses a separate
   startup path that already enables informational logging, it has had zero
   invocations in over 30 days, and touching it is deferred by owner
-  constraint. The fix must not require changes to it, and must not accidentally
-  alter its behavior via shared modules.
-- A future new Lambda added to the project should inherit the visibility fix
-  by default rather than silently reverting to the dark-logger state
-  (regression resistance).
+  constraint. The fix must not require changes to it, and must not
+  accidentally alter its behavior via shared modules (several of its modules
+  import shared code).
 - If log delivery configuration and code-level configuration disagree (one
   says informational, the other warning), the stricter one silently wins —
-  the deployed combination must be verified end-to-end, not assumed from
-  either half.
+  the deployed combination must be verified end-to-end against the
+  alias-qualified live invocation path, not assumed from either half.
+- Design note (non-normative): the most regression-resistant mechanism is one
+  that lives where every function inherits it (all seven instantiate the same
+  shared terraform module), so a future Lambda does not silently revert to
+  the dark-logger state. If the chosen mechanism achieves this, verification
+  is by inspection of the shared module; if not, this remains an accepted
+  gap, documented in the plan.
 
 ## Requirements *(mandatory)*
 
 ### Functional Requirements
 
 - **FR-001**: Informational-level log messages emitted by any backend module
-  in the four batch/request Lambdas (dashboard, ingestion, analysis,
-  notification) MUST be recorded in that function's CloudWatch log group.
+  in the six in-scope functions (dashboard, ingestion, analysis, metrics,
+  notification, canary) MUST be recorded in that function's CloudWatch log
+  group.
 - **FR-002**: Debug-level log messages MUST remain suppressed by default in
   all deployed environments.
 - **FR-003**: Warning- and error-level log output that is visible today MUST
   remain visible with unchanged severity semantics.
-- **FR-004**: Existing structured log lines (the dashboard service logger's
-  JSON output and the metrics module's structured JSON output) MUST continue
-  to be emitted exactly once per event and remain machine-parseable as they
-  are today.
+- **FR-004**: Structured log lines (the dashboard service logger's JSON
+  output and the metrics module's structured JSON output) MUST show no
+  additional duplication or format corruption relative to a pre-deploy
+  baseline. The baseline (including whether the metrics module's structured
+  logger already double-emits due to propagation) MUST be measured and
+  recorded before the fix is enabled, not assumed.
 - **FR-005**: The change MUST NOT create new cloud resources; it may only
   modify configuration or code of existing functions and their delivery
-  settings. (Standing owner constraint.)
+  settings. Modifying the existing log metric filter's pattern (if the
+  chosen mechanism changes line format) is a permitted modification, not a
+  new resource. (Standing owner constraint.)
 - **FR-006**: The streaming (SSE) function MUST NOT require changes and MUST
   NOT change observable behavior as a result of this feature, including via
   modules it shares with other functions.
 - **FR-007**: The visibility configuration MUST be applied through the
   project's normal delivery pipeline (infrastructure code and/or application
-  code in git), not via console or one-off CLI mutation, so it survives
-  redeploys and is visible in review. (Lesson from the frozen-env
-  incidents: out-of-band configuration is a defect class in this project.)
-- **FR-008**: Each of the four functions MUST have a verifiable post-deploy
+  code in git), not via console or one-off CLI mutation. Two project-specific
+  traps MUST be respected: (a) the shared lambda module ignores drift on
+  environment variables, so any environment-variable mechanism MUST go
+  through the established CI wiring-script pattern rather than a terraform
+  `environment` edit that will silently no-op; (b) live traffic invokes a
+  pinned alias, so configuration applied to the unpublished version is not
+  live until publish — verification MUST target the alias-qualified path.
+- **FR-008**: Each of the six functions MUST have a verifiable post-deploy
   check demonstrating an informational line from a non-entrypoint module
-  reaching its log group; the check for the dashboard function MUST be
-  executable on demand (the other three may rely on their scheduled/triggered
-  runs).
+  reaching its log group. The dashboard check MUST be executable on demand;
+  the other five MAY use scheduled runs (canary fires every 5 minutes) or a
+  synthetic trigger (e.g., the notification digest's documented test event) —
+  "wait for organic traffic" is not an acceptable verification plan for a
+  function that may not organically emit for a week.
 - **FR-009**: Log severity MUST remain distinguishable per line after the
   change (an operator can filter informational vs warning vs error).
-- **FR-010**: Third-party library loggers MUST NOT gain unbounded
-  informational verbosity: the change either scopes visibility to
-  first-party modules or demonstrates that affected third-party loggers do
-  not materially increase per-invocation log volume.
+- **FR-010**: Informational visibility MUST be scoped to first-party module
+  loggers. Third-party HTTP-client loggers (httpx and its dependencies) MUST
+  be pinned to warning-or-stricter as part of this feature. (AR#1 removed the
+  former "or demonstrate no material volume increase" branch: it was
+  satisfiable while leaking a credential at low volume.)
 - **FR-011**: Modules and entrypoints that already configure their own
-  logging levels MUST retain at least their current visibility (no
-  regression to stricter levels, no duplicate emission).
+  logging LEVELS retain their current effective levels (no regression to
+  stricter levels, no duplicate emission). This preservation covers level
+  configuration ONLY — it does not endorse the CONTENT of existing log
+  calls; known content defects are listed under FR-012 and carded, not
+  protected.
+- **FR-012** (content safety): Enabling informational visibility MUST NOT
+  newly expose secrets, credentials, or personal data (CWE-312). Before
+  enablement, every currently-dark informational call site in modules that
+  handle credentials or personal data MUST be reviewed; identified exposures
+  MUST be fixed or masked in the same change. Known cases from AR#1 that this
+  requirement covers:
+  - The external market-data adapter that passes its API key as a URL
+    parameter, combined with the HTTP client's URL logging (blocked by
+    FR-010's pin; the key-in-URL pattern itself is carded as separate
+    hygiene).
+  - The notification module's currently-dark lines logging full recipient
+    email addresses (must be masked before they become visible).
+  - Already-visible today and OUT of this feature's causal scope, but
+    recorded so preservation is not misread as endorsement: the notification
+    entrypoint logs the raw invocation event, which for magic-link events
+    contains the recipient email and a live sign-in token. This pre-existing
+    CWE-312 defect MUST be carded as its own fix; this feature MUST NOT
+    widen it.
 
 ### Key Entities
 
@@ -186,11 +272,13 @@ remain suppressed and the per-request increase is a bounded, reviewed number.
 - **Log group**: The per-function CloudWatch destination; the boundary at
   which visibility is verified.
 - **Logger**: A named per-module emitter whose effective severity threshold
-  decides whether a line is recorded; ~67 first-party module loggers exist,
-  plus third-party library loggers.
+  decides whether a line is recorded; 71 first-party modules create loggers
+  (67 emit calls), plus third-party library loggers.
 - **Delivery configuration**: The function-level settings (format, level
   floor) that the platform applies before code-level configuration is
   consulted.
+- **Log consumer**: Anything that parses or matches recorded lines — the one
+  metric filter, the deploy smoke grep, and human operators' queries.
 
 ## Success Criteria *(mandatory)*
 
@@ -199,41 +287,80 @@ remain suppressed and the per-request increase is a bounded, reviewed number.
 - **SC-001**: An informational diagnostic emitted by a non-entrypoint backend
   module appears in the dashboard function's log group within one deploy
   cycle of the fix landing (the original incident gap, closed).
-- **SC-002**: 100% of the four in-scope functions show at least one
+- **SC-002**: 100% of the six in-scope functions show at least one
   informational line from a non-entrypoint module in their log group within
-  one week of deploy (all four verified, not just dashboard).
-- **SC-003**: Zero regressions in existing log consumers: no lost
-  warning/error lines, no duplicated or malformed structured JSON events, no
-  metric filter/alarm that stops matching (verified by before/after
-  comparison on a fixed workload).
-- **SC-004**: Debug-level lines remain absent from all four log groups
+  one week of deploy, using synthetic triggers where organic traffic does not
+  exercise one (all six verified, not just dashboard).
+- **SC-003**: Zero regressions across the named log-consumer inventory: no
+  lost warning/error lines, no additional structured-JSON duplication versus
+  the measured baseline, the metric filter still fires on its target
+  pattern (migrated in-change if format changed), and the deploy smoke grep
+  still matches. Verified by before/after comparison on a fixed workload.
+- **SC-004**: Debug-level lines remain absent from all six log groups
   post-deploy (spot-checked over one week of normal traffic).
 - **SC-005**: Per-invocation log event count on a representative dashboard
   request increases by a bounded, reviewed amount, and monthly CloudWatch
   ingestion cost projection stays within the project's existing budget
   envelope (~$60/month total project spend).
-- **SC-006**: The next incident's responder can classify a session-refresh
-  failure from CloudWatch logs alone (the specific capability whose absence
-  defined the 2026-07-25 incident experience).
+- **SC-006** (refresh-classification drill, replaces the former unfalsifiable
+  "next incident" criterion): exercising all three session-refresh outcomes
+  against preprod (cookie absent; cookie rejected; cookie valid) yields all
+  three classification lines queryable in the dashboard log group. Testable
+  the day the fix deploys.
+- **SC-007** (content safety): the FR-012 review is executed and recorded;
+  zero credentials and zero unmasked personal data appear in any of the six
+  log groups attributable to newly visible lines (verified by targeted
+  queries for the known-risk patterns during the first week).
 
 ## Assumptions
 
-- The diagnosis of record (2026-07-26, live-evidence-backed): the darkness
-  mechanism is the root logger's default WARNING threshold — the platform
-  attaches a log handler but nothing sets the level, because the functions'
-  delivery configuration specifies no application log level. Warning+ lines
-  were always visible (488 stdlib warning events in a 48h window on the
-  dashboard group; zero stdlib informational events). The fix design may rely
-  on this mechanism.
+- The diagnosis of record (2026-07-25 local / 2026-07-26 UTC, live-evidence-
+  backed): the darkness mechanism is the root logger's default WARNING
+  threshold — the platform attaches a log handler but nothing sets the
+  level, because the functions' delivery configuration specifies no
+  application log level. Warning+ lines were always visible (48h dashboard
+  window: 488 stdlib warning events, zero stdlib informational events —
+  CloudWatch filter-log-events over `/aws/lambda/preprod-sentiment-dashboard`,
+  patterns `[WARNING]` / `[INFO]`, run 2026-07-26 UTC during diagnosis; the
+  query is re-runnable at plan time and the plan MUST re-record it). The fix
+  design may rely on this mechanism.
 - "Informational visibility" is defined at the log-group boundary: a line
   counts as visible only when it is queryable in CloudWatch, not when it is
   merely written by code.
-- The five entrypoints that already self-configure levels (analysis,
-  ingestion, notification, canary, chaos-restore handlers) and the metrics
-  module's self-handled structured logger are existing behavior to preserve,
-  not defects to fix here.
-- Choosing between delivery-level configuration, code-level configuration, or
-  structured-logging adoption (and any combination) is a planning decision;
-  this spec constrains outcomes (FR-001..FR-011), not mechanism.
+- Mechanism choice is a planning decision, but AR#1 established it is NOT
+  free: the delivery-configuration route (platform-level log level) is
+  hard-coupled to JSON line format, which structurally breaks consumer #1
+  (the Text-pattern metric filter) and risks double-encoding the existing
+  structured JSON — choosing it obligates the in-change migration permitted
+  by FR-005/SC-003. Code-level routes preserve Text format. The spec
+  constrains outcomes (FR-001..FR-012) either way.
 - Production functions follow the same fix through the normal pipeline;
   preprod is the verification environment.
+
+## Adversarial Review #1
+
+Independent refuter attacked the Stage-1 spec against the codebase and live
+terraform (13 findings: 2 CRITICAL, 4 HIGH, 5 MEDIUM, 2 LOW). All CRITICAL
+and HIGH findings resolved by spec edits in this revision; MEDIUM/LOW
+resolved or absorbed as noted.
+
+| # | Sev | Finding (compressed) | Resolution |
+|---|-----|----------------------|------------|
+| 1 | CRITICAL | FR-010's "no material volume increase" branch was satisfiable while leaking the Finnhub API key (key passed as URL param + httpx logs full URL at INFO; currently dark, this feature would light it) | FR-010 rewritten: first-party scoping mandatory, httpx pinned ≥ WARNING; new FR-012 content-safety requirement; US3 AC3; SC-007. Key-in-URL carded as separate hygiene |
+| 2 | CRITICAL | Assumptions' "preserve existing behavior" clause codified the notification entrypoint's raw-event INFO dump (recipient email + live magic-link token, already visible today) as protected behavior | FR-011 narrowed to LEVEL preservation only; FR-012 lists the defect explicitly as carded-not-endorsed; feature must not widen it |
+| 3 | HIGH | Function inventory wrong: 7 terraform lambda modules exist; metrics Lambda absent from spec entirely; canary deployed (5-min schedule) but excluded; chaos-restore listed but NOT deployed | New Scope section: six in-scope functions (adds metrics + canary); chaos-restore noted code-only; FR-001/008 + SC-002/004/007 updated to six |
+| 4 | HIGH | Mechanism-neutrality false: platform ApplicationLogLevel requires JSON format → structurally breaks the one Text-pattern metric filter + double-encode risk on StructuredLogger | Assumption rewritten to state the coupling; FR-005 explicitly permits in-change filter migration; SC-003 requires migrated-with-proof if format changes |
+| 5 | HIGH | FR-007 ignored two terraform traps: module ignores env drift (env-var mechanism would silently no-op) and live alias pins published versions (config on $LATEST isn't live) | FR-007 amended with both traps; FR-008/edge case require alias-qualified verification |
+| 6 | HIGH | SC-002 "within one week" unfalsifiable for notification (hourly digest can run empty; non-entrypoint INFO may never fire organically) | FR-008 + SC-002 permit synthetic triggers; canary's 5-min schedule noted as evidence source |
+| 7 | MEDIUM | SC-006 unfalsifiable ("next incident's responder…") | Replaced with the three-outcome refresh drill, testable at deploy |
+| 8 | MEDIUM | FR-010 "materially" weasel word | Moot — branch deleted (finding 1) |
+| 9 | MEDIUM | FR-004 asserted an unmeasured single-emission baseline (StructuredLogger never sets propagate=False; may double-emit TODAY) | FR-004 rephrased to measured-baseline + no-additional-duplication; edge case records the unknown |
+| 10 | MEDIUM | Future-Lambda inheritance was aspiration dressed as requirement; shared-code bootstrap route collides with FR-006 (SSE imports shared modules) | Demoted to explicit non-normative design note favoring the shared-terraform-module locus; accepted-gap language if not achieved |
+| 11 | MEDIUM | "Any metric filters or alarms" acceptance set undefined; spec never established the real inventory | US2 now embeds the complete verified inventory (1 metric filter, 1 deploy grep, metric-based alarms, structured-JSON parsers); SC-003 scoped to it |
+| 12 | LOW | Third-party edge case misaimed (botocore/urllib3 quiet at INFO; the real risk is httpx, unnamed) | Edge case rewritten to name httpx; AWS-SDK scare dropped |
+| 13 | LOW | Counts (67 vs 71 files), unverifiable 488/0 claim, Created date off by one | 71/67 both stated; evidence query documented + plan-time re-record required; date fixed to 2026-07-25 |
+
+**Gate: 0 CRITICAL, 0 HIGH remaining.** Two follow-up cards spawned outside
+this feature's scope (owner board): (a) notification entrypoint logs raw
+magic-link event — pre-existing CWE-312, fix independently; (b) Finnhub
+adapter passes API key as URL parameter — hygiene fix independent of logging.

--- a/specs/001-lambda-log-visibility/spec.md
+++ b/specs/001-lambda-log-visibility/spec.md
@@ -51,15 +51,17 @@ function is not deployed — terraform TODO TD-2).
   queries are the detection mechanism for any logger that proves this wrong,
   and adding a pin is a one-line change to the helper.
 - Q: What counts as the notification function's FR-008 evidence, given a
-  synthetic empty-digest run exercises only entrypoint-level INFO and a real
-  send would consume SendGrid quota (100/day) against a real recipient? →
-  A: Accepted evidence pair: (1) synthetic digest trigger produces the
-  entrypoint INFO line in the log group (proves the function's runtime level
-  config), plus (2) the coverage-guard test proves the helper call, plus
-  (3) the masked sendgrid_service line is unit-tested for shape. No real
-  email is sent for verification. Evidence: eventbridge digest test event
-  exists (modules/eventbridge input template); no sandbox-mode send path is
-  wired in sendgrid_service.py; quota constraint is real.
+  real send would consume SendGrid quota (100/day) against a real recipient?
+  → A (REVISED by AR#2 — the original premise "empty digest exercises only
+  entrypoint INFO" was factually wrong): a synthetic empty-digest invoke
+  (flat payload `{"notification_type": "digest"}`, accepted by the handler
+  directly) DOES execute a genuinely dark non-entrypoint module —
+  digest_service uses a bare un-leveled module logger and emits INFO on
+  every run including empty ones ("Found users due for digest" count=0,
+  "Digest processing complete"; both PII-safe). Notification's FR-008
+  evidence = that digest_service line appearing post-deploy (it cannot
+  appear pre-deploy), plus the unit-tested masked sendgrid_service line
+  shape. No real email is sent; no test-mode send path exists or is needed.
 - Q: SC-005's "bounded, reviewed amount" — what bound? → A: Guardrail: a
   representative dashboard request adds ≤10 new INFO lines (p50), and
   projected CloudWatch ingestion delta at current traffic is <$1/month.
@@ -264,8 +266,15 @@ in the enabled output.
   pinned alias, so configuration applied to the unpublished version is not
   live until publish — verification MUST target the alias-qualified path.
 - **FR-008**: Each of the six functions MUST have a verifiable post-deploy
-  check demonstrating an informational line from a non-entrypoint module
-  reaching its log group. The dashboard check MUST be executable on demand;
+  check demonstrating an informational line that CANNOT appear pre-deploy
+  reaching its log group — i.e., a line from a currently-dark (un-leveled,
+  non-entrypoint) logger. AR#2 established that canary and metrics contain
+  NO such first-party line (canary imports no first-party modules; metrics'
+  only INFO is its self-handled structured logger, visible today) — for
+  them, the evidence line is the configuration helper's own self-test probe
+  (one static INFO line per cold start on the helper's un-leveled child
+  logger), which by construction can only appear when the fix is live.
+  The dashboard check MUST be executable on demand;
   the other five MAY use scheduled runs (canary fires every 5 minutes) or a
   synthetic trigger — "wait for organic traffic" is not an acceptable
   verification plan for a function that may not organically emit for a week.
@@ -302,11 +311,13 @@ in the enabled output.
   - The notification module's currently-dark lines logging full recipient
     email addresses (must be masked before they become visible).
   - Already-visible today and OUT of this feature's causal scope, but
-    recorded so preservation is not misread as endorsement: the notification
-    entrypoint logs the raw invocation event, which for magic-link events
-    contains the recipient email and a live sign-in token. This pre-existing
-    CWE-312 defect MUST be carded as its own fix; this feature MUST NOT
-    widen it.
+    recorded so preservation is not misread as endorsement (all in the
+    notification entrypoint, whose logger is INFO today): the raw invocation
+    event dump (for magic-link events: recipient email + live sign-in
+    token), and the full-recipient-email lines "Alert email sent to …" /
+    "Magic link email sent to …" plus their error-path counterparts. These
+    pre-existing CWE-312 defects MUST be carded as one fix; this feature
+    MUST NOT widen them.
 
 ### Key Entities
 

--- a/specs/001-lambda-log-visibility/tasks.md
+++ b/specs/001-lambda-log-visibility/tasks.md
@@ -3,7 +3,7 @@
 **Input**: Design documents from `/specs/001-lambda-log-visibility/`
 **Prerequisites**: plan.md (post-AR#2), spec.md (post-Clarifications), research.md, data-model.md, contracts/logging-config.md, quickstart.md
 **Tests**: TDD explicitly requested — contract tests precede implementation.
-**Ordering constraint (hard)**: T004/T005 pre-deploy baselines MUST complete before the merge/deploy task T020.
+**Ordering constraint (hard)**: T002-T005 pre-deploy baselines MUST complete before the deploy task T022.
 
 ## Phase 1: Setup & Pre-Deploy Baselines
 

--- a/specs/001-lambda-log-visibility/tasks.md
+++ b/specs/001-lambda-log-visibility/tasks.md
@@ -11,15 +11,15 @@
 - [ ] T002 [P] Record pre-deploy log-shape samples: capture 50 recent events from each of the six log groups (`/aws/lambda/preprod-sentiment-{dashboard,ingestion,analysis,metrics,notification,canary}`) into `specs/001-lambda-log-visibility/evidence/pre-deploy/` (SC-003 comparison input)
 - [ ] T003 [P] FR-004 baseline: count StructuredLogger duplicate emissions over 24h on `/aws/lambda/preprod-sentiment-metrics` (same logical event appearing 2x); record count + query in `specs/001-lambda-log-visibility/evidence/pre-deploy/metrics-dup-baseline.md`
 - [ ] T004 [P] SC-005 baseline: run 20 identical dashboard requests (alias-qualified invoke, same route), count INFO events per request-id, record p50 in `specs/001-lambda-log-visibility/evidence/pre-deploy/dashboard-p50-baseline.md`
-- [ ] T005 [P] SC-003 positive control (pre): fire one synthetic ImportModuleError-shaped log line at the dashboard log group's active stream context (or locate a historical one); record whether metric `dashboard_import_errors` incremented in `specs/001-lambda-log-visibility/evidence/pre-deploy/filter-control.md` (research R-9 question)
+- [ ] T005 [P] SC-003 positive control (pre): `aws logs put-log-events` one synthetic ImportModuleError-shaped line into a FRESH test stream in the dashboard log group (filters evaluate group-wide at ingestion — AR#3 confirmed viable; needs operator `logs:CreateLogStream`/`PutLogEvents`); record whether metric `dashboard_import_errors` incremented in `specs/001-lambda-log-visibility/evidence/pre-deploy/filter-control.md` (research R-9 question)
 
 **Checkpoint**: evidence/pre-deploy/ populated — deploy-gating baselines exist.
 
 ## Phase 2: Foundational (helper + contract tests — blocks all user stories)
 
 - [ ] T006 Write failing contract tests C-1..C-6, C-8 in `tests/unit/shared/test_logging_config.py`: C-1 re-assert level every call; C-2 httpx/httpcore WARNING pins survive LOG_LEVEL=DEBUG; C-3 zero handler mutations; C-4 self-test line emits exactly once per process (latch scoped to emission only, reset hook for tests); C-5 import of module is side-effect-free; C-6 other loggers' levels untouched; C-8 self-test line goes through `logging.getLogger("src.lambdas.shared.logging_config")`, static message
-- [ ] T007 Implement `src/lambdas/shared/logging_config.py::configure_lambda_logging()` to pass T006: root setLevel from LOG_LEVEL env (unset→INFO), explicit own-level pins httpx/httpcore=WARNING, once-per-process self-test INFO emission, documented test reset hook, no handlers/formatters/propagation touched
-- [ ] T008 Write failing coverage-guard test in `tests/unit/test_entrypoint_logging_coverage.py`: glob `src/lambdas/*/handler.py`, exclude exactly `{sse_streaming, chaos_restore}` (documented in-test), assert each remaining handler module source contains a top-level `configure_lambda_logging(` call before any handler def (C-7; AR#2 F4 — no hardcoded function list)
+- [ ] T007 Implement `src/lambdas/shared/logging_config.py::configure_lambda_logging()` to pass T006: root setLevel from LOG_LEVEL env (unset→INFO), explicit own-level pins httpx/httpcore=WARNING, once-per-process self-test INFO emission, documented test reset hook, no handlers/formatters/propagation touched. STATED DEPENDENCY (AR#3): C-8's evidence value assumes awslambdaric bootstrap attaches the root handler BEFORE importing the handler module (research R-1 source read: `main()` runs `_setup_logging` before `_get_handler`) — record this in the module docstring; if it were ever false the self-test would fall to logging.lastResort (WARNING) and drop
+- [ ] T008 Write failing coverage-guard test in `tests/unit/test_entrypoint_logging_coverage.py`: glob `src/lambdas/*/handler.py`, exclude exactly `{sse_streaming, chaos_restore}` (documented in-test), assert per file: character index of top-level `configure_lambda_logging(` call < index of the first line matching `^def ` in the module source (AR#3 precise criterion — not "before lambda_handler", not docstring-fooled) (C-7; AR#2 F4 — no hardcoded function list)
 
 **Checkpoint**: helper green under contract tests; guard red (no entrypoint wired yet).
 
@@ -43,7 +43,7 @@
 **Goal**: nothing newly visible leaks secrets/PII (FR-012, SC-007).
 **Independent test**: unit tests for masked shapes; grep-audit recorded.
 
-- [ ] T016 [P] [US3] Mask recipient email in `src/lambdas/notification/sendgrid_service.py` lines ~136/141 (`s***@domain` shape); unit test the masked line shape in `tests/unit/notification/test_sendgrid_service.py` (create or extend)
+- [ ] T016 [P] [US3] Mask recipient email in `src/lambdas/notification/sendgrid_service.py` lines ~136/141 ONLY (`s***@domain` shape); do NOT touch the handler.py:56/170/220 lines — those are T018's card, already visible today, out of this feature's causal scope (AR#3 over-masking guardrail); unit test the masked line shape in `tests/unit/notification/test_sendgrid_service.py` (create or extend)
 - [ ] T017 [P] [US3] Confirm httpx pin closes the finnhub key-in-URL path: unit test in `tests/unit/shared/test_logging_config.py` — with root=DEBUG (worst case), an httpx-logger INFO record is NOT emitted (pin holds); reference research R-5/R-8
 - [ ] T018 [US3] Card the two out-of-scope defects on the owner board follow-up list (do NOT fix here): (a) notification entrypoint raw-event dump + full-email lines (handler.py:56/170/220 + error paths) — pre-existing CWE-312; (b) finnhub API key passed as URL query param (adapter hygiene). Record card refs in `specs/001-lambda-log-visibility/evidence/cards.md`
 
@@ -54,8 +54,8 @@
 **Goal**: byte-compatible existing lines; on-demand dashboard proof exists.
 **Independent test**: script runs against preprod pre-deploy (refresh lines absent) and post-deploy (present).
 
-- [ ] T019 [US2] Write `scripts/verify-log-visibility.py`: alias-qualified dashboard invokes for the three refresh outcomes (no cookie / garbage cookie / valid session via server-mint pattern from tests/e2e conftest), then `filter_log_events` asserting `refresh.cookie_absent`, `refresh.rejected`, `refresh.success` and the C-8 self-test line; exit non-zero on any missing (FR-008 dashboard + SC-006 drill)
-- [ ] T020 [US2] Write preprod E2E `tests/e2e/test_log_visibility.py` (marker `preprod`): per-function dark-line assertions — dashboard: refresh.* lines; ingestion: `storage.py` "Storage operation complete"; analysis: sentiment.py INFO site; metrics: C-8 self-test line; notification: synthetic empty-digest invoke (flat payload) then digest_service "Found users due for digest"/"Digest processing complete"; canary: C-8 self-test line within 15 min window
+- [ ] T019 [US2] Write `scripts/verify-log-visibility.py`: alias-qualified dashboard invokes for the three refresh outcomes — (a) POST /api/v2/auth/refresh with no cookie → `refresh.cookie_absent`; (b) same with garbage cookie → `refresh.rejected`; (c) POST /api/v2/auth/anonymous (CSRF-exempt), capture the `refresh_token=anon.…` Set-Cookie, replay it to /refresh → `refresh.success` via the anon branch (AR#3: NO bearer/JWT-secret needed; a bearer cannot reach refresh.success — the branch requires a refresh COOKIE). Then `filter_log_events` asserting all three lines + the C-8 self-test line; exit non-zero on any missing (FR-008 dashboard + SC-006 drill)
+- [ ] T020 [US2] Write preprod E2E `tests/e2e/test_log_visibility.py` (marker `preprod`): per-function dark-line assertions — dashboard: refresh.* lines; ingestion: `storage.py:185` "Storage operation complete"; analysis: a pinned sentiment.py INFO line (research R-2 set); metrics: C-8 self-test line; notification: synthetic empty-digest invoke (flat payload) then digest_service:154/656 lines; canary: C-8 self-test line. AR#3 flake guard: C-8 is COLD-START-ONLY (once-per-process latch survives freeze/thaw) — window every C-8 `filter_log_events` query from the function's LastModified/publish timestamp, never "now minus N minutes"
 
 **Checkpoint**: verification artifacts exist and fail against current preprod (proves they discriminate).
 
@@ -72,7 +72,7 @@
 
 ## Dependencies & Execution Order
 
-- Phase 1 (T002-T005) parallel; independent of Phases 2-5 EXCEPT T020/T022: baselines MUST exist before deploy (hard gate).
+- Phase 1 (T002-T005) parallel; independent of Phases 2-5. Hard gate: baselines (T002-T005) MUST complete before T022 (deploy) — they do not gate test AUTHORING (T019/T020).
 - Phase 2 strictly sequential (T006 → T007 → T008 red).
 - Phase 3: T009-T014 parallel (six files, disjoint); T015 after all.
 - Phase 4: T016/T017 parallel after T007; T018 anytime.
@@ -101,3 +101,39 @@ pre-merge-blocking riders (FR-012 content safety + discriminating
 verification), NOT optional polish — the merge task T021 requires
 T003/T004/T005/T016/T017/T019/T020 complete. Single PR; single revert
 restores status quo.
+
+## Adversarial Review #3
+
+Independent implementation-readiness reviewer, all claims code-grounded.
+Findings: 1 HIGH, 2 MEDIUM, 2 LOW, 1 INFO — all applied to task text above.
+
+- **Highest-risk task**: T007 — not for implementation difficulty but for
+  evidential dependencies: (a) C-8's value assumes awslambdaric attaches the
+  root handler before handler-module import (true per research R-1 source
+  read; now a STATED dependency in T007), and (b) C-8 is cold-start-only, so
+  every C-8 query must window from the function's publish timestamp (folded
+  into T020). T009 confirmed safe (powertools never touches root, R-4);
+  T013 confirmed safe (same env var, same default, one root handler — no
+  fight, no duplication).
+- **Most likely rework source**: T019 as originally worded — the conftest
+  bearer-mint pattern can NEVER reach `refresh.success` (branch requires a
+  refresh COOKIE: router_v2.py:732-736) and is locally invalid post-JWT-
+  rotation anyway. REQUIRED amendment applied: anonymous-cookie recipe
+  (POST /auth/anonymous → capture anon refresh cookie → replay to /refresh
+  → auth.py:3479 anon branch → refresh.success at :762). No secret, no
+  OAuth, no bearer needed. Note: the existing E2E suite only ever tests
+  refresh REJECTION — this recipe is new ground, no in-repo prior art.
+- **Sequencing**: no blocking holes; T019/T020 pre-merge fail-first runs
+  schedulable (preprod lacks the fix until T022); T005 injection viable
+  (filters evaluate PutLogEvents at ingestion); dependency wording fixed
+  (baselines gate T022, not T020).
+- **Destructive-misinterpretation check**: all six wire targets + every
+  line anchor verified against source; T016 over-masking guardrail added;
+  T008 criterion pinned (call index < first `^def ` line). No
+  two-dashboards confusion: all paths are backend src/lambdas + log groups.
+- **Scope integrity**: glob-minus-exclusions yields exactly the six
+  in-scope functions; nothing touches SSE; C-5 keeps SSE's shared imports
+  inert; no new AWS resources anywhere.
+
+**Gate: READY FOR IMPLEMENTATION** (required T019 amendment applied;
+recommended T007/T020 amendments applied).

--- a/specs/001-lambda-log-visibility/tasks.md
+++ b/specs/001-lambda-log-visibility/tasks.md
@@ -7,19 +7,19 @@
 
 ## Phase 1: Setup & Pre-Deploy Baselines
 
-- [ ] T001 Verify branch `001-lambda-log-visibility` is current with origin/main; venv active (`source .venv/bin/activate`)
-- [ ] T002 [P] Record pre-deploy log-shape samples: capture 50 recent events from each of the six log groups (`/aws/lambda/preprod-sentiment-{dashboard,ingestion,analysis,metrics,notification,canary}`) into `specs/001-lambda-log-visibility/evidence/pre-deploy/` (SC-003 comparison input)
-- [ ] T003 [P] FR-004 baseline: count StructuredLogger duplicate emissions over 24h on `/aws/lambda/preprod-sentiment-metrics` (same logical event appearing 2x); record count + query in `specs/001-lambda-log-visibility/evidence/pre-deploy/metrics-dup-baseline.md`
-- [ ] T004 [P] SC-005 baseline: run 20 identical dashboard requests (alias-qualified invoke, same route), count INFO events per request-id, record p50 in `specs/001-lambda-log-visibility/evidence/pre-deploy/dashboard-p50-baseline.md`
-- [ ] T005 [P] SC-003 positive control (pre): `aws logs put-log-events` one synthetic ImportModuleError-shaped line into a FRESH test stream in the dashboard log group (filters evaluate group-wide at ingestion — AR#3 confirmed viable; needs operator `logs:CreateLogStream`/`PutLogEvents`); record whether metric `dashboard_import_errors` incremented in `specs/001-lambda-log-visibility/evidence/pre-deploy/filter-control.md` (research R-9 question)
+- [X] T001 Verify branch `001-lambda-log-visibility` is current with origin/main; venv active (`source .venv/bin/activate`)
+- [X] T002 [P] Record pre-deploy log-shape samples: capture 50 recent events from each of the six log groups (`/aws/lambda/preprod-sentiment-{dashboard,ingestion,analysis,metrics,notification,canary}`) into `specs/001-lambda-log-visibility/evidence/pre-deploy/` (SC-003 comparison input)
+- [X] T003 [P] FR-004 baseline: count StructuredLogger duplicate emissions over 24h on `/aws/lambda/preprod-sentiment-metrics` (same logical event appearing 2x); record count + query in `specs/001-lambda-log-visibility/evidence/pre-deploy/metrics-dup-baseline.md`
+- [X] T004 [P] SC-005 baseline: run 20 identical dashboard requests (alias-qualified invoke, same route), count INFO events per request-id, record p50 in `specs/001-lambda-log-visibility/evidence/pre-deploy/dashboard-p50-baseline.md`
+- [X] T005 [P] SC-003 positive control (pre): `aws logs put-log-events` one synthetic ImportModuleError-shaped line into a FRESH test stream in the dashboard log group (filters evaluate group-wide at ingestion — AR#3 confirmed viable; needs operator `logs:CreateLogStream`/`PutLogEvents`); record whether metric `dashboard_import_errors` incremented in `specs/001-lambda-log-visibility/evidence/pre-deploy/filter-control.md` (research R-9 question)
 
 **Checkpoint**: evidence/pre-deploy/ populated — deploy-gating baselines exist.
 
 ## Phase 2: Foundational (helper + contract tests — blocks all user stories)
 
-- [ ] T006 Write failing contract tests C-1..C-6, C-8 in `tests/unit/shared/test_logging_config.py`: C-1 re-assert level every call; C-2 httpx/httpcore WARNING pins survive LOG_LEVEL=DEBUG; C-3 zero handler mutations; C-4 self-test line emits exactly once per process (latch scoped to emission only, reset hook for tests); C-5 import of module is side-effect-free; C-6 other loggers' levels untouched; C-8 self-test line goes through `logging.getLogger("src.lambdas.shared.logging_config")`, static message
-- [ ] T007 Implement `src/lambdas/shared/logging_config.py::configure_lambda_logging()` to pass T006: root setLevel from LOG_LEVEL env (unset→INFO), explicit own-level pins httpx/httpcore=WARNING, once-per-process self-test INFO emission, documented test reset hook, no handlers/formatters/propagation touched. STATED DEPENDENCY (AR#3): C-8's evidence value assumes awslambdaric bootstrap attaches the root handler BEFORE importing the handler module (research R-1 source read: `main()` runs `_setup_logging` before `_get_handler`) — record this in the module docstring; if it were ever false the self-test would fall to logging.lastResort (WARNING) and drop
-- [ ] T008 Write failing coverage-guard test in `tests/unit/test_entrypoint_logging_coverage.py`: glob `src/lambdas/*/handler.py`, exclude exactly `{sse_streaming, chaos_restore}` (documented in-test), assert per file: character index of top-level `configure_lambda_logging(` call < index of the first line matching `^def ` in the module source (AR#3 precise criterion — not "before lambda_handler", not docstring-fooled) (C-7; AR#2 F4 — no hardcoded function list)
+- [X] T006 Write failing contract tests C-1..C-6, C-8 in `tests/unit/shared/test_logging_config.py`: C-1 re-assert level every call; C-2 httpx/httpcore WARNING pins survive LOG_LEVEL=DEBUG; C-3 zero handler mutations; C-4 self-test line emits exactly once per process (latch scoped to emission only, reset hook for tests); C-5 import of module is side-effect-free; C-6 other loggers' levels untouched; C-8 self-test line goes through `logging.getLogger("src.lambdas.shared.logging_config")`, static message
+- [X] T007 Implement `src/lambdas/shared/logging_config.py::configure_lambda_logging()` to pass T006: root setLevel from LOG_LEVEL env (unset→INFO), explicit own-level pins httpx/httpcore=WARNING, once-per-process self-test INFO emission, documented test reset hook, no handlers/formatters/propagation touched. STATED DEPENDENCY (AR#3): C-8's evidence value assumes awslambdaric bootstrap attaches the root handler BEFORE importing the handler module (research R-1 source read: `main()` runs `_setup_logging` before `_get_handler`) — record this in the module docstring; if it were ever false the self-test would fall to logging.lastResort (WARNING) and drop
+- [X] T008 Write failing coverage-guard test in `tests/unit/test_entrypoint_logging_coverage.py`: glob `src/lambdas/*/handler.py`, exclude exactly `{sse_streaming, chaos_restore}` (documented in-test), assert per file: character index of top-level `configure_lambda_logging(` call < index of the first line matching `^def ` in the module source (AR#3 precise criterion — not "before lambda_handler", not docstring-fooled) (C-7; AR#2 F4 — no hardcoded function list)
 
 **Checkpoint**: helper green under contract tests; guard red (no entrypoint wired yet).
 
@@ -28,13 +28,13 @@
 **Goal**: INFO from first-party modules visible in all six functions' log groups.
 **Independent test**: quickstart preprod steps 1-2 post-deploy; guard green locally.
 
-- [ ] T009 [P] [US1] Wire `configure_lambda_logging()` at import top-level in `src/lambdas/dashboard/handler.py` (before Powertools app/resolver setup; powertools Logger untouched)
-- [ ] T010 [P] [US1] Wire in `src/lambdas/ingestion/handler.py` (keep existing module-logger setLevel(INFO) at ~:116 — FR-011)
-- [ ] T011 [P] [US1] Wire in `src/lambdas/analysis/handler.py` (keep ~:78 setLevel; log_structured print path untouched)
-- [ ] T012 [P] [US1] Wire in `src/lambdas/metrics/handler.py` (currently configures nothing; StructuredLogger untouched)
-- [ ] T013 [P] [US1] Wire in `src/lambdas/notification/handler.py` (keep LOG_LEVEL env read at ~:33 — same semantics, no duplicate config)
-- [ ] T014 [P] [US1] Wire in `src/lambdas/canary/handler.py` (keep ~:25 setLevel)
-- [ ] T015 [US1] Run T008 guard → green; run full unit suite (`pytest tests/unit/ -v`) → no regressions (FR-011/C-6 verified across suites)
+- [X] T009 [P] [US1] Wire `configure_lambda_logging()` at import top-level in `src/lambdas/dashboard/handler.py` (before Powertools app/resolver setup; powertools Logger untouched)
+- [X] T010 [P] [US1] Wire in `src/lambdas/ingestion/handler.py` (keep existing module-logger setLevel(INFO) at ~:116 — FR-011)
+- [X] T011 [P] [US1] Wire in `src/lambdas/analysis/handler.py` (keep ~:78 setLevel; log_structured print path untouched)
+- [X] T012 [P] [US1] Wire in `src/lambdas/metrics/handler.py` (currently configures nothing; StructuredLogger untouched)
+- [X] T013 [P] [US1] Wire in `src/lambdas/notification/handler.py` (keep LOG_LEVEL env read at ~:33 — same semantics, no duplicate config)
+- [X] T014 [P] [US1] Wire in `src/lambdas/canary/handler.py` (keep ~:25 setLevel)
+- [X] T015 [US1] Run T008 guard → green; run full unit suite (`pytest tests/unit/ -v`) → no regressions (FR-011/C-6 verified across suites)
 
 **Checkpoint**: all six entrypoints wired; guard + contract tests green — US1 code-complete.
 
@@ -43,9 +43,9 @@
 **Goal**: nothing newly visible leaks secrets/PII (FR-012, SC-007).
 **Independent test**: unit tests for masked shapes; grep-audit recorded.
 
-- [ ] T016 [P] [US3] Mask recipient email in `src/lambdas/notification/sendgrid_service.py` lines ~136/141 ONLY (`s***@domain` shape); do NOT touch the handler.py:56/170/220 lines — those are T018's card, already visible today, out of this feature's causal scope (AR#3 over-masking guardrail); unit test the masked line shape in `tests/unit/notification/test_sendgrid_service.py` (create or extend)
-- [ ] T017 [P] [US3] Confirm httpx pin closes the finnhub key-in-URL path: unit test in `tests/unit/shared/test_logging_config.py` — with root=DEBUG (worst case), an httpx-logger INFO record is NOT emitted (pin holds); reference research R-5/R-8
-- [ ] T018 [US3] Card the two out-of-scope defects on the owner board follow-up list (do NOT fix here): (a) notification entrypoint raw-event dump + full-email lines (handler.py:56/170/220 + error paths) — pre-existing CWE-312; (b) finnhub API key passed as URL query param (adapter hygiene). Record card refs in `specs/001-lambda-log-visibility/evidence/cards.md`
+- [X] T016 [P] [US3] Mask recipient email in `src/lambdas/notification/sendgrid_service.py` lines ~136/141 ONLY (`s***@domain` shape); do NOT touch the handler.py:56/170/220 lines — those are T018's card, already visible today, out of this feature's causal scope (AR#3 over-masking guardrail); unit test the masked line shape in `tests/unit/notification/test_sendgrid_service.py` (create or extend)
+- [X] T017 [P] [US3] Confirm httpx pin closes the finnhub key-in-URL path: unit test in `tests/unit/shared/test_logging_config.py` — with root=DEBUG (worst case), an httpx-logger INFO record is NOT emitted (pin holds); reference research R-5/R-8
+- [X] T018 [US3] Card the two out-of-scope defects on the owner board follow-up list (do NOT fix here): (a) notification entrypoint raw-event dump + full-email lines (handler.py:56/170/220 + error paths) — pre-existing CWE-312; (b) finnhub API key passed as URL query param (adapter hygiene). Record card refs in `specs/001-lambda-log-visibility/evidence/cards.md`
 
 **Checkpoint**: FR-012 satisfied; SC-007 pre-conditions in place.
 
@@ -54,8 +54,8 @@
 **Goal**: byte-compatible existing lines; on-demand dashboard proof exists.
 **Independent test**: script runs against preprod pre-deploy (refresh lines absent) and post-deploy (present).
 
-- [ ] T019 [US2] Write `scripts/verify-log-visibility.py`: alias-qualified dashboard invokes for the three refresh outcomes — (a) POST /api/v2/auth/refresh with no cookie → `refresh.cookie_absent`; (b) same with garbage cookie → `refresh.rejected`; (c) POST /api/v2/auth/anonymous (CSRF-exempt), capture the `refresh_token=anon.…` Set-Cookie, replay it to /refresh → `refresh.success` via the anon branch (AR#3: NO bearer/JWT-secret needed; a bearer cannot reach refresh.success — the branch requires a refresh COOKIE). Then `filter_log_events` asserting all three lines + the C-8 self-test line; exit non-zero on any missing (FR-008 dashboard + SC-006 drill)
-- [ ] T020 [US2] Write preprod E2E `tests/e2e/test_log_visibility.py` (marker `preprod`): per-function dark-line assertions — dashboard: refresh.* lines; ingestion: `storage.py:185` "Storage operation complete"; analysis: a pinned sentiment.py INFO line (research R-2 set); metrics: C-8 self-test line; notification: synthetic empty-digest invoke (flat payload) then digest_service:154/656 lines; canary: C-8 self-test line. AR#3 flake guard: C-8 is COLD-START-ONLY (once-per-process latch survives freeze/thaw) — window every C-8 `filter_log_events` query from the function's LastModified/publish timestamp, never "now minus N minutes"
+- [X] T019 [US2] Write `scripts/verify-log-visibility.py`: alias-qualified dashboard invokes for the three refresh outcomes — (a) POST /api/v2/auth/refresh with no cookie → `refresh.cookie_absent`; (b) same with garbage cookie → `refresh.rejected`; (c) POST /api/v2/auth/anonymous (CSRF-exempt), capture the `refresh_token=anon.…` Set-Cookie, replay it to /refresh → `refresh.success` via the anon branch (AR#3: NO bearer/JWT-secret needed; a bearer cannot reach refresh.success — the branch requires a refresh COOKIE). Then `filter_log_events` asserting all three lines + the C-8 self-test line; exit non-zero on any missing (FR-008 dashboard + SC-006 drill)
+- [X] T020 [US2] Write preprod E2E `tests/e2e/test_log_visibility.py` (marker `preprod`): per-function dark-line assertions — dashboard: refresh.* lines; ingestion: `storage.py:185` "Storage operation complete"; analysis: a pinned sentiment.py INFO line (research R-2 set); metrics: C-8 self-test line; notification: synthetic empty-digest invoke (flat payload) then digest_service:154/656 lines; canary: C-8 self-test line. AR#3 flake guard: C-8 is COLD-START-ONLY (once-per-process latch survives freeze/thaw) — window every C-8 `filter_log_events` query from the function's LastModified/publish timestamp, never "now minus N minutes"
 
 **Checkpoint**: verification artifacts exist and fail against current preprod (proves they discriminate).
 

--- a/specs/001-lambda-log-visibility/tasks.md
+++ b/specs/001-lambda-log-visibility/tasks.md
@@ -1,0 +1,103 @@
+# Tasks: Lambda Log Visibility
+
+**Input**: Design documents from `/specs/001-lambda-log-visibility/`
+**Prerequisites**: plan.md (post-AR#2), spec.md (post-Clarifications), research.md, data-model.md, contracts/logging-config.md, quickstart.md
+**Tests**: TDD explicitly requested — contract tests precede implementation.
+**Ordering constraint (hard)**: T004/T005 pre-deploy baselines MUST complete before the merge/deploy task T020.
+
+## Phase 1: Setup & Pre-Deploy Baselines
+
+- [ ] T001 Verify branch `001-lambda-log-visibility` is current with origin/main; venv active (`source .venv/bin/activate`)
+- [ ] T002 [P] Record pre-deploy log-shape samples: capture 50 recent events from each of the six log groups (`/aws/lambda/preprod-sentiment-{dashboard,ingestion,analysis,metrics,notification,canary}`) into `specs/001-lambda-log-visibility/evidence/pre-deploy/` (SC-003 comparison input)
+- [ ] T003 [P] FR-004 baseline: count StructuredLogger duplicate emissions over 24h on `/aws/lambda/preprod-sentiment-metrics` (same logical event appearing 2x); record count + query in `specs/001-lambda-log-visibility/evidence/pre-deploy/metrics-dup-baseline.md`
+- [ ] T004 [P] SC-005 baseline: run 20 identical dashboard requests (alias-qualified invoke, same route), count INFO events per request-id, record p50 in `specs/001-lambda-log-visibility/evidence/pre-deploy/dashboard-p50-baseline.md`
+- [ ] T005 [P] SC-003 positive control (pre): fire one synthetic ImportModuleError-shaped log line at the dashboard log group's active stream context (or locate a historical one); record whether metric `dashboard_import_errors` incremented in `specs/001-lambda-log-visibility/evidence/pre-deploy/filter-control.md` (research R-9 question)
+
+**Checkpoint**: evidence/pre-deploy/ populated — deploy-gating baselines exist.
+
+## Phase 2: Foundational (helper + contract tests — blocks all user stories)
+
+- [ ] T006 Write failing contract tests C-1..C-6, C-8 in `tests/unit/shared/test_logging_config.py`: C-1 re-assert level every call; C-2 httpx/httpcore WARNING pins survive LOG_LEVEL=DEBUG; C-3 zero handler mutations; C-4 self-test line emits exactly once per process (latch scoped to emission only, reset hook for tests); C-5 import of module is side-effect-free; C-6 other loggers' levels untouched; C-8 self-test line goes through `logging.getLogger("src.lambdas.shared.logging_config")`, static message
+- [ ] T007 Implement `src/lambdas/shared/logging_config.py::configure_lambda_logging()` to pass T006: root setLevel from LOG_LEVEL env (unset→INFO), explicit own-level pins httpx/httpcore=WARNING, once-per-process self-test INFO emission, documented test reset hook, no handlers/formatters/propagation touched
+- [ ] T008 Write failing coverage-guard test in `tests/unit/test_entrypoint_logging_coverage.py`: glob `src/lambdas/*/handler.py`, exclude exactly `{sse_streaming, chaos_restore}` (documented in-test), assert each remaining handler module source contains a top-level `configure_lambda_logging(` call before any handler def (C-7; AR#2 F4 — no hardcoded function list)
+
+**Checkpoint**: helper green under contract tests; guard red (no entrypoint wired yet).
+
+## Phase 3: User Story 1 — Operator debugs from logs (P1) 🎯 MVP
+
+**Goal**: INFO from first-party modules visible in all six functions' log groups.
+**Independent test**: quickstart preprod steps 1-2 post-deploy; guard green locally.
+
+- [ ] T009 [P] [US1] Wire `configure_lambda_logging()` at import top-level in `src/lambdas/dashboard/handler.py` (before Powertools app/resolver setup; powertools Logger untouched)
+- [ ] T010 [P] [US1] Wire in `src/lambdas/ingestion/handler.py` (keep existing module-logger setLevel(INFO) at ~:116 — FR-011)
+- [ ] T011 [P] [US1] Wire in `src/lambdas/analysis/handler.py` (keep ~:78 setLevel; log_structured print path untouched)
+- [ ] T012 [P] [US1] Wire in `src/lambdas/metrics/handler.py` (currently configures nothing; StructuredLogger untouched)
+- [ ] T013 [P] [US1] Wire in `src/lambdas/notification/handler.py` (keep LOG_LEVEL env read at ~:33 — same semantics, no duplicate config)
+- [ ] T014 [P] [US1] Wire in `src/lambdas/canary/handler.py` (keep ~:25 setLevel)
+- [ ] T015 [US1] Run T008 guard → green; run full unit suite (`pytest tests/unit/ -v`) → no regressions (FR-011/C-6 verified across suites)
+
+**Checkpoint**: all six entrypoints wired; guard + contract tests green — US1 code-complete.
+
+## Phase 4: User Story 3 — Content safety riders (P3 but pre-deploy-blocking per FR-012)
+
+**Goal**: nothing newly visible leaks secrets/PII (FR-012, SC-007).
+**Independent test**: unit tests for masked shapes; grep-audit recorded.
+
+- [ ] T016 [P] [US3] Mask recipient email in `src/lambdas/notification/sendgrid_service.py` lines ~136/141 (`s***@domain` shape); unit test the masked line shape in `tests/unit/notification/test_sendgrid_service.py` (create or extend)
+- [ ] T017 [P] [US3] Confirm httpx pin closes the finnhub key-in-URL path: unit test in `tests/unit/shared/test_logging_config.py` — with root=DEBUG (worst case), an httpx-logger INFO record is NOT emitted (pin holds); reference research R-5/R-8
+- [ ] T018 [US3] Card the two out-of-scope defects on the owner board follow-up list (do NOT fix here): (a) notification entrypoint raw-event dump + full-email lines (handler.py:56/170/220 + error paths) — pre-existing CWE-312; (b) finnhub API key passed as URL query param (adapter hygiene). Record card refs in `specs/001-lambda-log-visibility/evidence/cards.md`
+
+**Checkpoint**: FR-012 satisfied; SC-007 pre-conditions in place.
+
+## Phase 5: User Story 2 — Consumers keep working (P2) + verification tooling
+
+**Goal**: byte-compatible existing lines; on-demand dashboard proof exists.
+**Independent test**: script runs against preprod pre-deploy (refresh lines absent) and post-deploy (present).
+
+- [ ] T019 [US2] Write `scripts/verify-log-visibility.py`: alias-qualified dashboard invokes for the three refresh outcomes (no cookie / garbage cookie / valid session via server-mint pattern from tests/e2e conftest), then `filter_log_events` asserting `refresh.cookie_absent`, `refresh.rejected`, `refresh.success` and the C-8 self-test line; exit non-zero on any missing (FR-008 dashboard + SC-006 drill)
+- [ ] T020 [US2] Write preprod E2E `tests/e2e/test_log_visibility.py` (marker `preprod`): per-function dark-line assertions — dashboard: refresh.* lines; ingestion: `storage.py` "Storage operation complete"; analysis: sentiment.py INFO site; metrics: C-8 self-test line; notification: synthetic empty-digest invoke (flat payload) then digest_service "Found users due for digest"/"Digest processing complete"; canary: C-8 self-test line within 15 min window
+
+**Checkpoint**: verification artifacts exist and fail against current preprod (proves they discriminate).
+
+## Phase 6: Merge, Deploy & Post-Deploy Verification
+
+- [ ] T021 Pre-push gate: `make validate` + `pytest tests/unit/` + security-alert check per CLAUDE.md pre-push checklist; PR with plan-linked description; owner-gated push per standing rule
+- [ ] T022 Merge → deploy pipeline; monitor Deploy-to-Preprod + Preprod Integration Tests (Monitor tool pattern; stuck-credentials watch)
+- [ ] T023 Post-deploy: run `scripts/verify-log-visibility.py` (SC-001 + SC-006); run `pytest tests/e2e/test_log_visibility.py -m preprod` (FR-008 all six; SC-002 start)
+- [ ] T024 [P] SC-003 comparison: re-capture the six log-group samples (as T002) post-deploy; diff warning/error line shapes (FR-003), powertools/StructuredLogger JSON byte-shape (FR-004 vs T003 baseline — no ADDITIONAL duplication), re-run T005 positive control identically; record verdicts in `specs/001-lambda-log-visibility/evidence/post-deploy/`
+- [ ] T025 [P] SC-005 close: re-run T004's 20-request workload, p50 delta ≤10 INFO lines; project monthly ingestion delta <$1; record in evidence/post-deploy/
+- [ ] T026 [P] SC-004/SC-007 week-one watch: scheduled queries (token= pattern AND @-address pattern AND `[DEBUG]`) across six groups; record daily results in evidence/post-deploy/week-one.md; SC-004 caveat: a deliberate LOG_LEVEL=DEBUG window, if any, must be recorded
+
+**Checkpoint**: SC-001..SC-007 all evidenced; feature DONE pending week-one watch closure.
+
+## Dependencies & Execution Order
+
+- Phase 1 (T002-T005) parallel; independent of Phases 2-5 EXCEPT T020/T022: baselines MUST exist before deploy (hard gate).
+- Phase 2 strictly sequential (T006 → T007 → T008 red).
+- Phase 3: T009-T014 parallel (six files, disjoint); T015 after all.
+- Phase 4: T016/T017 parallel after T007; T018 anytime.
+- Phase 5: T019/T020 after T007 (reference the self-test line name); both must FAIL against pre-deploy preprod (discrimination proof) — run before merge.
+- Phase 6 strictly sequential from T021; T024-T026 parallel after T023.
+
+## Requirement → Task Map
+
+| Req | Tasks | | Req | Tasks |
+|---|---|---|---|---|
+| FR-001 | T007, T009-T014, T023 | | FR-008 | T019, T020, T023 |
+| FR-002 | T006(C-1), T026 | | FR-009 | T024 |
+| FR-003 | T024 | | FR-010 | T006(C-2), T007, T017 |
+| FR-004 | T003, T024 | | FR-011 | T006(C-6), T010/T011/T013/T014, T015 |
+| FR-005 | (no infra tasks — satisfied by construction; T021 review confirms) | | FR-012 | T016, T017, T018 |
+| FR-006 | T008 exclusion + T006(C-5) | | SC-001 | T023 |
+| FR-007 | T021/T022 (normal pipeline; no console mutation anywhere) | | SC-002 | T023, T026 |
+| SC-003 | T002, T005, T024 | | SC-004 | T026 |
+| SC-005 | T004, T025 | | SC-006 | T019, T023 |
+| SC-007 | T016, T017, T026 | | | |
+
+## Implementation Strategy
+
+MVP = Phases 1-3 (visibility live, guard green). Phases 4-5 are
+pre-merge-blocking riders (FR-012 content safety + discriminating
+verification), NOT optional polish — the merge task T021 requires
+T003/T004/T005/T016/T017/T019/T020 complete. Single PR; single revert
+restores status quo.

--- a/src/lambdas/analysis/handler.py
+++ b/src/lambdas/analysis/handler.py
@@ -56,6 +56,10 @@ from typing import Any
 import boto3
 from aws_lambda_powertools import Tracer
 
+from src.lambdas.shared.logging_config import configure_lambda_logging
+
+configure_lambda_logging()
+
 tracer = Tracer(service="sentiment-analyzer-analysis")
 
 from src.lambdas.analysis.sentiment import (

--- a/src/lambdas/canary/handler.py
+++ b/src/lambdas/canary/handler.py
@@ -21,6 +21,10 @@ import boto3
 from aws_lambda_powertools import Tracer
 from botocore.exceptions import ClientError
 
+from src.lambdas.shared.logging_config import configure_lambda_logging
+
+configure_lambda_logging()
+
 logger = logging.getLogger(__name__)
 logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
 

--- a/src/lambdas/dashboard/handler.py
+++ b/src/lambdas/dashboard/handler.py
@@ -81,6 +81,7 @@ from src.lambdas.dashboard.metrics import sanitize_item_for_response
 from src.lambdas.shared.dynamodb import get_table, parse_dynamodb_item
 from src.lambdas.shared.env_validation import validate_critical_env_vars
 from src.lambdas.shared.errors.session_errors import SessionRevokedException
+from src.lambdas.shared.logging_config import configure_lambda_logging
 from src.lambdas.shared.logging_utils import (
     get_safe_error_info,
     get_safe_error_message_for_user,
@@ -98,6 +99,8 @@ from src.lambdas.shared.utils.event_helpers import get_query_params
 validate_critical_env_vars(["SCHEDULER_ROLE_ARN"])
 
 # Structured logging (FR-028: module-level logging replaces lifespan)
+configure_lambda_logging()
+
 logger = Logger(service="dashboard")
 tracer = Tracer(service="dashboard")
 

--- a/src/lambdas/ingestion/handler.py
+++ b/src/lambdas/ingestion/handler.py
@@ -78,6 +78,10 @@ import boto3
 from aws_lambda_powertools import Tracer
 from botocore.config import Config
 
+from src.lambdas.shared.logging_config import configure_lambda_logging
+
+configure_lambda_logging()
+
 tracer = Tracer(service="sentiment-analyzer-ingestion")
 
 from src.lambdas.ingestion.alerting import (

--- a/src/lambdas/metrics/handler.py
+++ b/src/lambdas/metrics/handler.py
@@ -51,7 +51,10 @@ import boto3
 from aws_lambda_powertools import Tracer
 from boto3.dynamodb.conditions import Key
 
+from src.lambdas.shared.logging_config import configure_lambda_logging
 from src.lib.metrics import emit_metric, log_structured
+
+configure_lambda_logging()
 
 tracer = Tracer(service="sentiment-analyzer-metrics")
 

--- a/src/lambdas/notification/handler.py
+++ b/src/lambdas/notification/handler.py
@@ -25,7 +25,10 @@ from src.lambdas.notification.sendgrid_service import (
     RateLimitExceededError,
 )
 from src.lambdas.shared.env_validation import validate_critical_env_vars
+from src.lambdas.shared.logging_config import configure_lambda_logging
 from src.lib.metrics import emit_metric
+
+configure_lambda_logging()
 
 tracer = Tracer(service="sentiment-analyzer-notification")
 

--- a/src/lambdas/notification/sendgrid_service.py
+++ b/src/lambdas/notification/sendgrid_service.py
@@ -21,6 +21,20 @@ from sendgrid.helpers.mail import Mail
 from src.lambdas.shared.secrets import SecretRetrievalError, get_secret
 
 logger = logging.getLogger(__name__)
+
+
+def _mask_email(email: str) -> str:
+    """Mask a recipient address for logs: 'scott@example.com' -> 's***@example.com'.
+
+    Feature 001 (FR-012): these lines were dark before root-level INFO went
+    live; masking prevents the visibility fix from newly exposing PII.
+    """
+    local, sep, domain = email.partition("@")
+    if not sep:
+        return "***"
+    return f"{local[:1]}***@{domain}"
+
+
 tracer = Tracer()
 
 # Template directory path
@@ -133,12 +147,16 @@ class EmailService:
 
             # 202 = Accepted (queued for sending)
             if response.status_code == 202:
-                logger.info(f"Email sent to {to_email}, subject: {subject[:50]}")
+                logger.info(
+                    f"Email sent to {_mask_email(to_email)}, subject: {subject[:50]}"
+                )
                 return True
 
             # Other success codes
             if 200 <= response.status_code < 300:
-                logger.info(f"Email sent to {to_email}, status: {response.status_code}")
+                logger.info(
+                    f"Email sent to {_mask_email(to_email)}, status: {response.status_code}"
+                )
                 return True
 
             logger.warning(

--- a/src/lambdas/shared/logging_config.py
+++ b/src/lambdas/shared/logging_config.py
@@ -1,0 +1,65 @@
+"""Central logging-level configuration for Lambda entrypoints (feature 001).
+
+Sets the ROOT logger level so first-party module loggers' INFO records become
+visible in CloudWatch, and pins noisy third-party HTTP-client loggers to
+WARNING so their per-request URL logging (which can carry credentials in
+query strings) never lights up. Level-setter ONLY: never attaches handlers or
+formatters, never touches propagation.
+
+Stated dependency (research R-1, AR#3): awslambdaric's bootstrap ``main()``
+runs ``_setup_logging`` — attaching the LambdaLoggerHandler to the root
+logger — BEFORE ``_get_handler`` imports the entrypoint module that calls
+this function. That ordering is what makes the once-per-process self-test
+line below land in CloudWatch on every cold start. If it ever changed, the
+line would fall to ``logging.lastResort`` (WARNING threshold) and drop.
+
+Deliberately NOT imported by src/lambdas/sse_streaming (FR-006): importing
+this module has no side effects; only an explicit call configures anything.
+"""
+
+import logging
+import os
+
+_PINNED_LOGGERS = ("httpx", "httpcore")
+
+SELF_TEST_MESSAGE = "logging configured: root INFO visibility active (feature 001)"
+
+_selftest_emitted = False
+
+
+def configure_lambda_logging(*, default_level: int = logging.INFO) -> None:
+    """Set root logger level, pin third-party loggers, emit self-test once.
+
+    Level resolution: explicit ``LOG_LEVEL`` env (name or numeric) wins —
+    including a deliberate DEBUG for temporary diagnostics; unset or invalid
+    falls back to ``default_level`` (INFO). Levels re-assert on EVERY call
+    (contract C-1); only the self-test emission is once-per-process (C-4).
+    The httpx/httpcore pins hold regardless of LOG_LEVEL (C-2, FR-010).
+    """
+    global _selftest_emitted
+
+    logging.getLogger().setLevel(
+        _resolve_level(os.environ.get("LOG_LEVEL"), default_level)
+    )
+    for name in _PINNED_LOGGERS:
+        logging.getLogger(name).setLevel(logging.WARNING)
+
+    if not _selftest_emitted:
+        _selftest_emitted = True
+        logging.getLogger(__name__).info(SELF_TEST_MESSAGE)
+
+
+def _resolve_level(raw: str | None, default: int) -> int:
+    if not raw:
+        return default
+    value = raw.strip().upper()
+    if value.isdigit():
+        return int(value)
+    resolved = logging.getLevelName(value)
+    return resolved if isinstance(resolved, int) else default
+
+
+def _reset_for_tests() -> None:
+    """Test hook: re-arm the self-test latch (unit tests only)."""
+    global _selftest_emitted
+    _selftest_emitted = False

--- a/tests/e2e/test_log_visibility.py
+++ b/tests/e2e/test_log_visibility.py
@@ -1,0 +1,152 @@
+# Target: backend Lambda CloudWatch log groups (not either dashboard UI)
+"""FR-008 preprod E2E: dark-line evidence per function (feature 001).
+
+Each assertion targets a line that CANNOT appear pre-deploy:
+- dashboard: refresh.* classification lines (un-leveled stdlib logger)
+- ingestion: storage.py "Storage operation complete" (dark module INFO)
+- analysis: sentiment.py dark module INFO
+- metrics + canary: the C-8 self-test line (their ONLY discriminating line)
+- notification: digest_service dark INFO on a synthetic empty-digest invoke
+
+AR#3 flake guard: C-8 emits once per COLD START, so C-8 queries window from
+the function's LastModified timestamp, never "now minus N minutes".
+"""
+
+import json
+import os
+import time
+from datetime import UTC, datetime
+
+import boto3
+import pytest
+
+pytestmark = pytest.mark.preprod
+
+REGION = os.environ.get("AWS_REGION", "us-east-1")
+ENV = os.environ.get("AWS_ENV", "preprod")
+SELF_TEST_MESSAGE = "logging configured: root INFO visibility active (feature 001)"
+POLL_TIMEOUT_S = 180
+POLL_INTERVAL_S = 15
+
+
+def _log_group(fn: str) -> str:
+    return f"/aws/lambda/{ENV}-sentiment-{fn}"
+
+
+def _function_name(fn: str) -> str:
+    return f"{ENV}-sentiment-{fn}"
+
+
+def _last_modified_ms(lambda_client, fn: str) -> int:
+    cfg = lambda_client.get_function_configuration(FunctionName=_function_name(fn))
+    dt = datetime.strptime(cfg["LastModified"], "%Y-%m-%dT%H:%M:%S.%f%z")
+    return int(dt.timestamp() * 1000)
+
+
+def _find_line(logs_client, group: str, pattern: str, start_ms: int) -> bool:
+    deadline = time.time() + POLL_TIMEOUT_S
+    while time.time() < deadline:
+        resp = logs_client.filter_log_events(
+            logGroupName=group,
+            startTime=start_ms,
+            filterPattern=f'"{pattern}"',
+            limit=1,
+        )
+        if resp.get("events"):
+            return True
+        time.sleep(POLL_INTERVAL_S)
+    return False
+
+
+@pytest.fixture(scope="module")
+def logs_client():
+    return boto3.client("logs", region_name=REGION)
+
+
+@pytest.fixture(scope="module")
+def lambda_client():
+    return boto3.client("lambda", region_name=REGION)
+
+
+class TestSelfTestLinePerColdStart:
+    """C-8 probe: the only discriminating evidence for metrics and canary."""
+
+    @pytest.mark.parametrize("fn", ["metrics", "canary"])
+    def test_self_test_line_since_deploy(self, logs_client, lambda_client, fn):
+        start_ms = _last_modified_ms(lambda_client, fn)
+        assert _find_line(logs_client, _log_group(fn), SELF_TEST_MESSAGE, start_ms), (
+            f"{fn}: C-8 self-test line absent since LastModified — root-level "
+            "fix not live (or no cold start yet in window)"
+        )
+
+
+class TestDashboardRefreshClassification:
+    """SC-006 drill — asserted via scripts/verify-log-visibility.py logic."""
+
+    def test_refresh_lines_visible(self, logs_client, lambda_client):
+        import subprocess
+        import sys
+        from pathlib import Path
+
+        script = (
+            Path(__file__).resolve().parents[2] / "scripts" / "verify-log-visibility.py"
+        )
+        # S603: argv is sys.executable + a repo-fixed script path — no
+        # untrusted input reaches the subprocess.
+        result = subprocess.run(  # noqa: S603
+            [sys.executable, str(script)],
+            capture_output=True,
+            text=True,
+            timeout=300,
+        )
+        assert (
+            result.returncode == 0
+        ), f"verify-log-visibility failed:\n{result.stdout}\n{result.stderr}"
+
+
+class TestNotificationDigestDarkLines:
+    def test_synthetic_empty_digest_emits_digest_service_info(
+        self, logs_client, lambda_client
+    ):
+        start_ms = int(time.time() * 1000) - 10_000
+        lambda_client.invoke(
+            FunctionName=_function_name("notification"),
+            Payload=json.dumps({"notification_type": "digest"}).encode(),
+        )
+        found = _find_line(
+            logs_client,
+            _log_group("notification"),
+            "Digest processing complete",
+            start_ms,
+        ) or _find_line(
+            logs_client,
+            _log_group("notification"),
+            "Found users due for digest",
+            start_ms,
+        )
+        assert found, (
+            "notification: digest_service dark INFO lines absent after "
+            "synthetic empty-digest invoke — root-level fix not live"
+        )
+
+
+class TestScheduledFunctionsDarkModuleLines:
+    """Ingestion/analysis emit dark module INFO on every real cycle."""
+
+    def test_ingestion_storage_line(self, logs_client):
+        start_ms = int((datetime.now(UTC).timestamp() - 2 * 3600) * 1000)
+        assert _find_line(
+            logs_client, _log_group("ingestion"), "Storage operation complete", start_ms
+        ), "ingestion: storage.py dark INFO absent in last 2h of scheduled cycles"
+
+    def test_analysis_sentiment_line(self, logs_client, lambda_client):
+        # Analysis runs on ingestion notifications; window from last deploy to
+        # tolerate quiet market periods, and accept the C-8 line as fallback
+        # evidence (same discriminating power).
+        start_ms = _last_modified_ms(lambda_client, "analysis")
+        found = _find_line(
+            logs_client, _log_group("analysis"), "Sentiment analysis", start_ms
+        ) or _find_line(
+            logs_client, _log_group("analysis"), SELF_TEST_MESSAGE, start_ms
+        )
+        assert found, "analysis: no dark INFO (module line or C-8) since deploy"

--- a/tests/unit/notification/test_sendgrid_service.py
+++ b/tests/unit/notification/test_sendgrid_service.py
@@ -431,3 +431,56 @@ class TestClearApiKeyCache:
         clear_api_key_cache()
         # Should not raise an error
         assert True
+
+
+class TestMaskEmail:
+    """FR-012 masked-line shape (feature 001-lambda-log-visibility, T016).
+
+    The 'Email sent to ...' INFO lines were dark pre-feature; with root-level
+    INFO live they become visible, so the recipient must be masked.
+    """
+
+    @pytest.mark.parametrize(
+        ("raw", "masked"),
+        [
+            ("scott@example.com", "s***@example.com"),
+            ("a@b.io", "a***@b.io"),
+            ("long.local.part@sub.domain.org", "l***@sub.domain.org"),
+        ],
+    )
+    def test_masks_local_part_keeps_domain(self, raw, masked):
+        from src.lambdas.notification.sendgrid_service import _mask_email
+
+        assert _mask_email(raw) == masked
+
+    def test_no_at_sign_fully_masked(self):
+        from src.lambdas.notification.sendgrid_service import _mask_email
+
+        assert _mask_email("not-an-email") == "***"
+
+    def test_send_email_success_log_masks_recipient(self, caplog):
+        """The emitted INFO line must never contain the full address."""
+        import logging as _logging
+
+        from src.lambdas.notification.sendgrid_service import EmailService
+
+        with patch("src.lambdas.notification.sendgrid_service.SendGridAPIClient") as m:
+            m.return_value.send.return_value = MagicMock(status_code=202)
+            service = EmailService(
+                secret_arn="arn:test",
+                from_email="sender@example.com",
+                api_key="SG.test-key",  # pragma: allowlist secret
+            )
+            with caplog.at_level(_logging.INFO):
+                assert service.send_email(
+                    to_email="sensitive.user@example.com",
+                    subject="hi",
+                    html_content="<p>hi</p>",
+                )
+        sent_lines = [
+            r.getMessage() for r in caplog.records if "Email sent" in r.getMessage()
+        ]
+        assert sent_lines, "expected an 'Email sent' INFO line"
+        for line in sent_lines:
+            assert "sensitive.user@example.com" not in line
+            assert "s***@example.com" in line

--- a/tests/unit/shared/test_logging_config.py
+++ b/tests/unit/shared/test_logging_config.py
@@ -1,0 +1,152 @@
+"""Contract tests C-1..C-6, C-8 for configure_lambda_logging().
+
+Contract: specs/001-lambda-log-visibility/contracts/logging-config.md
+"""
+
+import importlib
+import logging
+
+import pytest
+
+from src.lambdas.shared import logging_config
+from src.lambdas.shared.logging_config import (
+    SELF_TEST_MESSAGE,
+    configure_lambda_logging,
+)
+
+PINNED = ("httpx", "httpcore")
+SELF_TEST_LOGGER = "src.lambdas.shared.logging_config"
+
+
+@pytest.fixture(autouse=True)
+def _restore_logging_state():
+    """Snapshot and restore levels touched by the helper; reset the latch."""
+    saved = {name: logging.getLogger(name).level for name in ("", *PINNED)}
+    yield
+    logging_config._reset_for_tests()
+    for name, level in saved.items():
+        logging.getLogger(name).setLevel(level)
+
+
+class TestC1LevelReassertsEveryCall:
+    def test_sets_root_to_info_by_default(self, monkeypatch):
+        monkeypatch.delenv("LOG_LEVEL", raising=False)
+        logging.getLogger().setLevel(logging.WARNING)
+        configure_lambda_logging()
+        assert logging.getLogger().level == logging.INFO
+
+    def test_reasserts_after_external_mutation(self, monkeypatch):
+        monkeypatch.delenv("LOG_LEVEL", raising=False)
+        configure_lambda_logging()
+        logging.getLogger().setLevel(logging.WARNING)
+        configure_lambda_logging()
+        assert logging.getLogger().level == logging.INFO
+
+    def test_explicit_log_level_env_wins(self, monkeypatch):
+        monkeypatch.setenv("LOG_LEVEL", "WARNING")
+        configure_lambda_logging()
+        assert logging.getLogger().level == logging.WARNING
+
+    def test_invalid_log_level_falls_back_to_info(self, monkeypatch):
+        monkeypatch.setenv("LOG_LEVEL", "NOT_A_LEVEL")
+        configure_lambda_logging()
+        assert logging.getLogger().level == logging.INFO
+
+
+class TestC2ThirdPartyPins:
+    def test_httpx_httpcore_pinned_to_warning(self, monkeypatch):
+        monkeypatch.delenv("LOG_LEVEL", raising=False)
+        configure_lambda_logging()
+        for name in PINNED:
+            assert logging.getLogger(name).level == logging.WARNING
+
+    def test_pins_hold_under_deliberate_debug(self, monkeypatch):
+        monkeypatch.setenv("LOG_LEVEL", "DEBUG")
+        configure_lambda_logging()
+        assert logging.getLogger().level == logging.DEBUG
+        for name in PINNED:
+            assert logging.getLogger(name).level == logging.WARNING
+
+    def test_httpx_info_record_not_emitted_even_at_root_debug(
+        self, monkeypatch, caplog
+    ):
+        """FR-010/T017: worst case (root DEBUG), httpx INFO must not pass."""
+        monkeypatch.setenv("LOG_LEVEL", "DEBUG")
+        configure_lambda_logging()
+        with caplog.at_level(logging.DEBUG):
+            logging.getLogger("httpx").info(
+                "HTTP Request: GET https://api.example.com/news?token=SHOULD-NEVER-APPEAR"
+            )
+        assert not any(
+            r.name == "httpx" and "SHOULD-NEVER-APPEAR" in r.getMessage()
+            for r in caplog.records
+        )
+
+
+class TestC3NoHandlerMutations:
+    def test_handler_counts_unchanged(self, monkeypatch):
+        monkeypatch.delenv("LOG_LEVEL", raising=False)
+        before = {
+            name: list(logging.getLogger(name).handlers) for name in ("", *PINNED)
+        }
+        configure_lambda_logging()
+        after = {name: list(logging.getLogger(name).handlers) for name in ("", *PINNED)}
+        assert before == after
+
+
+class TestC4SelfTestOncePerProcess:
+    def test_emits_exactly_once_across_calls(self, monkeypatch, caplog):
+        monkeypatch.delenv("LOG_LEVEL", raising=False)
+        with caplog.at_level(logging.INFO):
+            configure_lambda_logging()
+            configure_lambda_logging()
+            configure_lambda_logging()
+        emissions = [
+            r
+            for r in caplog.records
+            if r.name == SELF_TEST_LOGGER and r.getMessage() == SELF_TEST_MESSAGE
+        ]
+        assert len(emissions) == 1
+
+    def test_latch_does_not_suppress_level_reassertion(self, monkeypatch):
+        """The latch is emission-only — C-1 must still re-assert (AR#2 F5)."""
+        monkeypatch.delenv("LOG_LEVEL", raising=False)
+        configure_lambda_logging()
+        logging.getLogger().setLevel(logging.CRITICAL)
+        logging.getLogger("httpx").setLevel(logging.DEBUG)
+        configure_lambda_logging()
+        assert logging.getLogger().level == logging.INFO
+        assert logging.getLogger("httpx").level == logging.WARNING
+
+
+class TestC5ImportSideEffectFree:
+    def test_reimport_does_not_configure(self):
+        root = logging.getLogger()
+        root.setLevel(logging.WARNING)
+        handlers_before = list(root.handlers)
+        importlib.reload(logging_config)
+        assert root.level == logging.WARNING
+        assert list(root.handlers) == handlers_before
+
+
+class TestC6OtherLoggersUntouched:
+    def test_first_party_logger_levels_preserved(self, monkeypatch):
+        monkeypatch.delenv("LOG_LEVEL", raising=False)
+        preset = logging.getLogger("src.lambdas.test_preset_module")
+        preset.setLevel(logging.INFO)
+        unset = logging.getLogger("src.lambdas.test_unset_module")
+        assert unset.level == logging.NOTSET
+        configure_lambda_logging()
+        assert preset.level == logging.INFO
+        assert unset.level == logging.NOTSET
+
+
+class TestC8SelfTestLineShape:
+    def test_logger_name_level_and_static_message(self, monkeypatch, caplog):
+        monkeypatch.delenv("LOG_LEVEL", raising=False)
+        with caplog.at_level(logging.INFO):
+            configure_lambda_logging()
+        [record] = [r for r in caplog.records if r.name == SELF_TEST_LOGGER]
+        assert record.levelno == logging.INFO
+        assert record.getMessage() == SELF_TEST_MESSAGE
+        assert record.args in (None, ())

--- a/tests/unit/test_entrypoint_logging_coverage.py
+++ b/tests/unit/test_entrypoint_logging_coverage.py
@@ -1,0 +1,66 @@
+"""Contract C-7 coverage guard (feature 001-lambda-log-visibility).
+
+Every DEPLOYED non-SSE Lambda entrypoint must call configure_lambda_logging()
+at module import top-level, before any function definition. The entrypoint
+set is DERIVED by glob, never hardcoded (AR#2 F4): a new src/lambdas/<name>/
+handler.py enters the walked set automatically and fails here until wired.
+
+Exclusions (documented, exact):
+- sse_streaming: owner-deferred function with its own basicConfig(INFO)
+  startup path and no awslambdaric (FR-006 forbids touching it).
+- chaos_restore: code exists but the function is NOT deployed
+  (infrastructure/terraform main.tf TODO TD-2). If it ever deploys, remove
+  it from this set — the guard will then enforce the call.
+"""
+
+import re
+from pathlib import Path
+
+EXCLUDED_DIRS = {"sse_streaming", "chaos_restore"}
+CALL_TOKEN = "configure_lambda_logging("
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LAMBDAS_DIR = REPO_ROOT / "src" / "lambdas"
+
+
+def _deployed_entrypoints() -> list[Path]:
+    return sorted(
+        p
+        for p in LAMBDAS_DIR.glob("*/handler.py")
+        if p.parent.name not in EXCLUDED_DIRS
+    )
+
+
+def test_glob_finds_expected_entrypoint_set():
+    names = {p.parent.name for p in _deployed_entrypoints()}
+    assert names, "no entrypoints found — src/lambdas layout changed?"
+    # The six known functions must be present; superset allowed (a new
+    # Lambda joins the guard automatically — that is the point).
+    assert {
+        "dashboard",
+        "ingestion",
+        "analysis",
+        "metrics",
+        "notification",
+        "canary",
+    } <= names
+
+
+def test_every_deployed_entrypoint_calls_configure_lambda_logging():
+    failures = []
+    for handler in _deployed_entrypoints():
+        source = handler.read_text()
+        call_idx = source.find(CALL_TOKEN)
+        if call_idx == -1:
+            failures.append(f"{handler.relative_to(REPO_ROOT)}: no {CALL_TOKEN} call")
+            continue
+        # AR#3 criterion: call index must precede the first top-level def —
+        # anchored line match, so docstrings/nested defs can't fool it.
+        first_def = re.search(r"^def ", source, flags=re.MULTILINE)
+        if first_def is not None and call_idx > first_def.start():
+            failures.append(
+                f"{handler.relative_to(REPO_ROOT)}: {CALL_TOKEN} appears after "
+                "the first top-level def — must run at import, before handlers"
+            )
+    assert not failures, (
+        "entrypoints missing import-time logging config:\n" + "\n".join(failures)
+    )


### PR DESCRIPTION
## Summary

Fixes the dark-stdlib-loggers defect from the 2026-07-25 OAuth incident close: the root logger sat at Python's default WARNING (awslambdaric attaches a handler but only sets the level when LoggingConfig has an ApplicationLogLevel — none did), so `logger.info` from 67 first-party modules never reached CloudWatch.

- New `src/lambdas/shared/logging_config.py`: root level → INFO (LOG_LEVEL env override), `httpx`/`httpcore` pinned to WARNING (blocks the finnhub key-in-URL exposure path), one self-test INFO probe per cold start (the per-function deploy evidence line).
- Wired at import top-level in all six deployed non-SSE entrypoints; CI coverage guard derives the entrypoint set by glob so a future Lambda can't silently regress.
- FR-012 content safety: recipient emails masked in the newly-visible sendgrid INFO lines.
- Ride-alongs: metrics Lambda ZIP was missing aws-lambda-powertools (7-day ImportModuleError crash-loop, 26k errors/day, unalerted) — one-line pin fixes it; canary ZIP now bundles `src/lambdas/shared`.
- Verification: `scripts/verify-log-visibility.py` (3 refresh-outcome probes + self-test line) proven to FAIL against pre-deploy preprod — the same run passing post-deploy is the SC-001/SC-006 evidence. Preprod E2E `tests/e2e/test_log_visibility.py` asserts a discriminating dark line per function.

Spec/plan/tasks with three adversarial-review appendices: `specs/001-lambda-log-visibility/`. Text log format and all existing consumers byte-identical by construction; single-revert rollback.

## Test plan
- [x] 4053 unit tests green (incl. 15 new contract/guard tests)
- [x] make validate green; 0 open CodeQL alerts
- [ ] Post-deploy: verify script + preprod E2E (T023), consumer comparison (T024), p50 delta (T025), week-one content-safety watch (T026)

🤖 Generated with [Claude Code](https://claude.com/claude-code)