### PR TITLE
fix(toolchain): loan pip-audit ignores for mcp PYSEC-2026-3481/3482/3483

### DIFF
--- a/.pip-audit-ignore
+++ b/.pip-audit-ignore
@@ -16,3 +16,6 @@ PYSEC-2025-217     2026-10-22   transformers 4.57.6; no fixed release listed; up
 PYSEC-2026-2288    2026-10-22   transformers 4.57.6; fix is 5.0.0 (major); upgrade deferred to Feature 1399 (torch/transformers decision)
 PYSEC-2026-2289    2026-10-22   transformers 4.57.6; fix is 5.3.0 (major); upgrade deferred to Feature 1399 (torch/transformers decision)
 PYSEC-2026-2290    2026-10-22   transformers 4.57.6; fix is 5.5.0 (major); upgrade deferred to Feature 1399 (torch/transformers decision)
+PYSEC-2026-3481    2026-09-30   mcp 1.23.3 is a strict transitive pin of semgrep 1.172.0 (latest release as of 2026-07-29); dev-only SAST tooling, never deployed to Lambda; remove when semgrep ships mcp>=1.27.2
+PYSEC-2026-3482    2026-09-30   mcp 1.23.3 is a strict transitive pin of semgrep 1.172.0 (latest release as of 2026-07-29); dev-only SAST tooling, never deployed to Lambda; remove when semgrep ships mcp>=1.27.2
+PYSEC-2026-3483    2026-09-30   mcp 1.23.3 is a strict transitive pin of semgrep 1.172.0 (latest release as of 2026-07-29); dev-only SAST tooling, never deployed to Lambda; remove when semgrep ships mcp>=1.28.1


### PR DESCRIPTION
## Summary

The blocking Dependency Vulnerability Scan (Feature 1400 gate, made real in #976's era) went red on every PR within hours of landing: three new PYSEC-2026 advisories were published against `mcp 1.23.3`, which `semgrep==1.172.0` pins strictly (`mcp==1.23.3`). Verified against PyPI: **semgrep 1.172.0 is the latest release**, so there is no upgrade path today — this is exactly the case the auto-expiring ignore ledger exists for.

First observed on PR #977's run (job 90775126188); reproduced locally with `pip-audit -r requirements-dev.txt --no-deps` and bisected to the semgrep pin alone.

## Changes

Three loan entries in `.pip-audit-ignore`, expiry **2026-09-30** (62 days, under the 90-day max):

| ID | Fix version | Disposition |
|---|---|---|
| PYSEC-2026-3481 | mcp 1.27.2 | ignore until semgrep ships it |
| PYSEC-2026-3482 | mcp 1.27.2 | ignore until semgrep ships it |
| PYSEC-2026-3483 | mcp 1.28.1 | ignore until semgrep ships it |

Justification: mcp is a transitive of dev-only SAST tooling; it never reaches the Lambda images. Past expiry the gate fails CI by design, forcing a fresh decision (upgrade or renew).

## Verification

- `scripts/pip-audit-gate.sh` exits 0 locally with 7 entries active (5 prod ignored / 8 dev ignored, zero unignored)
- Without the entries it reproduces the exact CI failure (3 findings, same IDs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)