### PR TITLE
fix(001): boundary-aware SuppressFilter repair + notification powertools pin

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -286,6 +286,7 @@ jobs:
             pydantic==2.12.4 \
             python-json-logger==4.0.0 \
             aws-xray-sdk==2.14.0 \
+            aws-lambda-powertools==3.7.0 \
             -t packages/notification-deps/ \
             --platform manylinux2014_x86_64 \
             --implementation cp \

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -125,7 +125,7 @@
         "filename": ".github/workflows/deploy.yml",
         "hashed_secret": "dc724af18fbdd4e59189f5fe768a5f8311527050",
         "is_verified": false,
-        "line_number": 449,
+        "line_number": 450,
         "is_added": false,
         "is_removed": false
       }
@@ -2506,5 +2506,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-26T03:58:25Z"
+  "generated_at": "2026-07-26T05:59:18Z"
 }

--- a/specs/001-lambda-log-visibility/contracts/logging-config.md
+++ b/specs/001-lambda-log-visibility/contracts/logging-config.md
@@ -53,3 +53,9 @@ def configure_lambda_logging(*, default_level: int = logging.INFO) -> None:
   glob catches any new `src/lambdas/<name>/handler.py` in CI, which is
   detection at PR time — accepted as the strongest guard available without
   the platform-level mechanism (signposted O1).
+
+## Post-deploy addendum (2026-07-26)
+
+| # | Guarantee | Verifying test |
+|---|---|---|
+| C-9 | Any powertools `SuppressFilter` on a root handler is replaced with a name-boundary filter: records named exactly the service or `service.*` stay suppressed (dedup intent), all other records — including `src.lambdas.<service>.*` module loggers — pass. No-op when powertools/filter absent. ORDERING: an entrypoint that constructs a powertools Logger MUST call the helper AFTER that construction (dashboard does) | unit (TestC9SuppressFilterRepair) |

--- a/specs/001-lambda-log-visibility/evidence/cards.md
+++ b/specs/001-lambda-log-visibility/evidence/cards.md
@@ -48,3 +48,13 @@ convention).
   in the ZIP) is fixed IN feature 001's PR (deploy.yml one-line pin, same as
   Feature 1227's ingestion fix) because FR-008/SC-002 are unachievable while
   the function cannot import its handler. The filter fix remains carded.
+
+## Card D — notification hourly digest schedule never fires (found by T023)
+
+- /aws/lambda/preprod-sentiment-notification: zero invocations in 7+ days
+  despite modules/eventbridge hourly digest rule. This silence is what hid
+  the notification ZIP's missing-powertools ImportModuleError (fixed in the
+  001 follow-up PR).
+- Fix shape: verify the EventBridge rule state/target/permissions; add an
+  invocation-count alarm (metric-based) so a silent scheduled function is
+  loud.

--- a/specs/001-lambda-log-visibility/research.md
+++ b/specs/001-lambda-log-visibility/research.md
@@ -163,3 +163,30 @@ ImportModuleError-shaped line, watch the metric); outcome either proves the
 filter alive (then Text preservation keeps it alive) or proves it
 dead-on-arrival (then card its fix separately; this feature changes nothing
 about it either way).
+
+## R-10: SECOND masking layer found post-deploy — powertools SuppressFilter substring bug (2026-07-26)
+
+Feature 001's own discriminating verification caught it: root=INFO went live
+(C-8 visible) yet route-phase dashboard records still dropped.
+`Logger(service="dashboard")` (handler.py) installs powertools'
+`SuppressFilter("dashboard")` on every ROOT handler (logger.py:374-383,
+powertools 3.23.0) to dedup its own propagated records — but
+`SuppressFilter.filter` (filters.py:4-16) is a raw SUBSTRING test:
+`"dashboard" in "src.lambdas.dashboard.router_v2"` → suppressed. Every
+dashboard module logger was silenced at the root handler since that Logger
+landed, INDEPENDENT of the root-level bug (two stacked masks). Deterministic
+3/3 local repro with remove-filter control; awslambdaric and aws_xray_sdk
+exonerated by source read. Fix: `_repair_powertools_suppress_filters()` in
+the helper swaps it for a name-boundary filter (suppresses exactly
+`dashboard` and `dashboard.*` — the documented intent); dashboard entrypoint
+now calls the helper AFTER Logger() (the filter exists only post-init).
+Upstream powertools issue worth filing.
+
+## R-11: notification ZIP missing powertools + digest schedule dead (2026-07-26)
+
+Notification E2E failure was a BROKEN DEPLOY, not dark loggers: its ZIP pip
+list lacks aws-lambda-powertools while handler.py imports Tracer →
+Runtime.ImportModuleError on every invoke (same class as metrics/1227).
+Masked because the function has ZERO invocations in 7+ days — the hourly
+digest EventBridge schedule evidently never fires (new card D). Pin added in
+the follow-up PR.

--- a/src/lambdas/dashboard/handler.py
+++ b/src/lambdas/dashboard/handler.py
@@ -99,9 +99,13 @@ from src.lambdas.shared.utils.event_helpers import get_query_params
 validate_critical_env_vars(["SCHEDULER_ROLE_ARN"])
 
 # Structured logging (FR-028: module-level logging replaces lifespan)
-configure_lambda_logging()
-
 logger = Logger(service="dashboard")
+
+# AFTER Logger(): powertools installs a substring-matching SuppressFilter on
+# the root handler at first init, which silently swallowed every
+# src.lambdas.dashboard.* record; the helper replaces it with a
+# name-boundary-aware filter (contract C-9).
+configure_lambda_logging()
 tracer = Tracer(service="dashboard")
 
 # Configuration from environment

--- a/src/lambdas/shared/logging_config.py
+++ b/src/lambdas/shared/logging_config.py
@@ -44,9 +44,54 @@ def configure_lambda_logging(*, default_level: int = logging.INFO) -> None:
     for name in _PINNED_LOGGERS:
         logging.getLogger(name).setLevel(logging.WARNING)
 
+    _repair_powertools_suppress_filters()
+
     if not _selftest_emitted:
         _selftest_emitted = True
         logging.getLogger(__name__).info(SELF_TEST_MESSAGE)
+
+
+class _BoundarySuppressFilter(logging.Filter):
+    """Name-boundary-aware replacement for powertools' SuppressFilter (C-9).
+
+    Powertools installs SuppressFilter(service) on every ROOT handler to
+    dedup its own propagated records, but its filter() is a raw SUBSTRING
+    test: with service="dashboard" it also rejects every record from
+    "src.lambdas.dashboard.*" module loggers — total log loss for the
+    subtree, discovered live 2026-07-26. This filter suppresses exactly the
+    powertools logger and its children (the documented intent) and nothing
+    else.
+    """
+
+    def __init__(self, service: str):
+        super().__init__()
+        self.logger = service  # attribute name mirrors SuppressFilter's
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        return not (
+            record.name == self.logger or record.name.startswith(self.logger + ".")
+        )
+
+
+def _repair_powertools_suppress_filters() -> None:
+    """Swap any powertools SuppressFilter on root handlers for the boundary-
+    aware version. No-op when powertools is absent or no filter is installed.
+
+    Ordering: powertools installs the filter during the first
+    ``Logger(service=...)`` init, so the entrypoint must call
+    ``configure_lambda_logging()`` AFTER constructing its powertools Logger
+    (the dashboard handler does; the other five have no powertools Logger
+    and this is a no-op).
+    """
+    try:
+        from aws_lambda_powertools.logging.filters import SuppressFilter
+    except ImportError:  # powertools not packaged in this Lambda
+        return
+    for handler in logging.getLogger().handlers:
+        for flt in list(handler.filters):
+            if type(flt) is SuppressFilter:
+                handler.removeFilter(flt)
+                handler.addFilter(_BoundarySuppressFilter(flt.logger))
 
 
 def _resolve_level(raw: str | None, default: int) -> int:

--- a/tests/unit/shared/test_logging_config.py
+++ b/tests/unit/shared/test_logging_config.py
@@ -150,3 +150,56 @@ class TestC8SelfTestLineShape:
         assert record.levelno == logging.INFO
         assert record.getMessage() == SELF_TEST_MESSAGE
         assert record.args in (None, ())
+
+
+class TestC9SuppressFilterRepair:
+    """C-9: powertools SuppressFilter substring bug repaired at root handlers.
+
+    Live defect 2026-07-26: Logger(service="dashboard") installs
+    SuppressFilter("dashboard") on the awslambdaric root handler; its raw
+    substring match rejects every src.lambdas.dashboard.* record.
+    """
+
+    @pytest.fixture()
+    def root_handler_with_suppress(self):
+        from aws_lambda_powertools.logging.filters import SuppressFilter
+
+        handler = logging.NullHandler()
+        handler.addFilter(SuppressFilter("dashboard"))
+        root = logging.getLogger()
+        root.addHandler(handler)
+        yield handler
+        root.removeHandler(handler)
+
+    def _record(self, name):
+        return logging.LogRecord(name, logging.INFO, __file__, 1, "msg", None, None)
+
+    def test_module_subtree_records_pass_after_repair(
+        self, monkeypatch, root_handler_with_suppress
+    ):
+        monkeypatch.delenv("LOG_LEVEL", raising=False)
+        handler = root_handler_with_suppress
+        assert not handler.filter(self._record("src.lambdas.dashboard.router_v2"))
+        configure_lambda_logging()
+        assert handler.filter(self._record("src.lambdas.dashboard.router_v2"))
+        assert handler.filter(self._record("src.lambdas.dashboard.auth"))
+
+    def test_powertools_own_records_still_suppressed(
+        self, monkeypatch, root_handler_with_suppress
+    ):
+        monkeypatch.delenv("LOG_LEVEL", raising=False)
+        handler = root_handler_with_suppress
+        configure_lambda_logging()
+        assert not handler.filter(self._record("dashboard"))
+        assert not handler.filter(self._record("dashboard.child"))
+
+    def test_noop_without_suppress_filter(self, monkeypatch):
+        monkeypatch.delenv("LOG_LEVEL", raising=False)
+        handler = logging.NullHandler()
+        root = logging.getLogger()
+        root.addHandler(handler)
+        try:
+            configure_lambda_logging()
+            assert handler.filters == []
+        finally:
+            root.removeHandler(handler)


### PR DESCRIPTION
## Summary

Feature 001's post-deploy verification caught a SECOND masking layer under the root-level bug it fixed:

- **powertools `SuppressFilter` substring bug**: `Logger(service="dashboard")` installs `SuppressFilter("dashboard")` on the awslambdaric root handler (dedup of its own propagated records), but its `filter()` is a raw substring test — `"dashboard" in "src.lambdas.dashboard.router_v2"` — so every dashboard module logger has been rejected at the root handler since that Logger landed. `configure_lambda_logging()` now swaps it for a name-boundary filter (suppresses exactly `dashboard`/`dashboard.*`, the documented intent); the dashboard entrypoint calls the helper AFTER `Logger()` (the filter exists only post-init). Deterministic 3/3 repro with remove-filter control; awslambdaric + aws_xray_sdk exonerated by source read. Worth filing upstream.
- **notification ZIP missing `aws-lambda-powertools`**: handler imports `Tracer` but the package pip list never included it — `Runtime.ImportModuleError` on every invoke, masked because the hourly digest schedule apparently never fires (zero invocations in 7+ days; carded separately as Card D). Same class as the metrics fix in #965 and the 1227 ingestion fix.

Post-merge: `scripts/verify-log-visibility.py` must flip to PASS (all three refresh.* lines + C-8), closing SC-001/SC-006; notification E2E re-run closes its FR-008 check.

## Test plan
- [x] 4061 unit tests green (3 new C-9 contract tests)
- [x] Local end-to-end repro: refresh.cookie_absent reaches root handler with fix, blocked without
- [ ] Post-deploy: verify script PASS + notification synthetic digest emits digest_service lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)