### PR TITLE
fix(001): metrics aws-xray-sdk pin (crash-loop round 2) + E2E health probe + T024-T026 evidence

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -241,6 +241,7 @@ jobs:
             boto3==1.41.0 \
             python-json-logger==4.0.0 \
             aws-lambda-powertools==3.7.0 \
+            aws-xray-sdk==2.14.0 \
             -t packages/metrics-deps/ \
             --platform manylinux2014_x86_64 \
             --implementation cp \

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -125,7 +125,7 @@
         "filename": ".github/workflows/deploy.yml",
         "hashed_secret": "dc724af18fbdd4e59189f5fe768a5f8311527050",
         "is_verified": false,
-        "line_number": 451,
+        "line_number": 452,
         "is_added": false,
         "is_removed": false
       }
@@ -2506,5 +2506,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-26T06:40:48Z"
+  "generated_at": "2026-07-29T14:18:56Z"
 }

--- a/specs/001-lambda-log-visibility/evidence/cards.md
+++ b/specs/001-lambda-log-visibility/evidence/cards.md
@@ -73,3 +73,22 @@ convention).
 - Fix shape: diagnose the DynamoDB query (likely GSI name/permissions on
   the users table digest index); newly-visible ERROR lines now make this
   loud in CloudWatch.
+
+## Card F — metrics crash-loop round 2 + the verification gap it exposed
+
+- The #965 powertools pin peeled ONE onion layer: 43s later the metrics
+  Lambda began failing on `No module named 'aws_xray_sdk'` (powertools
+  Tracer lazy-loads it at construction, tracer.py:29) — ~14,600 errors over
+  3 days, zero healthy invocations, caught only by the T024 measurement
+  sweep. Fixed: aws-xray-sdk==2.14.0 pinned + isolated import simulation
+  now part of the fix discipline.
+- Verification gap (recorded honestly): the E2E's C-8 assertion PASSED
+  throughout — C-8 emits at handler import before Tracer() fails, so it
+  proves logging visibility, not function health. E2E now adds a synthetic
+  invoke asserting no FunctionError for metrics (and notification already
+  has one).
+- Standing gap for the board: NO deploy smoke step exercises ZIP-Lambda
+  imports (dashboard has one; metrics/notification/canary/ingestion don't),
+  and the dead import-error metric filter (Card C) means ImportModuleError
+  storms are silent. An import smoke per ZIP Lambda in the deploy pipeline
+  would have caught all three onion layers pre-merge.

--- a/specs/001-lambda-log-visibility/evidence/post-deploy/logshape-analysis.json
+++ b/specs/001-lambda-log-visibility/evidence/post-deploy/logshape-analysis.json
@@ -1,0 +1,359 @@
+{
+  "logGroupName": "/aws/lambda/preprod-sentiment-analysis",
+  "collectedAt": "2026-07-29T13:56:50.277861+00:00",
+  "windowUsed": "24h",
+  "error": null,
+  "eventCount": 50,
+  "events": [
+    {
+      "logStreamName": "2026/07/29/[$LATEST]8e95f44cb80c4712abc396088b8d39e5",
+      "timestamp": 1785293288938,
+      "message": "START RequestId: 7bebdd52-7785-4859-ab68-c59a7b80d700 Version: $LATEST\n",
+      "ingestionTime": 1785293290343,
+      "eventId": "39813370741253047955421203505459200405939699745505476629"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]8e95f44cb80c4712abc396088b8d39e5",
+      "timestamp": 1785293288939,
+      "message": "{\"timestamp\": \"2026-07-29T02:48:08.939371+00:00\", \"level\": \"INFO\", \"message\": \"Analysis started\", \"request_id\": \"7bebdd52-7785-4859-ab68-c59a7b80d700\", \"source_id\": \"dedup:ba13c617afeffe836ef96884b4159068\", \"ticker_count\": 1}\n",
+      "ingestionTime": 1785293290343,
+      "eventId": "39813370741275348700619734128600736124212348107011457046"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]e3830eb90bd74aa5bb22d43149155b03",
+      "timestamp": 1785293288941,
+      "message": "START RequestId: 14285381-436b-4223-b0e8-765afec836ac Version: $LATEST\n",
+      "ingestionTime": 1785293290327,
+      "eventId": "39813370741319950191016795374864837539271230513357193237"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]e3830eb90bd74aa5bb22d43149155b03",
+      "timestamp": 1785293288942,
+      "message": "{\"timestamp\": \"2026-07-29T02:48:08.942555+00:00\", \"level\": \"INFO\", \"message\": \"Analysis started\", \"request_id\": \"14285381-436b-4223-b0e8-765afec836ac\", \"source_id\": \"dedup:828f1d9fb1784911928c5e098b25a432\", \"ticker_count\": 1}\n",
+      "ingestionTime": 1785293290327,
+      "eventId": "39813370741342250936215325998006373257543878874863173654"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]8e95f44cb80c4712abc396088b8d39e5",
+      "timestamp": 1785293289048,
+      "message": "{\"timestamp\": \"2026-07-29T02:48:09.048782+00:00\", \"level\": \"INFO\", \"message\": \"Inference complete\", \"source_id\": \"dedup:ba13c617afeffe836ef96884b4159068\", \"sentiment\": \"negative\", \"score\": 0.9589, \"inference_time_ms\": 82.36}\n",
+      "ingestionTime": 1785293290343,
+      "eventId": "39813370743706129927259572051028129415931019511163322391"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]e3830eb90bd74aa5bb22d43149155b03",
+      "timestamp": 1785293289090,
+      "message": "{\"timestamp\": \"2026-07-29T02:48:09.089925+00:00\", \"level\": \"INFO\", \"message\": \"Inference complete\", \"source_id\": \"dedup:828f1d9fb1784911928c5e098b25a432\", \"sentiment\": \"negative\", \"score\": 0.8902, \"inference_time_ms\": 122.56}\n",
+      "ingestionTime": 1785293290327,
+      "eventId": "39813370744642761225597858222953659561895836377748275223"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]8e95f44cb80c4712abc396088b8d39e5",
+      "timestamp": 1785293289114,
+      "message": "[WARNING]\t2026-07-29T02:48:09.114Z\t7bebdd52-7785-4859-ab68-c59a7b80d700\tItem already analyzed, skipping\n",
+      "ingestionTime": 1785293290343,
+      "eventId": "39813370745177979110362593178369486821925811370558029848"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]e3830eb90bd74aa5bb22d43149155b03",
+      "timestamp": 1785293289168,
+      "message": "[WARNING]\t2026-07-29T02:48:09.168Z\t14285381-436b-4223-b0e8-765afec836ac\tItem already analyzed, skipping\n",
+      "ingestionTime": 1785293290327,
+      "eventId": "39813370746382219351083246827993445587162408575214747672"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]8e95f44cb80c4712abc396088b8d39e5",
+      "timestamp": 1785293289168,
+      "message": "{\"timestamp\": \"2026-07-29T02:48:09.168149+00:00\", \"level\": \"INFO\", \"message\": \"Analysis completed\", \"source_id\": \"dedup:ba13c617afeffe836ef96884b4159068\", \"sentiment\": \"negative\", \"score\": 0.9589, \"model_version\": \"a4b88c6\", \"inference_time_ms\": 82.36, \"execution_time_ms\": 204.72, \"updated\": false}\n",
+      "ingestionTime": 1785293290343,
+      "eventId": "39813370746382219351083246828012415608648822891880972313"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]8e95f44cb80c4712abc396088b8d39e5",
+      "timestamp": 1785293289170,
+      "message": "END RequestId: 7bebdd52-7785-4859-ab68-c59a7b80d700\n",
+      "ingestionTime": 1785293290343,
+      "eventId": "39813370746426820841480308074295487045194119614892933146"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]8e95f44cb80c4712abc396088b8d39e5",
+      "timestamp": 1785293289170,
+      "message": "REPORT RequestId: 7bebdd52-7785-4859-ab68-c59a7b80d700\tDuration: 231.16 ms\tBilled Duration: 232 ms\tMemory Size: 2048 MB\tMax Memory Used: 856 MB\t\nXRAY TraceId: 1-6a6969cc-3f6ae7a7451479fb448ba5eb\tSegmentId: ed6a601d648fee71\tSampled: true\t\n",
+      "ingestionTime": 1785293290343,
+      "eventId": "39813370746426820841480308074295487045194119614892933147"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]e3830eb90bd74aa5bb22d43149155b03",
+      "timestamp": 1785293289239,
+      "message": "{\"timestamp\": \"2026-07-29T02:48:09.239359+00:00\", \"level\": \"INFO\", \"message\": \"Analysis completed\", \"source_id\": \"dedup:828f1d9fb1784911928c5e098b25a432\", \"sentiment\": \"negative\", \"score\": 0.8902, \"model_version\": \"a4b88c6\", \"inference_time_ms\": 122.56, \"execution_time_ms\": 268.94, \"updated\": false}\n",
+      "ingestionTime": 1785293290327,
+      "eventId": "39813370747965572260178921071042481584520442242139357209"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]e3830eb90bd74aa5bb22d43149155b03",
+      "timestamp": 1785293289241,
+      "message": "END RequestId: 14285381-436b-4223-b0e8-765afec836ac\n",
+      "ingestionTime": 1785293290327,
+      "eventId": "39813370748010173750575982317325553021065738965151318042"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]e3830eb90bd74aa5bb22d43149155b03",
+      "timestamp": 1785293289241,
+      "message": "REPORT RequestId: 14285381-436b-4223-b0e8-765afec836ac\tDuration: 299.39 ms\tBilled Duration: 300 ms\tMemory Size: 2048 MB\tMax Memory Used: 861 MB\t\nXRAY TraceId: 1-6a6969cc-3f6ae7a7451479fb448ba5eb\tSegmentId: 51cea05b123e11f5\tSampled: true\t\n",
+      "ingestionTime": 1785293290327,
+      "eventId": "39813370748010173750575982317325553021065738965151318043"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]ae2379200797483fb31e4d83adcaf2d5",
+      "timestamp": 1785294783419,
+      "message": "[INFO]\t2026-07-29T03:13:03.418Z\t\tlogging configured: root INFO visibility active (feature 001)\n",
+      "ingestionTime": 1785294791749,
+      "eventId": "39813404069293033000665408505989411399863175733956837376"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]ae2379200797483fb31e4d83adcaf2d5",
+      "timestamp": 1785294783468,
+      "message": "[INFO]\t2026-07-29T03:13:03.467Z\t\tsuccessfully patched module sqlite3\n",
+      "ingestionTime": 1785294791749,
+      "eventId": "39813404070385769515393409039924661595222945447749877761"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]ae2379200797483fb31e4d83adcaf2d5",
+      "timestamp": 1785294783473,
+      "message": "[INFO]\t2026-07-29T03:13:03.473Z\t\tsuccessfully patched module botocore\n",
+      "ingestionTime": 1785294791749,
+      "eventId": "39813404070497273241386062155632340186586187255279779842"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]ae2379200797483fb31e4d83adcaf2d5",
+      "timestamp": 1785294783512,
+      "message": "[INFO]\t2026-07-29T03:13:03.512Z\t\tsuccessfully patched module requests\n",
+      "ingestionTime": 1785294791749,
+      "eventId": "39813404071367002304128756458152233199219473354013016067"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]124f9d52788d479fbe2aad4441323441",
+      "timestamp": 1785294783574,
+      "message": "[INFO]\t2026-07-29T03:13:03.574Z\t\tlogging configured: root INFO visibility active (feature 001)\n",
+      "ingestionTime": 1785294790888,
+      "eventId": "39813404072749648506437655091886439079735407816662384640"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]124f9d52788d479fbe2aad4441323441",
+      "timestamp": 1785294783635,
+      "message": "[INFO]\t2026-07-29T03:13:03.635Z\t\tsuccessfully patched module botocore\n",
+      "ingestionTime": 1785294790888,
+      "eventId": "39813404074109993963548023103520117894366957868527190017"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]124f9d52788d479fbe2aad4441323441",
+      "timestamp": 1785294783643,
+      "message": "[INFO]\t2026-07-29T03:13:03.643Z\t\tsuccessfully patched module sqlite3\n",
+      "ingestionTime": 1785294790888,
+      "eventId": "39813404074288399925136268088652403640548144760575033346"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]ae2379200797483fb31e4d83adcaf2d5",
+      "timestamp": 1785294783650,
+      "message": "START RequestId: 5770e50a-fbe6-40c9-977b-a1ecbf2744ba Version: $LATEST\n",
+      "ingestionTime": 1785294791749,
+      "eventId": "39813404074444505141525982451684162320844947241838313476"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]ae2379200797483fb31e4d83adcaf2d5",
+      "timestamp": 1785294783650,
+      "message": "{\"timestamp\": \"2026-07-29T03:13:03.650823+00:00\", \"level\": \"INFO\", \"message\": \"Analysis started\", \"request_id\": \"5770e50a-fbe6-40c9-977b-a1ecbf2744ba\", \"source_id\": \"dedup:1401ce4558bfa9344efab1d23f3b9392\", \"ticker_count\": 1}\n",
+      "ingestionTime": 1785294791749,
+      "eventId": "39813404074444505141525982451684162320844947241838313477"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]ae2379200797483fb31e4d83adcaf2d5",
+      "timestamp": 1785294783651,
+      "message": "[INFO]\t2026-07-29T03:13:03.650Z\t5770e50a-fbe6-40c9-977b-a1ecbf2744ba\tLoading sentiment model from /tmp/model\n",
+      "ingestionTime": 1785294791749,
+      "eventId": "39813404074466805886724513074825698039117595603344293894"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]ae2379200797483fb31e4d83adcaf2d5",
+      "timestamp": 1785294783651,
+      "message": "[INFO]\t2026-07-29T03:13:03.651Z\t5770e50a-fbe6-40c9-977b-a1ecbf2744ba\tDownloading model from S3: s3://sentiment-analyzer-models-218795110243/distilbert/v1.0.0/model.tar.gz\n",
+      "ingestionTime": 1785294791749,
+      "eventId": "39813404074466805886724513074825698039117595603344293895"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]ae2379200797483fb31e4d83adcaf2d5",
+      "timestamp": 1785294783664,
+      "message": "[INFO]\t2026-07-29T03:13:03.664Z\t5770e50a-fbe6-40c9-977b-a1ecbf2744ba\tFound credentials in environment variables.\n",
+      "ingestionTime": 1785294791749,
+      "eventId": "39813404074756715574305411175665662376662024302922039304"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]124f9d52788d479fbe2aad4441323441",
+      "timestamp": 1785294783689,
+      "message": "[INFO]\t2026-07-29T03:13:03.689Z\t\tsuccessfully patched module requests\n",
+      "ingestionTime": 1785294790888,
+      "eventId": "39813404075314234204268676753163046681089969389850132483"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]124f9d52788d479fbe2aad4441323441",
+      "timestamp": 1785294783867,
+      "message": "START RequestId: 9600f213-5e8b-4428-8ff7-f8f79ae04b10 Version: $LATEST\n",
+      "ingestionTime": 1785294790888,
+      "eventId": "39813404079283766849607127672356404533621377737914646532"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]124f9d52788d479fbe2aad4441323441",
+      "timestamp": 1785294783868,
+      "message": "{\"timestamp\": \"2026-07-29T03:13:03.867918+00:00\", \"level\": \"INFO\", \"message\": \"Analysis started\", \"request_id\": \"9600f213-5e8b-4428-8ff7-f8f79ae04b10\", \"source_id\": \"dedup:1401ce4558bfa9344efab1d23f3b9392\", \"ticker_count\": 1}\n",
+      "ingestionTime": 1785294790888,
+      "eventId": "39813404079306067594805658295497940251894026099420626949"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]124f9d52788d479fbe2aad4441323441",
+      "timestamp": 1785294783868,
+      "message": "[INFO]\t2026-07-29T03:13:03.868Z\t9600f213-5e8b-4428-8ff7-f8f79ae04b10\tLoading sentiment model from /tmp/model\n",
+      "ingestionTime": 1785294790888,
+      "eventId": "39813404079306067594805658295497940251894026099420626950"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]124f9d52788d479fbe2aad4441323441",
+      "timestamp": 1785294783868,
+      "message": "[INFO]\t2026-07-29T03:13:03.868Z\t9600f213-5e8b-4428-8ff7-f8f79ae04b10\tDownloading model from S3: s3://sentiment-analyzer-models-218795110243/distilbert/v1.0.0/model.tar.gz\n",
+      "ingestionTime": 1785294790888,
+      "eventId": "39813404079306067594805658295497940251894026099420626951"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]124f9d52788d479fbe2aad4441323441",
+      "timestamp": 1785294783884,
+      "message": "[INFO]\t2026-07-29T03:13:03.884Z\t9600f213-5e8b-4428-8ff7-f8f79ae04b10\tFound credentials in environment variables.\n",
+      "ingestionTime": 1785294790888,
+      "eventId": "39813404079662879517982148265762511744256399883516313608"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]ae2379200797483fb31e4d83adcaf2d5",
+      "timestamp": 1785294785467,
+      "message": "[INFO]\t2026-07-29T03:13:05.467Z\t5770e50a-fbe6-40c9-977b-a1ecbf2744ba\tModel downloaded from S3\n",
+      "ingestionTime": 1785294791749,
+      "eventId": "39813404114964959167256124699854562422247020098204729353"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]124f9d52788d479fbe2aad4441323441",
+      "timestamp": 1785294785480,
+      "message": "[INFO]\t2026-07-29T03:13:05.480Z\t9600f213-5e8b-4428-8ff7-f8f79ae04b10\tModel downloaded from S3\n",
+      "ingestionTime": 1785294790888,
+      "eventId": "39813404115254868854837022799653518107403184847061057545"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]124f9d52788d479fbe2aad4441323441",
+      "timestamp": 1785294787622,
+      "message": "[INFO]\t2026-07-29T03:13:07.622Z\t9600f213-5e8b-4428-8ff7-f8f79ae04b10\tModel extracted successfully\n",
+      "ingestionTime": 1785294790888,
+      "eventId": "39813404163023065070089617568823026647415975192871108618"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]ae2379200797483fb31e4d83adcaf2d5",
+      "timestamp": 1785294788529,
+      "message": "[INFO]\t2026-07-29T03:13:08.529Z\t5770e50a-fbe6-40c9-977b-a1ecbf2744ba\tModel extracted successfully\n",
+      "ingestionTime": 1785294791749,
+      "eventId": "39813404183249840965156892759236931773096303029516763146"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]124f9d52788d479fbe2aad4441323441",
+      "timestamp": 1785294792336,
+      "message": "Device set to use cpu\n",
+      "ingestionTime": 1785294801354,
+      "eventId": "39813404268148777935962975070675119176424632584287027200"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]124f9d52788d479fbe2aad4441323441",
+      "timestamp": 1785294792336,
+      "message": "[INFO]\t2026-07-29T03:13:12.336Z\t9600f213-5e8b-4428-8ff7-f8f79ae04b10\tModel loaded successfully\n",
+      "ingestionTime": 1785294801354,
+      "eventId": "39813404268148777935962975070675119176424632584287027201"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]124f9d52788d479fbe2aad4441323441",
+      "timestamp": 1785294792530,
+      "message": "{\"timestamp\": \"2026-07-29T03:13:12.530155+00:00\", \"level\": \"INFO\", \"message\": \"Inference complete\", \"source_id\": \"dedup:1401ce4558bfa9344efab1d23f3b9392\", \"sentiment\": \"positive\", \"score\": 0.8934, \"inference_time_ms\": 151.33}\n",
+      "ingestionTime": 1785294801354,
+      "eventId": "39813404272475122504477915960133048521318414716447227906"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]124f9d52788d479fbe2aad4441323441",
+      "timestamp": 1785294792711,
+      "message": "{\"timestamp\": \"2026-07-29T03:13:12.711706+00:00\", \"level\": \"INFO\", \"message\": \"Time-series fanout complete\", \"tickers_written\": 1, \"tickers_failed\": 0}\n",
+      "ingestionTime": 1785294801354,
+      "eventId": "39813404276511557385411958748751013528667768149029683203"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]124f9d52788d479fbe2aad4441323441",
+      "timestamp": 1785294792745,
+      "message": "{\"timestamp\": \"2026-07-29T03:13:12.745533+00:00\", \"level\": \"INFO\", \"message\": \"Analysis completed\", \"source_id\": \"dedup:1401ce4558bfa9344efab1d23f3b9392\", \"sentiment\": \"positive\", \"score\": 0.8934, \"model_version\": \"a4b88c6\", \"inference_time_ms\": 151.33, \"execution_time_ms\": 8844.06, \"updated\": true}\n",
+      "ingestionTime": 1785294801354,
+      "eventId": "39813404277269782722161999935563227949937812440233017348"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]124f9d52788d479fbe2aad4441323441",
+      "timestamp": 1785294792749,
+      "message": "END RequestId: 9600f213-5e8b-4428-8ff7-f8f79ae04b10\n",
+      "ingestionTime": 1785294801354,
+      "eventId": "39813404277358985702956122428129370823028405886256939013"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]124f9d52788d479fbe2aad4441323441",
+      "timestamp": 1785294792749,
+      "message": "REPORT RequestId: 9600f213-5e8b-4428-8ff7-f8f79ae04b10\tDuration: 8882.33 ms\tBilled Duration: 9860 ms\tMemory Size: 2048 MB\tMax Memory Used: 856 MB\tInit Duration: 976.99 ms\t\nXRAY TraceId: 1-6a696fa8-08f8ce831361251305f4f277\tSegmentId: 5805632761289e31\tSampled: true\t\n",
+      "ingestionTime": 1785294801354,
+      "eventId": "39813404277358985702956122428129370823028405886256939014"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]ae2379200797483fb31e4d83adcaf2d5",
+      "timestamp": 1785294793148,
+      "message": "Device set to use cpu\n",
+      "ingestionTime": 1785294802167,
+      "eventId": "39813404286256983037169841062585371842167536027468824576"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]ae2379200797483fb31e4d83adcaf2d5",
+      "timestamp": 1785294793148,
+      "message": "[INFO]\t2026-07-29T03:13:13.148Z\t5770e50a-fbe6-40c9-977b-a1ecbf2744ba\tModel loaded successfully\n",
+      "ingestionTime": 1785294802167,
+      "eventId": "39813404286256983037169841062585371842167536027468824577"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]ae2379200797483fb31e4d83adcaf2d5",
+      "timestamp": 1785294793402,
+      "message": "{\"timestamp\": \"2026-07-29T03:13:13.402164+00:00\", \"level\": \"INFO\", \"message\": \"Inference complete\", \"source_id\": \"dedup:1401ce4558bfa9344efab1d23f3b9392\", \"sentiment\": \"positive\", \"score\": 0.8934, \"inference_time_ms\": 213.31}\n",
+      "ingestionTime": 1785294802167,
+      "eventId": "39813404291921372317596619340535444283420219849987850242"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]ae2379200797483fb31e4d83adcaf2d5",
+      "timestamp": 1785294793501,
+      "message": "[WARNING]\t2026-07-29T03:13:13.500Z\t5770e50a-fbe6-40c9-977b-a1ecbf2744ba\tItem already analyzed, skipping\n",
+      "ingestionTime": 1785294802167,
+      "eventId": "39813404294129146092251151031547480392412407639079911427"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]ae2379200797483fb31e4d83adcaf2d5",
+      "timestamp": 1785294793563,
+      "message": "{\"timestamp\": \"2026-07-29T03:13:13.562932+00:00\", \"level\": \"INFO\", \"message\": \"Analysis completed\", \"source_id\": \"dedup:1401ce4558bfa9344efab1d23f3b9392\", \"sentiment\": \"positive\", \"score\": 0.8934, \"model_version\": \"a4b88c6\", \"inference_time_ms\": 213.31, \"execution_time_ms\": 9879.67, \"updated\": false}\n",
+      "ingestionTime": 1785294802167,
+      "eventId": "39813404295511792294560049666322694925316606052450697220"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]ae2379200797483fb31e4d83adcaf2d5",
+      "timestamp": 1785294793565,
+      "message": "END RequestId: 5770e50a-fbe6-40c9-977b-a1ecbf2744ba\n",
+      "ingestionTime": 1785294802167,
+      "eventId": "39813404295556393784957110912605766361861902775462658053"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]ae2379200797483fb31e4d83adcaf2d5",
+      "timestamp": 1785294793565,
+      "message": "REPORT RequestId: 5770e50a-fbe6-40c9-977b-a1ecbf2744ba\tDuration: 9915.00 ms\tBilled Duration: 10593 ms\tMemory Size: 2048 MB\tMax Memory Used: 838 MB\tInit Duration: 677.41 ms\t\nXRAY TraceId: 1-6a696fa8-08f8ce831361251305f4f277\tSegmentId: 2aff4c4e152bdc84\tSampled: true\t\n",
+      "ingestionTime": 1785294802167,
+      "eventId": "39813404295556393784957110912605766361861902775462658054"
+    }
+  ]
+}

--- a/specs/001-lambda-log-visibility/evidence/post-deploy/logshape-canary.json
+++ b/specs/001-lambda-log-visibility/evidence/post-deploy/logshape-canary.json
@@ -1,0 +1,359 @@
+{
+  "logGroupName": "/aws/lambda/preprod-sentiment-canary",
+  "collectedAt": "2026-07-29T13:56:57.531194+00:00",
+  "windowUsed": "1h",
+  "error": null,
+  "eventCount": 50,
+  "events": [
+    {
+      "logStreamName": "2026/07/29/[$LATEST]515f6058c7fe48cf8ddf903548d2971a",
+      "timestamp": 1785331929992,
+      "message": "START RequestId: 9e18b3ef-4dfa-4574-85df-585d2182c34d Version: $LATEST\n",
+      "ingestionTime": 1785331939012,
+      "eventId": "39814232465552504617950715960165933279315190804644495360"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]515f6058c7fe48cf8ddf903548d2971a",
+      "timestamp": 1785331929992,
+      "message": "[INFO]\t2026-07-29T13:32:09.992Z\t9e18b3ef-4dfa-4574-85df-585d2182c34d\tCanary invocation started\n",
+      "ingestionTime": 1785331939012,
+      "eventId": "39814232465552504617950715960165933279315190804644495361"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]515f6058c7fe48cf8ddf903548d2971a",
+      "timestamp": 1785331930072,
+      "message": "[INFO]\t2026-07-29T13:32:10.072Z\t9e18b3ef-4dfa-4574-85df-585d2182c34d\tSubmitted synthetic trace\n",
+      "ingestionTime": 1785331939012,
+      "eventId": "39814232467336564233833165811488790741127059725122928642"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]515f6058c7fe48cf8ddf903548d2971a",
+      "timestamp": 1785331930390,
+      "message": "[WARNING]\t2026-07-29T13:32:10.390Z\t9e18b3ef-4dfa-4574-85df-585d2182c34d\tNo canary traces found\n",
+      "ingestionTime": 1785331939012,
+      "eventId": "39814232474428201206965903970497149151829238684024700931"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]515f6058c7fe48cf8ddf903548d2971a",
+      "timestamp": 1785331960413,
+      "message": "[WARNING]\t2026-07-29T13:32:40.412Z\t9e18b3ef-4dfa-4574-85df-585d2182c34d\tNo canary traces found\n",
+      "ingestionTime": 1785331969432,
+      "eventId": "39814233143963474302450802585599723063052280548710940672"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]515f6058c7fe48cf8ddf903548d2971a",
+      "timestamp": 1785332020619,
+      "message": "[WARNING]\t2026-07-29T13:33:40.619Z\t9e18b3ef-4dfa-4574-85df-585d2182c34d\tNo canary traces found\n",
+      "ingestionTime": 1785332029638,
+      "eventId": "39814234486602139725185499517683625859925860230500581376"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]515f6058c7fe48cf8ddf903548d2971a",
+      "timestamp": 1785332020810,
+      "message": "[INFO]\t2026-07-29T13:33:40.810Z\t9e18b3ef-4dfa-4574-85df-585d2182c34d\tMetrics emitted\n",
+      "ingestionTime": 1785332029638,
+      "eventId": "39814234490861582058104848537716948050001697278142840833"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]515f6058c7fe48cf8ddf903548d2971a",
+      "timestamp": 1785332020810,
+      "message": "[INFO]\t2026-07-29T13:33:40.810Z\t9e18b3ef-4dfa-4574-85df-585d2182c34d\tCanary complete\n",
+      "ingestionTime": 1785332029638,
+      "eventId": "39814234490861582058104848537716948050001697278142840834"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]515f6058c7fe48cf8ddf903548d2971a",
+      "timestamp": 1785332020870,
+      "message": "END RequestId: 9e18b3ef-4dfa-4574-85df-585d2182c34d\n",
+      "ingestionTime": 1785332029638,
+      "eventId": "39814234492199626770016685926209091146360598968501665795"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]515f6058c7fe48cf8ddf903548d2971a",
+      "timestamp": 1785332020870,
+      "message": "REPORT RequestId: 9e18b3ef-4dfa-4574-85df-585d2182c34d\tDuration: 90877.57 ms\tBilled Duration: 90878 ms\tMemory Size: 128 MB\tMax Memory Used: 93 MB\t\n",
+      "ingestionTime": 1785332029638,
+      "eventId": "39814234492199626770016685926209091146360598968501665796"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]515f6058c7fe48cf8ddf903548d2971a",
+      "timestamp": 1785332230079,
+      "message": "START RequestId: d79ab56e-51b8-430f-9d5c-37b134a95fb4 Version: $LATEST\n",
+      "ingestionTime": 1785332239097,
+      "eventId": "39814239157716229009409822996975392447420663192699142144"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]515f6058c7fe48cf8ddf903548d2971a",
+      "timestamp": 1785332230090,
+      "message": "[INFO]\t2026-07-29T13:37:10.090Z\td79ab56e-51b8-430f-9d5c-37b134a95fb4\tCanary invocation started\n",
+      "ingestionTime": 1785332239097,
+      "eventId": "39814239157961537206593659851532285348419795169264926721"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]515f6058c7fe48cf8ddf903548d2971a",
+      "timestamp": 1785332230230,
+      "message": "[INFO]\t2026-07-29T13:37:10.153Z\td79ab56e-51b8-430f-9d5c-37b134a95fb4\tSubmitted synthetic trace\n",
+      "ingestionTime": 1785332239097,
+      "eventId": "39814239161083641534387947091347285906590565780102184962"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]515f6058c7fe48cf8ddf903548d2971a",
+      "timestamp": 1785332230441,
+      "message": "[WARNING]\t2026-07-29T13:37:10.441Z\td79ab56e-51b8-430f-9d5c-37b134a95fb4\tNo canary traces found\n",
+      "ingestionTime": 1785332239097,
+      "eventId": "39814239165789098771277908574211322462119370057864052739"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]515f6058c7fe48cf8ddf903548d2971a",
+      "timestamp": 1785332260474,
+      "message": "[WARNING]\t2026-07-29T13:37:40.474Z\td79ab56e-51b8-430f-9d5c-37b134a95fb4\tNo canary traces found\n",
+      "ingestionTime": 1785332269487,
+      "eventId": "39814239835547379318748113420692565810017296063713771520"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]515f6058c7fe48cf8ddf903548d2971a",
+      "timestamp": 1785332320664,
+      "message": "[WARNING]\t2026-07-29T13:38:40.664Z\td79ab56e-51b8-430f-9d5c-37b134a95fb4\tNo canary traces found\n",
+      "ingestionTime": 1785332329682,
+      "eventId": "39814241177829232818306320382499081602978857873341415424"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]515f6058c7fe48cf8ddf903548d2971a",
+      "timestamp": 1785332320851,
+      "message": "[INFO]\t2026-07-29T13:38:40.851Z\td79ab56e-51b8-430f-9d5c-37b134a95fb4\tMetrics emitted\n",
+      "ingestionTime": 1785332329682,
+      "eventId": "39814241181999472170431546909966260919964101474959753217"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]515f6058c7fe48cf8ddf903548d2971a",
+      "timestamp": 1785332320851,
+      "message": "[INFO]\t2026-07-29T13:38:40.851Z\td79ab56e-51b8-430f-9d5c-37b134a95fb4\tCanary complete\n",
+      "ingestionTime": 1785332329682,
+      "eventId": "39814241181999472170431546909966260919964101474959753218"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]515f6058c7fe48cf8ddf903548d2971a",
+      "timestamp": 1785332320931,
+      "message": "END RequestId: d79ab56e-51b8-430f-9d5c-37b134a95fb4\n",
+      "ingestionTime": 1785332329682,
+      "eventId": "39814241183783531786313996761289118381775970395438186499"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]515f6058c7fe48cf8ddf903548d2971a",
+      "timestamp": 1785332320931,
+      "message": "REPORT RequestId: d79ab56e-51b8-430f-9d5c-37b134a95fb4\tDuration: 90851.39 ms\tBilled Duration: 90852 ms\tMemory Size: 128 MB\tMax Memory Used: 93 MB\t\n",
+      "ingestionTime": 1785332329682,
+      "eventId": "39814241183783531786313996761289118381775970395438186500"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]515f6058c7fe48cf8ddf903548d2971a",
+      "timestamp": 1785332530044,
+      "message": "START RequestId: 3cfa1f80-f6ed-4925-8e76-f16cd44d19b1 Version: $LATEST\n",
+      "ingestionTime": 1785332539067,
+      "eventId": "39814245847159262486648194010378411386360194977609678848"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]515f6058c7fe48cf8ddf903548d2971a",
+      "timestamp": 1785332530045,
+      "message": "[INFO]\t2026-07-29T13:42:10.045Z\t3cfa1f80-f6ed-4925-8e76-f16cd44d19b1\tCanary invocation started\n",
+      "ingestionTime": 1785332539067,
+      "eventId": "39814245847181563231846724633519947104632843339115659265"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]515f6058c7fe48cf8ddf903548d2971a",
+      "timestamp": 1785332530214,
+      "message": "[INFO]\t2026-07-29T13:42:10.214Z\t3cfa1f80-f6ed-4925-8e76-f16cd44d19b1\tSubmitted synthetic trace\n",
+      "ingestionTime": 1785332539067,
+      "eventId": "39814245850950389170398399944439483492710416433626349570"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]515f6058c7fe48cf8ddf903548d2971a",
+      "timestamp": 1785332530464,
+      "message": "[WARNING]\t2026-07-29T13:42:10.464Z\t3cfa1f80-f6ed-4925-8e76-f16cd44d19b1\tNo canary traces found\n",
+      "ingestionTime": 1785332539067,
+      "eventId": "39814245856525575470031055729823413060872506810121453571"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]515f6058c7fe48cf8ddf903548d2971a",
+      "timestamp": 1785332560500,
+      "message": "[WARNING]\t2026-07-29T13:42:40.500Z\t3cfa1f80-f6ed-4925-8e76-f16cd44d19b1\tNo canary traces found\n",
+      "ingestionTime": 1785332569515,
+      "eventId": "39814246526350758253096852445799667847207829348056956928"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]515f6058c7fe48cf8ddf903548d2971a",
+      "timestamp": 1785332620691,
+      "message": "[WARNING]\t2026-07-29T13:43:40.691Z\t3cfa1f80-f6ed-4925-8e76-f16cd44d19b1\tNo canary traces found\n",
+      "ingestionTime": 1785332629708,
+      "eventId": "39814247868654912497853590030744890773839067254700441600"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]515f6058c7fe48cf8ddf903548d2971a",
+      "timestamp": 1785332620871,
+      "message": "[INFO]\t2026-07-29T13:43:40.871Z\t3cfa1f80-f6ed-4925-8e76-f16cd44d19b1\tMetrics emitted\n",
+      "ingestionTime": 1785332629708,
+      "eventId": "39814247872669046633589102196221320062915772325776916481"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]515f6058c7fe48cf8ddf903548d2971a",
+      "timestamp": 1785332620872,
+      "message": "[INFO]\t2026-07-29T13:43:40.872Z\t3cfa1f80-f6ed-4925-8e76-f16cd44d19b1\tCanary complete\n",
+      "ingestionTime": 1785332629708,
+      "eventId": "39814247872691347378787632819362855781188420687282896898"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]515f6058c7fe48cf8ddf903548d2971a",
+      "timestamp": 1785332620932,
+      "message": "END RequestId: 3cfa1f80-f6ed-4925-8e76-f16cd44d19b1\n",
+      "ingestionTime": 1785332629708,
+      "eventId": "39814247874029392090699470207854998877547322377641721859"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]515f6058c7fe48cf8ddf903548d2971a",
+      "timestamp": 1785332620933,
+      "message": "REPORT RequestId: 3cfa1f80-f6ed-4925-8e76-f16cd44d19b1\tDuration: 90888.11 ms\tBilled Duration: 90889 ms\tMemory Size: 128 MB\tMax Memory Used: 93 MB\t\n",
+      "ingestionTime": 1785332629708,
+      "eventId": "39814247874051692835898000830996534595819970739147702276"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]515f6058c7fe48cf8ddf903548d2971a",
+      "timestamp": 1785332829972,
+      "message": "START RequestId: 7051f18a-2f33-4c5b-8979-d7e0720438f9 Version: $LATEST\n",
+      "ingestionTime": 1785332838990,
+      "eventId": "39814252535777168391540931967488222825228809088538116096"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]515f6058c7fe48cf8ddf903548d2971a",
+      "timestamp": 1785332829992,
+      "message": "[INFO]\t2026-07-29T13:47:09.992Z\t7051f18a-2f33-4c5b-8979-d7e0720438f9\tCanary invocation started\n",
+      "ingestionTime": 1785332838990,
+      "eventId": "39814252536223183295511544430318937190681776318657724417"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]515f6058c7fe48cf8ddf903548d2971a",
+      "timestamp": 1785332830074,
+      "message": "[INFO]\t2026-07-29T13:47:10.074Z\t7051f18a-2f33-4c5b-8979-d7e0720438f9\tSubmitted synthetic trace\n",
+      "ingestionTime": 1785332838990,
+      "eventId": "39814252538051844401791055527924866089038941962148118530"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]515f6058c7fe48cf8ddf903548d2971a",
+      "timestamp": 1785332830302,
+      "message": "[WARNING]\t2026-07-29T13:47:10.302Z\t7051f18a-2f33-4c5b-8979-d7e0720438f9\tNo canary traces found\n",
+      "ingestionTime": 1785332838990,
+      "eventId": "39814252543136414307056037604195009855202768385511653379"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]515f6058c7fe48cf8ddf903548d2971a",
+      "timestamp": 1785332860335,
+      "message": "[WARNING]\t2026-07-29T13:47:40.335Z\t7051f18a-2f33-4c5b-8979-d7e0720438f9\tNo canary traces found\n",
+      "ingestionTime": 1785332869351,
+      "eventId": "39814253212894694854526242450641462704303329601835433984"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]515f6058c7fe48cf8ddf903548d2971a",
+      "timestamp": 1785332920536,
+      "message": "[WARNING]\t2026-07-29T13:48:40.536Z\t7051f18a-2f33-4c5b-8979-d7e0720438f9\tNo canary traces found\n",
+      "ingestionTime": 1785332929558,
+      "eventId": "39814254555421856551268286267019266699171704922657325056"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]515f6058c7fe48cf8ddf903548d2971a",
+      "timestamp": 1785332920712,
+      "message": "[INFO]\t2026-07-29T13:48:40.712Z\t7051f18a-2f33-4c5b-8979-d7e0720438f9\tMetrics emitted\n",
+      "ingestionTime": 1785332929558,
+      "eventId": "39814254559346787706209675939929553115157816547709878273"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]515f6058c7fe48cf8ddf903548d2971a",
+      "timestamp": 1785332920712,
+      "message": "[INFO]\t2026-07-29T13:48:40.712Z\t7051f18a-2f33-4c5b-8979-d7e0720438f9\tCanary complete\n",
+      "ingestionTime": 1785332929558,
+      "eventId": "39814254559346787706209675939929553115157816547709878274"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]515f6058c7fe48cf8ddf903548d2971a",
+      "timestamp": 1785332920793,
+      "message": "END RequestId: 7051f18a-2f33-4c5b-8979-d7e0720438f9\n",
+      "ingestionTime": 1785332929558,
+      "eventId": "39814254561153148067290656414393946295242333829694291971"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]515f6058c7fe48cf8ddf903548d2971a",
+      "timestamp": 1785332920793,
+      "message": "REPORT RequestId: 7051f18a-2f33-4c5b-8979-d7e0720438f9\tDuration: 90826.03 ms\tBilled Duration: 90827 ms\tMemory Size: 128 MB\tMax Memory Used: 93 MB\t\n",
+      "ingestionTime": 1785332929558,
+      "eventId": "39814254561153148067290656414393946295242333829694291972"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]515f6058c7fe48cf8ddf903548d2971a",
+      "timestamp": 1785333129925,
+      "message": "START RequestId: c385abf5-e044-40c2-ad71-eb3f20ccdf76 Version: $LATEST\n",
+      "ingestionTime": 1785333138942,
+      "eventId": "39814259224952592926396935503171315065435636306237652992"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]515f6058c7fe48cf8ddf903548d2971a",
+      "timestamp": 1785333129952,
+      "message": "[INFO]\t2026-07-29T13:52:09.952Z\tc385abf5-e044-40c2-ad71-eb3f20ccdf76\tCanary invocation started\n",
+      "ingestionTime": 1785333138942,
+      "eventId": "39814259225554713046757262327992779458797142066899124225"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]515f6058c7fe48cf8ddf903548d2971a",
+      "timestamp": 1785333130072,
+      "message": "[INFO]\t2026-07-29T13:52:10.072Z\tc385abf5-e044-40c2-ad71-eb3f20ccdf76\tSubmitted synthetic trace\n",
+      "ingestionTime": 1785333138942,
+      "eventId": "39814259228230802470580937104977065651514945447616774146"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]515f6058c7fe48cf8ddf903548d2971a",
+      "timestamp": 1785333130261,
+      "message": "[WARNING]\t2026-07-29T13:52:10.261Z\tc385abf5-e044-40c2-ad71-eb3f20ccdf76\tNo canary traces found\n",
+      "ingestionTime": 1785333138942,
+      "eventId": "39814259232445643313103224878727316405045485772247072771"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]515f6058c7fe48cf8ddf903548d2971a",
+      "timestamp": 1785333160288,
+      "message": "[WARNING]\t2026-07-29T13:52:40.288Z\tc385abf5-e044-40c2-ad71-eb3f20ccdf76\tNo canary traces found\n",
+      "ingestionTime": 1785333169304,
+      "eventId": "39814259902070119389382245986325911566033911322678198272"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]515f6058c7fe48cf8ddf903548d2971a",
+      "timestamp": 1785333220472,
+      "message": "[WARNING]\t2026-07-29T13:53:40.472Z\tc385abf5-e044-40c2-ad71-eb3f20ccdf76\tNo canary traces found\n",
+      "ingestionTime": 1785333229508,
+      "eventId": "39814261244218168417749269209293313548270168037244665856"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]515f6058c7fe48cf8ddf903548d2971a",
+      "timestamp": 1785333220653,
+      "message": "[INFO]\t2026-07-29T13:53:40.653Z\tc385abf5-e044-40c2-ad71-eb3f20ccdf76\tMetrics emitted\n",
+      "ingestionTime": 1785333229508,
+      "eventId": "39814261248254603298683311997911278555619521469827121153"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]515f6058c7fe48cf8ddf903548d2971a",
+      "timestamp": 1785333220653,
+      "message": "[INFO]\t2026-07-29T13:53:40.653Z\tc385abf5-e044-40c2-ad71-eb3f20ccdf76\tCanary complete\n",
+      "ingestionTime": 1785333229508,
+      "eventId": "39814261248254603298683311997911278555619521469827121154"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]515f6058c7fe48cf8ddf903548d2971a",
+      "timestamp": 1785333220733,
+      "message": "END RequestId: c385abf5-e044-40c2-ad71-eb3f20ccdf76\n",
+      "ingestionTime": 1785333229508,
+      "eventId": "39814261250038662914565761849234136017431390390305554435"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]515f6058c7fe48cf8ddf903548d2971a",
+      "timestamp": 1785333220733,
+      "message": "REPORT RequestId: c385abf5-e044-40c2-ad71-eb3f20ccdf76\tDuration: 90807.99 ms\tBilled Duration: 90808 ms\tMemory Size: 128 MB\tMax Memory Used: 93 MB\t\n",
+      "ingestionTime": 1785333229508,
+      "eventId": "39814261250038662914565761849234136017431390390305554436"
+    }
+  ]
+}

--- a/specs/001-lambda-log-visibility/evidence/post-deploy/logshape-dashboard.json
+++ b/specs/001-lambda-log-visibility/evidence/post-deploy/logshape-dashboard.json
@@ -1,0 +1,359 @@
+{
+  "logGroupName": "/aws/lambda/preprod-sentiment-dashboard",
+  "collectedAt": "2026-07-29T13:56:44.353291+00:00",
+  "windowUsed": "72h",
+  "error": null,
+  "eventCount": 50,
+  "events": [
+    {
+      "logStreamName": "2026/07/27/[140]3e531b8e57da4b8c9b2cbf54edf9a973",
+      "timestamp": 1785171293649,
+      "message": "[INFO]\t2026-07-27T16:54:53.649Z\t4bfa9fc9-ac24-4633-804f-8580ea2d610b\tCreated anonymous session\n",
+      "ingestionTime": 1785171295689,
+      "eventId": "39810650155397637849675554285117612478089336818149163073"
+    },
+    {
+      "logStreamName": "2026/07/27/[140]3e531b8e57da4b8c9b2cbf54edf9a973",
+      "timestamp": 1785171293652,
+      "message": "END RequestId: 4bfa9fc9-ac24-4633-804f-8580ea2d610b\n",
+      "ingestionTime": 1785171295689,
+      "eventId": "39810650155464540085271146154542219632907281902667104322"
+    },
+    {
+      "logStreamName": "2026/07/27/[140]3e531b8e57da4b8c9b2cbf54edf9a973",
+      "timestamp": 1785171293652,
+      "message": "REPORT RequestId: 4bfa9fc9-ac24-4633-804f-8580ea2d610b\tDuration: 10.18 ms\tBilled Duration: 11 ms\tMemory Size: 1024 MB\tMax Memory Used: 178 MB\t\nXRAY TraceId: 1-6a678d5d-0bc909e70575f0960e0a2491\tSegmentId: 0a0dcff5f9d25b6c\tSampled: true\t\n",
+      "ingestionTime": 1785171295689,
+      "eventId": "39810650155464540085271146154542219632907281902667104323"
+    },
+    {
+      "logStreamName": "2026/07/27/[140]3e531b8e57da4b8c9b2cbf54edf9a973",
+      "timestamp": 1785171295281,
+      "message": "START RequestId: ccc0f079-351f-464c-85ec-7082529fbe36 Version: 140\n",
+      "ingestionTime": 1785171295689,
+      "eventId": "39810650191792454013677531252103904699051462795909201988"
+    },
+    {
+      "logStreamName": "2026/07/27/[140]3e531b8e57da4b8c9b2cbf54edf9a973",
+      "timestamp": 1785171295283,
+      "message": "{\"level\":\"INFO\",\"location\":\"lambda_handler:1878\",\"message\":\"Dashboard Lambda invoked\",\"timestamp\":\"2026-07-27 16:54:55,283+0000\",\"service\":\"dashboard\",\"cold_start\":false,\"function_name\":\"preprod-sentiment-dashboard\",\"function_memory_size\":\"1024\",\"function_arn\":\"arn:aws:lambda:us-east-1:218795110243:function:preprod-sentiment-dashboard:live\",\"function_request_id\":\"ccc0f079-351f-464c-85ec-7082529fbe36\",\"path\":\"/api/v2/auth/oauth/urls\",\"method\":\"GET\",\"xray_trace_id\":\"1-6a678d5f-201c75a72eb138fc451ee905\"}\n",
+      "ingestionTime": 1785171295689,
+      "eventId": "39810650191837055504074592498386976135596759518921162821"
+    },
+    {
+      "logStreamName": "2026/07/27/[140]3e531b8e57da4b8c9b2cbf54edf9a973",
+      "timestamp": 1785171295291,
+      "message": "[INFO]\t2026-07-27T16:54:55.291Z\tccc0f079-351f-464c-85ec-7082529fbe36\tOAuth state stored\n",
+      "ingestionTime": 1785171295689,
+      "eventId": "39810650192015461465662837483519261881777946410969006150"
+    },
+    {
+      "logStreamName": "2026/07/27/[140]3e531b8e57da4b8c9b2cbf54edf9a973",
+      "timestamp": 1785171295294,
+      "message": "END RequestId: ccc0f079-351f-464c-85ec-7082529fbe36\n",
+      "ingestionTime": 1785171295689,
+      "eventId": "39810650192082363701258429352943869036595891495486947399"
+    },
+    {
+      "logStreamName": "2026/07/27/[140]3e531b8e57da4b8c9b2cbf54edf9a973",
+      "timestamp": 1785171295294,
+      "message": "REPORT RequestId: ccc0f079-351f-464c-85ec-7082529fbe36\tDuration: 12.51 ms\tBilled Duration: 13 ms\tMemory Size: 1024 MB\tMax Memory Used: 178 MB\t\nXRAY TraceId: 1-6a678d5f-201c75a72eb138fc451ee905\tSegmentId: d4a579a4facbc269\tSampled: true\t\n",
+      "ingestionTime": 1785171295689,
+      "eventId": "39810650192082363701258429352943869036595891495486947400"
+    },
+    {
+      "logStreamName": "2026/07/27/[140]3e531b8e57da4b8c9b2cbf54edf9a973",
+      "timestamp": 1785171295658,
+      "message": "START RequestId: f46a2a2f-9b41-4229-ad93-141afaff4bcd Version: 140\n",
+      "ingestionTime": 1785171304674,
+      "eventId": "39810650200199834953523576187325402321497060245448097792"
+    },
+    {
+      "logStreamName": "2026/07/27/[140]3e531b8e57da4b8c9b2cbf54edf9a973",
+      "timestamp": 1785171295659,
+      "message": "{\"level\":\"INFO\",\"location\":\"lambda_handler:1878\",\"message\":\"Dashboard Lambda invoked\",\"timestamp\":\"2026-07-27 16:54:55,659+0000\",\"service\":\"dashboard\",\"cold_start\":false,\"function_name\":\"preprod-sentiment-dashboard\",\"function_memory_size\":\"1024\",\"function_arn\":\"arn:aws:lambda:us-east-1:218795110243:function:preprod-sentiment-dashboard:live\",\"function_request_id\":\"f46a2a2f-9b41-4229-ad93-141afaff4bcd\",\"path\":\"/api/v2/auth/refresh\",\"method\":\"POST\",\"xray_trace_id\":\"1-6a678d5f-479d6bed00cacd1438d2cb0d\"}\n",
+      "ingestionTime": 1785171304674,
+      "eventId": "39810650200222135698722106810466938039769708606954078209"
+    },
+    {
+      "logStreamName": "2026/07/27/[140]3e531b8e57da4b8c9b2cbf54edf9a973",
+      "timestamp": 1785171295659,
+      "message": "[INFO]\t2026-07-27T16:54:55.659Z\tf46a2a2f-9b41-4229-ad93-141afaff4bcd\trefresh.cookie_absent\n",
+      "ingestionTime": 1785171304674,
+      "eventId": "39810650200222135698722106810466938039769708606954078210"
+    },
+    {
+      "logStreamName": "2026/07/27/[140]3e531b8e57da4b8c9b2cbf54edf9a973",
+      "timestamp": 1785171295661,
+      "message": "END RequestId: f46a2a2f-9b41-4229-ad93-141afaff4bcd\n",
+      "ingestionTime": 1785171304674,
+      "eventId": "39810650200266737189119168056750009476315005329966039043"
+    },
+    {
+      "logStreamName": "2026/07/27/[140]3e531b8e57da4b8c9b2cbf54edf9a973",
+      "timestamp": 1785171295661,
+      "message": "REPORT RequestId: f46a2a2f-9b41-4229-ad93-141afaff4bcd\tDuration: 2.54 ms\tBilled Duration: 3 ms\tMemory Size: 1024 MB\tMax Memory Used: 178 MB\t\nXRAY TraceId: 1-6a678d5f-479d6bed00cacd1438d2cb0d\tSegmentId: 7a3ab583f3eb50ee\tSampled: true\t\n",
+      "ingestionTime": 1785171304674,
+      "eventId": "39810650200266737189119168056750009476315005329966039044"
+    },
+    {
+      "logStreamName": "2026/07/27/[140]8e3f7031d6d449e29ee2b6187716e471",
+      "timestamp": 1785171295664,
+      "message": "START RequestId: d7436d3f-aa47-4039-9711-007078e4b4c9 Version: 140\n",
+      "ingestionTime": 1785171299339,
+      "eventId": "39810650200333639424714759919724883293845117657197314076"
+    },
+    {
+      "logStreamName": "2026/07/27/[140]8e3f7031d6d449e29ee2b6187716e471",
+      "timestamp": 1785171295665,
+      "message": "{\"level\":\"INFO\",\"location\":\"lambda_handler:1878\",\"message\":\"Dashboard Lambda invoked\",\"timestamp\":\"2026-07-27 16:54:55,664+0000\",\"service\":\"dashboard\",\"cold_start\":false,\"function_name\":\"preprod-sentiment-dashboard\",\"function_memory_size\":\"1024\",\"function_arn\":\"arn:aws:lambda:us-east-1:218795110243:function:preprod-sentiment-dashboard:live\",\"function_request_id\":\"d7436d3f-aa47-4039-9711-007078e4b4c9\",\"path\":\"/api/v2/runtime\",\"method\":\"GET\",\"xray_trace_id\":\"1-6a678d5f-275f4cf61ae1fcee4228e070\"}\n",
+      "ingestionTime": 1785171299339,
+      "eventId": "39810650200355940169913290542866419012117766018703294493"
+    },
+    {
+      "logStreamName": "2026/07/27/[140]8e3f7031d6d449e29ee2b6187716e471",
+      "timestamp": 1785171295667,
+      "message": "END RequestId: d7436d3f-aa47-4039-9711-007078e4b4c9\n",
+      "ingestionTime": 1785171299339,
+      "eventId": "39810650200400541660310351789149490448663062741715255326"
+    },
+    {
+      "logStreamName": "2026/07/27/[140]8e3f7031d6d449e29ee2b6187716e471",
+      "timestamp": 1785171295667,
+      "message": "REPORT RequestId: d7436d3f-aa47-4039-9711-007078e4b4c9\tDuration: 2.46 ms\tBilled Duration: 3 ms\tMemory Size: 1024 MB\tMax Memory Used: 178 MB\t\nXRAY TraceId: 1-6a678d5f-275f4cf61ae1fcee4228e070\tSegmentId: eac4645e19787e3f\tSampled: true\t\n",
+      "ingestionTime": 1785171299339,
+      "eventId": "39810650200400541660310351789149490448663062741715255327"
+    },
+    {
+      "logStreamName": "2026/07/27/[140]8e3f7031d6d449e29ee2b6187716e471",
+      "timestamp": 1785171295691,
+      "message": "START RequestId: 59fd0412-e191-4435-ad21-3e06a2185afd Version: 140\n",
+      "ingestionTime": 1785171299339,
+      "eventId": "39810650200935759545075086744546347687206623417858785312"
+    },
+    {
+      "logStreamName": "2026/07/27/[140]8e3f7031d6d449e29ee2b6187716e471",
+      "timestamp": 1785171295692,
+      "message": "{\"level\":\"INFO\",\"location\":\"lambda_handler:1878\",\"message\":\"Dashboard Lambda invoked\",\"timestamp\":\"2026-07-27 16:54:55,692+0000\",\"service\":\"dashboard\",\"cold_start\":false,\"function_name\":\"preprod-sentiment-dashboard\",\"function_memory_size\":\"1024\",\"function_arn\":\"arn:aws:lambda:us-east-1:218795110243:function:preprod-sentiment-dashboard:live\",\"function_request_id\":\"59fd0412-e191-4435-ad21-3e06a2185afd\",\"path\":\"/api/v2/auth/anonymous\",\"method\":\"POST\",\"xray_trace_id\":\"1-6a678d5f-09bc7ed4169e4f8f02b9160d\"}\n",
+      "ingestionTime": 1785171299339,
+      "eventId": "39810650200958060290273617367687883405479271779364765729"
+    },
+    {
+      "logStreamName": "2026/07/27/[140]8e3f7031d6d449e29ee2b6187716e471",
+      "timestamp": 1785171295702,
+      "message": "[INFO]\t2026-07-27T16:54:55.700Z\t59fd0412-e191-4435-ad21-3e06a2185afd\tCreated anonymous session\n",
+      "ingestionTime": 1785171299339,
+      "eventId": "39810650201181067742258923599103240588205755394424569890"
+    },
+    {
+      "logStreamName": "2026/07/27/[140]8e3f7031d6d449e29ee2b6187716e471",
+      "timestamp": 1785171295703,
+      "message": "END RequestId: 59fd0412-e191-4435-ad21-3e06a2185afd\n",
+      "ingestionTime": 1785171299339,
+      "eventId": "39810650201203368487457454222244776306478403755930550307"
+    },
+    {
+      "logStreamName": "2026/07/27/[140]8e3f7031d6d449e29ee2b6187716e471",
+      "timestamp": 1785171295703,
+      "message": "REPORT RequestId: 59fd0412-e191-4435-ad21-3e06a2185afd\tDuration: 11.09 ms\tBilled Duration: 12 ms\tMemory Size: 1024 MB\tMax Memory Used: 178 MB\t\nXRAY TraceId: 1-6a678d5f-09bc7ed4169e4f8f02b9160d\tSegmentId: 7a2c12c81c13559d\tSampled: true\t\n",
+      "ingestionTime": 1785171299339,
+      "eventId": "39810650201203368487457454222244776306478403755930550308"
+    },
+    {
+      "logStreamName": "2026/07/27/[140]8e3f7031d6d449e29ee2b6187716e471",
+      "timestamp": 1785171295754,
+      "message": "START RequestId: ff7af288-741f-4652-8a6b-0a40a9b41b78 Version: 140\n",
+      "ingestionTime": 1785171299339,
+      "eventId": "39810650202340706492582516002463097938383470192735551525"
+    },
+    {
+      "logStreamName": "2026/07/27/[140]8e3f7031d6d449e29ee2b6187716e471",
+      "timestamp": 1785171295755,
+      "message": "{\"level\":\"INFO\",\"location\":\"lambda_handler:1878\",\"message\":\"Dashboard Lambda invoked\",\"timestamp\":\"2026-07-27 16:54:55,755+0000\",\"service\":\"dashboard\",\"cold_start\":false,\"function_name\":\"preprod-sentiment-dashboard\",\"function_memory_size\":\"1024\",\"function_arn\":\"arn:aws:lambda:us-east-1:218795110243:function:preprod-sentiment-dashboard:live\",\"function_request_id\":\"ff7af288-741f-4652-8a6b-0a40a9b41b78\",\"path\":\"/api/v2/auth/oauth/urls\",\"method\":\"GET\",\"xray_trace_id\":\"1-6a678d5f-1dd9cc0263134eba251cb83c\"}\n",
+      "ingestionTime": 1785171299339,
+      "eventId": "39810650202363007237781046625604633656656118554241531942"
+    },
+    {
+      "logStreamName": "2026/07/27/[140]8e3f7031d6d449e29ee2b6187716e471",
+      "timestamp": 1785171295763,
+      "message": "[INFO]\t2026-07-27T16:54:55.763Z\tff7af288-741f-4652-8a6b-0a40a9b41b78\tOAuth state stored\n",
+      "ingestionTime": 1785171299339,
+      "eventId": "39810650202541413199369291610736919402837305446289375271"
+    },
+    {
+      "logStreamName": "2026/07/27/[140]8e3f7031d6d449e29ee2b6187716e471",
+      "timestamp": 1785171295765,
+      "message": "END RequestId: ff7af288-741f-4652-8a6b-0a40a9b41b78\n",
+      "ingestionTime": 1785171299339,
+      "eventId": "39810650202586014689766352857019990839382602169301336104"
+    },
+    {
+      "logStreamName": "2026/07/27/[140]8e3f7031d6d449e29ee2b6187716e471",
+      "timestamp": 1785171295766,
+      "message": "REPORT RequestId: ff7af288-741f-4652-8a6b-0a40a9b41b78\tDuration: 10.89 ms\tBilled Duration: 11 ms\tMemory Size: 1024 MB\tMax Memory Used: 178 MB\t\nXRAY TraceId: 1-6a678d5f-1dd9cc0263134eba251cb83c\tSegmentId: 1779b47b9ee0d723\tSampled: true\t\n",
+      "ingestionTime": 1785171299339,
+      "eventId": "39810650202608315434964883480161526557655250530807316521"
+    },
+    {
+      "logStreamName": "2026/07/27/[140]8e3f7031d6d449e29ee2b6187716e471",
+      "timestamp": 1785171301937,
+      "message": "START RequestId: 83edfe9a-78d5-46b5-b618-d528c0228b28 Version: 140\n",
+      "ingestionTime": 1785171310952,
+      "eventId": "39810650340226214055097358900617382815236108953894780928"
+    },
+    {
+      "logStreamName": "2026/07/27/[140]8e3f7031d6d449e29ee2b6187716e471",
+      "timestamp": 1785171301938,
+      "message": "{\"level\":\"INFO\",\"location\":\"lambda_handler:1878\",\"message\":\"Dashboard Lambda invoked\",\"timestamp\":\"2026-07-27 16:55:01,938+0000\",\"service\":\"dashboard\",\"cold_start\":false,\"function_name\":\"preprod-sentiment-dashboard\",\"function_memory_size\":\"1024\",\"function_arn\":\"arn:aws:lambda:us-east-1:218795110243:function:preprod-sentiment-dashboard:live\",\"function_request_id\":\"83edfe9a-78d5-46b5-b618-d528c0228b28\",\"path\":\"/api/v2/auth/refresh\",\"method\":\"POST\",\"xray_trace_id\":\"1-6a678d65-16a4e163445dbfa47b089374\"}\n",
+      "ingestionTime": 1785171310952,
+      "eventId": "39810650340248514800295889523758918533508757315400761345"
+    },
+    {
+      "logStreamName": "2026/07/27/[140]8e3f7031d6d449e29ee2b6187716e471",
+      "timestamp": 1785171301938,
+      "message": "[INFO]\t2026-07-27T16:55:01.938Z\t83edfe9a-78d5-46b5-b618-d528c0228b28\trefresh.cookie_absent\n",
+      "ingestionTime": 1785171310952,
+      "eventId": "39810650340248514800295889523758918533508757315400761346"
+    },
+    {
+      "logStreamName": "2026/07/27/[140]8e3f7031d6d449e29ee2b6187716e471",
+      "timestamp": 1785171301941,
+      "message": "END RequestId: 83edfe9a-78d5-46b5-b618-d528c0228b28\n",
+      "ingestionTime": 1785171310952,
+      "eventId": "39810650340315417035891481393183525688326702399918702595"
+    },
+    {
+      "logStreamName": "2026/07/27/[140]8e3f7031d6d449e29ee2b6187716e471",
+      "timestamp": 1785171301941,
+      "message": "REPORT RequestId: 83edfe9a-78d5-46b5-b618-d528c0228b28\tDuration: 2.72 ms\tBilled Duration: 3 ms\tMemory Size: 1024 MB\tMax Memory Used: 178 MB\t\nXRAY TraceId: 1-6a678d65-16a4e163445dbfa47b089374\tSegmentId: 630ddcbcf80b0e5c\tSampled: true\t\n",
+      "ingestionTime": 1785171310952,
+      "eventId": "39810650340315417035891481393183525688326702399918702596"
+    },
+    {
+      "logStreamName": "2026/07/27/[140]3e531b8e57da4b8c9b2cbf54edf9a973",
+      "timestamp": 1785171301942,
+      "message": "START RequestId: d6c24ba1-a2da-413c-a45c-df4cbe20b26d Version: 140\n",
+      "ingestionTime": 1785171304674,
+      "eventId": "39810650340337717781090012008735855946819363949029031941"
+    },
+    {
+      "logStreamName": "2026/07/27/[140]3e531b8e57da4b8c9b2cbf54edf9a973",
+      "timestamp": 1785171301943,
+      "message": "{\"level\":\"INFO\",\"location\":\"lambda_handler:1878\",\"message\":\"Dashboard Lambda invoked\",\"timestamp\":\"2026-07-27 16:55:01,943+0000\",\"service\":\"dashboard\",\"cold_start\":false,\"function_name\":\"preprod-sentiment-dashboard\",\"function_memory_size\":\"1024\",\"function_arn\":\"arn:aws:lambda:us-east-1:218795110243:function:preprod-sentiment-dashboard:live\",\"function_request_id\":\"d6c24ba1-a2da-413c-a45c-df4cbe20b26d\",\"path\":\"/api/v2/runtime\",\"method\":\"GET\",\"xray_trace_id\":\"1-6a678d65-21f39bd007d85ec21239e88f\"}\n",
+      "ingestionTime": 1785171304674,
+      "eventId": "39810650340360018526288542631877391665092012310535012358"
+    },
+    {
+      "logStreamName": "2026/07/27/[140]3e531b8e57da4b8c9b2cbf54edf9a973",
+      "timestamp": 1785171301945,
+      "message": "END RequestId: d6c24ba1-a2da-413c-a45c-df4cbe20b26d\n",
+      "ingestionTime": 1785171304674,
+      "eventId": "39810650340404620016685603878160463101637309033546973191"
+    },
+    {
+      "logStreamName": "2026/07/27/[140]3e531b8e57da4b8c9b2cbf54edf9a973",
+      "timestamp": 1785171301945,
+      "message": "REPORT RequestId: d6c24ba1-a2da-413c-a45c-df4cbe20b26d\tDuration: 2.29 ms\tBilled Duration: 3 ms\tMemory Size: 1024 MB\tMax Memory Used: 178 MB\t\nXRAY TraceId: 1-6a678d65-21f39bd007d85ec21239e88f\tSegmentId: 99b7691e42819f73\tSampled: true\t\n",
+      "ingestionTime": 1785171304674,
+      "eventId": "39810650340404620016685603878160463101637309033546973192"
+    },
+    {
+      "logStreamName": "2026/07/27/[140]3e531b8e57da4b8c9b2cbf54edf9a973",
+      "timestamp": 1785171301972,
+      "message": "START RequestId: d5012765-a28a-4b81-9ca2-5039f3c8dda7 Version: 140\n",
+      "ingestionTime": 1785171304674,
+      "eventId": "39810650341006740137045930702981927494998814794208444425"
+    },
+    {
+      "logStreamName": "2026/07/27/[140]3e531b8e57da4b8c9b2cbf54edf9a973",
+      "timestamp": 1785171301973,
+      "message": "{\"level\":\"INFO\",\"location\":\"lambda_handler:1878\",\"message\":\"Dashboard Lambda invoked\",\"timestamp\":\"2026-07-27 16:55:01,973+0000\",\"service\":\"dashboard\",\"cold_start\":false,\"function_name\":\"preprod-sentiment-dashboard\",\"function_memory_size\":\"1024\",\"function_arn\":\"arn:aws:lambda:us-east-1:218795110243:function:preprod-sentiment-dashboard:live\",\"function_request_id\":\"d5012765-a28a-4b81-9ca2-5039f3c8dda7\",\"path\":\"/api/v2/auth/anonymous\",\"method\":\"POST\",\"xray_trace_id\":\"1-6a678d65-0ff79857187f274c2a7a79fb\"}\n",
+      "ingestionTime": 1785171304674,
+      "eventId": "39810650341029040882244461326123463213271463155714424842"
+    },
+    {
+      "logStreamName": "2026/07/27/[140]3e531b8e57da4b8c9b2cbf54edf9a973",
+      "timestamp": 1785171301981,
+      "message": "[INFO]\t2026-07-27T16:55:01.981Z\td5012765-a28a-4b81-9ca2-5039f3c8dda7\tCreated anonymous session\n",
+      "ingestionTime": 1785171304674,
+      "eventId": "39810650341207446843832706311255748959452650047762268171"
+    },
+    {
+      "logStreamName": "2026/07/27/[140]3e531b8e57da4b8c9b2cbf54edf9a973",
+      "timestamp": 1785171301983,
+      "message": "END RequestId: d5012765-a28a-4b81-9ca2-5039f3c8dda7\n",
+      "ingestionTime": 1785171304674,
+      "eventId": "39810650341252048334229767557538820395997946770774229004"
+    },
+    {
+      "logStreamName": "2026/07/27/[140]3e531b8e57da4b8c9b2cbf54edf9a973",
+      "timestamp": 1785171301983,
+      "message": "REPORT RequestId: d5012765-a28a-4b81-9ca2-5039f3c8dda7\tDuration: 10.24 ms\tBilled Duration: 11 ms\tMemory Size: 1024 MB\tMax Memory Used: 178 MB\t\nXRAY TraceId: 1-6a678d65-0ff79857187f274c2a7a79fb\tSegmentId: d108b63f0da02162\tSampled: true\t\n",
+      "ingestionTime": 1785171304674,
+      "eventId": "39810650341252048334229767557538820395997946770774229005"
+    },
+    {
+      "logStreamName": "2026/07/27/[140]3e531b8e57da4b8c9b2cbf54edf9a973",
+      "timestamp": 1785171302030,
+      "message": "START RequestId: 42b5d1ee-b376-4d50-b7b7-cf9127044f22 Version: 140\n",
+      "ingestionTime": 1785171304674,
+      "eventId": "39810650342300183358560706845190999154812419761555308558"
+    },
+    {
+      "logStreamName": "2026/07/27/[140]3e531b8e57da4b8c9b2cbf54edf9a973",
+      "timestamp": 1785171302030,
+      "message": "{\"level\":\"INFO\",\"location\":\"lambda_handler:1878\",\"message\":\"Dashboard Lambda invoked\",\"timestamp\":\"2026-07-27 16:55:02,030+0000\",\"service\":\"dashboard\",\"cold_start\":false,\"function_name\":\"preprod-sentiment-dashboard\",\"function_memory_size\":\"1024\",\"function_arn\":\"arn:aws:lambda:us-east-1:218795110243:function:preprod-sentiment-dashboard:live\",\"function_request_id\":\"42b5d1ee-b376-4d50-b7b7-cf9127044f22\",\"path\":\"/api/v2/auth/oauth/urls\",\"method\":\"GET\",\"xray_trace_id\":\"1-6a678d66-322c98e64a7a36506196767b\"}\n",
+      "ingestionTime": 1785171304674,
+      "eventId": "39810650342300183358560706845190999154812419761555308559"
+    },
+    {
+      "logStreamName": "2026/07/27/[140]3e531b8e57da4b8c9b2cbf54edf9a973",
+      "timestamp": 1785171302037,
+      "message": "[INFO]\t2026-07-27T16:55:02.037Z\t42b5d1ee-b376-4d50-b7b7-cf9127044f22\tOAuth state stored\n",
+      "ingestionTime": 1785171304674,
+      "eventId": "39810650342456288574950421207181749182720958292097171472"
+    },
+    {
+      "logStreamName": "2026/07/27/[140]3e531b8e57da4b8c9b2cbf54edf9a973",
+      "timestamp": 1785171302039,
+      "message": "END RequestId: 42b5d1ee-b376-4d50-b7b7-cf9127044f22\n",
+      "ingestionTime": 1785171304674,
+      "eventId": "39810650342500890065347482453464820619266255015109132305"
+    },
+    {
+      "logStreamName": "2026/07/27/[140]3e531b8e57da4b8c9b2cbf54edf9a973",
+      "timestamp": 1785171302039,
+      "message": "REPORT RequestId: 42b5d1ee-b376-4d50-b7b7-cf9127044f22\tDuration: 8.85 ms\tBilled Duration: 9 ms\tMemory Size: 1024 MB\tMax Memory Used: 178 MB\t\nXRAY TraceId: 1-6a678d66-322c98e64a7a36506196767b\tSegmentId: f7d450966276eba6\tSampled: true\t\n",
+      "ingestionTime": 1785171304674,
+      "eventId": "39810650342500890065347482453464820619266255015109132306"
+    },
+    {
+      "logStreamName": "2026/07/27/[140]1208a07b3109428db0bff400761b5cb1",
+      "timestamp": 1785171845232,
+      "message": "[WARNING]\t2026-07-27T17:04:05.231Z\t\tCritical env var is empty or missing \u2014 feature may be degraded\n",
+      "ingestionTime": 1785171850931,
+      "eventId": "39810662456109576690792259234060274829307170072634064896"
+    },
+    {
+      "logStreamName": "2026/07/27/[140]1208a07b3109428db0bff400761b5cb1",
+      "timestamp": 1785171845406,
+      "message": "[INFO]\t2026-07-27T17:04:05.405Z\t\tlogging configured: root INFO visibility active (feature 001)\n",
+      "ingestionTime": 1785171850931,
+      "eventId": "39810662459989906355336587660687489808747984974674657281"
+    },
+    {
+      "logStreamName": "2026/07/27/[140]1208a07b3109428db0bff400761b5cb1",
+      "timestamp": 1785171845408,
+      "message": "{\"level\":\"INFO\",\"location\":\"<module>:134\",\"message\":\"Dashboard Lambda starting\",\"timestamp\":\"2026-07-27 17:04:05,408+0000\",\"service\":\"dashboard\",\"environment\":\"preprod\",\"table\":\"preprod-sentiment-items\"}\n",
+      "ingestionTime": 1785171850931,
+      "eventId": "39810662460034507845733648906970561245293281697686618114"
+    },
+    {
+      "logStreamName": "2026/07/27/[140]1208a07b3109428db0bff400761b5cb1",
+      "timestamp": 1785171846442,
+      "message": "{\"level\":\"INFO\",\"location\":\"<module>:202\",\"message\":\"API v2 routers included\",\"timestamp\":\"2026-07-27 17:04:06,442+0000\",\"service\":\"dashboard\"}\n",
+      "ingestionTime": 1785171850931,
+      "eventId": "39810662483093478381014313235318493939211687494870368259"
+    }
+  ]
+}

--- a/specs/001-lambda-log-visibility/evidence/post-deploy/logshape-ingestion.json
+++ b/specs/001-lambda-log-visibility/evidence/post-deploy/logshape-ingestion.json
@@ -1,0 +1,359 @@
+{
+  "logGroupName": "/aws/lambda/preprod-sentiment-ingestion",
+  "collectedAt": "2026-07-29T13:56:45.895253+00:00",
+  "windowUsed": "1h",
+  "error": null,
+  "eventCount": 50,
+  "events": [
+    {
+      "logStreamName": "2026/07/29/[$LATEST]bb15c1436bca4635860124dcd812b420",
+      "timestamp": 1785332267982,
+      "message": "REPORT RequestId: 6e1371bd-ed22-45ef-83f7-1d5cc51c2608\tDuration: 7657.36 ms\tBilled Duration: 7658 ms\tMemory Size: 512 MB\tMax Memory Used: 136 MB\t\nXRAY TraceId: 1-6a6a0224-375aa8260c4a487460db89fa\tSegmentId: 1e22883549649b57\tSampled: true\t\n",
+      "ingestionTime": 1785332269345,
+      "eventId": "39814240002981374269316031967171579586808591534253539342"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]bb15c1436bca4635860124dcd812b420",
+      "timestamp": 1785332560421,
+      "message": "START RequestId: ff3df652-40fc-4b07-a3cf-88128c54632f Version: $LATEST\n",
+      "ingestionTime": 1785332569441,
+      "eventId": "39814246524588999382412933217529079686681050553401671680"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]bb15c1436bca4635860124dcd812b420",
+      "timestamp": 1785332560422,
+      "message": "[INFO]\t2026-07-29T13:42:40.422Z\tff3df652-40fc-4b07-a3cf-88128c54632f\tFinancial ingestion started\n",
+      "ingestionTime": 1785332569441,
+      "eventId": "39814246524611300127611463840670615404953698914907652097"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]bb15c1436bca4635860124dcd812b420",
+      "timestamp": 1785332567113,
+      "message": "[INFO]\t2026-07-29T13:42:47.113Z\tff3df652-40fc-4b07-a3cf-88128c54632f\tFound active tickers\n",
+      "ingestionTime": 1785332569441,
+      "eventId": "39814246673825586250979863280686106367243885751422615554"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]bb15c1436bca4635860124dcd812b420",
+      "timestamp": 1785332567251,
+      "message": "[INFO]\t2026-07-29T13:42:47.251Z\tff3df652-40fc-4b07-a3cf-88128c54632f\tSecret retrieved from Secrets Manager\n",
+      "ingestionTime": 1785332569441,
+      "eventId": "39814246676903089088377089274218035488869359639247912963"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]bb15c1436bca4635860124dcd812b420",
+      "timestamp": 1785332567346,
+      "message": "[INFO]\t2026-07-29T13:42:47.346Z\tff3df652-40fc-4b07-a3cf-88128c54632f\tSecret retrieved from Secrets Manager\n",
+      "ingestionTime": 1785332569441,
+      "eventId": "39814246679021659882237498472663928724770953982316052484"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]bb15c1436bca4635860124dcd812b420",
+      "timestamp": 1785332567351,
+      "message": "[WARNING]\t2026-07-29T13:42:47.351Z\tff3df652-40fc-4b07-a3cf-88128c54632f\tALERT_TOPIC_ARN not configured, failure alerts will not be sent\n",
+      "ingestionTime": 1785332569441,
+      "eventId": "39814246679133163608230151588371607316134195789845954565"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]bb15c1436bca4635860124dcd812b420",
+      "timestamp": 1785332567351,
+      "message": "[INFO]\t2026-07-29T13:42:47.351Z\tff3df652-40fc-4b07-a3cf-88128c54632f\tUsing parallel ingestion mode\n",
+      "ingestionTime": 1785332569441,
+      "eventId": "39814246679133163608230151588371607316134195789845954566"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]bb15c1436bca4635860124dcd812b420",
+      "timestamp": 1785332567434,
+      "message": "[WARNING]\t2026-07-29T13:42:47.434Z\tff3df652-40fc-4b07-a3cf-88128c54632f\tParallel fetch failed\n",
+      "ingestionTime": 1785332569441,
+      "eventId": "39814246680984125459708193309119071932764009794842329095"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]bb15c1436bca4635860124dcd812b420",
+      "timestamp": 1785332567499,
+      "message": "[ERROR]\t2026-07-29T13:42:47.499Z\tff3df652-40fc-4b07-a3cf-88128c54632f\tFailed to emit metric: An error occurred (AccessDenied) when calling the PutMetricData operation: User: arn:aws:sts::218795110243:assumed-role/preprod-ingestion-lambda-role/preprod-sentiment-ingestion is not authorized to perform: cloudwatch:PutMetricData because no identity-based policy allows the cloudwatch:PutMetricData action\n",
+      "ingestionTime": 1785332569441,
+      "eventId": "39814246682433673897612683813318893620486153292731056136"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]bb15c1436bca4635860124dcd812b420",
+      "timestamp": 1785332567499,
+      "message": "[INFO]\t2026-07-29T13:42:47.499Z\tff3df652-40fc-4b07-a3cf-88128c54632f\tParallel fetch complete\n",
+      "ingestionTime": 1785332569441,
+      "eventId": "39814246682433673897612683813318893620486153292731056137"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]bb15c1436bca4635860124dcd812b420",
+      "timestamp": 1785332567499,
+      "message": "[WARNING]\t2026-07-29T13:42:47.499Z\tff3df652-40fc-4b07-a3cf-88128c54632f\tCollection failure recorded\n",
+      "ingestionTime": 1785332569441,
+      "eventId": "39814246682433673897612683813318893620486153292731056138"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]bb15c1436bca4635860124dcd812b420",
+      "timestamp": 1785332567499,
+      "message": "[INFO]\t2026-07-29T13:42:47.499Z\tff3df652-40fc-4b07-a3cf-88128c54632f\tIngestion metrics\n",
+      "ingestionTime": 1785332569441,
+      "eventId": "39814246682433673897612683813318893620486153292731056139"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]bb15c1436bca4635860124dcd812b420",
+      "timestamp": 1785332567562,
+      "message": "[ERROR]\t2026-07-29T13:42:47.562Z\tff3df652-40fc-4b07-a3cf-88128c54632f\tFailed to publish CloudWatch metrics: An error occurred (AccessDenied) when calling the PutMetricData operation: User: arn:aws:sts::218795110243:assumed-role/preprod-ingestion-lambda-role/preprod-sentiment-ingestion is not authorized to perform: cloudwatch:PutMetricData because no identity-based policy allows the cloudwatch:PutMetricData action\n",
+      "ingestionTime": 1785332569441,
+      "eventId": "39814246683838620845120113071235643871663000067607822348"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]bb15c1436bca4635860124dcd812b420",
+      "timestamp": 1785332567688,
+      "message": "[INFO]\t2026-07-29T13:42:47.688Z\tff3df652-40fc-4b07-a3cf-88128c54632f\tSelf-healing: no stale items found\n",
+      "ingestionTime": 1785332569441,
+      "eventId": "39814246686648514740134971587069144374016693617361354765"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]bb15c1436bca4635860124dcd812b420",
+      "timestamp": 1785332567885,
+      "message": "[INFO]\t2026-07-29T13:42:47.885Z\tff3df652-40fc-4b07-a3cf-88128c54632f\tFinancial ingestion completed\n",
+      "ingestionTime": 1785332569441,
+      "eventId": "39814246691041761544245504345951680873728420834039496718"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]bb15c1436bca4635860124dcd812b420",
+      "timestamp": 1785332567892,
+      "message": "END RequestId: ff3df652-40fc-4b07-a3cf-88128c54632f\n",
+      "ingestionTime": 1785332569441,
+      "eventId": "39814246691197866760635218707942430901636959364581359631"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]bb15c1436bca4635860124dcd812b420",
+      "timestamp": 1785332567893,
+      "message": "REPORT RequestId: ff3df652-40fc-4b07-a3cf-88128c54632f\tDuration: 7471.16 ms\tBilled Duration: 7472 ms\tMemory Size: 512 MB\tMax Memory Used: 136 MB\t\nXRAY TraceId: 1-6a6a0350-6c25c9190e615f535a585d52\tSegmentId: 0017ba924209d82a\tSampled: true\t\n",
+      "ingestionTime": 1785332569441,
+      "eventId": "39814246691220167505833749331083966619909607726087340048"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]bb15c1436bca4635860124dcd812b420",
+      "timestamp": 1785332860174,
+      "message": "START RequestId: 1502ff32-eba1-4e79-8ebe-f103bf02f586 Version: $LATEST\n",
+      "ingestionTime": 1785332869196,
+      "eventId": "39814253209304274877562812124666846109754236092419014656"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]bb15c1436bca4635860124dcd812b420",
+      "timestamp": 1785332860178,
+      "message": "[INFO]\t2026-07-29T13:47:40.178Z\t1502ff32-eba1-4e79-8ebe-f103bf02f586\tFinancial ingestion started\n",
+      "ingestionTime": 1785332869196,
+      "eventId": "39814253209393477858356934617232988982844829538442936321"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]bb15c1436bca4635860124dcd812b420",
+      "timestamp": 1785332860220,
+      "message": "[INFO]\t2026-07-29T13:47:40.220Z\t1502ff32-eba1-4e79-8ebe-f103bf02f586\tFound active tickers\n",
+      "ingestionTime": 1785332869196,
+      "eventId": "39814253210330109156695220789177489150296060721694113794"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]bb15c1436bca4635860124dcd812b420",
+      "timestamp": 1785332860413,
+      "message": "[INFO]\t2026-07-29T13:47:40.413Z\t1502ff32-eba1-4e79-8ebe-f103bf02f586\tSecret retrieved from Secrets Manager\n",
+      "ingestionTime": 1785332869196,
+      "eventId": "39814253214634152980011631055493882776917194492348334083"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]bb15c1436bca4635860124dcd812b420",
+      "timestamp": 1785332860418,
+      "message": "[WARNING]\t2026-07-29T13:47:40.418Z\t1502ff32-eba1-4e79-8ebe-f103bf02f586\tALERT_TOPIC_ARN not configured, failure alerts will not be sent\n",
+      "ingestionTime": 1785332869196,
+      "eventId": "39814253214745656706004284171201561368280436299878236164"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]bb15c1436bca4635860124dcd812b420",
+      "timestamp": 1785332860418,
+      "message": "[INFO]\t2026-07-29T13:47:40.418Z\t1502ff32-eba1-4e79-8ebe-f103bf02f586\tUsing parallel ingestion mode\n",
+      "ingestionTime": 1785332869196,
+      "eventId": "39814253214745656706004284171201561368280436299878236165"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]bb15c1436bca4635860124dcd812b420",
+      "timestamp": 1785332860488,
+      "message": "[WARNING]\t2026-07-29T13:47:40.488Z\t1502ff32-eba1-4e79-8ebe-f103bf02f586\tParallel fetch failed\n",
+      "ingestionTime": 1785332869196,
+      "eventId": "39814253216306708869901427791109061647365821605296865286"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]bb15c1436bca4635860124dcd812b420",
+      "timestamp": 1785332860554,
+      "message": "[ERROR]\t2026-07-29T13:47:40.554Z\t1502ff32-eba1-4e79-8ebe-f103bf02f586\tFailed to emit metric: An error occurred (AccessDenied) when calling the PutMetricData operation: User: arn:aws:sts::218795110243:assumed-role/preprod-ingestion-lambda-role/preprod-sentiment-ingestion is not authorized to perform: cloudwatch:PutMetricData because no identity-based policy allows the cloudwatch:PutMetricData action\n",
+      "ingestionTime": 1785332869196,
+      "eventId": "39814253217778558053004448918450419053360613464691572743"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]bb15c1436bca4635860124dcd812b420",
+      "timestamp": 1785332860554,
+      "message": "[INFO]\t2026-07-29T13:47:40.554Z\t1502ff32-eba1-4e79-8ebe-f103bf02f586\tParallel fetch complete\n",
+      "ingestionTime": 1785332869196,
+      "eventId": "39814253217778558053004448918450419053360613464691572744"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]bb15c1436bca4635860124dcd812b420",
+      "timestamp": 1785332860554,
+      "message": "[WARNING]\t2026-07-29T13:47:40.554Z\t1502ff32-eba1-4e79-8ebe-f103bf02f586\tCollection failure recorded\n",
+      "ingestionTime": 1785332869196,
+      "eventId": "39814253217778558053004448918450419053360613464691572745"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]bb15c1436bca4635860124dcd812b420",
+      "timestamp": 1785332860554,
+      "message": "[INFO]\t2026-07-29T13:47:40.554Z\t1502ff32-eba1-4e79-8ebe-f103bf02f586\tIngestion metrics\n",
+      "ingestionTime": 1785332869196,
+      "eventId": "39814253217778558053004448918450419053360613464691572746"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]bb15c1436bca4635860124dcd812b420",
+      "timestamp": 1785332860622,
+      "message": "[ERROR]\t2026-07-29T13:47:40.622Z\t1502ff32-eba1-4e79-8ebe-f103bf02f586\tFailed to publish CloudWatch metrics: An error occurred (AccessDenied) when calling the PutMetricData operation: User: arn:aws:sts::218795110243:assumed-role/preprod-ingestion-lambda-role/preprod-sentiment-ingestion is not authorized to perform: cloudwatch:PutMetricData because no identity-based policy allows the cloudwatch:PutMetricData action\n",
+      "ingestionTime": 1785332869196,
+      "eventId": "39814253219295008726504531292074847895900702047098241035"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]bb15c1436bca4635860124dcd812b420",
+      "timestamp": 1785332860732,
+      "message": "[INFO]\t2026-07-29T13:47:40.732Z\t1502ff32-eba1-4e79-8ebe-f103bf02f586\tSelf-healing: no stale items found\n",
+      "ingestionTime": 1785332869196,
+      "eventId": "39814253221748090698342899837643776905892021812756086796"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]bb15c1436bca4635860124dcd812b420",
+      "timestamp": 1785332860967,
+      "message": "[INFO]\t2026-07-29T13:47:40.967Z\t1502ff32-eba1-4e79-8ebe-f103bf02f586\tFinancial ingestion completed\n",
+      "ingestionTime": 1785332869196,
+      "eventId": "39814253226988765819997596275904670699964386766661484557"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]bb15c1436bca4635860124dcd812b420",
+      "timestamp": 1785332860977,
+      "message": "END RequestId: 1502ff32-eba1-4e79-8ebe-f103bf02f586\n",
+      "ingestionTime": 1785332869196,
+      "eventId": "39814253227211773271982902507320027882690870381721288718"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]bb15c1436bca4635860124dcd812b420",
+      "timestamp": 1785332860977,
+      "message": "REPORT RequestId: 1502ff32-eba1-4e79-8ebe-f103bf02f586\tDuration: 802.13 ms\tBilled Duration: 803 ms\tMemory Size: 512 MB\tMax Memory Used: 136 MB\t\nXRAY TraceId: 1-6a6a047c-5ad8132c3c100a566828a44d\tSegmentId: f1eb1ec368c2b474\tSampled: true\t\n",
+      "ingestionTime": 1785332869196,
+      "eventId": "39814253227211773271982902507320027882690870381721288719"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]bb15c1436bca4635860124dcd812b420",
+      "timestamp": 1785333160361,
+      "message": "START RequestId: dadf7412-efa7-4fd8-8a81-2a9a10d57163 Version: $LATEST\n",
+      "ingestionTime": 1785333169383,
+      "eventId": "39814259903698073788874981475753522663566662113486766080"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]bb15c1436bca4635860124dcd812b420",
+      "timestamp": 1785333160375,
+      "message": "[INFO]\t2026-07-29T13:52:40.375Z\tdadf7412-efa7-4fd8-8a81-2a9a10d57163\tFinancial ingestion started\n",
+      "ingestionTime": 1785333169383,
+      "eventId": "39814259904010284221654410199735022719383739174570491905"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]bb15c1436bca4635860124dcd812b420",
+      "timestamp": 1785333166996,
+      "message": "[INFO]\t2026-07-29T13:52:46.996Z\tdadf7412-efa7-4fd8-8a81-2a9a10d57163\tFound active tickers\n",
+      "ingestionTime": 1785333169383,
+      "eventId": "39814260051663518181125666019843013402588540705666826242"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]bb15c1436bca4635860124dcd812b420",
+      "timestamp": 1785333167121,
+      "message": "[INFO]\t2026-07-29T13:52:47.121Z\tdadf7412-efa7-4fd8-8a81-2a9a10d57163\tSecret retrieved from Secrets Manager\n",
+      "ingestionTime": 1785333169383,
+      "eventId": "39814260054451111330941993912534978186669585893914378243"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]bb15c1436bca4635860124dcd812b420",
+      "timestamp": 1785333167126,
+      "message": "[WARNING]\t2026-07-29T13:52:47.126Z\tdadf7412-efa7-4fd8-8a81-2a9a10d57163\tALERT_TOPIC_ARN not configured, failure alerts will not be sent\n",
+      "ingestionTime": 1785333169383,
+      "eventId": "39814260054562615056934647028242656778032827701444280324"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]bb15c1436bca4635860124dcd812b420",
+      "timestamp": 1785333167134,
+      "message": "[INFO]\t2026-07-29T13:52:47.134Z\tdadf7412-efa7-4fd8-8a81-2a9a10d57163\tUsing parallel ingestion mode\n",
+      "ingestionTime": 1785333169383,
+      "eventId": "39814260054741021018522892013374942524214014593492123653"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]bb15c1436bca4635860124dcd812b420",
+      "timestamp": 1785333167191,
+      "message": "[WARNING]\t2026-07-29T13:52:47.191Z\tdadf7412-efa7-4fd8-8a81-2a9a10d57163\tParallel fetch failed\n",
+      "ingestionTime": 1785333169383,
+      "eventId": "39814260056012163494839137532442478465754971199333007366"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]bb15c1436bca4635860124dcd812b420",
+      "timestamp": 1785333167243,
+      "message": "[ERROR]\t2026-07-29T13:52:47.243Z\tdadf7412-efa7-4fd8-8a81-2a9a10d57163\tFailed to emit metric: An error occurred (AccessDenied) when calling the PutMetricData operation: User: arn:aws:sts::218795110243:assumed-role/preprod-ingestion-lambda-role/preprod-sentiment-ingestion is not authorized to perform: cloudwatch:PutMetricData because no identity-based policy allows the cloudwatch:PutMetricData action\n",
+      "ingestionTime": 1785333169383,
+      "eventId": "39814260057171802245162729935802335815932685997643988999"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]bb15c1436bca4635860124dcd812b420",
+      "timestamp": 1785333167255,
+      "message": "[INFO]\t2026-07-29T13:52:47.254Z\tdadf7412-efa7-4fd8-8a81-2a9a10d57163\tParallel fetch complete\n",
+      "ingestionTime": 1785333169383,
+      "eventId": "39814260057439411187545097413500764435204466335715753992"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]bb15c1436bca4635860124dcd812b420",
+      "timestamp": 1785333167255,
+      "message": "[WARNING]\t2026-07-29T13:52:47.255Z\tdadf7412-efa7-4fd8-8a81-2a9a10d57163\tCollection failure recorded\n",
+      "ingestionTime": 1785333169383,
+      "eventId": "39814260057439411187545097413500764435204466335715753993"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]bb15c1436bca4635860124dcd812b420",
+      "timestamp": 1785333167255,
+      "message": "[INFO]\t2026-07-29T13:52:47.255Z\tdadf7412-efa7-4fd8-8a81-2a9a10d57163\tIngestion metrics\n",
+      "ingestionTime": 1785333169383,
+      "eventId": "39814260057439411187545097413500764435204466335715753994"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]bb15c1436bca4635860124dcd812b420",
+      "timestamp": 1785333167322,
+      "message": "[ERROR]\t2026-07-29T13:52:47.321Z\tdadf7412-efa7-4fd8-8a81-2a9a10d57163\tFailed to publish CloudWatch metrics: An error occurred (AccessDenied) when calling the PutMetricData operation: User: arn:aws:sts::218795110243:assumed-role/preprod-ingestion-lambda-role/preprod-sentiment-ingestion is not authorized to perform: cloudwatch:PutMetricData because no identity-based policy allows the cloudwatch:PutMetricData action\n",
+      "ingestionTime": 1785333169383,
+      "eventId": "39814260058933561115846649163983657559471906556616441867"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]bb15c1436bca4635860124dcd812b420",
+      "timestamp": 1785333167429,
+      "message": "[INFO]\t2026-07-29T13:52:47.428Z\tdadf7412-efa7-4fd8-8a81-2a9a10d57163\tSelf-healing: no stale items found\n",
+      "ingestionTime": 1785333169383,
+      "eventId": "39814260061319740852089425840127979414645281237756346380"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]bb15c1436bca4635860124dcd812b420",
+      "timestamp": 1785333167623,
+      "message": "[INFO]\t2026-07-29T13:52:47.623Z\tdadf7412-efa7-4fd8-8a81-2a9a10d57163\tFinancial ingestion completed\n",
+      "ingestionTime": 1785333169383,
+      "eventId": "39814260065646085420604366729585908759539063369916547085"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]bb15c1436bca4635860124dcd812b420",
+      "timestamp": 1785333167625,
+      "message": "END RequestId: dadf7412-efa7-4fd8-8a81-2a9a10d57163\n",
+      "ingestionTime": 1785333169383,
+      "eventId": "39814260065690686911001427975868980196084360092928507918"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]bb15c1436bca4635860124dcd812b420",
+      "timestamp": 1785333167625,
+      "message": "REPORT RequestId: dadf7412-efa7-4fd8-8a81-2a9a10d57163\tDuration: 7263.36 ms\tBilled Duration: 7264 ms\tMemory Size: 512 MB\tMax Memory Used: 136 MB\t\nXRAY TraceId: 1-6a6a05a8-21b303aa2d396c9f057c3f82\tSegmentId: 8d3da017f4bd6d1a\tSampled: true\t\n",
+      "ingestionTime": 1785333169383,
+      "eventId": "39814260065690686911001427975868980196084360092928507919"
+    }
+  ]
+}

--- a/specs/001-lambda-log-visibility/evidence/post-deploy/logshape-metrics.json
+++ b/specs/001-lambda-log-visibility/evidence/post-deploy/logshape-metrics.json
@@ -1,0 +1,359 @@
+{
+  "logGroupName": "/aws/lambda/preprod-sentiment-metrics",
+  "collectedAt": "2026-07-29T13:56:52.669074+00:00",
+  "windowUsed": "1h",
+  "error": null,
+  "eventCount": 50,
+  "events": [
+    {
+      "logStreamName": "2026/07/29/[$LATEST]91c470a370bc4fd08d5995937c3e4b54",
+      "timestamp": 1785333246612,
+      "message": "REPORT RequestId: 41764550-7275-41c7-a607-48f9ab0f33f4\tDuration: 750.43 ms\tBilled Duration: 751 ms\tMemory Size: 128 MB\tMax Memory Used: 74 MB\tStatus: error\tError Type: Runtime.ImportModuleError\nXRAY TraceId: 1-6a6a05fc-06d8eb8c5a780c261cb9e39b\tSegmentId: 6d97c510efa1fbe3\tSampled: true\t\n",
+      "ingestionTime": 1785333255621,
+      "eventId": "39814261827159647907339758160605660801788404883515637763"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]91c470a370bc4fd08d5995937c3e4b54",
+      "timestamp": 1785333261324,
+      "message": "[INFO]\t2026-07-29T13:54:21.324Z\t\tlogging configured: root INFO visibility active (feature 001)\n",
+      "ingestionTime": 1785333261331,
+      "eventId": "39814262155248211268122285825782331917531484540012462080"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]91c470a370bc4fd08d5995937c3e4b54",
+      "timestamp": 1785333261324,
+      "message": "[WARNING]\t2026-07-29T13:54:21.324Z\t\tLAMBDA_WARNING: Unhandled exception. The most likely cause is an issue in the function code. However, in rare cases, a Lambda runtime update can cause unexpected function behavior. For functions using managed runtimes, runtime updates can be triggered by a function change, or can be applied automatically. To determine if the runtime has been updated, check the runtime version in the INIT_START log entry. If this error correlates with a change in the runtime version, you may be able to mitigate this error by temporarily rolling back to the previous runtime version. For more information, see https://docs.aws.amazon.com/lambda/latest/dg/runtimes-update.html\r\n",
+      "ingestionTime": 1785333261331,
+      "eventId": "39814262155248211268122285825782331917531484540012462081"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]91c470a370bc4fd08d5995937c3e4b54",
+      "timestamp": 1785333261324,
+      "message": "[ERROR] Runtime.ImportModuleError: Unable to import module 'handler': No module named 'aws_xray_sdk'\nTraceback (most recent call last):",
+      "ingestionTime": 1785333261331,
+      "eventId": "39814262155248211268122285825782331917531484540012462082"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]91c470a370bc4fd08d5995937c3e4b54",
+      "timestamp": 1785333261371,
+      "message": "INIT_REPORT Init Duration: 715.02 ms\tPhase: invoke\tStatus: error\tError Type: Runtime.ImportModuleError\n",
+      "ingestionTime": 1785333270387,
+      "eventId": "39814262156296346292453225124382735130411305093687345152"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]91c470a370bc4fd08d5995937c3e4b54",
+      "timestamp": 1785333261371,
+      "message": "START RequestId: e717cc00-ceb2-470d-8e26-9f89961f85fd Version: $LATEST\n",
+      "ingestionTime": 1785333270387,
+      "eventId": "39814262156296346292453225124382735130411305093687345153"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]91c470a370bc4fd08d5995937c3e4b54",
+      "timestamp": 1785333261374,
+      "message": "END RequestId: e717cc00-ceb2-470d-8e26-9f89961f85fd\n",
+      "ingestionTime": 1785333270387,
+      "eventId": "39814262156363248528048816993807342285229250178205286402"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]91c470a370bc4fd08d5995937c3e4b54",
+      "timestamp": 1785333261374,
+      "message": "REPORT RequestId: e717cc00-ceb2-470d-8e26-9f89961f85fd\tDuration: 724.26 ms\tBilled Duration: 725 ms\tMemory Size: 128 MB\tMax Memory Used: 74 MB\tStatus: error\tError Type: Runtime.ImportModuleError\nXRAY TraceId: 1-6a6a0548-5a15cac540cc82027a106446\tSegmentId: c3db7b806fe3eed2\tSampled: true\t\n",
+      "ingestionTime": 1785333270387,
+      "eventId": "39814262156363248528048816993807342285229250178205286403"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]91c470a370bc4fd08d5995937c3e4b54",
+      "timestamp": 1785333305479,
+      "message": "[INFO]\t2026-07-29T13:55:05.479Z\t\tlogging configured: root INFO visibility active (feature 001)\n",
+      "ingestionTime": 1785333305500,
+      "eventId": "39814263139937615509241950693689140097161822655274680320"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]91c470a370bc4fd08d5995937c3e4b54",
+      "timestamp": 1785333305480,
+      "message": "[WARNING]\t2026-07-29T13:55:05.480Z\t\tLAMBDA_WARNING: Unhandled exception. The most likely cause is an issue in the function code. However, in rare cases, a Lambda runtime update can cause unexpected function behavior. For functions using managed runtimes, runtime updates can be triggered by a function change, or can be applied automatically. To determine if the runtime has been updated, check the runtime version in the INIT_START log entry. If this error correlates with a change in the runtime version, you may be able to mitigate this error by temporarily rolling back to the previous runtime version. For more information, see https://docs.aws.amazon.com/lambda/latest/dg/runtimes-update.html\r\n",
+      "ingestionTime": 1785333305500,
+      "eventId": "39814263139959916254440481316830675815434471016780660737"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]91c470a370bc4fd08d5995937c3e4b54",
+      "timestamp": 1785333305480,
+      "message": "[ERROR] Runtime.ImportModuleError: Unable to import module 'handler': No module named 'aws_xray_sdk'\nTraceback (most recent call last):",
+      "ingestionTime": 1785333305500,
+      "eventId": "39814263139959916254440481316830675815434471016780660738"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]91c470a370bc4fd08d5995937c3e4b54",
+      "timestamp": 1785333305529,
+      "message": "INIT_REPORT Init Duration: 717.03 ms\tPhase: invoke\tStatus: error\tError Type: Runtime.ImportModuleError\n",
+      "ingestionTime": 1785333313452,
+      "eventId": "39814263141052652769168481860379375789285515693181698048"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]91c470a370bc4fd08d5995937c3e4b54",
+      "timestamp": 1785333305529,
+      "message": "START RequestId: 34803fa9-4750-481f-b2f0-36ed81e8fe0d Version: $LATEST\n",
+      "ingestionTime": 1785333313452,
+      "eventId": "39814263141052652769168481860379375789285515693181698049"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]91c470a370bc4fd08d5995937c3e4b54",
+      "timestamp": 1785333305533,
+      "message": "END RequestId: 34803fa9-4750-481f-b2f0-36ed81e8fe0d\n",
+      "ingestionTime": 1785333313452,
+      "eventId": "39814263141141855749962604352945518662376109139205619714"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]91c470a370bc4fd08d5995937c3e4b54",
+      "timestamp": 1785333305533,
+      "message": "REPORT RequestId: 34803fa9-4750-481f-b2f0-36ed81e8fe0d\tDuration: 728.36 ms\tBilled Duration: 729 ms\tMemory Size: 128 MB\tMax Memory Used: 74 MB\tStatus: error\tError Type: Runtime.ImportModuleError\nXRAY TraceId: 1-6a6a0638-4274ab681ac8c9097a411531\tSegmentId: 9f27695a3436c8d0\tSampled: true\t\n",
+      "ingestionTime": 1785333313452,
+      "eventId": "39814263141141855749962604352945518662376109139205619715"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]91c470a370bc4fd08d5995937c3e4b54",
+      "timestamp": 1785333313423,
+      "message": "[INFO]\t2026-07-29T13:55:13.423Z\t\tlogging configured: root INFO visibility active (feature 001)\n",
+      "ingestionTime": 1785333313452,
+      "eventId": "39814263317094735366369220939662335833571681421391101956"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]91c470a370bc4fd08d5995937c3e4b54",
+      "timestamp": 1785333313424,
+      "message": "[WARNING]\t2026-07-29T13:55:13.424Z\t\tLAMBDA_WARNING: Unhandled exception. The most likely cause is an issue in the function code. However, in rare cases, a Lambda runtime update can cause unexpected function behavior. For functions using managed runtimes, runtime updates can be triggered by a function change, or can be applied automatically. To determine if the runtime has been updated, check the runtime version in the INIT_START log entry. If this error correlates with a change in the runtime version, you may be able to mitigate this error by temporarily rolling back to the previous runtime version. For more information, see https://docs.aws.amazon.com/lambda/latest/dg/runtimes-update.html\r\n",
+      "ingestionTime": 1785333313452,
+      "eventId": "39814263317117036111567751562803871551844329782897082373"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]91c470a370bc4fd08d5995937c3e4b54",
+      "timestamp": 1785333313424,
+      "message": "[ERROR] Runtime.ImportModuleError: Unable to import module 'handler': No module named 'aws_xray_sdk'\nTraceback (most recent call last):",
+      "ingestionTime": 1785333313452,
+      "eventId": "39814263317117036111567751562803871551844329782897082374"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]91c470a370bc4fd08d5995937c3e4b54",
+      "timestamp": 1785333313471,
+      "message": "INIT_REPORT Init Duration: 708.05 ms\tPhase: invoke\tStatus: error\tError Type: Runtime.ImportModuleError\n",
+      "ingestionTime": 1785333318299,
+      "eventId": "39814263318165171135898690856315200413143693982951014400"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]91c470a370bc4fd08d5995937c3e4b54",
+      "timestamp": 1785333313471,
+      "message": "START RequestId: 41764550-7275-41c7-a607-48f9ab0f33f4 Version: $LATEST\n",
+      "ingestionTime": 1785333318299,
+      "eventId": "39814263318165171135898690856315200413143693982951014401"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]91c470a370bc4fd08d5995937c3e4b54",
+      "timestamp": 1785333313476,
+      "message": "END RequestId: 41764550-7275-41c7-a607-48f9ab0f33f4\n",
+      "ingestionTime": 1785333318299,
+      "eventId": "39814263318276674861891343972022879004506935790480916482"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]91c470a370bc4fd08d5995937c3e4b54",
+      "timestamp": 1785333313476,
+      "message": "REPORT RequestId: 41764550-7275-41c7-a607-48f9ab0f33f4\tDuration: 719.35 ms\tBilled Duration: 720 ms\tMemory Size: 128 MB\tMax Memory Used: 74 MB\tStatus: error\tError Type: Runtime.ImportModuleError\nXRAY TraceId: 1-6a6a05fc-06d8eb8c5a780c261cb9e39b\tSegmentId: 66f566aa7a2454fe\tSampled: true\t\n",
+      "ingestionTime": 1785333318299,
+      "eventId": "39814263318276674861891343972022879004506935790480916483"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]91c470a370bc4fd08d5995937c3e4b54",
+      "timestamp": 1785333318294,
+      "message": "[INFO]\t2026-07-29T13:55:18.294Z\t\tlogging configured: root INFO visibility active (feature 001)\n",
+      "ingestionTime": 1785333318299,
+      "eventId": "39814263425721665228411886267941969642126741526294560772"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]91c470a370bc4fd08d5995937c3e4b54",
+      "timestamp": 1785333318294,
+      "message": "[WARNING]\t2026-07-29T13:55:18.294Z\t\tLAMBDA_WARNING: Unhandled exception. The most likely cause is an issue in the function code. However, in rare cases, a Lambda runtime update can cause unexpected function behavior. For functions using managed runtimes, runtime updates can be triggered by a function change, or can be applied automatically. To determine if the runtime has been updated, check the runtime version in the INIT_START log entry. If this error correlates with a change in the runtime version, you may be able to mitigate this error by temporarily rolling back to the previous runtime version. For more information, see https://docs.aws.amazon.com/lambda/latest/dg/runtimes-update.html\r\n",
+      "ingestionTime": 1785333318299,
+      "eventId": "39814263425721665228411886267941969642126741526294560773"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]91c470a370bc4fd08d5995937c3e4b54",
+      "timestamp": 1785333318294,
+      "message": "[ERROR] Runtime.ImportModuleError: Unable to import module 'handler': No module named 'aws_xray_sdk'\nTraceback (most recent call last):",
+      "ingestionTime": 1785333318299,
+      "eventId": "39814263425721665228411886267941969642126741526294560774"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]91c470a370bc4fd08d5995937c3e4b54",
+      "timestamp": 1785333318339,
+      "message": "INIT_REPORT Init Duration: 717.56 ms\tPhase: invoke\tStatus: error\tError Type: Runtime.ImportModuleError\n",
+      "ingestionTime": 1785333327486,
+      "eventId": "39814263426725198762345764320417474288935284915014270976"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]91c470a370bc4fd08d5995937c3e4b54",
+      "timestamp": 1785333318339,
+      "message": "START RequestId: ee192975-a934-499b-9588-cc0e133c40bf Version: $LATEST\n",
+      "ingestionTime": 1785333327486,
+      "eventId": "39814263426725198762345764320417474288935284915014270977"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]91c470a370bc4fd08d5995937c3e4b54",
+      "timestamp": 1785333318343,
+      "message": "END RequestId: ee192975-a934-499b-9588-cc0e133c40bf\n",
+      "ingestionTime": 1785333327486,
+      "eventId": "39814263426814401743139886812983617162025878361038192642"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]91c470a370bc4fd08d5995937c3e4b54",
+      "timestamp": 1785333318343,
+      "message": "REPORT RequestId: ee192975-a934-499b-9588-cc0e133c40bf\tDuration: 728.24 ms\tBilled Duration: 729 ms\tMemory Size: 128 MB\tMax Memory Used: 74 MB\tStatus: error\tError Type: Runtime.ImportModuleError\nXRAY TraceId: 1-6a6a0584-3f25ef307d9776411e08ee62\tSegmentId: 41806b02ea60e3f8\tSampled: true\t\n",
+      "ingestionTime": 1785333327486,
+      "eventId": "39814263426814401743139886812983617162025878361038192643"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]91c470a370bc4fd08d5995937c3e4b54",
+      "timestamp": 1785333365514,
+      "message": "[INFO]\t2026-07-29T13:56:05.514Z\t\tlogging configured: root INFO visibility active (feature 001)\n",
+      "ingestionTime": 1785333365532,
+      "eventId": "39814264478762853503027911068359881635565867580468756480"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]91c470a370bc4fd08d5995937c3e4b54",
+      "timestamp": 1785333365514,
+      "message": "[WARNING]\t2026-07-29T13:56:05.514Z\t\tLAMBDA_WARNING: Unhandled exception. The most likely cause is an issue in the function code. However, in rare cases, a Lambda runtime update can cause unexpected function behavior. For functions using managed runtimes, runtime updates can be triggered by a function change, or can be applied automatically. To determine if the runtime has been updated, check the runtime version in the INIT_START log entry. If this error correlates with a change in the runtime version, you may be able to mitigate this error by temporarily rolling back to the previous runtime version. For more information, see https://docs.aws.amazon.com/lambda/latest/dg/runtimes-update.html\r\n",
+      "ingestionTime": 1785333365532,
+      "eventId": "39814264478762853503027911068359881635565867580468756481"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]91c470a370bc4fd08d5995937c3e4b54",
+      "timestamp": 1785333365514,
+      "message": "[ERROR] Runtime.ImportModuleError: Unable to import module 'handler': No module named 'aws_xray_sdk'\nTraceback (most recent call last):",
+      "ingestionTime": 1785333365532,
+      "eventId": "39814264478762853503027911068359881635565867580468756482"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]91c470a370bc4fd08d5995937c3e4b54",
+      "timestamp": 1785333365565,
+      "message": "INIT_REPORT Init Duration: 741.11 ms\tPhase: invoke\tStatus: error\tError Type: Runtime.ImportModuleError\n",
+      "ingestionTime": 1785333365569,
+      "eventId": "39814264479900191508152972848623135791297506571304239104"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]91c470a370bc4fd08d5995937c3e4b54",
+      "timestamp": 1785333365565,
+      "message": "START RequestId: 6521eee9-537c-45cb-8aae-03f73d43d779 Version: $LATEST\n",
+      "ingestionTime": 1785333365569,
+      "eventId": "39814264479900191508152972848623135791297506571304239105"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]91c470a370bc4fd08d5995937c3e4b54",
+      "timestamp": 1785333365569,
+      "message": "END RequestId: 6521eee9-537c-45cb-8aae-03f73d43d779\n",
+      "ingestionTime": 1785333365581,
+      "eventId": "39814264479989394488947095341203696648803186301077618688"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]91c470a370bc4fd08d5995937c3e4b54",
+      "timestamp": 1785333365569,
+      "message": "REPORT RequestId: 6521eee9-537c-45cb-8aae-03f73d43d779\tDuration: 751.02 ms\tBilled Duration: 752 ms\tMemory Size: 128 MB\tMax Memory Used: 74 MB\tStatus: error\tError Type: Runtime.ImportModuleError\nXRAY TraceId: 1-6a6a0674-308e0476134af80f32bd1e49\tSegmentId: cc6999d49746b0fd\tSampled: true\t\n",
+      "ingestionTime": 1785333365581,
+      "eventId": "39814264479989394488947095341203696648803186301077618689"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]91c470a370bc4fd08d5995937c3e4b54",
+      "timestamp": 1785333369304,
+      "message": "[INFO]\t2026-07-29T13:56:09.304Z\t\tlogging configured: root INFO visibility active (feature 001)\n",
+      "ingestionTime": 1785333369309,
+      "eventId": "39814264563282677805458972779346468134849299838882545664"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]91c470a370bc4fd08d5995937c3e4b54",
+      "timestamp": 1785333369304,
+      "message": "[WARNING]\t2026-07-29T13:56:09.304Z\t\tLAMBDA_WARNING: Unhandled exception. The most likely cause is an issue in the function code. However, in rare cases, a Lambda runtime update can cause unexpected function behavior. For functions using managed runtimes, runtime updates can be triggered by a function change, or can be applied automatically. To determine if the runtime has been updated, check the runtime version in the INIT_START log entry. If this error correlates with a change in the runtime version, you may be able to mitigate this error by temporarily rolling back to the previous runtime version. For more information, see https://docs.aws.amazon.com/lambda/latest/dg/runtimes-update.html\r\n",
+      "ingestionTime": 1785333369309,
+      "eventId": "39814264563282677805458972779346468134849299838882545665"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]91c470a370bc4fd08d5995937c3e4b54",
+      "timestamp": 1785333369304,
+      "message": "[ERROR] Runtime.ImportModuleError: Unable to import module 'handler': No module named 'aws_xray_sdk'\nTraceback (most recent call last):",
+      "ingestionTime": 1785333369309,
+      "eventId": "39814264563282677805458972779346468134849299838882545666"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]91c470a370bc4fd08d5995937c3e4b54",
+      "timestamp": 1785333369352,
+      "message": "INIT_REPORT Init Duration: 714.96 ms\tPhase: invoke\tStatus: error\tError Type: Runtime.ImportModuleError\n",
+      "ingestionTime": 1785333371403,
+      "eventId": "39814264564353113574988442692671685299160805522862112768"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]91c470a370bc4fd08d5995937c3e4b54",
+      "timestamp": 1785333369352,
+      "message": "START RequestId: 5acd224e-93ea-4bff-9753-d05956310023 Version: $LATEST\n",
+      "ingestionTime": 1785333371403,
+      "eventId": "39814264564353113574988442692671685299160805522862112769"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]91c470a370bc4fd08d5995937c3e4b54",
+      "timestamp": 1785333369356,
+      "message": "END RequestId: 5acd224e-93ea-4bff-9753-d05956310023\n",
+      "ingestionTime": 1785333371403,
+      "eventId": "39814264564442316555782565185237828172251398968886034434"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]91c470a370bc4fd08d5995937c3e4b54",
+      "timestamp": 1785333369356,
+      "message": "REPORT RequestId: 5acd224e-93ea-4bff-9753-d05956310023\tDuration: 724.14 ms\tBilled Duration: 725 ms\tMemory Size: 128 MB\tMax Memory Used: 74 MB\tStatus: error\tError Type: Runtime.ImportModuleError\nXRAY TraceId: 1-6a6a05c0-09270ab8296d421e6d96fc04\tSegmentId: c97f3fe138b71060\tSampled: true\t\n",
+      "ingestionTime": 1785333371403,
+      "eventId": "39814264564442316555782565185237828172251398968886034435"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]91c470a370bc4fd08d5995937c3e4b54",
+      "timestamp": 1785333371398,
+      "message": "[INFO]\t2026-07-29T13:56:11.398Z\t\tlogging configured: root INFO visibility active (feature 001)\n",
+      "ingestionTime": 1785333371403,
+      "eventId": "39814264609980438251182097640253764884999353164098043908"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]91c470a370bc4fd08d5995937c3e4b54",
+      "timestamp": 1785333371398,
+      "message": "[WARNING]\t2026-07-29T13:56:11.398Z\t\tLAMBDA_WARNING: Unhandled exception. The most likely cause is an issue in the function code. However, in rare cases, a Lambda runtime update can cause unexpected function behavior. For functions using managed runtimes, runtime updates can be triggered by a function change, or can be applied automatically. To determine if the runtime has been updated, check the runtime version in the INIT_START log entry. If this error correlates with a change in the runtime version, you may be able to mitigate this error by temporarily rolling back to the previous runtime version. For more information, see https://docs.aws.amazon.com/lambda/latest/dg/runtimes-update.html\r\n",
+      "ingestionTime": 1785333371403,
+      "eventId": "39814264609980438251182097640253764884999353164098043909"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]91c470a370bc4fd08d5995937c3e4b54",
+      "timestamp": 1785333371398,
+      "message": "[ERROR] Runtime.ImportModuleError: Unable to import module 'handler': No module named 'aws_xray_sdk'\nTraceback (most recent call last):",
+      "ingestionTime": 1785333371403,
+      "eventId": "39814264609980438251182097640253764884999353164098043910"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]91c470a370bc4fd08d5995937c3e4b54",
+      "timestamp": 1785333371448,
+      "message": "INIT_REPORT Init Duration: 738.63 ms\tPhase: invoke\tStatus: error\tError Type: Runtime.ImportModuleError\n",
+      "ingestionTime": 1785333380464,
+      "eventId": "39814264611095475511108628808284405527395755858529157120"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]91c470a370bc4fd08d5995937c3e4b54",
+      "timestamp": 1785333371448,
+      "message": "START RequestId: 34803fa9-4750-481f-b2f0-36ed81e8fe0d Version: $LATEST\n",
+      "ingestionTime": 1785333380464,
+      "eventId": "39814264611095475511108628808284405527395755858529157121"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]91c470a370bc4fd08d5995937c3e4b54",
+      "timestamp": 1785333371452,
+      "message": "END RequestId: 34803fa9-4750-481f-b2f0-36ed81e8fe0d\n",
+      "ingestionTime": 1785333380464,
+      "eventId": "39814264611184678491902751300850548400486349304553078786"
+    },
+    {
+      "logStreamName": "2026/07/29/[$LATEST]91c470a370bc4fd08d5995937c3e4b54",
+      "timestamp": 1785333371452,
+      "message": "REPORT RequestId: 34803fa9-4750-481f-b2f0-36ed81e8fe0d\tDuration: 750.00 ms\tBilled Duration: 750 ms\tMemory Size: 128 MB\tMax Memory Used: 74 MB\tStatus: error\tError Type: Runtime.ImportModuleError\nXRAY TraceId: 1-6a6a0638-4274ab681ac8c9097a411531\tSegmentId: 78edc412a53eb648\tSampled: true\t\n",
+      "ingestionTime": 1785333380464,
+      "eventId": "39814264611184678491902751300850548400486349304553078787"
+    }
+  ]
+}

--- a/specs/001-lambda-log-visibility/evidence/post-deploy/logshape-notification.json
+++ b/specs/001-lambda-log-visibility/evidence/post-deploy/logshape-notification.json
@@ -1,0 +1,359 @@
+{
+  "logGroupName": "/aws/lambda/preprod-sentiment-notification",
+  "collectedAt": "2026-07-29T13:56:55.681775+00:00",
+  "windowUsed": "168h",
+  "error": null,
+  "eventCount": 50,
+  "events": [
+    {
+      "logStreamName": "2026/07/26/[$LATEST]f317a1f7e18442eb852a4d6e9b4b1119",
+      "timestamp": 1785049492617,
+      "message": "[INFO]\t2026-07-26T07:04:52.617Z\t20438eeb-7324-4a5f-acd8-8d85abec16ae\tFound credentials in environment variables.\n",
+      "ingestionTime": 1785049496067,
+      "eventId": "39807933901618087774893164905859504208790916935567343621"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]f317a1f7e18442eb852a4d6e9b4b1119",
+      "timestamp": 1785049493496,
+      "message": "[ERROR]\t2026-07-26T07:04:53.496Z\t20438eeb-7324-4a5f-acd8-8d85abec16ae\tFailed to query digest users\n",
+      "ingestionTime": 1785049496067,
+      "eventId": "39807933921220442804401582647269400570448826699324129286"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]f317a1f7e18442eb852a4d6e9b4b1119",
+      "timestamp": 1785049493496,
+      "message": "[ERROR]\t2026-07-26T07:04:53.496Z\t20438eeb-7324-4a5f-acd8-8d85abec16ae\tFailed to get users for digest\n",
+      "ingestionTime": 1785049496067,
+      "eventId": "39807933921220442804401582647269400570448826699324129287"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]f317a1f7e18442eb852a4d6e9b4b1119",
+      "timestamp": 1785049493496,
+      "message": "[INFO]\t2026-07-26T07:04:53.496Z\t20438eeb-7324-4a5f-acd8-8d85abec16ae\tDaily digest processing complete\n",
+      "ingestionTime": 1785049496067,
+      "eventId": "39807933921220442804401582647269400570448826699324129288"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]f317a1f7e18442eb852a4d6e9b4b1119",
+      "timestamp": 1785049493499,
+      "message": "END RequestId: 20438eeb-7324-4a5f-acd8-8d85abec16ae\n",
+      "ingestionTime": 1785049496067,
+      "eventId": "39807933921287345039997174516694007725266771783842070537"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]f317a1f7e18442eb852a4d6e9b4b1119",
+      "timestamp": 1785049493499,
+      "message": "REPORT RequestId: 20438eeb-7324-4a5f-acd8-8d85abec16ae\tDuration: 1197.80 ms\tBilled Duration: 2604 ms\tMemory Size: 256 MB\tMax Memory Used: 107 MB\tInit Duration: 1406.13 ms\t\nXRAY TraceId: 1-6a65b192-388b775d42c2ffb227abbf62\tSegmentId: da98644e05b46460\tSampled: true\t\n",
+      "ingestionTime": 1785049496067,
+      "eventId": "39807933921287345039997174516694007725266771783842070538"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]6f9e3c4b45234064bd53ce9d42cf7623",
+      "timestamp": 1785049939822,
+      "message": "INIT_START Runtime Version: python:3.13.mainlinev2.v18\tRuntime Version ARN: arn:aws:lambda:us-east-1::runtime:85016a02049aea54df8f85632acb695fe6e1c8623b63b4ed1d582917e22e8e4d\n",
+      "ingestionTime": 1785049942686,
+      "eventId": "39807943874622844283780487456269805408764901217512783872"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]6f9e3c4b45234064bd53ce9d42cf7623",
+      "timestamp": 1785049941200,
+      "message": "[INFO]\t2026-07-26T07:12:21.200Z\t\tlogging configured: root INFO visibility active (feature 001)\n",
+      "ingestionTime": 1785049942686,
+      "eventId": "39807943905353271167355686145306025188474343372753797121"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]6f9e3c4b45234064bd53ce9d42cf7623",
+      "timestamp": 1785049941214,
+      "message": "START RequestId: 194a506e-c51f-45c5-9ea4-5789d4f5303f Version: $LATEST\n",
+      "ingestionTime": 1785049942686,
+      "eventId": "39807943905665481600135114869287525244291420433837522946"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]6f9e3c4b45234064bd53ce9d42cf7623",
+      "timestamp": 1785049941215,
+      "message": "[INFO]\t2026-07-26T07:12:21.214Z\t194a506e-c51f-45c5-9ea4-5789d4f5303f\tNotification Lambda invoked: {\"notification_type\": \"digest\"}\n",
+      "ingestionTime": 1785049942686,
+      "eventId": "39807943905687782345333645492429060962564068795343503363"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]6f9e3c4b45234064bd53ce9d42cf7623",
+      "timestamp": 1785049941215,
+      "message": "[INFO]\t2026-07-26T07:12:21.215Z\t194a506e-c51f-45c5-9ea4-5789d4f5303f\tDaily digest handler invoked\n",
+      "ingestionTime": 1785049942686,
+      "eventId": "39807943905687782345333645492429060962564068795343503364"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]6f9e3c4b45234064bd53ce9d42cf7623",
+      "timestamp": 1785049941517,
+      "message": "[INFO]\t2026-07-26T07:12:21.517Z\t194a506e-c51f-45c5-9ea4-5789d4f5303f\tFound credentials in environment variables.\n",
+      "ingestionTime": 1785049942686,
+      "eventId": "39807943912422607395289893681172847880903873970149588997"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]6f9e3c4b45234064bd53ce9d42cf7623",
+      "timestamp": 1785049942396,
+      "message": "[ERROR]\t2026-07-26T07:12:22.396Z\t194a506e-c51f-45c5-9ea4-5789d4f5303f\tFailed to query digest users\n",
+      "ingestionTime": 1785049942686,
+      "eventId": "39807943932024962424798311422582744242561783733906374662"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]6f9e3c4b45234064bd53ce9d42cf7623",
+      "timestamp": 1785049942396,
+      "message": "[ERROR]\t2026-07-26T07:12:22.396Z\t194a506e-c51f-45c5-9ea4-5789d4f5303f\tFailed to get users for digest\n",
+      "ingestionTime": 1785049942686,
+      "eventId": "39807943932024962424798311422582744242561783733906374663"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]6f9e3c4b45234064bd53ce9d42cf7623",
+      "timestamp": 1785049942396,
+      "message": "[INFO]\t2026-07-26T07:12:22.396Z\t194a506e-c51f-45c5-9ea4-5789d4f5303f\tDaily digest processing complete\n",
+      "ingestionTime": 1785049942686,
+      "eventId": "39807943932024962424798311422582744242561783733906374664"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]6f9e3c4b45234064bd53ce9d42cf7623",
+      "timestamp": 1785049942416,
+      "message": "END RequestId: 194a506e-c51f-45c5-9ea4-5789d4f5303f\n",
+      "ingestionTime": 1785049942686,
+      "eventId": "39807943932470977328768923885413458608014750964025982985"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]6f9e3c4b45234064bd53ce9d42cf7623",
+      "timestamp": 1785049942416,
+      "message": "REPORT RequestId: 194a506e-c51f-45c5-9ea4-5789d4f5303f\tDuration: 1201.49 ms\tBilled Duration: 2590 ms\tMemory Size: 256 MB\tMax Memory Used: 107 MB\tInit Duration: 1388.22 ms\t\nXRAY TraceId: 1-6a65b353-0d8c44e6771d454061ce825a\tSegmentId: 82d6def404e5a20d\tSampled: true\t\n",
+      "ingestionTime": 1785049942686,
+      "eventId": "39807943932470977328768923885413458608014750964025982986"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]dc270b5f4fde416fbf1f8e23fc0b5b6f",
+      "timestamp": 1785051695802,
+      "message": "INIT_START Runtime Version: python:3.13.mainlinev2.v18\tRuntime Version ARN: arn:aws:lambda:us-east-1::runtime:85016a02049aea54df8f85632acb695fe6e1c8623b63b4ed1d582917e22e8e4d\n",
+      "ingestionTime": 1785051697487,
+      "eventId": "39807983034285397999584113651584171334204341016370020352"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]dc270b5f4fde416fbf1f8e23fc0b5b6f",
+      "timestamp": 1785051697162,
+      "message": "[INFO]\t2026-07-26T07:41:37.162Z\t\tlogging configured: root INFO visibility active (feature 001)\n",
+      "ingestionTime": 1785051697487,
+      "eventId": "39807983064614411469585761124072748185006112664503386113"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]dc270b5f4fde416fbf1f8e23fc0b5b6f",
+      "timestamp": 1785051697175,
+      "message": "START RequestId: 702f51c2-41d6-4e04-a30e-e3c6f9855e87 Version: $LATEST\n",
+      "ingestionTime": 1785051697487,
+      "eventId": "39807983064904321157166659224912712522550541364081131522"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]dc270b5f4fde416fbf1f8e23fc0b5b6f",
+      "timestamp": 1785051697176,
+      "message": "[INFO]\t2026-07-26T07:41:37.176Z\t702f51c2-41d6-4e04-a30e-e3c6f9855e87\tNotification Lambda invoked: {\"notification_type\": \"digest\"}\n",
+      "ingestionTime": 1785051697487,
+      "eventId": "39807983064926621902365189848054248240823189725587111939"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]dc270b5f4fde416fbf1f8e23fc0b5b6f",
+      "timestamp": 1785051697176,
+      "message": "[INFO]\t2026-07-26T07:41:37.176Z\t702f51c2-41d6-4e04-a30e-e3c6f9855e87\tDaily digest handler invoked\n",
+      "ingestionTime": 1785051697487,
+      "eventId": "39807983064926621902365189848054248240823189725587111940"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]dc270b5f4fde416fbf1f8e23fc0b5b6f",
+      "timestamp": 1785051697476,
+      "message": "[INFO]\t2026-07-26T07:41:37.476Z\t702f51c2-41d6-4e04-a30e-e3c6f9855e87\tFound credentials in environment variables.\n",
+      "ingestionTime": 1785051706491,
+      "eventId": "39807983071616845461924376801400065157652789357744619520"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]dc270b5f4fde416fbf1f8e23fc0b5b6f",
+      "timestamp": 1785051698317,
+      "message": "[ERROR]\t2026-07-26T07:41:38.317Z\t702f51c2-41d6-4e04-a30e-e3c6f9855e87\tFailed to query digest users\n",
+      "ingestionTime": 1785051706491,
+      "eventId": "39807983090371772173888630863431604224950061384274149377"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]dc270b5f4fde416fbf1f8e23fc0b5b6f",
+      "timestamp": 1785051698317,
+      "message": "[ERROR]\t2026-07-26T07:41:38.317Z\t702f51c2-41d6-4e04-a30e-e3c6f9855e87\tFailed to get users for digest\n",
+      "ingestionTime": 1785051706491,
+      "eventId": "39807983090371772173888630863431604224950061384274149378"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]dc270b5f4fde416fbf1f8e23fc0b5b6f",
+      "timestamp": 1785051698317,
+      "message": "[INFO]\t2026-07-26T07:41:38.317Z\t702f51c2-41d6-4e04-a30e-e3c6f9855e87\tDaily digest processing complete\n",
+      "ingestionTime": 1785051706491,
+      "eventId": "39807983090371772173888630863431604224950061384274149379"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]dc270b5f4fde416fbf1f8e23fc0b5b6f",
+      "timestamp": 1785051698319,
+      "message": "END RequestId: 702f51c2-41d6-4e04-a30e-e3c6f9855e87\n",
+      "ingestionTime": 1785051706491,
+      "eventId": "39807983090416373664285692109714675661495358107286110212"
+    },
+    {
+      "logStreamName": "2026/07/26/[$LATEST]dc270b5f4fde416fbf1f8e23fc0b5b6f",
+      "timestamp": 1785051698319,
+      "message": "REPORT RequestId: 702f51c2-41d6-4e04-a30e-e3c6f9855e87\tDuration: 1143.55 ms\tBilled Duration: 2513 ms\tMemory Size: 256 MB\tMax Memory Used: 107 MB\tInit Duration: 1369.32 ms\t\nXRAY TraceId: 1-6a65ba2f-3ab42733575803747a92c20e\tSegmentId: 2e07868f75efeca1\tSampled: true\t\n",
+      "ingestionTime": 1785051706491,
+      "eventId": "39807983090416373664285692109714675661495358107286110213"
+    },
+    {
+      "logStreamName": "2026/07/27/[$LATEST]fb90571374314e25aa7bba5a9d51e1da",
+      "timestamp": 1785169742211,
+      "message": "INIT_START Runtime Version: python:3.13.mainlinev2.v18\tRuntime Version ARN: arn:aws:lambda:us-east-1::runtime:85016a02049aea54df8f85632acb695fe6e1c8623b63b4ed1d582917e22e8e4d\n",
+      "ingestionTime": 1785169750384,
+      "eventId": "39810615557174108531722646959066820720358530843875934208"
+    },
+    {
+      "logStreamName": "2026/07/27/[$LATEST]fb90571374314e25aa7bba5a9d51e1da",
+      "timestamp": 1785169743425,
+      "message": "[INFO]\t2026-07-27T16:29:03.424Z\t\tlogging configured: root INFO visibility active (feature 001)\n",
+      "ingestionTime": 1785169750384,
+      "eventId": "39810615584247213202738823452891182703353641712136159233"
+    },
+    {
+      "logStreamName": "2026/07/27/[$LATEST]fb90571374314e25aa7bba5a9d51e1da",
+      "timestamp": 1785169743436,
+      "message": "START RequestId: 7371adb4-b83a-45a3-b720-8f879353a8c3 Version: $LATEST\n",
+      "ingestionTime": 1785169750384,
+      "eventId": "39810615584492521399922660307448075604352773688701943810"
+    },
+    {
+      "logStreamName": "2026/07/27/[$LATEST]fb90571374314e25aa7bba5a9d51e1da",
+      "timestamp": 1785169743437,
+      "message": "[INFO]\t2026-07-27T16:29:03.437Z\t7371adb4-b83a-45a3-b720-8f879353a8c3\tNotification Lambda invoked: {\"notification_type\": \"digest\"}\n",
+      "ingestionTime": 1785169750384,
+      "eventId": "39810615584514822145121190930589611322625422050207924227"
+    },
+    {
+      "logStreamName": "2026/07/27/[$LATEST]fb90571374314e25aa7bba5a9d51e1da",
+      "timestamp": 1785169743437,
+      "message": "[INFO]\t2026-07-27T16:29:03.437Z\t7371adb4-b83a-45a3-b720-8f879353a8c3\tDaily digest handler invoked\n",
+      "ingestionTime": 1785169750384,
+      "eventId": "39810615584514822145121190930589611322625422050207924228"
+    },
+    {
+      "logStreamName": "2026/07/27/[$LATEST]fb90571374314e25aa7bba5a9d51e1da",
+      "timestamp": 1785169743719,
+      "message": "[INFO]\t2026-07-27T16:29:03.719Z\t7371adb4-b83a-45a3-b720-8f879353a8c3\tFound credentials in environment variables.\n",
+      "ingestionTime": 1785169750384,
+      "eventId": "39810615590803632291106826656502683875512259994894401541"
+    },
+    {
+      "logStreamName": "2026/07/27/[$LATEST]fb90571374314e25aa7bba5a9d51e1da",
+      "timestamp": 1785169744558,
+      "message": "[ERROR]\t2026-07-27T16:29:04.558Z\t7371adb4-b83a-45a3-b720-8f879353a8c3\tFailed to query digest users\n",
+      "ingestionTime": 1785169750384,
+      "eventId": "39810615609513957512674019472251151506264235298411970566"
+    },
+    {
+      "logStreamName": "2026/07/27/[$LATEST]fb90571374314e25aa7bba5a9d51e1da",
+      "timestamp": 1785169744558,
+      "message": "[ERROR]\t2026-07-27T16:29:04.558Z\t7371adb4-b83a-45a3-b720-8f879353a8c3\tFailed to get users for digest\n",
+      "ingestionTime": 1785169750384,
+      "eventId": "39810615609513957512674019472251151506264235298411970567"
+    },
+    {
+      "logStreamName": "2026/07/27/[$LATEST]fb90571374314e25aa7bba5a9d51e1da",
+      "timestamp": 1785169744558,
+      "message": "[INFO]\t2026-07-27T16:29:04.558Z\t7371adb4-b83a-45a3-b720-8f879353a8c3\tDaily digest processing complete\n",
+      "ingestionTime": 1785169750384,
+      "eventId": "39810615609513957512674019472251151506264235298411970568"
+    },
+    {
+      "logStreamName": "2026/07/27/[$LATEST]fb90571374314e25aa7bba5a9d51e1da",
+      "timestamp": 1785169744560,
+      "message": "END RequestId: 7371adb4-b83a-45a3-b720-8f879353a8c3\n",
+      "ingestionTime": 1785169750384,
+      "eventId": "39810615609558559003071080718534222942809532021423931401"
+    },
+    {
+      "logStreamName": "2026/07/27/[$LATEST]fb90571374314e25aa7bba5a9d51e1da",
+      "timestamp": 1785169744560,
+      "message": "REPORT RequestId: 7371adb4-b83a-45a3-b720-8f879353a8c3\tDuration: 1122.96 ms\tBilled Duration: 2345 ms\tMemory Size: 256 MB\tMax Memory Used: 107 MB\tInit Duration: 1221.87 ms\t\nXRAY TraceId: 1-6a67874d-01758b3e593b56516a126a8a\tSegmentId: 3ca118b1d9fd13f1\tSampled: true\t\n",
+      "ingestionTime": 1785169750384,
+      "eventId": "39810615609558559003071080718534222942809532021423931402"
+    },
+    {
+      "logStreamName": "2026/07/27/[$LATEST]630bc44bf2544e759a66183f26d5c2a5",
+      "timestamp": 1785171117023,
+      "message": "INIT_START Runtime Version: python:3.13.mainlinev2.v18\tRuntime Version ARN: arn:aws:lambda:us-east-1::runtime:85016a02049aea54df8f85632acb695fe6e1c8623b63b4ed1d582917e22e8e4d\n",
+      "ingestionTime": 1785171120897,
+      "eventId": "39810646216506216414005711076919249503808079831772233728"
+    },
+    {
+      "logStreamName": "2026/07/27/[$LATEST]630bc44bf2544e759a66183f26d5c2a5",
+      "timestamp": 1785171118305,
+      "message": "[INFO]\t2026-07-27T16:51:58.305Z\t\tlogging configured: root INFO visibility active (feature 001)\n",
+      "ingestionTime": 1785171120897,
+      "eventId": "39810646245095771758521969944368040329343279282439127041"
+    },
+    {
+      "logStreamName": "2026/07/27/[$LATEST]630bc44bf2544e759a66183f26d5c2a5",
+      "timestamp": 1785171118317,
+      "message": "START RequestId: 88f28df0-36ab-455f-b278-ee624ea1ee1a Version: $LATEST\n",
+      "ingestionTime": 1785171120897,
+      "eventId": "39810646245363380700904337422066468948615059620510892034"
+    },
+    {
+      "logStreamName": "2026/07/27/[$LATEST]630bc44bf2544e759a66183f26d5c2a5",
+      "timestamp": 1785171118318,
+      "message": "[INFO]\t2026-07-27T16:51:58.318Z\t88f28df0-36ab-455f-b278-ee624ea1ee1a\tNotification Lambda invoked: {\"notification_type\": \"digest\"}\n",
+      "ingestionTime": 1785171120897,
+      "eventId": "39810646245385681446102868045208004666887707982016872451"
+    },
+    {
+      "logStreamName": "2026/07/27/[$LATEST]630bc44bf2544e759a66183f26d5c2a5",
+      "timestamp": 1785171118318,
+      "message": "[INFO]\t2026-07-27T16:51:58.318Z\t88f28df0-36ab-455f-b278-ee624ea1ee1a\tDaily digest handler invoked\n",
+      "ingestionTime": 1785171120897,
+      "eventId": "39810646245385681446102868045208004666887707982016872452"
+    },
+    {
+      "logStreamName": "2026/07/27/[$LATEST]630bc44bf2544e759a66183f26d5c2a5",
+      "timestamp": 1785171118607,
+      "message": "[INFO]\t2026-07-27T16:51:58.607Z\t88f28df0-36ab-455f-b278-ee624ea1ee1a\tFound credentials in environment variables.\n",
+      "ingestionTime": 1785171120897,
+      "eventId": "39810646251830596808478218133111827247683084457245212677"
+    },
+    {
+      "logStreamName": "2026/07/27/[$LATEST]630bc44bf2544e759a66183f26d5c2a5",
+      "timestamp": 1785171119487,
+      "message": "[ERROR]\t2026-07-27T16:51:59.487Z\t88f28df0-36ab-455f-b278-ee624ea1ee1a\tFailed to query digest users\n",
+      "ingestionTime": 1785171120897,
+      "eventId": "39810646271455252583185166497663259327613642582507978758"
+    },
+    {
+      "logStreamName": "2026/07/27/[$LATEST]630bc44bf2544e759a66183f26d5c2a5",
+      "timestamp": 1785171119487,
+      "message": "[ERROR]\t2026-07-27T16:51:59.487Z\t88f28df0-36ab-455f-b278-ee624ea1ee1a\tFailed to get users for digest\n",
+      "ingestionTime": 1785171120897,
+      "eventId": "39810646271455252583185166497663259327613642582507978759"
+    },
+    {
+      "logStreamName": "2026/07/27/[$LATEST]630bc44bf2544e759a66183f26d5c2a5",
+      "timestamp": 1785171119487,
+      "message": "[INFO]\t2026-07-27T16:51:59.487Z\t88f28df0-36ab-455f-b278-ee624ea1ee1a\tDaily digest processing complete\n",
+      "ingestionTime": 1785171120897,
+      "eventId": "39810646271455252583185166497663259327613642582507978760"
+    },
+    {
+      "logStreamName": "2026/07/27/[$LATEST]630bc44bf2544e759a66183f26d5c2a5",
+      "timestamp": 1785171119489,
+      "message": "END RequestId: 88f28df0-36ab-455f-b278-ee624ea1ee1a\n",
+      "ingestionTime": 1785171120897,
+      "eventId": "39810646271499854073582227743946330764158939305519939593"
+    },
+    {
+      "logStreamName": "2026/07/27/[$LATEST]630bc44bf2544e759a66183f26d5c2a5",
+      "timestamp": 1785171119489,
+      "message": "REPORT RequestId: 88f28df0-36ab-455f-b278-ee624ea1ee1a\tDuration: 1171.30 ms\tBilled Duration: 2462 ms\tMemory Size: 256 MB\tMax Memory Used: 106 MB\tInit Duration: 1290.53 ms\t\nXRAY TraceId: 1-6a678cac-370d7219559ef6fb780d6386\tSegmentId: fd84580507d90ce5\tSampled: true\t\n",
+      "ingestionTime": 1785171120897,
+      "eventId": "39810646271499854073582227743946330764158939305519939594"
+    }
+  ]
+}

--- a/specs/001-lambda-log-visibility/evidence/post-deploy/t024-consumer-comparison.md
+++ b/specs/001-lambda-log-visibility/evidence/post-deploy/t024-consumer-comparison.md
@@ -1,0 +1,128 @@
+# T024 SC-003 Consumer Comparison (post-deploy)
+
+Collected: 2026-07-29T13:54–14:10Z (UTC). Fix fully live since 2026-07-26 ~07:35Z
+(deploy run 30192710400). AWS identity:
+`arn:aws:iam::218795110243:user/sentiment-analyzer-preprod-deployer`, us-east-1.
+Method identical to pre-deploy T002: `filter_log_events` per group, window widened
+1h→6h→24h→72h→168h until >=50 events, most recent 50 kept. Raw samples:
+`logshape-<fn>.json` in this directory (same schema as pre-deploy).
+
+## 1. Shape classification (50 most recent events per group)
+
+| function | window used | events | platform | structured JSON | stdlib [LEVEL] | stdlib tab-LEVEL | print/other |
+|---|---|---|---|---|---|---|---|
+| dashboard | 72h | 50 | 29 | 11 | 10 | 0 | 0 |
+| ingestion | 1h | 50 | 10 | 0 | 40 | 0 | 0 |
+| analysis | 24h | 50 | 12 | 13 | 23 | 0 | 2 |
+| metrics | 1h | 50 | 29 | 0 | 21 | 0 | 0 |
+| notification | 168h | 50 | 18 | 0 | 32 | 0 | 0 |
+| canary | 1h | 50 | 15 | 0 | 35 | 0 | 0 |
+
+Pre-deploy (for diff): dashboard 37/12/1/0/0, ingestion 13/0/37/0/0,
+analysis 20/21/5/0/4, metrics 34/0/16/0/0, notification 0 events in 168h,
+canary 15/0/35/0/0.
+
+### Assertions
+
+**Warning/error line shape unchanged — PASS.** All request-scoped stdlib lines still
+follow `[LEVEL]\t<ts>\t<rid>\t<msg>`. Examples:
+
+- pre: `[WARNING]\t2026-07-26T01:56:40.041Z\td13b124b-...\tJWT audience mismatch detected` (dashboard)
+- post: `[WARNING]\t2026-07-29T02:48:09.114Z\t7bebdd52-...\tItem already analyzed, skipping` (analysis)
+- post: `[ERROR]\t2026-07-26T07:04:53.496Z\t20438eeb-...\tFailed to query digest users` (notification)
+
+Init-phase lines carry an empty request-id field (`[LEVEL]\t<ts>\t\t<msg>`) — still
+the 4-field tab shape; the runtime has no request id during INIT. Not a shape change.
+
+**Powertools JSON byte-shape identical — PASS.** Dashboard's pre-deploy keyset
+(`cold_start, function_arn, function_memory_size, function_name, function_request_id,
+level, location, message, method, path, service, timestamp, xray_trace_id`) appears
+identically post-deploy. Analysis's three pre-deploy StructuredLogger keysets all
+reappear unchanged. Additional keysets observed post-deploy (dashboard:
+`{environment, level, location, message, service, table, timestamp}` and the powertools
+core `{level, location, message, service, timestamp}`; analysis:
+`{level, message, tickers_failed, tickers_written, timestamp}`) are different log
+statements sampled in this window, same emitter patterns (powertools core keys /
+StructuredLogger core keys) — not a format change.
+
+**No wrapped/nested JSON — PASS.** 0 lines across all six groups where a JSON
+`message` field contains JSON, or a `[LEVEL]` line wraps a `"level"`-keyed JSON body.
+
+**Expected delta: new `[INFO]` stdlib lines — CONFIRMED.** stdlib line counts rose in
+every group. The new lines are exactly the root-visibility class the feature intended:
+
+- `[INFO]\t<ts>\t\tlogging configured: root INFO visibility active (feature 001)` (every group, init)
+- `[INFO]\t<ts>\t<rid>\tFound credentials in environment variables.` (botocore, now visible)
+- `[INFO]\t<ts>\t\tsuccessfully patched module sqlite3|botocore|requests` (aws_xray_sdk, analysis init)
+- **notification** went from 0 events in 168h pre-deploy to a fully logging function
+  (32 app lines in its most recent 50, incl. `[ERROR] ... Failed to query digest users`
+  lines that were previously invisible).
+
+Two side observations, recorded not judged:
+
+1. Dashboard init emits a newly visible
+   `[WARNING]\t<ts>\t\tCritical env var is empty or missing — feature may be degraded` —
+   shape-conforming, previously suppressed; someone should eventually chase which var.
+2. In the metrics group the runtime's `LAMBDA_WARNING: Unhandled exception...` text,
+   which pre-deploy appeared as a bare line, now arrives wrapped as
+   `[WARNING]\t<ts>\t\tLAMBDA_WARNING: ...`. Same text, now routed through the
+   [LEVEL]-tab wrapper. No consumer greps for the bare form per the T002 survey.
+
+## 2. FR-004 StructuredLogger duplication (metrics group)
+
+**Verdict: STILL VACUOUS — the metrics Lambda never ran healthy post-deploy.**
+The pre-deploy crash loop did not end on 07-26; it changed failure mode:
+
+- Last `No module named 'aws_lambda_powertools'` error: **2026-07-26T05:15:14Z**
+- First `No module named 'aws_xray_sdk'` error: **2026-07-26T05:15:57Z** (43s later)
+- Last `aws_xray_sdk` error: **2026-07-29T14:03Z** (ongoing at collection time)
+- Max gap between consecutive ImportModuleErrors since 07-26T00:00Z: ~1.2 min —
+  no healthy window exists.
+- Since 07-26T00:00Z: 15,484 START events; ImportModuleError module counts:
+  `aws_lambda_powertools` 952, `aws_xray_sdk` 14,587.
+
+Methodology (recorded as the go-forward baseline method): full-pagination
+`filter_log_events` over the last 24h (30,324 events: 17,316 platform, 13,008 stdlib
+`[LEVEL]`, **0 single-line JSON with a `level` key**); duplication tests (a) identical
+JSON payload emitted 2+ times → 0 candidates, (b) JSON `message` re-emitted as a
+stdlib text line within ±2s → 0 candidates. CloudWatch pattern `{ $.level = "*" }`
+over 07-26T00:00Z→now: **0 events**. `src/lib/metrics.py` StructuredLogger still
+never executes — the handler module now gets far enough to run the feature-001
+logging config (`logging configured: root INFO visibility active` appears at init)
+but dies importing `aws_xray_sdk`. Duplication count: N/A. Re-measure once the
+packaging is fixed for real.
+
+## 3. Positive control — metric filter `dashboard_import_errors`
+
+**Verdict: FILTER STILL DEAD.** Live put-log-events control remains IAM-blocked
+(not retried; pre-deploy denials in `filter-control.md` stand). Read-only evidence,
+07-25→07-28 (and 07-22→now, daily period):
+
+- `list-metrics --namespace SentimentAnalyzer/Packaging`: **empty** — the
+  `DashboardImportErrors` metric still has never been created.
+- `get-metric-statistics` DashboardImportErrors, hourly Sum 07-25→07-28: **no datapoints**.
+- Meanwhile ~15,500 real `Runtime.ImportModuleError` events occurred in
+  `/aws/lambda/preprod-sentiment-metrics` in that window. The filter caught none —
+  though to be fair to the pattern, the filter only watches the **dashboard** group.
+  This window therefore re-proves the coverage gap (the failing Lambda is unwatched);
+  the field-position mismatch remains proven statically only (filter pattern
+  unchanged: `[time, request_id, level=ERROR*, msg=...]`, verified via
+  `describe-metric-filters` today).
+
+## 4. Deploy smoke grep consumer
+
+Runs 30192710400 (2026-07-26T07:23Z), 30283419540 (07-27T16:09Z), 30283936781
+(07-27T16:16Z): all `success`, and each run's smoke steps individually succeeded
+("Smoke Test Dashboard Lambda Imports", "Smoke Test SSE Lambda Imports", "Smoke Test
+Analysis Lambda Imports", "Smoke Test (Post-Deployment)"). The new log shapes did not
+break the smoke grep. Note: no smoke step covers the **metrics** Lambda's imports —
+which is exactly how the `aws_xray_sdk` packaging regression shipped and stayed live
+for 3+ days.
+
+## Overall SC-003 verdict
+
+**PASS** — all consumer-facing shapes (warning/error tab lines, powertools JSON key
+sets, no nesting, smoke grep) are unchanged; the only delta is the intended new
+`[INFO]` visibility. Separate defect, not an SC-003 failure: the metrics Lambda is
+still crash-looping (now `aws_xray_sdk`), invisible to smoke tests and to the dead
+import-error metric filter.

--- a/specs/001-lambda-log-visibility/evidence/post-deploy/t025-p50-delta.md
+++ b/specs/001-lambda-log-visibility/evidence/post-deploy/t025-p50-delta.md
@@ -1,0 +1,35 @@
+# T025 SC-005 p50 Delta: INFO events per dashboard invocation (post-deploy)
+
+Collected: 2026-07-29T14:04–14:06Z (UTC). Fix live since 2026-07-26 ~07:35Z.
+Function: `preprod-sentiment-dashboard` qualifier `live` (boto3 `lambda.invoke`,
+RequestResponse, API Gateway REST v1 event via
+`tests/e2e/helpers/lambda_invoke_transport._build_apigw_rest_event`).
+Route: `GET /health`. Invocations: 20 identical requests, serial.
+Same method as pre-deploy `dashboard-p50-baseline.md`: request id from
+`ResponseMetadata.RequestId`, 45s settle, all group events in [start-10s, end+60s]
+pulled (85 events; pre-deploy pulled 83), every non-platform line containing the
+request id classified stdlib `[INFO]` vs powertools JSON `"level":"INFO"` vs other.
+
+## Results (per invocation)
+
+| metric | p50 | min | max | mean | pre-deploy p50 | delta |
+|---|---|---|---|---|---|---|
+| stdlib `[INFO]` lines | 0.0 | 0 | 1 | 0.05 | 0.0 | **0.0** |
+| powertools JSON INFO lines | 1.0 | 1 | 1 | 1.00 | 1.0 | **0.0** |
+| invoke wall latency (ms) | 155.9 | 140.1 | 3469.2 | 324.6 | 154 | +1.9 |
+
+Status codes: [200]; FunctionError: [None]. Raw per-invocation data:
+`t025-p50-raw.json`.
+
+The single non-zero stdlib count was invocation 0 (the cold start, 3469ms wall /
+2120ms Init): one newly visible botocore line,
+`[INFO]\t2026-07-29T14:04:32.837Z\t<rid>\tFound credentials in environment variables.`
+Warm invocations emit exactly what they did pre-deploy: one powertools JSON INFO
+("Dashboard Lambda invoked"), zero stdlib lines.
+
+## SC-005 verdict
+
+**PASS.** p50 INFO events per invocation: stdlib 0.0 (unchanged), powertools 1.0
+(unchanged). Delta = 0, well under the ≤10 ceiling; even the worst case (cold start)
+adds exactly 1 line. Root INFO visibility costs nothing on the warm request path for
+this function.

--- a/specs/001-lambda-log-visibility/evidence/post-deploy/t025-p50-raw.json
+++ b/specs/001-lambda-log-visibility/evidence/post-deploy/t025-p50-raw.json
@@ -1,0 +1,228 @@
+{
+  "collectedAt": "2026-07-29T14:05:22.641141+00:00",
+  "function": "preprod-sentiment-dashboard",
+  "qualifier": "live",
+  "path": "/health",
+  "invocations": [
+    {
+      "i": 0,
+      "request_id": "519a6689-86fd-413f-a39b-50443b376ff5",
+      "status_code": 200,
+      "function_error": null,
+      "latency_ms": 3469.2,
+      "ts": 1785333869.5073524,
+      "stdlib_info": 1,
+      "powertools_json_info": 1,
+      "other_app_lines": 0
+    },
+    {
+      "i": 1,
+      "request_id": "fdfe9249-7f86-42f6-ba9b-88746e9947c0",
+      "status_code": 200,
+      "function_error": null,
+      "latency_ms": 185.0,
+      "ts": 1785333872.976606,
+      "stdlib_info": 0,
+      "powertools_json_info": 1,
+      "other_app_lines": 0
+    },
+    {
+      "i": 2,
+      "request_id": "4ee46fff-9494-460e-a97b-2a7dd172f89c",
+      "status_code": 200,
+      "function_error": null,
+      "latency_ms": 179.0,
+      "ts": 1785333873.161687,
+      "stdlib_info": 0,
+      "powertools_json_info": 1,
+      "other_app_lines": 0
+    },
+    {
+      "i": 3,
+      "request_id": "5ddc0a65-ed24-4ff9-a01c-f0cf027848a2",
+      "status_code": 200,
+      "function_error": null,
+      "latency_ms": 159.0,
+      "ts": 1785333873.3408608,
+      "stdlib_info": 0,
+      "powertools_json_info": 1,
+      "other_app_lines": 0
+    },
+    {
+      "i": 4,
+      "request_id": "704ef0c5-8e72-4fc2-aeb6-19953c77a212",
+      "status_code": 200,
+      "function_error": null,
+      "latency_ms": 152.0,
+      "ts": 1785333873.4999654,
+      "stdlib_info": 0,
+      "powertools_json_info": 1,
+      "other_app_lines": 0
+    },
+    {
+      "i": 5,
+      "request_id": "e15aa504-cf8c-4efc-92fc-3309ee33cc7e",
+      "status_code": 200,
+      "function_error": null,
+      "latency_ms": 160.3,
+      "ts": 1785333873.6520214,
+      "stdlib_info": 0,
+      "powertools_json_info": 1,
+      "other_app_lines": 0
+    },
+    {
+      "i": 6,
+      "request_id": "e41df40b-9a3d-4120-9d3a-69e0b547427e",
+      "status_code": 200,
+      "function_error": null,
+      "latency_ms": 207.8,
+      "ts": 1785333873.8124874,
+      "stdlib_info": 0,
+      "powertools_json_info": 1,
+      "other_app_lines": 0
+    },
+    {
+      "i": 7,
+      "request_id": "58f8da19-05a1-4707-bfa1-f810b0a873ac",
+      "status_code": 200,
+      "function_error": null,
+      "latency_ms": 153.8,
+      "ts": 1785333874.0203557,
+      "stdlib_info": 0,
+      "powertools_json_info": 1,
+      "other_app_lines": 0
+    },
+    {
+      "i": 8,
+      "request_id": "04b2d3a0-5d18-415f-9be1-89095f72a1d8",
+      "status_code": 200,
+      "function_error": null,
+      "latency_ms": 145.6,
+      "ts": 1785333874.174273,
+      "stdlib_info": 0,
+      "powertools_json_info": 1,
+      "other_app_lines": 0
+    },
+    {
+      "i": 9,
+      "request_id": "a6e34d58-2a08-4349-ba37-e7536c9740f1",
+      "status_code": 200,
+      "function_error": null,
+      "latency_ms": 151.3,
+      "ts": 1785333874.3199863,
+      "stdlib_info": 0,
+      "powertools_json_info": 1,
+      "other_app_lines": 0
+    },
+    {
+      "i": 10,
+      "request_id": "5d8f6bff-93a2-4534-b062-5617aae2b9d9",
+      "status_code": 200,
+      "function_error": null,
+      "latency_ms": 140.1,
+      "ts": 1785333874.4714465,
+      "stdlib_info": 0,
+      "powertools_json_info": 1,
+      "other_app_lines": 0
+    },
+    {
+      "i": 11,
+      "request_id": "3c3b8cfc-6e09-4add-9a78-d6cf9b19d312",
+      "status_code": 200,
+      "function_error": null,
+      "latency_ms": 149.4,
+      "ts": 1785333874.6117198,
+      "stdlib_info": 0,
+      "powertools_json_info": 1,
+      "other_app_lines": 0
+    },
+    {
+      "i": 12,
+      "request_id": "e72ac536-3e04-4db4-9d1d-04ef9f4fd0f5",
+      "status_code": 200,
+      "function_error": null,
+      "latency_ms": 146.9,
+      "ts": 1785333874.7612536,
+      "stdlib_info": 0,
+      "powertools_json_info": 1,
+      "other_app_lines": 0
+    },
+    {
+      "i": 13,
+      "request_id": "e6fdce1b-7f1d-4bd9-bf4c-eda4e7d08bd8",
+      "status_code": 200,
+      "function_error": null,
+      "latency_ms": 151.1,
+      "ts": 1785333874.9083118,
+      "stdlib_info": 0,
+      "powertools_json_info": 1,
+      "other_app_lines": 0
+    },
+    {
+      "i": 14,
+      "request_id": "4b3d781c-b455-4413-be61-3f691bf548de",
+      "status_code": 200,
+      "function_error": null,
+      "latency_ms": 161.4,
+      "ts": 1785333875.059527,
+      "stdlib_info": 0,
+      "powertools_json_info": 1,
+      "other_app_lines": 0
+    },
+    {
+      "i": 15,
+      "request_id": "42a91354-4ec8-45a1-b5b7-2f224a5e56bc",
+      "status_code": 200,
+      "function_error": null,
+      "latency_ms": 158.4,
+      "ts": 1785333875.2209983,
+      "stdlib_info": 0,
+      "powertools_json_info": 1,
+      "other_app_lines": 0
+    },
+    {
+      "i": 16,
+      "request_id": "dd101d5c-0f77-43e1-b533-bbdd60191f4d",
+      "status_code": 200,
+      "function_error": null,
+      "latency_ms": 154.6,
+      "ts": 1785333875.3794856,
+      "stdlib_info": 0,
+      "powertools_json_info": 1,
+      "other_app_lines": 0
+    },
+    {
+      "i": 17,
+      "request_id": "6b1e775a-aad2-4e21-a05b-459c5480e2c9",
+      "status_code": 200,
+      "function_error": null,
+      "latency_ms": 156.2,
+      "ts": 1785333875.534106,
+      "stdlib_info": 0,
+      "powertools_json_info": 1,
+      "other_app_lines": 0
+    },
+    {
+      "i": 18,
+      "request_id": "40a7d65a-88db-4fe7-a432-0807b4f14f06",
+      "status_code": 200,
+      "function_error": null,
+      "latency_ms": 156.0,
+      "ts": 1785333875.6903193,
+      "stdlib_info": 0,
+      "powertools_json_info": 1,
+      "other_app_lines": 0
+    },
+    {
+      "i": 19,
+      "request_id": "94dbe64f-53e2-46ce-920f-b36d99835d43",
+      "status_code": 200,
+      "function_error": null,
+      "latency_ms": 155.8,
+      "ts": 1785333875.8463883,
+      "stdlib_info": 0,
+      "powertools_json_info": 1,
+      "other_app_lines": 0
+    }
+  ]
+}

--- a/specs/001-lambda-log-visibility/evidence/post-deploy/week-one.md
+++ b/specs/001-lambda-log-visibility/evidence/post-deploy/week-one.md
@@ -1,0 +1,43 @@
+# T026 Week-One Watch — secret/PII/DEBUG leak patterns
+
+Window under watch: 2026-07-26T07:35Z (fix fully live) → end of week one
+(~2026-08-02). Days 4–7 append below.
+
+Patterns, per log group (`filter_log_events`, full pagination, window start
+2026-07-26T07:35Z):
+
+- `"token="` — expect 0 (secret leak; SC-001/SC-002 hygiene)
+- email heuristic — union of `"@gmail.com"` hits and `"sent to"` hits; any FULL
+  email in a line emitted by `sendgrid_service` = FAIL; masked `s***@` forms OK;
+  full emails from the KNOWN pre-existing entrypoint lines `handler.py:170/220`
+  recorded-not-endorsed
+- `"[DEBUG]"` — expect 0 (SC-004)
+
+## Day 3 — 2026-07-29T14:08Z (window 07-26T07:35Z → 07-29T14:08Z)
+
+| group | `token=` | email: `@gmail.com` | email: `sent to` | full emails | masked | `[DEBUG]` |
+|---|---|---|---|---|---|---|
+| dashboard | 0 | 0 | 0 | 0 | 0 | 0 |
+| ingestion | 0 | 0 | 0 | 0 | 0 | 0 |
+| analysis | 0 | 0 | 0 | 0 | 0 | 0 |
+| metrics | 0 | 0 | 0 | 0 | 0 | 0 |
+| notification | 0 | 0 | 0 | 0 | 0 | 0 |
+| canary | 0 | 0 | 0 | 0 | 0 | 0 |
+
+**Verdict (day 3): PASS across all six groups, all three patterns.** Zero hits
+everywhere, so nothing to redact and no full-vs-masked adjudication needed.
+
+Notes:
+
+- The notification group is now actually logging (it was silent pre-deploy), and its
+  new lines in the window include digest-query errors but no email-bearing lines —
+  the sendgrid_service send path and the handler.py:170/220 entrypoint lines did not
+  fire in this window, so the email check is clean-by-absence there, not
+  clean-by-masking. Re-check on a day a digest actually sends.
+- The metrics group's high event volume in the window is its ongoing
+  `aws_xray_sdk` ImportModuleError crash loop (see t024-consumer-comparison.md §2);
+  none of the watch patterns appear in it.
+- Collection identity `sentiment-analyzer-preprod-deployer`; no AWS denials during
+  this day's collection.
+
+<!-- Day 4–7 entries: append below this line, same table + verdict format. -->

--- a/tests/e2e/test_log_visibility.py
+++ b/tests/e2e/test_log_visibility.py
@@ -72,7 +72,14 @@ def lambda_client():
 
 
 class TestSelfTestLinePerColdStart:
-    """C-8 probe: the only discriminating evidence for metrics and canary."""
+    """C-8 probe: the only discriminating evidence for metrics and canary.
+
+    HARD LESSON (metrics, 2026-07-26..29): C-8 emits during handler import
+    BEFORE later imports/constructions can fail — the metrics function
+    crash-looped for 3 days on Tracer()'s lazy aws_xray_sdk import while
+    this test's C-8 assertion passed. C-8 proves the LOGGING fix only;
+    function health needs its own probe (below).
+    """
 
     @pytest.mark.parametrize("fn", ["metrics", "canary"])
     def test_self_test_line_since_deploy(self, logs_client, lambda_client, fn):
@@ -80,6 +87,15 @@ class TestSelfTestLinePerColdStart:
         assert _find_line(logs_client, _log_group(fn), SELF_TEST_MESSAGE, start_ms), (
             f"{fn}: C-8 self-test line absent since LastModified — root-level "
             "fix not live (or no cold start yet in window)"
+        )
+
+    def test_metrics_function_actually_healthy(self, lambda_client):
+        """Synthetic invoke must complete without FunctionError — catches the
+        packaging-onion class (ImportModuleError) that C-8 cannot see."""
+        resp = lambda_client.invoke(FunctionName=_function_name("metrics"))
+        assert resp.get("FunctionError") is None, (
+            "metrics invoke errored — packaging/import regression "
+            "(C-8 alone cannot detect this)"
         )
 
 


### PR DESCRIPTION
## Summary

The T024 measurement sweep found the metrics Lambda **never recovered**: the #965 powertools pin peeled one onion layer and 43s later it began failing on `No module named 'aws_xray_sdk'` (powertools `Tracer` lazy-loads it at construction) — ~14,600 errors over 3 days, zero healthy invocations, invisible to the dead import-error filter (Card C) and to the C-8 assertion (which emits at import, before `Tracer()` fails — honest lesson recorded in-test and as Card F).

- `aws-xray-sdk==2.14.0` pinned into the metrics package; isolated `python -S` import simulation of the corrected pin set passes.
- Metrics E2E gains a synthetic-invoke `FunctionError` health probe (the check C-8 structurally cannot provide).
- T024/T025/T026 evidence committed: consumer shapes byte-stable (SC-003 PASS), p50 delta 0 vs baseline (SC-005 PASS), week-one day-3 content queries clean — 0 `token=`, 0 unmasked emails, 0 `[DEBUG]` across all six groups (SC-004/SC-007 on track).
- Card F: the standing gap — no deploy smoke exercises ZIP-Lambda imports; an import smoke per ZIP package would have caught all three onion layers pre-merge.

## Test plan
- [x] Isolated import simulation: METRICS IMPORT OK
- [x] ruff clean
- [ ] Post-merge: metrics health probe green in Preprod Integration Tests; metrics crash-loop ends

🤖 Generated with [Claude Code](https://claude.com/claude-code)