### PR TITLE
fix(test): deflake chaos-degradation banner-reappears wait

### DIFF
--- a/frontend/tests/e2e/chaos-degradation.spec.ts
+++ b/frontend/tests/e2e/chaos-degradation.spec.ts
@@ -224,12 +224,17 @@ test.describe('Chaos: API Degradation', () => {
     );
 
     const searchInput = page.getByPlaceholder(/search tickers/i);
+    // Register the listener BEFORE the action that triggers it. The route above
+    // is a route.fulfill mock, so it answers with no network latency: an
+    // act-then-wait ordering can miss the response entirely and then block until
+    // the timeout waiting for a second one that never arrives.
+    const searchResponse = page.waitForResponse(
+      (r) => r.url().includes('/tickers/search') && r.ok(),
+      { timeout: 15000 },
+    );
     await searchInput.fill('');
     await searchInput.fill('TSLA');
-    await page.waitForResponse(
-      (r) => r.url().includes('/tickers/search') && r.ok(),
-      { timeout: 5000 },
-    );
+    await searchResponse;
 
     // Remove the success mock
     await page.unroute('**/api/v2/tickers/search**');


### PR DESCRIPTION
## What

`frontend/tests/e2e/chaos-degradation.spec.ts` — "dismissed banner reappears on new degradation cycle" intermittently times out on the `waitForResponse` for `/tickers/search`.

## Root cause

The listener was registered *after* the `fill()` that triggers the request:

```ts
await searchInput.fill('TSLA');
await page.waitForResponse((r) => r.url().includes('/tickers/search') && r.ok(), { timeout: 5000 });
```

`waitForResponse` subscribes at call time and does not look backwards. The route in question is a `route.fulfill` mock, so it answers with zero network latency. When the 200 lands inside the gap between the action and the subscription, the listener goes on waiting for a *second* ok() response that never arrives, and dies at the 5s cap.

Evidence, not inference: the CI failure artifact's page snapshot (captured at the moment of timeout) shows the search combobox already containing `TSLA` and the results listbox already rendering `option "TSLATesla Inc. NASDAQ" [selected]`. The response arrived and rendered. The test just missed observing it.

Why this line and not the three others in the file with the same shape: it is the only one with both a short 5s cap and an `r.ok()` predicate, and it is immediately followed by `page.unroute`, so no later request can accidentally satisfy it. The others sit on the default 30s with a looser predicate and usually get rescued by a follow-on request.

A cache-dedupe explanation was considered and ruled out: `triggerHealthBanner` only searches AAPL, GOOG and MSFT, so the TSLA query is cold.

## Fix

Promise-first ordering, plus a cap that tolerates CI contention:

```ts
const searchResponse = page.waitForResponse(..., { timeout: 15000 });
await searchInput.fill('');
await searchInput.fill('TSLA');
await searchResponse;
```

## Verification

- Post-fix: 5/5 passing locally (`--repeat-each=5`, Desktop Chrome).
- Pre-fix: 10/10 passing locally (`--repeat-each=10 --workers=4`). The race does **not** reproduce on an idle dev box; CI contention is what tips it. Stated plainly so the local green is not read as proof.

## Deliberately not in this PR

The same act-then-wait shape appears at spec lines 178/183/188 and in `helpers/chaos-helpers.ts`. Sweeping them is mechanical and near-zero risk, but bundling would blur the signal: if the flake survives this change, the diagnosis is cleanly falsified. Tracked as a separate board card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)