### PR TITLE
docs(001): spec the waitForResponse race sweep

### DIFF
--- a/specs/001-waitforresponse-race-sweep/contracts/helper-api.md
+++ b/specs/001-waitforresponse-race-sweep/contracts/helper-api.md
@@ -1,0 +1,146 @@
+# Contract: `searchAndAwaitResponse`
+
+**Location**: `frontend/tests/e2e/helpers/search-helpers.ts`
+**Consumers**: the 18 URL-scoped ticker-search wait sites across 3 spec files
+(`chart-edge-cases.spec.ts` 4, `ticker-search-gaps.spec.ts` 9, `chaos-degradation.spec.ts` 5).
+
+## Signature
+
+```ts
+export async function searchAndAwaitResponse(
+  page: Page,
+  searchInput: Locator,
+  query: string,
+  options?: {
+    predicate?: (response: Response) => boolean;
+    timeout?: number;
+    clearFirst?: boolean;
+  },
+): Promise<Response>;
+```
+
+## Behaviour
+
+1. Create the response promise **before** any interaction with the input. This ordering is the
+   entire point of the helper and MUST NOT be reordered.
+2. If `clearFirst` is true, `fill('')` before filling the query. Safe to bracket inside the single
+   listener because an empty query never fetches (`ticker-input.tsx:37`,
+   `enabled: query.length >= 1`). Playwright documents `locator.clear()` as equivalent to
+   `fill('')`, so a caller replacing an existing `.clear()` with `clearFirst: true` is not changing
+   behaviour.
+3. `fill(query)`.
+4. Await and return the matched `Response`.
+
+**Required shape for the throw path.** The interactions MUST be structured so the promise cannot be
+left unhandled if `fill()` throws. One of these two, and the implementation states which:
+
+```ts
+// Option A: try/finally, with the finally attaching the sink
+const responsePromise = page.waitForResponse(predicate, { timeout });
+let ok = false;
+try {
+  if (clearFirst) await searchInput.fill('');
+  await searchInput.fill(query);
+  ok = true;
+} finally {
+  // Reached on the throw path too. Without this the listener rejects at `timeout`
+  // with nobody awaiting it, which surfaces against an unrelated test.
+  if (!ok) responsePromise.catch(() => {});
+}
+return await responsePromise;
+
+// Option B: sink attached at creation
+const responsePromise = page.waitForResponse(predicate, { timeout });
+responsePromise.catch(() => {});   // on the creation line; promise is never unhandled
+if (clearFirst) await searchInput.fill('');
+await searchInput.fill(query);
+return await responsePromise;
+```
+
+Neither is optional. This is new code, so unlike the 6 already-correct inline sites there is no
+FR-004 constraint against writing it properly.
+
+## Defaults
+
+| Option | Default | Rationale |
+|---|---|---|
+| `predicate` | `(r) => r.url().includes('/api/v2/tickers/search')` | Matches the 13 glob-pattern sites' existing behaviour. It does **not** match all 18: see "Sites requiring an explicit predicate" below |
+| `timeout` | `15000` | FR-006 / research D3 — below the 30s test-level timeout so failures name the wait. Tests with more than two converted waits also need `test.setTimeout(60000)` for this cap to bind |
+| `clearFirst` | `false` | Callers that clear are explicit about it |
+
+## Sites requiring an explicit predicate
+
+Five of the 18 URL-scoped sites are not covered by the default. The default was described in an
+earlier draft as matching all 18; that was untrue.
+
+| Site | Original predicate | Effect of the default | Required |
+|---|---|---|---|
+| `chaos-degradation.spec.ts:131` | `url.includes('/tickers/search') && r.status() === 500` | Drops the status check, **widening** the match. FR-002 forbids this | MUST pass the original predicate explicitly |
+| `chaos-degradation.spec.ts:138` | `url.includes('/tickers/search') && r.status() === 200` | Same widening | MUST pass the original predicate explicitly |
+| `chaos-degradation.spec.ts:178` | `url.includes('/tickers/search')` (no `/api/v2` prefix) | **Narrows** the match. Permitted, but must be called out per FR-002 | Declare the narrowing in the converting task |
+| `chaos-degradation.spec.ts:183` | same as `:178` | Narrows | Declare the narrowing |
+| `chaos-degradation.spec.ts:188` | same as `:178` | Narrows | Declare the narrowing |
+
+## Guarantees
+
+- **G1**: The listener is registered before the action. Callers cannot get the ordering wrong.
+- **G2**: The listener never escapes as an unhandled rejection, **including when an interaction
+  throws**. On the success path the promise is awaited and returned. On the throw path the helper
+  has already attached a rejection sink (Behaviour, "Required shape for the throw path"), so the
+  caller sees the interaction's own error and the listener's later timeout rejection is swallowed
+  rather than surfacing against an unrelated test.
+
+  An earlier wording, *"the returned promise is always awaited inside the helper"*, promised more
+  than any code could deliver: if `searchInput.fill()` throws, control never reaches the await, so
+  no amount of "awaited on every return path" covers the case. The guarantee is now stated as what
+  the required shape actually produces. It is also the reason G2 is checkable: a reviewer looks for
+  the `finally` sink or the `.catch(() => {})` on the creation line, rather than counting return
+  paths in a function that has one.
+
+  This is the internal guarantee FR-012 relies on. The inline sites are still not required to carry
+  `try/finally`. They are existing code, several of them FR-004-protected, and their unhandled-
+  rejection window only opens on a throw that fails the test anyway.
+- **G3**: The helper does not widen a *supplied* predicate. A caller supplying a predicate gets
+  exactly that predicate. The **default** predicate carries no such guarantee: it is URL-only, so it
+  widens any site whose original predicate included a status check. Any caller whose original
+  predicate included a status MUST supply that predicate explicitly (see the table above).
+
+## Non-guarantees, stated so callers do not assume them
+
+- **N1**: It does not detect cache-served queries. Calling it for a repeat of the same query inside
+  the 30s `staleTime` window will hang until timeout, because no request is made
+  (`ticker-input.tsx:38`). Callers in that situation must assert on the UI instead — see
+  `ticker-search-gaps.spec.ts:242-247` for the existing precedent. Enforced by FR-010, not by code.
+- **N2**: It does not disambiguate between a request and its `retry: 1` retry
+  (`providers.tsx:48`). Where a prior interaction errored, the caller MUST supply a query-scoped
+  predicate (FR-002 / research D4).
+- **N3**: It is not used by the 9 non-search sites. `chaos-scenarios.spec.ts:102/105/108` and
+  `chaos-helpers.ts:364/367/370` wait on status without a URL predicate and keep doing so, and
+  `chaos-scenarios.spec.ts:219/222/225` use `page.waitForEvent('requestfailed')`, which takes no
+  predicate at all. All 9 get inline promise-first conversion instead (FR-005), under the accepted
+  risk recorded in the FR-002 exception.
+
+## Usage
+
+```ts
+// URL-scoped search site (the common case)
+await searchAndAwaitResponse(page, searchInput, 'AAPL');
+
+// Clearing before the next query
+await searchAndAwaitResponse(page, searchInput, 'GOOG', { clearFirst: true });
+
+// Error-path site needing a query-scoped predicate (research D4)
+await searchAndAwaitResponse(page, searchInput, 'GOOG', {
+  clearFirst: true,
+  predicate: (r) => r.url().includes('q=GOOG') && r.status() === 200,
+});
+```
+
+## What this contract replaces
+
+```ts
+// Before — listener registered after the action that triggers it
+await searchInput.fill('');
+await searchInput.fill('GOOG');
+await page.waitForResponse((r) => r.url().includes('/tickers/search'));
+```

--- a/specs/001-waitforresponse-race-sweep/data-model.md
+++ b/specs/001-waitforresponse-race-sweep/data-model.md
@@ -1,0 +1,52 @@
+# Data Model: `waitForResponse` race sweep
+
+**Not applicable.** This feature introduces no persisted entities, no schema, and no storage.
+
+It changes Playwright test sources under `frontend/tests/e2e/`, adds one test helper module, adds
+one scan script, and edits card entries in `CLEANUP-BOARD.html`. No DynamoDB table, no S3 object,
+no API contract, and no product data structure is touched.
+
+The nearest thing to a modelled entity is the classification the scan script assigns to each wait
+call site, which exists only as scan output and is never persisted. The scanned population is every
+`page.waitForResponse(...)` and every `page.waitForEvent('requestfailed'|'response')` under
+`frontend/tests/e2e/`.
+
+## Classification rule (FR-011)
+
+Stated here and in the script itself, because SC-001's "RACY 0" would otherwise rest on an
+undocumented heuristic:
+
+- **`RACY`** — an awaited `page.waitForResponse(...)` or
+  `page.waitForEvent('requestfailed'|'response')` whose **immediately preceding non-comment,
+  non-blank line** performs a triggering action: `.fill(`, `.click(`, `.press(`, `.selectOption(`,
+  `.clear(`, `.goto(`, `.reload(`, `.evaluate(`, `.type(`, `.check(`, `.tap(`, `.setInputFiles(`,
+  `.dispatchEvent(`.
+- **`PROMISE-FIRST`** — the wait is assigned to a variable before the triggering action and awaited
+  after it.
+- **`OTHER`** — neither shape. Requires human triage, and is printed under an explicit "requires
+  human triage" banner rather than folded into the summary counts alone.
+
+`.evaluate(` earns its place in the list from the tree, not from theory:
+`error-visibility-search.spec.ts:158` triggers its request via
+`retryButton.evaluate((el) => el.click())`.
+
+The adjacency part of the rule is load-bearing. `chaos-scenarios.spec.ts:138` classifies as `OTHER`
+rather than `RACY` only because an `await expect(...).toBeVisible({ timeout: 2000 })` sits between
+its `page.reload()` and the wait.
+
+## Counts
+
+| Category | Baseline (inline sites) | Target (inline sites) |
+|---|---|---|
+| `RACY` | 27 | 0 |
+| `PROMISE-FIRST` | 6 | 16 |
+| `OTHER` | 1 (`chaos-scenarios.spec.ts:138`) | 1 (same site) |
+| **Total** | **34** | **17** |
+
+Plus, at target: exactly **18** `searchAndAwaitResponse(` call sites.
+
+The total is **not** invariant, and an earlier draft's claim that it was fixed at 31 was wrong. The
+18 helper-routed sites stop being inline wait call sites the moment they become
+`searchAndAwaitResponse(...)` calls, and the helper contributes one internal wait in their place.
+The target 16 breaks down as 6 pre-existing promise-first + 6 status-only inline conversions +
+3 `requestfailed` inline conversions + 1 internal to the helper.

--- a/specs/001-waitforresponse-race-sweep/plan.md
+++ b/specs/001-waitforresponse-race-sweep/plan.md
@@ -133,6 +133,14 @@ classification rule is documented in the script itself (FR-011), keyed on the im
 non-comment, non-blank line. Establishes the 27/6/1 baseline (34 total) before any edit, so SC-001
 has a before-and-after.
 
+The script is **standard-library only** and is written to a consumed interface, because the dependent
+regression-guard feature wires it into a pre-commit hook and the required CI `Lint` job. Beyond the
+RACY exit branch it must report files-scanned, exit non-zero on a zero-file scan, print findings to
+stdout with remediation guidance, ignore file arguments in favour of its fixed root, and assert its
+own interpreter floor. FR-011 states the obligations; T001 criteria 5, 6, 8, 12 and 13 make each one
+checkable. Getting this wrong is not cosmetic: a venv-only or file-list-driven detector passes every
+test in this feature and is inert in the one that consumes it.
+
 **Phase B — Helper (FR-005).** Add `frontend/tests/e2e/helpers/search-helpers.ts` with a
 predicate-parameterised `searchAndAwaitResponse`. Contract in `contracts/helper-api.md`.
 

--- a/specs/001-waitforresponse-race-sweep/plan.md
+++ b/specs/001-waitforresponse-race-sweep/plan.md
@@ -1,0 +1,224 @@
+# Implementation Plan: Sweep the act-then-wait `waitForResponse` race class
+
+**Branch**: `001-waitforresponse-race-sweep` | **Date**: 2026-07-30 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/001-waitforresponse-race-sweep/spec.md`
+
+## Summary
+
+Convert 27 Playwright call sites from act-then-wait to promise-first ordering, tightening predicates
+where earlier registration would let a stale `retry: 1` response satisfy the wait. Introduce one
+predicate-parameterised helper for the 18 URL-scoped search sites; the other 9 (6 status-only 503,
+3 `waitForEvent('requestfailed')`) convert inline. Commit the inventory scan so the "zero racy
+sites" criterion is reproducible. Prove the fix by forcing the race with injected delay against pre-
+and post-fix code at the two sites where injection is sound, because the race does not reproduce on
+an idle machine.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x (test sources only)
+**Primary Dependencies**: `@playwright/test` ^1.57.0; no new dependencies
+**Storage**: N/A
+**Testing**: Playwright (customer dashboard suite, `frontend/tests/e2e/`), run via `npx playwright test`
+**Target Platform**: Desktop Chrome (Chromium) only, matching `.github/workflows/pr-checks.yml`; CI on ubuntu-latest.
+The other four configured Playwright projects (Mobile Chrome, Mobile Safari, firefox, webkit) are not
+exercised by CI and are therefore not verified by this feature.
+**Project Type**: web (frontend test infrastructure)
+**Performance Goals**: N/A. The relevant metric is the Playwright job's attributable false-red rate, target 0.
+**Constraints**: Test-only. No product code. No new AWS resources. GPG-signed commits. Playwright E2E job stays non-required.
+**Test-level timeout**: `playwright.config.ts` sets no `timeout`, so the cap is Playwright's default 30000ms.
+Any test with more than two converted waits gets an explicit `test.setTimeout(60000)` so FR-006's
+15000ms per-call cap can actually bind (FR-006, research D3).
+**Scale/Scope**: 27 conversions across 5 files, 1 new helper, 1 new scan script, 4 board-card edits
+(2 cards corrected, 2 added).
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+The constitution governs the sentiment-analyzer service (ingestion, inference, admin API, secrets,
+DB access). This feature changes only Playwright test sources and a board file. Gate-by-gate:
+
+| Gate | Applicability | Status |
+|---|---|---|
+| Functional requirements (ingest, dedupe, sentiment, admin API) | Not touched | PASS (N/A) |
+| Availability / latency / throughput NFRs | Not touched | PASS (N/A) |
+| Auth on management endpoints | Not touched | PASS (N/A) |
+| Secrets not in source control | No secrets introduced; mocks contain synthetic tickers only | PASS |
+| TLS in transit | Not touched | PASS (N/A) |
+| SQL injection / unsafe DB access | No DB access | PASS (N/A) |
+| Log redaction | No logging changes | PASS (N/A) |
+
+Project-level gates that do apply:
+
+| Gate | Status |
+|---|---|
+| GPG-signed commits, no `--no-verify` | Enforced by pre-commit and the block-no-verify hook |
+| No new AWS resources | PASS — none |
+| Two-dashboard rule: this is the **customer** dashboard (Next.js/Amplify), tested by `frontend/tests/e2e/*.spec.ts` via `npx playwright test`, not the HTMX/Lambda pytest suite | PASS — every touched file carries the `// Target: Customer Dashboard (Next.js/Amplify)` header |
+| No unjustified fallback patterns | PASS — conversions remove a failure mode, add none |
+| No silent failures | Strengthened: FR-006's explicit 15s cap makes a hung wait report as a `waitForResponse` timeout instead of an opaque test timeout |
+
+**Result: PASS.** No violations, no complexity deviations to track.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/001-waitforresponse-race-sweep/
+├── spec.md              # Stage 1 + AR#1 appendix + Clarifications appendix
+├── plan.md              # this file + AR#2 appendix
+├── research.md          # decisions D1-D4 with rationale and rejected alternatives
+├── data-model.md        # N/A rationale (no data entities)
+├── contracts/
+│   └── helper-api.md    # the helper's signature and behavioural contract
+├── tasks.md             # Stage 7 + AR#3 appendix
+└── quickstart.md        # how to run the verification procedures
+```
+
+### Source Code (repository root)
+
+```text
+frontend/
+├── src/                                  # READ ONLY — no changes
+└── tests/e2e/
+    ├── helpers/
+    │   ├── search-helpers.ts             # NEW — predicate-parameterised search-and-await
+    │   └── chaos-helpers.ts              # MODIFIED — 3 sites (364/367/370), plus the `test`
+│                                     #   import and the helper-side setTimeout raise (T012)
+    ├── chaos-degradation.spec.ts         # MODIFIED — 5 sites
+    ├── chaos-scenarios.spec.ts           # MODIFIED — 6 sites (3 waitForResponse, 3 waitForEvent)
+    ├── chart-edge-cases.spec.ts          # MODIFIED — 4 sites
+    ├── ticker-search-gaps.spec.ts        # MODIFIED — 9 sites
+    ├── chaos-cross-browser.spec.ts       # UNCHANGED BUT AFFECTED (calls triggerHealthBanner at :35)
+    ├── chaos-error-boundary.spec.ts      # UNCHANGED BUT AFFECTED (calls triggerHealthBanner at :63)
+    └── error-visibility-search.spec.ts   # UNCHANGED — already correct
+
+scripts/
+└── scan-waitforresponse-race.py          # NEW — the committed inventory scan (FR-011)
+
+CLEANUP-BOARD.html                        # MODIFIED — 2 cards corrected, 2 added
+```
+
+## Design Decisions
+
+Full rationale and rejected alternatives in [research.md](./research.md). Summary:
+
+- **D1 — Helper vs 27 inline conversions.** Both. One helper
+  (`searchAndAwaitResponse`) for the 18 URL-scoped search sites; inline promise-first for the
+  9 non-search sites (6 status-only 503, whose predicates must stay status-only per FR-005, and
+  3 `waitForEvent('requestfailed')` sites, which take no predicate at all).
+- **D2 — Response wait vs UI-outcome assertion.** Keep response waits. Switching to UI assertions
+  would change what several tests prove (that a *request* was made and answered, which is what
+  `recordSuccess()`/failure-counter behaviour keys on). Out of scope to redesign assertions during a
+  race fix.
+- **D3 — Timeout policy.** Explicit 15000ms on every converted call, plus
+  `test.setTimeout(60000)` on any test containing more than two converted waits. Rationale in
+  FR-006: it is a diagnosability choice, not a fix. 4 of the 5 observed failures hit the 30s
+  *test-level* timeout, so a per-call cap below it converts opaque test timeouts into named
+  `waitForResponse` timeouts. On multi-wait tests that reasoning inverts unless the test cap is
+  raised: `chaos-degradation.spec.ts:196` runs about seven sequential waits inside one 30s budget,
+  so the second hang would blow the test cap first and report opaquely.
+- **D4 — Predicate scoping.** Tighten to include the query where a prior interaction's `retry: 1`
+  response could otherwise match. Applies to the URL-scoped error-path search sites; success-path
+  sites produce exactly one response and need no tightening. Does **not** apply to the 6 status-only
+  or 3 `requestfailed` sites, which are an explicit accepted risk under the FR-002 exception.
+
+## Implementation Phases
+
+**Phase A — Scan artifact (FR-011).** Commit `scripts/scan-waitforresponse-race.py`, which
+classifies every `waitForResponse` and `waitForEvent('requestfailed'|'response')` under
+`frontend/tests/e2e/` as RACY / PROMISE-FIRST / OTHER and exits non-zero if any RACY remain. The
+classification rule is documented in the script itself (FR-011), keyed on the immediately preceding
+non-comment, non-blank line. Establishes the 27/6/1 baseline (34 total) before any edit, so SC-001
+has a before-and-after.
+
+**Phase B — Helper (FR-005).** Add `frontend/tests/e2e/helpers/search-helpers.ts` with a
+predicate-parameterised `searchAndAwaitResponse`. Contract in `contracts/helper-api.md`.
+
+**Phase C — Conversions (FR-001, FR-002, FR-010, FR-012).** Per file, smallest blast radius first:
+`chart-edge-cases` (4) → `ticker-search-gaps` (9) → `chaos-scenarios` (6: 3 `waitForResponse` +
+3 `waitForEvent`) → `chaos-degradation` (5) → `chaos-helpers` (3, plus the `triggerHealthBanner`
+docstring correction required by FR-005). `chaos-helpers.ts` last because `triggerHealthBanner` is a
+precondition of the whole chaos suite, so its change must be validated against already-converted
+callers and against the two unedited callers (`chaos-cross-browser.spec.ts:35`,
+`chaos-error-boundary.spec.ts:63`).
+
+**Phase D — Verification (SC-003).** Fault injection first (a), then contention (b). Injection runs
+only at the two sound targets, `ticker-search-gaps.spec.ts:22` (site `:38`) and
+`chart-edge-cases.spec.ts` (site `:72`), where the mock produces exactly one matching response. It
+is the falsifiable step: it must make pre-fix code fail *at those sites*. If it does not, the
+diagnosis is wrong and the work stops for re-analysis rather than proceeding to a green-looking
+result. Non-reproduction at the 6 status-only or 3 `requestfailed` sites is expected and is not a
+stop condition; those are covered by contention only.
+
+**Phase E — Board (FR-008, FR-009).** JSON surgery on `CLEANUP-BOARD.html`: `raw_decode` the array
+after `const CARDS = `, edit the two cards in place, append the merge-required follow-up card, add
+the `dynamodb_throttle` dead-branch card, re-dump, validate parse and count (118 → 120).
+
+## Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Predicate tightening changes what a test proves | Medium | High | FR-002 requires per-site justification; AR#3 reviews each changed predicate |
+| `triggerHealthBanner` conversion destabilises the chaos suite | Medium | High | Converted last, validated against already-converted callers; full chaos suite run before commit |
+| Fault injection fails to reproduce on pre-fix code **at a single-response site** (`ticker-search-gaps.spec.ts:22` → site `:38`, `chart-edge-cases.spec.ts` → site `:72`) | Low | Critical | Stop condition. It would falsify the diagnosis. Scope matters: non-reproduction at the 6 status-only 503 sites or the 3 `requestfailed` sites is EXPECTED, because `retry: 1` plus the blanket `**/api/**` 503 route keep supplying a matching response, so it is not a stop condition there. Those 9 are covered by contention SC-003(b) only. `chaos-degradation.spec.ts:196` is not an injection target at all: PR #981 already converted its site. |
+| A converted site is actually cache-served and now hangs | Low | Medium | FR-010; the one known instance is already documented at `ticker-search-gaps.spec.ts:242-247` |
+| Board JSON surgery corrupts the file | Low | Medium | Parse-and-count validation after re-dump; the file is in git |
+
+## Complexity Tracking
+
+No constitution violations. One design choice warrants justification:
+
+| Choice | Why needed | Simpler alternative rejected because |
+|---|---|---|
+| A helper *and* inline conversions, rather than one uniform treatment | The 27 sites are not homogeneous. 18 are URL-scoped to ticker search, 6 wait on any 503 with no URL predicate, and 3 are `waitForEvent('requestfailed')` waits that accept no predicate | Forcing all 27 through a search-scoped helper would narrow the 6 status-only predicates and could not express the 3 event waits at all, changing what those tests assert (AR#1 finding F-04) |
+
+---
+
+## Adversarial Review #2
+
+Reviewer: an independent agent, run against the full artifact suite (spec, plan, research,
+data-model, contract, quickstart) rather than any single document, and instructed to treat every
+artifact claim as a suspect until checked against the tree. The orchestrator did not accept the
+three CRITICAL findings on the reviewer's word: the missed `waitForEvent('requestfailed')` sites,
+the stale fault-injection target, and the fabricated C1 import evidence were each re-verified
+independently against the working tree before being written into the artifacts.
+
+### Drift findings
+
+| ID | Sev | What drifted | Resolution |
+|---|---|---|---|
+| D-01 | CRITICAL | SC-001 was arithmetically impossible. It claimed post-sweep PROMISE-FIRST 30 with the total invariant at 31, but the 18 helper-routed sites stop being inline call sites once they become `searchAndAwaitResponse(...)` calls, and the helper adds one internal wait. | SC-001 rewritten to RACY 0 / PROMISE-FIRST 16 / OTHER 1, total 17, with the 16 derived term by term, plus a requirement that exactly 18 `searchAndAwaitResponse(` call sites exist. data-model.md and quickstart section 1 corrected to match. |
+| D-02 | CRITICAL | The fault-injection gate named `chaos-degradation.spec.ts:196` / "dismissed banner reappears" as its target. PR #981 already converted that site; it is promise-first at `:231-237` and protected by FR-004, so stashing this feature's work cannot restore the old shape. | SC-003(a) and quickstart section 3 retargeted to the two sites whose mock produces exactly one matching response: `ticker-search-gaps.spec.ts:22` (site `:38`) and `chart-edge-cases.spec.ts` (site `:72`). |
+| D-03 | HIGH | SC-005 and quickstart section 6 said 118 → 119, but the work adds two cards. | 118 → 120 everywhere; FR-009 now authorises both cards by name. |
+| D-04 | HIGH | FR-002 (tighten predicates) contradicted FR-005 (exempt `triggerHealthBanner`), with no stated resolution. | FR-002 gained an explicit accepted-risk exception covering the 6 status-only and 3 `requestfailed` sites, with the reason and the residual risk both stated. |
+| D-05 | HIGH | C1's evidence was fabricated: seven importers claimed, six exist; `helpers/verification.ts` only mentions chaos-helpers in a comment; the two specs said to "import it today" contain zero references. | C1's evidence rewritten to the verified grep. The conclusion (new `search-helpers.ts`) is unchanged and strengthened. |
+| D-06 | HIGH | The contract claimed its default predicate "matches the 18 URL-scoped sites' existing behaviour". False for 5 of 18: two carry status checks the default would drop (widening, which FR-002 forbids) and three use a shorter path (narrowing, permitted but undeclared). | Defaults rationale corrected to the 13 glob-pattern sites; G3 amended; a "sites requiring an explicit predicate" list added naming all five. |
+| D-07 | MEDIUM | plan.md contradicted itself on board scope: Technical Context said "3 board-card edits", Project Structure said "2 cards corrected, 1 added". | Both now read "2 cards corrected, 2 added". |
+| D-08 | MEDIUM | SC-001's "RACY 0" silently depended on an undocumented adjacency heuristic, which is the only reason `chaos-scenarios.spec.ts:138` classifies as `OTHER`. | FR-011 now states the classification rule in full and requires the script to document it; data-model.md states it too. |
+| D-09 | MEDIUM | research D4's "Applies to" clause captured `chaos-scenarios.spec.ts:102/105/108`, which the spec exempts elsewhere. | D4's applies / does-not-apply lists rewritten to match the FR-002 exception. |
+
+### New findings
+
+| ID | Sev | Finding | Resolution |
+|---|---|---|---|
+| N-01 | CRITICAL | Three sites of the same act-then-wait class were missed: `chaos-scenarios.spec.ts:219/222/225`, each `fill(X)` followed by `page.waitForEvent('requestfailed', { timeout: 5000 })` under `api_timeout`, which uses `route.abort` and so fires with even less latency than `route.fulfill`. | Scope 24 → 27. Inventory table gains a `waitForEvent` row; FR-001 updated; the 3 join the inline-conversion group (9 inline, 18 helper-routed). |
+| N-02 | HIGH | Injection is unsound on the 6 status-only and 3 `requestfailed` sites: `retry: 1` plus the blanket `**/api/**` 503 route mean a matching response keeps arriving, so the listener resolves whatever the injected gap. The Risk table treated any non-reproduction as a critical stop. | SC-003(a), quickstart section 3, and the Risk row now scope the stop condition to the single-response sites and state that non-reproduction elsewhere is expected. |
+| N-03 | HIGH | Two files that call `triggerHealthBanner` (`chaos-cross-browser.spec.ts:35`, `chaos-error-boundary.spec.ts:63`) appeared in no file list and no verification command, so the helper's blast radius was under-verified. | Both added to the Source Code tree as UNCHANGED BUT AFFECTED, and to the quickstart smoke and contention commands, along with `chaos-scenarios.spec.ts`. |
+| N-04 | HIGH | FR-006's timeout reasoning inverted on multi-wait tests. `chaos-degradation.spec.ts:196` runs about seven sequential waits inside the default 30000ms test cap, so the second 15000ms hang blows the test cap first and reports opaquely, the exact outcome FR-006 exists to prevent. | FR-006 keeps 15000ms per call and adds a mandatory `test.setTimeout(60000)` for any test with more than two converted waits. Mirrored into research D3 and this plan. |
+| N-05 | MEDIUM | FR-012 was unimplementable as written, and the merged reference commit violated it: `chaos-degradation.spec.ts:231-236` leaves the promise unawaited if a `fill()` throws, and FR-004 forbids amending it. | FR-012 relaxed to a success-path await plus the helper's internal guarantee, with the reasoning stated so a future reader does not read it as an oversight. The "never as an unhandled rejection" absolute is removed. |
+| N-06 | MEDIUM | Technical Context claimed a Chromium/Firefox/WebKit target, but every verification command and CI itself run `--project="Desktop Chrome"` only. | Target Platform narrowed to Desktop Chrome, with a note that the other four configured projects are not exercised by CI and are not verified here. |
+| N-07 | LOW | The sampling method omitted that `pr-checks.yml` passes `--retries=0`, without which the ~20% rate is not re-derivable from other workflows (`nightly-e2e` does not pass it). | Flag recorded in the spec's Context section as part of the method. |
+
+### Scope-definition lesson
+
+The class was defined by method name (`waitForResponse`, and an explicit exclusion list that named
+`waitForEvent('response')`) rather than by shape. That is why 3 of 27 sites were missed: they use
+`waitForEvent('requestfailed')`, which is the same defect with a different call. The class is a
+shape, a listener registered after the action that triggers it, and the committed scan (FR-011) now
+encodes the shape rule so the definition cannot drift back to a list of method names.
+
+### Gate
+
+**0 CRITICAL, 0 HIGH remaining.**

--- a/specs/001-waitforresponse-race-sweep/quickstart.md
+++ b/specs/001-waitforresponse-race-sweep/quickstart.md
@@ -1,0 +1,152 @@
+# Quickstart: verifying the `waitForResponse` race sweep
+
+All commands from the repo root unless stated. Python steps need the venv:
+`source .venv/bin/activate`.
+
+## 1. Inventory scan (SC-001)
+
+```bash
+python scripts/scan-waitforresponse-race.py
+```
+
+Baseline before the sweep: `RACY 27 / PROMISE-FIRST 6 / OTHER 1` (34 inline sites total).
+Target after the sweep: `RACY 0 / PROMISE-FIRST 16 / OTHER 1` (17 inline sites total), exit code 0.
+
+The total drops because the 18 helper-routed sites stop being inline wait call sites once they
+become `searchAndAwaitResponse(...)` calls, and the helper adds one internal wait. The 16 is
+6 pre-existing promise-first + 6 status-only inline conversions + 3 `requestfailed` inline
+conversions + 1 inside the helper. Check the other half of SC-001 too:
+
+```bash
+grep -rn "searchAndAwaitResponse(" frontend/tests/e2e/ --include="*.spec.ts" | wc -l   # expect 18
+```
+
+The script exits non-zero while any `RACY` site remains, so it doubles as a check the dependent
+regression-guard feature can wire into CI.
+
+## 2. Smoke run (SC-002 — precondition only, not evidence)
+
+```bash
+cd frontend
+npx playwright test tests/e2e/chaos-degradation.spec.ts \
+  tests/e2e/chaos-scenarios.spec.ts tests/e2e/chart-edge-cases.spec.ts \
+  tests/e2e/ticker-search-gaps.spec.ts \
+  tests/e2e/chaos-cross-browser.spec.ts tests/e2e/chaos-error-boundary.spec.ts \
+  --project="Desktop Chrome"
+```
+
+`chaos-cross-browser.spec.ts` (`:35`) and `chaos-error-boundary.spec.ts` (`:63`) are not edited by
+this feature but they call `triggerHealthBanner`, so they are in the helper's blast radius and must
+run.
+
+Green here proves nothing about the race. Pre-fix code passes this too. It only catches gross
+breakage from the conversions.
+
+## 3. Fault injection (SC-003a — the actual gate)
+
+The race does not reproduce on an idle machine, so force it. Temporarily insert a delay between the
+action and the listener registration, which is exactly the gap the race exploits.
+
+**Pick the target carefully. Injection is only sound where the mock produces exactly one matching
+response.** The two valid targets:
+
+| Target test | Racy site | Why it is sound |
+|---|---|---|
+| `ticker-search-gaps.spec.ts:22` | `:38` | Returns a single 200 with empty results. Not an error, so `retry: 1` does not fire a second response |
+| `chart-edge-cases.spec.ts` | `:72` | Single matching response from its `route.fulfill` mock |
+
+**`chaos-degradation.spec.ts:196` is NOT a valid target.** PR #981 already converted that test's
+racy site. It is now promise-first at `:231-237` and is one of the 6 protected already-correct sites
+(FR-004). Restoring this feature's conversions will not bring the old shape back, so injecting
+there measures nothing.
+
+**The 6 status-only 503 sites (`chaos-helpers.ts:364/367/370`,
+`chaos-scenarios.spec.ts:102/105/108`) and the 3 `requestfailed` sites
+(`chaos-scenarios.spec.ts:219/222/225`) cannot be validated by injection at all.** `retry: 1`
+(`frontend/src/app/providers.tsx:48`) plus the blanket `page.route('**/api/**', …503)` mean a
+matching response keeps arriving, so the listener resolves however wide the injected gap. Their
+non-reproduction is EXPECTED and does not falsify anything. They are covered by the contention
+procedure in section 4 (SC-003b) only.
+
+**Step 1, pre-fix baseline.** Restore the two target files to their pre-sweep content. Do not use
+`git stash`: by the time you reach Phase D the conversions are committed, so there is nothing to
+stash.
+
+```bash
+BASE=$(git merge-base main HEAD)
+git checkout $BASE -- frontend/tests/e2e/ticker-search-gaps.spec.ts \
+                      frontend/tests/e2e/chart-edge-cases.spec.ts
+# widen the gap at the racy site, in the spec file, e.g.:
+#   await searchInput.fill('ZZZZZ');
+#   await new Promise((r) => setTimeout(r, 250));   // <-- injected
+#   await page.waitForResponse('**/api/v2/tickers/search**');
+cd frontend
+npx playwright test tests/e2e/ticker-search-gaps.spec.ts \
+  tests/e2e/chart-edge-cases.spec.ts --project="Desktop Chrome"
+cd .. && git checkout HEAD -- frontend/tests/e2e/ticker-search-gaps.spec.ts \
+                              frontend/tests/e2e/chart-edge-cases.spec.ts
+```
+
+**Expected: FAIL at the injected site.** If it passes, the diagnosis is wrong: stop and re-analyse
+rather than proceeding. That stop condition is the whole value of this step, and it applies to these
+two sites only.
+
+**Step 2, post-fix.** The seam moved. After conversion both targets are single
+`searchAndAwaitResponse(...)` calls, so the fill and the await both live inside the helper. The
+delay MUST go inside `frontend/tests/e2e/helpers/search-helpers.ts`, between
+`await searchInput.fill(query);` and `await responsePromise;`.
+
+Injecting the delay in the `.spec.ts` file instead does NOT satisfy this step. There, the only
+position after the action is after the helper has already awaited, so the delay lands once the
+promise has resolved and the test passes without exercising anything.
+
+**Negative control.** With the delay in that seam, flip the helper's statement order to the pre-fix
+shape (create the promise below the fill). It MUST fail. Restore promise-first: it MUST pass. If
+both orderings pass, the delay is not in the seam and the result is void.
+
+**Expected: PASS, with the negative control failing.**
+
+Do **not** commit the injection patch.
+
+## 4. Contention (SC-003b)
+
+```bash
+cd frontend
+npx playwright test tests/e2e/chaos-degradation.spec.ts \
+  tests/e2e/chaos-scenarios.spec.ts tests/e2e/chart-edge-cases.spec.ts \
+  tests/e2e/ticker-search-gaps.spec.ts \
+  tests/e2e/chaos-cross-browser.spec.ts tests/e2e/chaos-error-boundary.spec.ts \
+  --project="Desktop Chrome" --repeat-each=20 --workers=8
+```
+
+**Expected: 20/20 for every affected test.** This is the only verification the 6 status-only and
+3 `requestfailed` sites get, since injection is unsound on them (section 3).
+`chaos-cross-browser.spec.ts` and `chaos-error-boundary.spec.ts` are here because they call
+`triggerHealthBanner` without being edited.
+
+## 5. Test-count parity (SC-004)
+
+Compare the pass/fail/skip tally against the pre-sweep run. It must be identical except that
+failures become passes. Any drop in the passed count, or any new skip, means a test was weakened to
+reach green.
+
+## 6. Board validation (SC-005)
+
+```bash
+python - <<'PY'
+import json
+s = open('CLEANUP-BOARD.html').read()
+i = s.index('const CARDS = ') + len('const CARDS = ')
+cards, _ = json.JSONDecoder().raw_decode(s[i:])
+print('cards:', len(cards))          # expect 120 (118 + 2 new)
+PY
+```
+
+The two new cards are the merge-required follow-up and the `dynamodb_throttle` dead-branch trap
+(FR-009). FR-008's two edits are in place and do not change the count.
+
+Then open the board in a browser and confirm it renders with no console error.
+
+## Reference
+
+PR #981 (`8c27271`) is the merged reference conversion — one site, promise-first, 15s cap.

--- a/specs/001-waitforresponse-race-sweep/quickstart.md
+++ b/specs/001-waitforresponse-race-sweep/quickstart.md
@@ -1,7 +1,8 @@
 # Quickstart: verifying the `waitForResponse` race sweep
 
-All commands from the repo root unless stated. Python steps need the venv:
-`source .venv/bin/activate`.
+All commands from the repo root unless stated. Python steps run under the venv
+(`source .venv/bin/activate`) — except the scan script, which is standard-library only by
+requirement (FR-011) and must work under a bare `python3` as well. Both invocations are exercised.
 
 ## 1. Inventory scan (SC-001)
 
@@ -21,8 +22,17 @@ conversions + 1 inside the helper. Check the other half of SC-001 too:
 grep -rn "searchAndAwaitResponse(" frontend/tests/e2e/ --include="*.spec.ts" | wc -l   # expect 18
 ```
 
-The script exits non-zero while any `RACY` site remains, so it doubles as a check the dependent
-regression-guard feature can wire into CI.
+The script exits non-zero while any `RACY` site remains, **and** when a scan examines zero files, so
+a moved or emptied scan root cannot read as a clean tree. It is standard-library only, so the same
+invocation works on a CI runner with no venv:
+
+```bash
+python3 -I -S scripts/scan-waitforresponse-race.py     # stdlib-only sandbox; must behave identically
+```
+
+That is how the dependent regression-guard feature runs it, in a pre-commit hook and in the required
+`Lint` job. `-I -S` is the faithful sandbox here: clearing `VIRTUAL_ENV` leaves `.venv/bin` on
+`PATH`, and `/usr/bin/python3` is the wrong version.
 
 ## 2. Smoke run (SC-002 — precondition only, not evidence)
 

--- a/specs/001-waitforresponse-race-sweep/research.md
+++ b/specs/001-waitforresponse-race-sweep/research.md
@@ -1,0 +1,150 @@
+# Research: `waitForResponse` race sweep
+
+## R1 — Is promise-first actually the canonical fix?
+
+**Source**: playwright.dev, `class-page` (retrieved via Context7, 2026-07-30).
+
+> "Ensure the promise is initiated before the action that triggers the request."
+
+The documented shape, repeated for `waitForRequest`, `waitForNavigation` and `waitForEvent`:
+
+```js
+const requestPromise = page.waitForRequest('https://example.com/resource');  // note: no await
+await page.getByText('trigger request').click();
+const request = await requestPromise;
+```
+
+**Conclusion**: the target pattern is the vendor-documented one, not a local invention. The 6
+already-correct sites in this repo independently arrived at it.
+
+## R2 — Why does the race fire against mocks specifically?
+
+`page.waitForResponse()` subscribes at call time and does not replay already-received responses.
+The same is true of `page.waitForEvent('requestfailed')`. With a real network the round-trip
+reliably outlives the microtask gap between the action and the subscription, so act-then-wait
+usually works by luck. 24 of the 27 racy sites are answered by `route.fulfill`, which replies with
+no network latency, collapsing that margin; the other 3 (`chaos-scenarios.spec.ts:219/222/225`) are
+answered by `route.abort` under the `api_timeout` scenario, which collapses it further still. Under
+CI worker contention the JS gap widens and the mock wins.
+
+**Evidence, not inference**: the failure artifact for run 30512923260 contains a page snapshot taken
+at the moment of timeout showing the search combobox holding `TSLA` and the results listbox already
+rendering `option "TSLATesla Inc. NASDAQ" [selected]`. The response arrived and rendered; only the
+listener missed it.
+
+## R3 — Product-code behaviour that constrains conversions
+
+Read from `frontend/src`, not from comments.
+
+| Fact | Source | Consequence |
+|---|---|---|
+| No debounce exists | `ticker-input.tsx:33-39` keys `useQuery` on `query`; no debounce hook under `frontend/src` | A successful `fill()` produces exactly one request. The `// Debounced search query` comment at `:33` is false and misled an earlier spec draft. |
+| Empty query never fetches | `ticker-input.tsx:37` — `enabled: query.length >= 1` | `fill(''); fill('X')` is safe to bracket with one listener. |
+| Errors retry once | `providers.tsx:48` — `retry: 1` | An errored search yields a *second* response ~1s later. This is the real multi-response source, and it only affects error-path sites. |
+| Repeats within 30s may be cache-served | `ticker-input.tsx:38` — `staleTime: 30000` | A wait around a repeated query can hang with no request at all. Already documented at `ticker-search-gaps.spec.ts:242-247`. |
+
+## D1 — Shared helper vs 27 inline conversions
+
+**Decision**: both. A predicate-parameterised helper for the 18 URL-scoped search sites; inline
+promise-first for the 9 non-search sites.
+
+**Rationale**: the sites are not homogeneous. 18 wait on the ticker-search endpoint.
+`chaos-scenarios.spec.ts:102/105/108` wait on `r.url().includes('/api/') && r.status() === 503`,
+`chaos-helpers.ts:364/367/370` wait on `resp.status() === 503` with no URL predicate at all under a
+blanket `page.route('**/api/**', …503)`, and `chaos-scenarios.spec.ts:219/222/225` use
+`page.waitForEvent('requestfailed')`, which takes no predicate at all.
+
+**Rejected — one uniform search-scoped helper for all 27**: would narrow the 6 status-only
+predicates to `/tickers/search` and could not express the 3 event waits, changing what those tests
+assert. That is a semantic change smuggled inside a race fix (AR#1 F-04).
+
+**Rejected — 27 inline conversions, no helper**: fixes today and leaves the interaction unnamed, so
+the next author hand-rolls it again. The 6 already-correct sites prove local fixes do not generalise.
+
+## D2 — Response wait vs UI-outcome assertion
+
+**Decision**: keep response waits. Do not convert to UI assertions.
+
+**Rationale**: a UI assertion (the option appearing in the `Ticker search results` listbox) is
+race-free by construction and was seriously considered. But several tests exist specifically to
+prove a *request* was made and answered — the health banner's failure counter and `recordSuccess()`
+key on responses, not on rendered options. Replacing the response wait with a UI wait would change
+what those tests prove.
+
+**Rejected because**: redesigning assertions during a race fix conflates two changes and makes the
+CI signal ambiguous. If the flake survives, we would not know whether the ordering fix failed or the
+assertion swap broke something. Carried as a possible future simplification, not done here.
+
+## D3 — Timeout policy
+
+**Decision**: explicit `{ timeout: 15000 }` on every converted call.
+
+**Rationale**: not a fix — ordering is the fix, and a longer cap only makes a race less likely.
+The value is diagnosability. Four of the five observed failures hit Playwright's 30s *test-level*
+timeout, which reports as an opaque "Test timeout of 30000ms exceeded" and does not name the wait.
+A per-call cap comfortably below the test timeout converts those into
+"`page.waitForResponse: Timeout 15000ms exceeded`", which names the failing construct.
+
+**Corollary — multi-wait tests need `test.setTimeout(60000)`.** The reasoning above holds only while
+a single hung wait fits inside the test budget. `playwright.config.ts` sets no `timeout`, so the
+test-level cap is Playwright's default 30000ms. `chaos-degradation.spec.ts:196` performs about seven
+sequential waits inside that one budget (two `triggerHealthBanner` calls at 3 waits each, plus the
+TSLA wait), so a second 15000ms hang blows the 30s test cap before the per-call cap can fire, and
+reports opaquely. That is the exact outcome D3 exists to prevent, so any test containing more than
+two converted waits gets an explicit `test.setTimeout(60000)`. Affected: the test at `chaos-degradation.spec.ts:148` (three waits at :178/:183/:188), tests calling
+`triggerHealthBanner`, and the three-search sequences in `chaos-scenarios.spec.ts`
+(`:102/105/108` and `:219/222/225`).
+
+**Rejected — leave the default 30s**: keeps every future failure opaque.
+**Rejected — keep 5s**: too tight for CI contention; it is what made the first failure fire early.
+**Rejected — raise the per-call cap instead of the test cap**: makes the race less likely without
+removing it, which is the masking behaviour FR-006 explicitly disclaims.
+
+## D4 — Predicate scoping
+
+**Decision**: tighten predicates to include the query where a prior interaction's response could
+otherwise satisfy the wait. Leave single-response success paths alone.
+
+**Rationale**: promise-first registration widens the window backwards. With `retry: 1`, an errored
+search fires a retry ~1s later. The highest-risk instance is `chaos-degradation.spec.ts:131/138`,
+whose mock returns 500 on the first call and 200 on every later call: a listener for
+`/tickers/search` + `status === 200` registered before `fill('GOOG')` can match the *AAPL retry*
+rather than the GOOG response, and the test would then assert on a state that GOOG has not reached
+yet — passing for the wrong reason.
+
+**Applies to**: the URL-scoped ticker-search error-path sites, where a preceding interaction errored
+and the predicate therefore needs query scoping (`q=GOOG`, per spec C2).
+
+**Does not apply to**: success-path URL-scoped sites, which produce exactly one response (no
+debounce, per R3). It also does **not** apply to the 6 status-only sites
+(`chaos-helpers.ts:364/367/370`, `chaos-scenarios.spec.ts:102/105/108`) or the 3 `requestfailed`
+sites (`chaos-scenarios.spec.ts:219/222/225`). An earlier draft's "applies to error-path sites"
+wording captured those, which contradicted the spec's own exemption. They are an explicit accepted
+risk under the FR-002 exception: they run under blanket failure routes where ANY failing response
+legitimately signals "the API is failing", which is exactly what the health-monitor failure counter
+keys on. Per-request sequencing is not what they assert, so matching a retry or a sibling endpoint's
+failure is not a false pass. Residual risk, stated rather than hidden: those waits confirm "a
+failure occurred", not "THIS search's failure occurred".
+
+## D5 — Verification strategy
+
+**Decision**: fault injection as the primary gate; contention as a secondary.
+
+**Rationale**: the race does not reproduce on an idle dev box — pre-fix code passed 10/10 under
+`--repeat-each=10 --workers=4`. Any strategy resting on local green measures nothing, which is
+exactly the trap AR#1 flagged in the first draft's SC-002.
+
+Injection makes the claim falsifiable: patch a delay between the action and the listener
+registration in the pre-fix code and the test MUST fail. If it does not, the diagnosis is wrong and
+the work stops. Only then does post-fix green mean anything.
+
+Injection is only sound where the mock produces exactly one matching response, so the targets are
+`ticker-search-gaps.spec.ts:22` (site `:38`) and `chart-edge-cases.spec.ts` (site `:72`). At the 6
+status-only 503 sites and the 3 `requestfailed` sites, `retry: 1` plus the blanket
+`page.route('**/api/**', …503)` keep supplying a matching response, so the listener resolves however
+wide the injected gap is. Non-reproduction there is expected and is not a stop condition; those
+sites are covered by contention only.
+
+**Rejected — CPU throttling alone**: probabilistic, so a green run is weak evidence.
+**Rejected — trusting CI over several PRs**: slow, and a 20% rate needs many runs to distinguish
+"fixed" from "got lucky".

--- a/specs/001-waitforresponse-race-sweep/spec.md
+++ b/specs/001-waitforresponse-race-sweep/spec.md
@@ -511,8 +511,18 @@ test suite and report", and Python is the repo standard with venv and pre-commit
 **Answer**: No. Commit it as a runnable artifact only.
 
 **Evidence**: enforcement is the dependent regression-guard feature, listed in this spec's Out of
-Scope. The script exits non-zero when `RACY > 0` so the guard can wire it in without modification,
-but this feature does not add it to pre-commit or any workflow.
+Scope. This feature does not add the script to pre-commit or any workflow.
+
+**Amended after the guard feature was specified.** This answer originally read "the script exits
+non-zero when `RACY > 0` so the guard can wire it in without modification". That was wrong in a way
+worth recording: the guard's own review derived six requirements on this script that T001 did not
+carry, four of which its criteria actively contradicted. Exiting non-zero on `RACY > 0` is necessary
+and nowhere near sufficient. T001 criteria 5, 6, 8, 12 and 13 now carry the full contract
+(stdlib-only invocation, five summary numbers including files-scanned, non-zero on a zero-file scan,
+findings on stdout, remediation guidance in the failure output, a fixed scan root that ignores file
+arguments, and an in-script interpreter floor). The contract of record is
+`specs/002-waitforresponse-lint-guard/contracts/detector-cli.md`. With those folded in, the original
+claim holds: the guard wires this script in without modifying it.
 
 ### C5 — Should the six already-correct sites adopt the helper for consistency?
 

--- a/specs/001-waitforresponse-race-sweep/spec.md
+++ b/specs/001-waitforresponse-race-sweep/spec.md
@@ -302,6 +302,20 @@ failure that produced this bug class in the first place.
   `retryButton.evaluate((el) => el.click())`. A list stopping at `.reload(` would miss it. The
   earlier six-token list was the same method-name-shaped mistake that hid the three
   `waitForEvent('requestfailed')` sites.
+
+  **The scan is also a consumed interface, not only an artifact.** The dependent regression-guard
+  feature wires this script into a pre-commit hook and into the required CI `Lint` job, so its
+  invocation, output and exit codes are a contract rather than an implementation detail. The scan
+  MUST therefore: import only the standard library, so it runs under a bare `python3` on a CI runner
+  with no virtualenv and no project dependencies; write findings to **stdout**; report the number of
+  **files scanned** alongside the three classification counts and the total; exit **non-zero** when
+  the scan examined zero files, whatever the cause, so a moved or emptied scan root cannot read as a
+  clean tree; carry remediation guidance in its failure output; scan a **fixed root**, ignoring any
+  file arguments, since the guard invokes it with `pass_filenames: false` against untracked files;
+  and assert its own interpreter floor, because the guard invokes a bare `python3` that resolves
+  from the committing shell's `PATH`. `specs/002-waitforresponse-lint-guard/contracts/detector-cli.md`
+  is the contract of record and carries the reasoning for each. T001 criteria 5, 6, 8, 12 and 13
+  make them checkable.
 - **FR-012**: Converted sites MUST await the listener promise on the success path, so a timeout
   surfaces as a test failure. The helper additionally handles the throw path internally (contract G2, which specifies the
   required shape rather than promising an unconditional await). A
@@ -500,11 +514,19 @@ handling needed.
 
 ### C3 — What language for the scan script (FR-011)?
 
-**Answer**: Python 3.13, at `scripts/scan-waitforresponse-race.py`, run under the project venv.
+**Answer**: Python 3.13, at `scripts/scan-waitforresponse-race.py`, **standard library only**, so it
+runs both under the project venv and under a bare `python3` with nothing installed.
 
 **Evidence**: `scripts/` already holds `audit-e2e-skips.py`, which does the closely analogous job of
 scanning the E2E suite and reporting counts. Following that precedent keeps one idiom for "scan the
 test suite and report", and Python is the repo standard with venv and pre-commit already wired.
+
+**Amended with C4.** This answer originally read "run under the project venv" and nothing more. The
+dependent guard runs this script in the CI `Lint` job, which installs ruff and no project
+dependencies at all, so a venv-only script would be permanently red there. Stdlib-only is the
+constraint that makes the same file work in both places. Verify with `python3 -I -S`, which is the
+faithful sandbox: clearing `VIRTUAL_ENV` leaves `.venv/bin` on `PATH`, and `/usr/bin/python3` is the
+wrong version. See T001 criterion 8.
 
 ### C4 — Should the scan be enforced in CI as part of this feature?
 

--- a/specs/001-waitforresponse-race-sweep/spec.md
+++ b/specs/001-waitforresponse-race-sweep/spec.md
@@ -1,0 +1,523 @@
+# Feature Specification: Sweep the act-then-wait `waitForResponse` race class
+
+**Feature Branch**: `001-waitforresponse-race-sweep`
+**Created**: 2026-07-30
+**Status**: Draft (post Adversarial Review #1)
+**Input**: User description: "Sweep the act-then-wait `page.waitForResponse` race class across the frontend Playwright E2E suite"
+
+## Context
+
+The customer-dashboard Playwright suite (`frontend/tests/e2e/`) contains 27 call sites where a
+network listener is registered *after* the action that triggers the request:
+
+```ts
+await searchInput.fill('AAPL');
+await page.waitForResponse('**/api/v2/tickers/search**');
+```
+
+`page.waitForResponse()` subscribes at call time and does not inspect responses already received.
+Playwright's own documentation is explicit: *"Ensure the promise is initiated before the action that
+triggers the request."* (playwright.dev, `class-page`). 24 of the 27 sites are answered by a
+`route.fulfill` mock, which replies with no network latency at all, so the response can land inside
+the gap between the action and the subscription. The remaining 3 are `page.waitForEvent('requestfailed')`
+waits under the `api_timeout` chaos scenario, which uses `route.abort` and therefore fires with even
+less latency than `route.fulfill`. When the event lands in the gap, the listener goes on waiting for
+a second one that never arrives and the test dies at its timeout.
+
+### Confirmed CI failures
+
+Sampling method, so this is re-derivable: the 30 most recent `PR Checks` workflow runs as of
+2026-07-30, of which 25 actually executed the Playwright job. Six of those 25 were red; five are
+attributable to this race class. The sixth (`30460832567`) is the unrelated user-menu dismissal
+flake tracked separately as #950. `pr-checks.yml` runs Playwright with `--retries=0`, so a red run
+means one failed attempt, not three. That flag is part of the method: without it the rate is not
+re-derivable from other workflows, because `nightly-e2e` does not pass it.
+
+| Run | Test | Failing site | Cap hit |
+|---|---|---|---|
+| 30512923260 | `chaos-degradation.spec.ts:196` | `:229` (already fixed by #981) | `waitForResponse` 5000ms |
+| 30512621168 | `ticker-search-gaps.spec.ts:22` | `:38` | test-level 30000ms |
+| 30510400002 | `ticker-search-gaps.spec.ts:46` | `:77` | test-level 30000ms |
+| 30463441189 | `ticker-search-gaps.spec.ts:206` | `:211` | test-level 30000ms |
+| 30463171597 | `chart-edge-cases.spec.ts:144` | `:161` | test-level 30000ms |
+
+Attributable red rate in the sampled window: **5 of 25 runs (~20%)**.
+
+Two cautions this table earns:
+
+1. **The binding cap is usually the test-level timeout, not the `waitForResponse` timeout.** Only
+   the first failure hit a per-call cap. Raising per-call timeouts would not have changed the shape
+   of the other four. Timeout policy is therefore secondary; ordering is the fix.
+2. **Run/commit distinction.** `30512621168` is a `push`-event run; its sibling `pull_request` run
+   on the same commit (`30512623219`) passed. Runs are not independent samples of distinct commits,
+   so the ~20% figure describes runs, not commits, and is stated that way deliberately.
+
+The Playwright E2E job is **not** merge-required, so these reds are absorbed silently. Playwright
+was green on the recent main runs (#976/#977/#978/#979) — the job is intermittently red on PRs, not
+persistently red. The board card claiming otherwise is corrected by FR-008.
+
+One instance is already fixed and merged: PR #981 (`8c27271`) converted
+`chaos-degradation.spec.ts:229`. That commit is the reference implementation.
+
+### Inventory (verified against `8c27271`)
+
+31 `waitForResponse` plus 3 `waitForEvent('requestfailed')` occurrences exist in
+`frontend/tests/e2e/`, 34 total, fully accounted for as 27 racy + 6 already-correct + 1 triaged.
+
+An earlier draft of this section said "No other same-class API (`waitForRequest`,
+`waitForEvent('response')`, `waitForNavigation`) appears in the suite." That sentence was wrong. It
+enumerated `waitForEvent('response')` specifically and thereby excluded
+`waitForEvent('requestfailed')` on a technicality, which hid three sites of exactly the same class.
+Recorded as a scope-definition lesson: **the class is defined by SHAPE (a listener registered after
+the triggering action), not by method name.** The committed scan (FR-011) encodes the shape rule so
+the definition cannot drift back to a method-name list.
+
+| File | Racy sites | Lines |
+|---|---|---|
+| `ticker-search-gaps.spec.ts` | 9 | 38, 77, 82, 109, 129, 144, 162, 211, 219 |
+| `chaos-degradation.spec.ts` | 5 | 131, 138, 178, 183, 188 |
+| `chart-edge-cases.spec.ts` | 4 | 72, 130, 161, 218 |
+| `helpers/chaos-helpers.ts` | 3 | 364, 367, 370 (inside `triggerHealthBanner`) |
+| `chaos-scenarios.spec.ts` | 3 | 102, 105, 108 |
+| `chaos-scenarios.spec.ts` (`waitForEvent('requestfailed')`) | 3 | 219, 222, 225 |
+| **Total** | **27** | |
+
+Already correct, and the target state to copy — do not modify: `chaos-degradation.spec.ts:231`,
+`chaos-scenarios.spec.ts:251`, `error-visibility-search.spec.ts:142`, `:157`,
+`ticker-search-gaps.spec.ts:231`, `:237`.
+
+Triaged and **not** racy in practice: `chaos-scenarios.spec.ts:138`. Its action is `page.reload()`,
+and the backing `lambda_cold_start` handler delays 3s before `route.continue()`. An
+`await expect(...).toBeVisible({ timeout: 2000 })` sits between the reload and the wait, so the
+listener can register up to 2s later than the action. The worst-case margin ahead of the response is
+therefore about 1s, not the 2.8s an earlier draft claimed. Still safe, but the correct margin is
+what is recorded. Act-then-wait in form, safe in practice. Left unconverted with this reason
+recorded (FR-003). That intervening assertion is also why the FR-011 classifier files it as `OTHER`
+rather than `RACY`: the classification rule keys on the immediately preceding non-comment,
+non-blank line.
+
+### The 27 do not share one shape
+
+An earlier draft asserted all sites were `fill()` + wait on the ticker-search endpoint. That is
+false for 9 of them, and the difference drives the design:
+
+- 18 sites wait on the ticker-search endpoint (URL-scoped).
+- `chaos-scenarios.spec.ts:102/105/108` wait on `r.url().includes('/api/') && r.status() === 503`.
+- `helpers/chaos-helpers.ts:364/367/370` wait on `resp.status() === 503` with **no URL predicate at
+  all**, under a `page.route('**/api/**', …503)` blanket block (`chaos-helpers.ts:347`).
+- `chaos-scenarios.spec.ts:219/222/225` wait on `page.waitForEvent('requestfailed')`, which takes no
+  URL predicate at all, under the `api_timeout` scenario's `route.abort`.
+
+A single search-scoped helper cannot absorb the last nine without narrowing their predicates, which
+would change what they assert. They get inline promise-first conversion instead: 9 inline
+(6 status-only 503 + 3 `requestfailed`) and 18 helper-routed.
+
+### Product-code facts that constrain the fix
+
+Established by reading `frontend/src`, not by reading comments:
+
+- **There is no debounce.** `ticker-input.tsx:33-39` keys `useQuery` directly on `query`; no
+  debounce hook exists anywhere under `frontend/src`. The source comment `// Debounced search query`
+  at `ticker-input.tsx:33` is wrong, and it misled an earlier draft of this spec.
+- **An empty fill cannot trigger a request.** `ticker-input.tsx:37` sets `enabled: query.length >= 1`.
+  React Query does not fetch while disabled, and with no debounce there is no trailing fire from the
+  previous value. `fill(''); fill('X')` sequences are therefore safe to bracket with a single
+  listener.
+- **Errors produce a second response.** `providers.tsx:48` sets `retry: 1`, so a failed search fires
+  a retry roughly 1s later. This, not debounce, is the real source of multiple responses — and only
+  on error paths.
+- **Repeat queries within 30s may serve from cache with no network request at all.**
+  `ticker-input.tsx:38` sets `staleTime: 30000`. A wait registered around a cache-served query hangs
+  until timeout. `ticker-search-gaps.spec.ts:242-247` already documents this and deliberately omits
+  a wait.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - CI signal is trustworthy (Priority: P1)
+
+An engineer opens a PR. The Playwright E2E job either passes, or it fails for a reason that is
+about their change. It does not fail because a mock answered faster than a listener attached.
+
+**Why this priority**: This is the whole point. A job with a ~20% false-red rate teaches everyone to
+ignore it, which is worse than not running it — a real frontend regression lands unnoticed behind
+the noise. It also blocks the owner's deferred decision on making the job merge-required, which
+cannot happen while the job flakes.
+
+**Independent Test**: Convert the sites and run the suite under the adversarial-timing procedure in
+SC-003, which forces the failure mode rather than hoping to observe it.
+
+**Acceptance Scenarios**:
+
+1. **Given** a converted call site, **When** the mocked response resolves before the test's next
+   statement executes, **Then** the wait still observes it and the test proceeds.
+2. **Given** a converted call site, **When** the response is genuinely slow, **Then** the wait blocks
+   until it arrives or the configured timeout elapses, exactly as before.
+3. **Given** a converted site whose predicate is not query-scoped, **When** a prior interaction's
+   `retry: 1` response is in flight, **Then** the wait resolves on the intended request and not on
+   the stale retry.
+
+---
+
+### User Story 2 - The interaction has a name (Priority: P2)
+
+A test author needs "type a query and wait for the search response". They call one documented helper
+instead of hand-rolling a two-statement sequence whose correctness depends on statement order.
+
+**Why this priority**: Converting sites inline fixes today's bug and leaves the 25th author free to
+reintroduce it. Naming the interaction reduces the opportunity. It does not remove it — nothing in
+this feature *enforces* helper use; that is the dependent regression-guard feature. Lower than P1
+because the conversions deliver the CI benefit on their own.
+
+**Independent Test**: A new test can perform a search-and-await in a single call, and that call is
+race-free by construction.
+
+**Acceptance Scenarios**:
+
+1. **Given** the helper, **When** a caller uses it, **Then** the listener is registered before the
+   fill without the caller having to think about ordering.
+2. **Given** a caller needing a non-search predicate, **When** it uses the helper, **Then** it can
+   supply its own predicate rather than being forced onto a search-scoped one.
+
+---
+
+### User Story 3 - The board states verified facts (Priority: P3)
+
+Someone reading `CLEANUP-BOARD.html` gets the actual failure history, not an overstated one.
+
+**Why this priority**: The board is the campaign's ground truth. A card asserting "fails on main and
+every PR" when the cited main runs were green corrodes trust in every other card. Cheap to fix,
+independent of the code change.
+
+**Acceptance Scenarios**:
+
+1. **Given** the Playwright flake card, **When** it is read, **Then** it states the verified rate
+   with its sampling method and does not claim main was red from this cause.
+2. **Given** the `MASTER: CI/CD hygiene` card, **When** its children list is read, **Then** it
+   carries the same corrected framing.
+
+---
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: All 27 inventoried racy call sites MUST be converted so the response or event listener
+  is registered before the action that triggers the request.
+- **FR-002**: Conversion MUST NOT weaken what a test asserts. Each converted predicate MUST remain
+  at least as specific as the original. Where promise-first registration widens the window such that
+  a prior interaction's response could satisfy the predicate, the predicate MUST be tightened
+  (for example by matching the query string) so the wait resolves on the intended request. Any
+  deliberate change to a predicate's meaning MUST be called out in the task that makes it.
+
+  **Exception, accepted as a stated risk**: the 6 status-only sites
+  (`helpers/chaos-helpers.ts:364/367/370`, `chaos-scenarios.spec.ts:102/105/108`) and the 3
+  `requestfailed` sites (`chaos-scenarios.spec.ts:219/222/225`) are exempt from the tightening
+  requirement. They run under blanket failure routes (`page.route('**/api/**', …503)`, or
+  `api_timeout`'s `route.abort`) where ANY failing response legitimately signals "the API is
+  failing", which is exactly what the health-monitor failure counter keys on. Per-request sequencing
+  is not what those tests assert, so matching a retry or a sibling endpoint's failure is not a false
+  pass. Residual risk, recorded rather than hidden: these waits confirm "a failure occurred", not
+  "THIS search's failure occurred". A regression that made only one of three searches fail would
+  still satisfy them.
+- **FR-003**: `chaos-scenarios.spec.ts:138` MUST be left unconverted, with the recorded reason that
+  its 3s `lambda_cold_start` delay leaves an ordering margin of roughly 1s even after the
+  intervening 2000ms assertion, which makes the gap immaterial.
+- **FR-004**: The six already-correct sites MUST remain unmodified.
+- **FR-005**: A shared helper MUST expose the search-and-await interaction for the 18 URL-scoped
+  search sites. The helper MUST accept a caller-supplied predicate so that non-search callers are
+  not forced onto a search-scoped one. `triggerHealthBanner`'s three waits MUST become promise-first
+  but MUST retain their existing status-only predicate; narrowing them to `/tickers/search` is out
+  of scope for this feature.
+
+  **Consequence of the FR-002 exception**: `triggerHealthBanner`'s docstring
+  (`chaos-helpers.ts:334-344`; `:345` is the `export async function` line itself) currently claims
+  its waits "confirm the failure was recorded" for each
+  search. The status-only predicate does not prove that: it proves a failing response was observed,
+  which any of the three searches or a retry could have produced. The docstring MUST be updated to
+  match what the predicate actually proves, and a task MUST carry that edit explicitly so it is not
+  lost as an incidental change.
+- **FR-006**: Every converted call MUST resolve to a 15000ms timeout, chosen so a hung wait fails
+  inside Playwright's 30s test-level timeout and reports as a `waitForResponse` timeout rather than
+  an opaque test timeout. This is a diagnosability requirement, not a fix; ordering is the fix.
+
+  **How it is carried, and therefore how it is audited**, differs by site class. The earlier wording
+  "explicit 15000ms on every converted call" was unauditable at the helper-routed sites, which pass
+  no `timeout` argument at all:
+  - **The 9 inline sites** (`chaos-scenarios.spec.ts` 3 status-503 + 3 `requestfailed`,
+    `helpers/chaos-helpers.ts` 3 status-503) MUST carry a literal `{ timeout: 15000 }` on the call.
+    Audited by reading the call.
+  - **The 18 helper-routed sites** carry it via the helper's documented `timeout` default of `15000`
+    (`contracts/helper-api.md`, Defaults table). They pass no `timeout` argument, and MUST NOT be
+    expected to. Audited at the helper's default, once, not at 18 call sites.
+
+  **Multi-wait tests need the test cap raised for the per-call cap to bind.** `playwright.config.ts`
+  sets no `timeout`, so the test-level cap is Playwright's default 30000ms. A test with several
+  sequential 15000ms waits blows the 30s test cap before the second per-call cap can fire, and
+  reports opaquely, which is the exact outcome FR-006 exists to prevent.
+  `chaos-degradation.spec.ts:196` performs about seven sequential waits inside that one 30s budget
+  (two `triggerHealthBanner` calls at 3 waits each, plus the TSLA wait). Therefore: any test
+  containing more than two converted waits MUST get an explicit `test.setTimeout(60000)`. Affected
+  tests are those that call `triggerHealthBanner` and those that perform the three-search sequences
+  (`chaos-scenarios.spec.ts:102/105/108` and `:219/222/225`), plus the test at
+  `chaos-degradation.spec.ts:148`, which holds three converted waits at `:178/:183/:188`.
+
+**Where `test.setTimeout(60000)` goes.** For tests that own their converted waits directly, the call
+sits at the top of the test. For the three waits inside `triggerHealthBanner`, the raise belongs in
+the helper itself: `chaos-helpers.ts` already imports from `@playwright/test`, so it can import
+`test` and call `test.setTimeout(Math.max(test.info().timeout, 60000))` on entry, using `Math.max` rather
+than a bare `60000` so the helper can only ever raise a caller's cap, never lower it
+(`chaos-accessibility.spec.ts:29` sets a deliberate `test.setTimeout(30_000)` and imports this
+helper). That covers all seven `triggerHealthBanner(page)`
+call sites at once, including `chaos-cross-browser.spec.ts:35` and `chaos-error-boundary.spec.ts:63`,
+which are otherwise untouched by this feature. Per-caller raises were rejected: they would grow the
+diff from 5 files to 7, and would leave the rule for a future caller to remember, which is the same
+failure that produced this bug class in the first place.
+
+- **FR-007**: No product-code changes. Test changes MUST be confined to `frontend/tests/e2e/`.
+  The board edits under FR-008 and FR-009, and the scan script under FR-011 (which lives under
+  `scripts/`), are the only permitted changes outside that directory.
+- **FR-008**: The Playwright flake card and the `MASTER: CI/CD hygiene` card in
+  `CLEANUP-BOARD.html` MUST be corrected to the verified facts and re-scoped to this sweep.
+- **FR-009**: Two follow-up cards MUST be created in `CLEANUP-BOARD.html`: (1) the owner's deferred
+  decision on making the Playwright E2E job merge-required, and (2) the `dynamodb_throttle`
+  dead-branch trap (`chaos-helpers.ts:169-189`, byte-identical `if`/`else` branches, recorded in
+  Edge Cases). This feature MUST NOT change the job's required status and MUST NOT fix the dead
+  branch.
+- **FR-010**: Sites where the query is served from React Query cache with no network request MUST
+  be identified and left unconverted. A wait MUST NOT be introduced where none exists today. The
+  helper MUST NOT be applied to a repeat of the same query within the 30s `staleTime` window.
+- **FR-011**: The inventory scan MUST be committed as a runnable artifact so SC-001 is reproducible
+  by anyone, rather than existing only in a shell history. The scan MUST document its classification
+  rule explicitly, in the script itself, so SC-001's "RACY 0" does not rest on an undocumented
+  heuristic. The rule is: **RACY** = an awaited `page.waitForResponse(...)` or
+  `page.waitForEvent('requestfailed'|'response')` whose immediately preceding non-comment,
+  non-blank line performs a triggering action (`.fill(`, `.click(`, `.press(`, `.selectOption(`,
+  `.clear(`, `.goto(`, `.reload(`, `.evaluate(`, `.type(`, `.check(`, `.tap(`, `.setInputFiles(`,
+  `.dispatchEvent(`). Anything else that is neither that shape nor promise-first is `OTHER` and
+  requires human triage, and `OTHER` sites MUST be printed under an explicit "requires human triage"
+  banner so a shape the classifier cannot place is visible rather than counted as clean by omission.
+
+  The token list is not theoretical. `.evaluate(` is live in the suite today:
+  `error-visibility-search.spec.ts:158` triggers its request with
+  `retryButton.evaluate((el) => el.click())`. A list stopping at `.reload(` would miss it. The
+  earlier six-token list was the same method-name-shaped mistake that hid the three
+  `waitForEvent('requestfailed')` sites.
+- **FR-012**: Converted sites MUST await the listener promise on the success path, so a timeout
+  surfaces as a test failure. The helper additionally handles the throw path internally (contract G2, which specifies the
+  required shape rather than promising an unconditional await). A
+  `try/finally` is **not** required at the inline sites, and this is deliberate rather than an
+  oversight: an unhandled rejection can only occur when an intervening action throws, and an
+  intervening action that throws fails the test regardless. The rejection is then noise attached to
+  an already-failing test, not a new failure mode. The absolute "awaited on every path, never as an
+  unhandled rejection" wording of an earlier draft was unimplementable: the merged reference
+  conversion at `chaos-degradation.spec.ts:231-236` leaves the promise unawaited if a `fill()`
+  throws, and FR-004 protects that site from amendment.
+
+### Key Entities
+
+- **Racy call site**: defined by shape, not by method name. An awaited `page.waitForResponse(...)`
+  or `page.waitForEvent('requestfailed'|'response')` whose triggering action executes immediately
+  before it. Formalised as the classifier rule in FR-011.
+- **Promise-first conversion**: listener created, action performed, promise awaited.
+- **Search-and-await helper**: the named interaction covering fill-then-wait, parameterised by
+  predicate.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: After the sweep the committed inventory scan (FR-011) reports **RACY 0,
+  PROMISE-FIRST 16, OTHER 1, total 17** inline occurrences across `frontend/tests/e2e/`. The 16
+  is computed as 6 pre-existing promise-first + 6 status-only inline conversions + 3 `requestfailed`
+  inline conversions + 1 internal to the helper. The `OTHER` is the single triaged site
+  (`chaos-scenarios.spec.ts:138`). The total drops from 34 because the 18 helper-routed sites stop
+  being inline wait call sites when they become `searchAndAwaitResponse(...)` calls, and the helper
+  contributes one internal wait in their place. Additionally, exactly **18**
+  `searchAndAwaitResponse(` call sites MUST exist under `frontend/tests/e2e/`, counted over
+  `*.spec.ts` only. An unfiltered grep also matches the helper's own `export async function` line
+  and returns 19, which would read as a false failure.
+- **SC-002** *(precondition, non-evidential)*: the customer-dashboard Playwright suite passes
+  locally. This is a smoke check only. Pre-fix code passed 10/10 locally, so local green proves
+  nothing about the race and MUST NOT be cited as evidence of the fix.
+- **SC-003** *(the actual gate)*: the race is **forced**, not merely hoped-absent. Two procedures,
+  both required:
+  - **(a) Fault injection.** With a temporary patch that awaits a delay between the action and the
+    listener registration on the pre-fix code, the injected tests MUST fail. The same injection
+    against the converted code MUST pass. This demonstrates the conversion removes the race rather
+    than reducing its probability. The injection patch MUST NOT be committed.
+
+    **Valid injection targets are only sites whose mock produces exactly one matching response.**
+    Named explicitly: `ticker-search-gaps.spec.ts:22` (site `:38`, which returns a single 200 with
+    empty results and does not retry because it is not an error) and `chart-edge-cases.spec.ts`
+    (site `:72`).
+
+    `chaos-degradation.spec.ts:196` is **NOT** a valid injection target. PR #981 already converted
+    its racy site; it is now promise-first at `:231-237` and is one of the 6 protected
+    already-correct sites under FR-004. Stashing this feature's conversions does not bring the old
+    shape back.
+
+    Injection is **unsound** on the 6 status-only 503 sites and the 3 `requestfailed` sites.
+    `retry: 1` (`frontend/src/app/providers.tsx:48`) plus the blanket
+    `page.route('**/api/**', …503)` mean a matching response keeps arriving, so the listener
+    resolves anyway no matter how wide the injected gap is. Non-reproduction at those sites is
+    EXPECTED and does not falsify the diagnosis. Those 9 sites are covered by the contention
+    procedure (b) only.
+  - **(b) Contention.** `npx playwright test <the affected files> --project="Desktop Chrome"
+    --repeat-each=20 --workers=8` MUST pass 20/20 for every affected test. The file list MUST
+    include `chaos-cross-browser.spec.ts` and `chaos-error-boundary.spec.ts`, which call
+    `triggerHealthBanner` (at `:35` and `:63` respectively) and are therefore affected without being
+    edited, and `chaos-scenarios.spec.ts`.
+- **SC-004**: Test count is unchanged — no test is skipped, deleted, or weakened to reach green.
+  Verified by comparing the pre- and post-sweep pass/fail/skip tallies.
+- **SC-005**: The `CARDS` array literal in `CLEANUP-BOARD.html` still parses (via `raw_decode` on
+  the text following `const CARDS = `), the board renders without a JS error, and the array length
+  goes from 118 to 120 (two cards added by FR-009: the merge-required follow-up and the
+  `dynamodb_throttle` dead-branch trap; FR-008 edits two existing cards in place).
+
+## Edge Cases
+
+- **Dangling listener promises.** A promise created and not awaited becomes an unhandled rejection
+  on timeout, which Playwright may surface against an unrelated test. Bounded, not eliminated: the
+  only way to reach that state is for an intervening action to throw, which fails the test anyway,
+  so the rejection rides an already-failing test. FR-012 requires the success-path await and the
+  helper's internal guarantee (contract G2), and deliberately does not require `try/finally` at the
+  inline sites.
+- **Cross-interaction predicate matching.** `retry: 1` means an errored search fires a second
+  response ~1s later. A status-only predicate registered early can match that retry instead of the
+  intended request. Covered by FR-002. Highest-risk instance:
+  `chaos-degradation.spec.ts:131/138`, whose mock returns 500 on the first call and 200 thereafter.
+- **Cache-served repeats.** `staleTime: 30000` means a repeated query may produce no request at all.
+  Covered by FR-010.
+- **`triggerHealthBanner` is called by the tests that flake.** Changing it changes the preconditions
+  of every chaos test, so its blast radius is the whole chaos suite, not one file.
+- **The race does not reproduce on an idle dev box.** Covered by SC-003(a), which forces it.
+- **Timeouts that mask rather than fix.** Raising a cap makes a race less likely without removing
+  it. FR-006 sets timeouts for diagnosability only and is explicitly not the fix.
+- **Empty fill.** Settled, not open: `enabled: query.length >= 1` means it cannot trigger a request.
+- **A latent trap in `dynamodb_throttle`.** `chaos-helpers.ts:169-189` has byte-identical `if`/`else`
+  branches (both 503) despite a comment claiming reads may succeed from cache. Three of the 27 sites
+  work only because of that dead branch. Out of scope to fix; carded under FR-009 so a future
+  correction of the comment-to-code mismatch does not silently break them.
+
+## Out of Scope
+
+- Making the Playwright E2E job merge-required (owner deferred; carded, not done).
+- Adopting `eslint-plugin-playwright` wholesale. Its 59 rules include none for this pattern, and
+  enabling it would flag unrelated violations across the suite.
+- The regression guard preventing reintroduction — separate feature, depends on this one.
+- Narrowing `triggerHealthBanner`'s predicates from status-only to URL-scoped.
+- Fixing the `dynamodb_throttle` dead branch, or the wrong `// Debounced search query` comment.
+- Any product-code change to search, caching, or the health banner.
+- The other known Playwright flakes tracked separately (sanity-suite Tiingo latency, user-menu
+  dismissal #950).
+
+---
+
+## Adversarial Review #1
+
+Reviewer: independent agent, instructed to treat the spec as a suspect and verify every factual
+claim against the repo and CI. Orchestrator independently re-verified the highest-impact findings
+before accepting them (the three additional CI runs, `enabled: query.length >= 1`, `retry: 1`, and
+the chaos-helper predicates) rather than taking the reviewer's word.
+
+### Findings
+
+Historical record. Counts and section titles below are as they stood at AR#1 (24 racy,
+118 to 119 cards). Adversarial Review #2 later raised the count to 27 and the cards to 120; see
+plan.md's AR#2 appendix. Left unedited so the review trail is not rewritten after the fact.
+
+| ID | Sev | Finding | Resolution |
+|---|---|---|---|
+| F-01 | CRITICAL | Only 2 CI failures cited; 5 exist. Runs `30510400002`, `30463441189`, `30463171597` are the same `waitForResponse` timeout and were omitted. | Failure table rewritten with all 5. Orchestrator re-verified each via `gh run view --log-failed`. |
+| F-02 | CRITICAL | SC-001 cites an "inventory scan" that exists nowhere in the repo — unrunnable criterion. | FR-011 added requiring the scan be committed; SC-001 now cites it and states exact expected counts. |
+| F-03 | CRITICAL | SC-003 "adversarial timing" undefined; two engineers could not run the same test. | SC-003 rewritten as two concrete required procedures: fault injection (a) and contention (b), with exact commands and pass bars. |
+| F-04 | HIGH | FR-005 contradicted FR-002: routing `triggerHealthBanner` through a search-scoped helper narrows its status-only predicate. | FR-005 rewritten — helper takes a caller-supplied predicate; `triggerHealthBanner` keeps status-only. Narrowing moved to Out of Scope. |
+| F-05 | HIGH | FR-007 ("confined to `frontend/tests/e2e/`") contradicted FR-008 (edit root-level `CLEANUP-BOARD.html`). | FR-007 reworded to scope the confinement to test changes and name the permitted exceptions. |
+| F-06 | HIGH | Missing category: sites that deliberately omit a wait because React Query serves from cache (`staleTime: 30000`). Converting one would hang. | FR-010 added. `ticker-search-gaps.spec.ts:242-247` cited as the existing documented instance. |
+| F-07 | HIGH | Predicates match on URL+status but never on query. `retry: 1` means promise-first can match a prior interaction's retry, passing for the wrong reason. Worst case `chaos-degradation.spec.ts:131/138`. | FR-002 rewritten to require predicate tightening where the window widens. New acceptance scenario US1-3. |
+| F-08 | HIGH | SC-002 accepted "passes locally", which the spec's own edge case declares meaningless. | SC-002 demoted to a labelled non-evidential precondition; SC-003 is the sole gate. |
+| F-09 | MEDIUM | The "debounce" premise is false — no debounce exists; the source comment lies. Real multiplicity is `retry: 1`. | Product-code facts section added; edge case rewritten around retry. Verified directly. |
+| F-10 | MEDIUM | "All 24 share one shape" false for 6 of 24 (3 wait on any `/api/` 503, 3 on any 503 with no URL predicate). | New section "The 24 do not share one shape"; FR-005 design changed accordingly. |
+| F-11 | MEDIUM | FR-006 was a requirement to hold a meeting, and misidentified the binding cap — 4 of 5 failures hit the test-level timeout, not a per-call one. | FR-006 now states the value (15000ms) and its purpose (diagnosability), explicitly not the fix. Caution added to the failure table. |
+| F-12 | MEDIUM | SC-005 claimed the HTML file "parses as valid JSON" — impossible. | Restated against the `CARDS` array literal via `raw_decode`, with the exact 118→119 count. (Reviewer overreached slightly: the array literal does parse; the file does not. Wording fixed either way.) |
+| F-13 | MEDIUM | Sampling method unstated and double-counting: `30512621168` is a push run whose sibling PR run passed. | Method, window, and the run/commit distinction now stated explicitly in the Context section. |
+| F-14 | MEDIUM | The `fill('')` edge case was left open as a gating unknown; it is settled — `enabled: query.length >= 1`. | Moved from open question to settled fact with citation. |
+| F-15 | LOW | US2 claimed naming the interaction "removes the opportunity" to reintroduce; nothing enforces it. | Softened to "reduces", with the enforcement gap named and pointed at the dependent feature. |
+| F-16 | LOW | `dynamodb_throttle`'s `if`/`else` branches are byte-identical; 3 of the 24 sites depend on that dead branch. | Recorded as an edge case and carded. Not fixed here. |
+
+### Self-defeat check
+
+The reviewer was asked specifically whether a spec criticising an overstated board claim contained
+overstated claims of its own. It did: the "2 of 17" rate was both understated in magnitude and
+derived by an unstated method. This is the same failure mode the spec exists to correct on the
+board. Corrected, with the method now written down so the next reader can re-derive it.
+
+### Gate
+
+**0 CRITICAL, 0 HIGH remaining.** All 3 CRITICAL and 5 HIGH findings resolved in the text above.
+8 MEDIUM/LOW also resolved rather than deferred, except F-16 which is deliberately carded as out of
+scope.
+
+---
+
+## Clarifications
+
+Five ambiguities were identified. **All five were resolved from the codebase without user input.**
+None are deferred to the Phase 2 summary.
+
+### C1 — Where does the helper live?
+
+**Question**: New `helpers/search-helpers.ts`, or extend the existing `helpers/chaos-helpers.ts`?
+
+**Answer**: New file, `frontend/tests/e2e/helpers/search-helpers.ts`.
+
+**Evidence**: `grep -rn "from './helpers/chaos-helpers'" frontend/tests/e2e/` returns exactly SIX
+importers, all chaos-scoped: `chaos-cross-browser`, `chaos-cached-data`, `chaos-error-boundary`,
+`chaos-degradation`, `chaos-accessibility`, `chaos-scenarios`. `helpers/verification.ts` only
+*mentions* chaos-helpers in a comment; it does not import it. `chart-edge-cases.spec.ts` and
+`ticker-search-gaps.spec.ts` contain ZERO references to chaos-helpers.
+
+That strengthens the conclusion rather than weakening it: two of the four files needing the search
+helper do not import the chaos module at all today, so putting a general search helper there would
+force them to start importing chaos route machinery for a plain search interaction.
+
+An earlier draft of this clarification claimed seven importers including `helpers/verification.ts`,
+and claimed `chart-edge-cases.spec.ts` and `ticker-search-gaps.spec.ts` imported it today. Both
+claims were fabricated from a carelessly read grep. Caught in Adversarial Review #2 and corrected
+here.
+
+### C2 — What exactly does a query-scoped predicate match on?
+
+**Question**: Research D4 requires tightening predicates "by matching the query string". What is the
+actual parameter name?
+
+**Answer**: `q`. A query-scoped predicate is `r.url().includes('q=GOOG')`.
+
+**Evidence**: `frontend/src/lib/api/tickers.ts:28-31` — `api.get('/api/v2/tickers/search', { params: { q: query, limit } })`.
+Input is upper-cased before it reaches the query (`ticker-input.tsx` `handleChange`,
+`e.target.value.toUpperCase()`), so the literal matches the test's own fill value with no case
+handling needed.
+
+### C3 — What language for the scan script (FR-011)?
+
+**Answer**: Python 3.13, at `scripts/scan-waitforresponse-race.py`, run under the project venv.
+
+**Evidence**: `scripts/` already holds `audit-e2e-skips.py`, which does the closely analogous job of
+scanning the E2E suite and reporting counts. Following that precedent keeps one idiom for "scan the
+test suite and report", and Python is the repo standard with venv and pre-commit already wired.
+
+### C4 — Should the scan be enforced in CI as part of this feature?
+
+**Answer**: No. Commit it as a runnable artifact only.
+
+**Evidence**: enforcement is the dependent regression-guard feature, listed in this spec's Out of
+Scope. The script exits non-zero when `RACY > 0` so the guard can wire it in without modification,
+but this feature does not add it to pre-commit or any workflow.
+
+### C5 — Should the six already-correct sites adopt the helper for consistency?
+
+**Answer**: No. Leave them byte-unchanged.
+
+**Evidence**: FR-004. They are already race-free, so touching them adds diff surface and review load
+with no defect fixed, and it would blur the CI signal this feature depends on — if the flake
+survives, the diff should contain only changes that could plausibly have caused it.

--- a/specs/001-waitforresponse-race-sweep/tasks.md
+++ b/specs/001-waitforresponse-race-sweep/tasks.md
@@ -1,0 +1,1119 @@
+# Tasks: Sweep the act-then-wait `waitForResponse` race class
+
+**Feature Branch**: `001-waitforresponse-race-sweep`
+**Input**: Design documents from `/specs/001-waitforresponse-race-sweep/`
+**Prerequisites**: spec.md, plan.md, research.md, data-model.md, contracts/helper-api.md, quickstart.md
+
+**Format**: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no ordering dependency)
+- **[Story]**: US1 (trustworthy CI signal, P1), US2 (named interaction, P2), US3 (board states verified facts, P3)
+- Every task cites the FR/SC it satisfies and states testable acceptance criteria
+
+---
+
+## How to read the line numbers in this document
+
+Line numbers in this document are **PRE-SWEEP locators** recorded against commit `8c27271`. Phase C
+conversions are net line-additive, so downstream line numbers **WILL** drift during implementation.
+Match sites by file plus the quoted original statement plus the enclosing test or function name.
+Never match by line number alone.
+
+This applies to the verification tasks too. T018 states expected scan output as **per-file counts**
+plus enclosing test or function names, deliberately not as line numbers, because the post-sweep scan
+cannot report pre-sweep lines and a line-pinned expectation would read as a failure that is not
+there.
+
+---
+
+## Standing Constraints (apply to every task)
+
+| Constraint | Source | Enforcement |
+|---|---|---|
+| Every commit GPG-signed (`git commit -S`) | CLAUDE.md, plan Constitution Check | Commit fails without a signature; never bypass |
+| Never `--no-verify` / `commit -n` | CLAUDE.md, `block-no-verify.sh` hook | Hook denies the command |
+| Activate the venv before any Python work (`source .venv/bin/activate`) | CLAUDE.md | `python --version` must report 3.13.x |
+| Test-only changes. No product code. | FR-007 | `git diff --stat` must show no path under `frontend/src/` |
+| Permitted paths outside `frontend/tests/e2e/`: `scripts/scan-waitforresponse-race.py`, `CLEANUP-BOARD.html`, `specs/001-waitforresponse-race-sweep/` | FR-007 | Audited by T025 |
+| The Playwright E2E job stays **non-required** | FR-009, Out of Scope | No edit to `.github/workflows/pr-checks.yml` |
+| Target is the **customer** dashboard (Next.js/Amplify), run via `npx playwright test` from `frontend/` | CLAUDE.md two-dashboard rule | Every touched file already carries `// Target: Customer Dashboard (Next.js/Amplify)` (verified) |
+| Verification runs use `--project="Desktop Chrome"` only | plan Technical Context, AR#2 N-06 | The other four configured projects are not exercised by CI and are not verified here |
+| The fault-injection patch is **never committed** | SC-003(a) | T022 confirms a clean tree |
+
+---
+
+## Phase A — Scan artifact and baselines (FR-011, SC-001, SC-004)
+
+**Purpose**: make the "zero racy sites" claim reproducible, and capture the before-state so SC-001
+and SC-004 have something to compare against. Nothing in Phase C may start until T002 has recorded
+the baseline, because a baseline taken after a conversion is worthless.
+
+- [ ] **T001** [US1] Write the committed inventory scan at `scripts/scan-waitforresponse-race.py`
+  - **Files**: `scripts/scan-waitforresponse-race.py` (NEW)
+  - **Satisfies**: FR-011, and enables SC-001
+  - **Acceptance criteria**:
+    1. The script scans every `*.ts` file under `frontend/tests/e2e/` (spec files **and** `helpers/`).
+    2. It classifies **both** `page.waitForResponse(...)` **and**
+       `page.waitForEvent('requestfailed'|'response')`. A script that matches only `waitForResponse`
+       fails this task — that method-name framing is exactly what hid 3 sites (AR#2 N-01).
+    3. The classification rule is documented **in the script itself** (module docstring), verbatim
+       to FR-011: `RACY` = an awaited wait whose immediately preceding non-comment, non-blank line
+       performs a triggering action (`.fill(`, `.click(`, `.press(`, `.selectOption(`, `.clear(`,
+       `.goto(`, `.reload(`, `.evaluate(`, `.type(`, `.check(`, `.tap(`, `.setInputFiles(`,
+       `.dispatchEvent(`); `PROMISE-FIRST` = wait assigned to a variable before the triggering
+       action and awaited after it; `OTHER` = neither, requires human triage.
+       The `.evaluate(` token is not hypothetical: `error-visibility-search.spec.ts:158` triggers
+       via `retryButton.evaluate((el) => el.click())`. A token list missing it would misclassify a
+       live shape.
+    4. Comment lines are **excluded from the call-site population**. Verified count: a naive
+       `grep -rn "waitForResponse\|waitForEvent"` over `frontend/tests/e2e/` returns **41** lines, of
+       which **7 are comments** (`error-visibility-search.spec.ts:141`, `helpers/chaos-helpers.ts:338`,
+       `helpers/chaos-helpers.ts:392`, `ticker-search-gaps.spec.ts:37`, `:230`, `:236`, `:243`).
+       The script MUST report **34**, not 41.
+    5. Output names every site as `file:line CLASSIFICATION` plus a summary line with the four counts.
+    6. `sys.exit(1)` when `RACY > 0`; `sys.exit(0)` otherwise. Assert both branches by running the
+       script before and after Phase C (T002 → exit 1; T018 → exit 0).
+    7. It classifies `chaos-scenarios.spec.ts:138` as `OTHER` (an intervening
+       `await expect(...).toBeVisible({ timeout: 2000 })` separates its `page.reload()` from the wait).
+       If it reports `RACY` there, the adjacency rule is not implemented correctly.
+    8. Runs under the project venv: `source .venv/bin/activate && python scripts/scan-waitforresponse-race.py`.
+    9. NOT wired into pre-commit or any workflow (spec C4). `grep -rn "scan-waitforresponse-race" .pre-commit-config.yaml .github/` returns nothing.
+    10. `OTHER` sites are printed under an explicit **"requires human triage"** banner, not folded
+        into the summary counts alone. A shape the classifier cannot place must be *visible*, or it
+        gets counted as clean by omission. The banner lists each `OTHER` site with its file, its
+        enclosing test or function name, and the statement text.
+    11. The module docstring carries `# Target: Customer Dashboard (Next.js/Amplify)` and the
+        `--help` output names `frontend/tests/e2e/` as the scanned root. Two existing scripts
+        (`scripts/audit-e2e-skips.py`, `scripts/check-false-pass-patterns.sh`) default to the
+        **admin** pytest suite under `tests/`, and this repo has a documented history of confusing
+        the two dashboards (CLAUDE.md, "Two Dashboards"). A reader must not have to open the source
+        to learn which suite this scans.
+
+- [ ] **T002** [US1] Capture the pre-sweep scan baseline (depends on T001)
+  - **Files**: none modified; output recorded in the T001/T002 commit message and pasted into this
+    file's `## Execution Log` section below
+  - **Satisfies**: SC-001 (the "before" half)
+  - **Acceptance criteria**:
+    1. Run **before any conversion exists in the tree**.
+    2. Output is exactly `RACY 27 / PROMISE-FIRST 6 / OTHER 1`, total **34**.
+    3. Exit code is **1**.
+    4. The 27 RACY lines match the spec inventory table exactly:
+       `ticker-search-gaps.spec.ts` 38/77/82/109/129/144/162/211/219 (9);
+       `chaos-degradation.spec.ts` 131/138/178/183/188 (5);
+       `chart-edge-cases.spec.ts` 72/130/161/218 (4);
+       `helpers/chaos-helpers.ts` 364/367/370 (3);
+       `chaos-scenarios.spec.ts` 102/105/108 (3) and 219/222/225 (3).
+    5. The 6 PROMISE-FIRST lines are `chaos-degradation.spec.ts:231`, `chaos-scenarios.spec.ts:251`,
+       `error-visibility-search.spec.ts:142`, `:157`, `ticker-search-gaps.spec.ts:231`, `:237`.
+    6. **Any deviation from 27/6/1/34 halts the sweep** until the inventory or the classifier is
+       reconciled. A baseline that does not reproduce the spec's numbers means one of them is wrong.
+
+- [ ] **T003** [P] [US1] Capture the pre-sweep Playwright pass/fail/skip tally
+  - **Files**: none modified; tally recorded in `## Execution Log`
+  - **Satisfies**: SC-004 (the "before" half)
+  - **Acceptance criteria**:
+    1. `cd frontend && npx playwright test tests/e2e/chaos-degradation.spec.ts tests/e2e/chaos-scenarios.spec.ts tests/e2e/chart-edge-cases.spec.ts tests/e2e/ticker-search-gaps.spec.ts tests/e2e/chaos-cross-browser.spec.ts tests/e2e/chaos-error-boundary.spec.ts --project="Desktop Chrome"`
+    2. The passed / failed / skipped counts are written down verbatim, with the git SHA they were
+       taken at.
+    3. This is a **counting** run, not an evidential one. Do not cite it as evidence the race exists
+       or is fixed (SC-002 is explicitly non-evidential).
+  - **Parallel**: independent of T001/T002 — no shared files.
+
+---
+
+## Phase B — The helper (FR-005, US2)
+
+- [ ] **T004** [US2] Create `searchAndAwaitResponse` per the contract
+  - **Files**: `frontend/tests/e2e/helpers/search-helpers.ts` (NEW)
+  - **Satisfies**: FR-005, FR-006, FR-012 (contract G2), US2 acceptance scenarios 1 and 2
+  - **Acceptance criteria**:
+    1. Signature matches `contracts/helper-api.md` exactly:
+       `searchAndAwaitResponse(page, searchInput, query, options?: { predicate?, timeout?, clearFirst? }): Promise<Response>`.
+    2. **G1** — the response promise is created before any interaction with the input. A reviewer
+       reading the function body sees `const responsePromise = page.waitForResponse(...)` on a line
+       strictly above the first `searchInput.fill(...)`. The scan (T001) classifies the helper's
+       internal wait as `PROMISE-FIRST`.
+    3. **G2** requires that the listener cannot escape as an unhandled rejection, **even when an
+       interaction throws**. "Awaited on every return path" is not a checkable criterion here: the
+       helper has exactly one return path, so the wording is vacuous, and it does not cover the real
+       hole, which is `searchInput.fill()` throwing *before* the await is ever reached. Check the
+       shape instead. It MUST be one of the two forms the contract now names
+       (`contracts/helper-api.md`, "Required shape for the throw path"), and a reviewer states which:
+       - **Option A**, `try { ...clearFirst/fill... } finally { }` wrapping the interactions, with
+         the `finally` attaching a rejection sink on the throw path, or
+       - **Option B**, `.catch(() => {})` attached to `responsePromise` **at creation**, on the line
+         it is created, so the promise is never unhandled regardless of what happens after.
+
+       This is the helper, which is **new code**. Unlike the 6 protected inline sites, there is no
+       FR-004 obstacle to doing it properly, so the FR-012 "no `try/finally` required" carve-out
+       does not apply here. That carve-out exists for sites this feature may not touch.
+    4. **G3** — a caller-supplied `predicate` is passed through unmodified. No wrapping, no `&&`,
+       no widening. Assert by reading the body: the supplied predicate reaches `waitForResponse`
+       untouched.
+    5. Defaults: `predicate` = `(r) => r.url().includes('/api/v2/tickers/search')`,
+       `timeout` = `15000` (FR-006), `clearFirst` = `false`.
+    6. A comment on the default predicate records that it matches **13 of the 18** URL-scoped sites,
+       not all 18, and points at the contract's "Sites requiring an explicit predicate" table
+       (AR#2 D-06).
+    7. `clearFirst: true` performs `fill('')` before `fill(query)`, both inside the single listener,
+       with a comment citing `ticker-input.tsx:37` (`enabled: query.length >= 1`) as why an empty
+       fill cannot trigger a request.
+    8. Non-guarantees N1 (cache-served queries) and N2 (`retry: 1` disambiguation) are stated in the
+       JSDoc so a caller cannot assume them.
+    9. File carries the `// Target: Customer Dashboard (Next.js/Amplify)` header.
+    10. `cd frontend && npx tsc --noEmit` passes.
+
+---
+
+## Phase C — Conversions (FR-001, FR-002, FR-003, FR-004, FR-006, FR-010, FR-012)
+
+**Ordering is deliberate and MUST be preserved**: `chart-edge-cases` → `ticker-search-gaps` →
+`chaos-scenarios` → `chaos-degradation` → `chaos-helpers`. `chaos-helpers.ts` is last because
+`triggerHealthBanner` is a precondition of the whole chaos suite; its change must be validated
+against already-converted callers and against the two unedited callers
+(`chaos-cross-browser.spec.ts:35`, `chaos-error-boundary.spec.ts:63`). Smallest blast radius first
+for everything above it.
+
+### C.1 — `chart-edge-cases.spec.ts` (4 sites)
+
+- [ ] **T005** [US1] Convert the 4 URL-scoped sites to `searchAndAwaitResponse`
+  - **Files**: `frontend/tests/e2e/chart-edge-cases.spec.ts`
+  - **Satisfies**: FR-001, FR-002, FR-005, FR-006, FR-012
+  - **Acceptance criteria**:
+    1. Sites `:72`, `:130`, `:161`, `:218` — each currently `await searchInput.fill('AAPL');` followed
+       by `await page.waitForResponse('**/api/v2/tickers/search**');` — become a single
+       `await searchAndAwaitResponse(page, searchInput, 'AAPL');`.
+    2. All four sites use the **default** predicate. Justified: the original is the glob
+       `'**/api/v2/tickers/search**'`, and the default `r.url().includes('/api/v2/tickers/search')`
+       matches the same population. No widening, so FR-002 is satisfied with no declaration needed.
+    3. No query scoping is added. Justified per research D4: the `beforeEach` mock at
+       `chart-edge-cases.spec.ts:32-40` `route.fulfill`s a **200** for ticker search, so `retry: 1`
+       never fires and exactly one matching response exists per test.
+    4. Each of the four tests contains exactly **one** converted wait, so **no `test.setTimeout(60000)`
+       is added here** (FR-006 applies only above two waits). Verify by counting
+       `searchAndAwaitResponse(` per test body.
+    5. Import added: `import { searchAndAwaitResponse } from './helpers/search-helpers';`.
+    6. `npx tsc --noEmit` passes and
+       `npx playwright test tests/e2e/chart-edge-cases.spec.ts --project="Desktop Chrome"` is green.
+    7. The scan (T001) reports zero `RACY` in this file.
+
+### C.2 — `ticker-search-gaps.spec.ts` (9 sites)
+
+- [ ] **T006** [US1] Convert the 9 URL-scoped sites to `searchAndAwaitResponse`
+  - **Files**: `frontend/tests/e2e/ticker-search-gaps.spec.ts`
+  - **Satisfies**: FR-001, FR-002, FR-005, FR-006, FR-010, FR-012
+  - **Acceptance criteria**:
+    1. Sites `:38`, `:77`, `:82`, `:109`, `:129`, `:144`, `:162`, `:211`, `:219` all become
+       `searchAndAwaitResponse(...)` calls with the default predicate (all nine originals are the
+       glob `'**/api/v2/tickers/search**'` — no widening, no declaration needed).
+    2. **`.clear()` → `clearFirst: true` at `:219`** (test `'duplicate ticker switches to existing
+       chip without adding'`). The original sequence is
+       `await searchInput.clear(); await searchInput.fill('GOOGL'); await page.waitForResponse(...)`.
+       The helper's `clearFirst: true` performs `fill('')`. Playwright documents `locator.clear()`
+       as equivalent to `fill('')`, so this is not a behavioural change and needs no declaration
+       beyond a one-line note in the commit message. No fallback shape is offered; use the helper.
+    3. **FR-010 hold-out**: `ticker-search-gaps.spec.ts:242-247` is left **byte-unchanged**. It
+       deliberately omits a wait because the repeated `AAPL` query is served from React Query cache
+       inside the 30s `staleTime` window (`ticker-input.tsx:38`) and no network request occurs.
+       Introducing `searchAndAwaitResponse` there would hang until timeout (contract N1).
+       `git diff frontend/tests/e2e/ticker-search-gaps.spec.ts` shows no hunk touching that range.
+    4. The two already-correct sites `:231` and `:237` are left **byte-unchanged** (FR-004, spec C5).
+    5. No test in this file exceeds two converted waits (max is 2, in the tests at `:46` and `:206`),
+       so **no `test.setTimeout(60000)` is added here**. Verify by counting.
+    6. The stale comment at `:37` ("Wait for debounced search response") disappears with the
+       conversion. Do not replace it with another debounce claim — there is no debounce
+       (`ticker-input.tsx:33-39`, research R3).
+    7. `npx tsc --noEmit` passes; the file is green under `--project="Desktop Chrome"`.
+    8. The scan reports zero `RACY` in this file and still reports `:231`/`:237` as `PROMISE-FIRST`.
+
+### C.3 — `chaos-scenarios.spec.ts` (6 sites: 3 `waitForResponse` + 3 `waitForEvent`)
+
+- [ ] **T007** [US1] Convert `:102/:105/:108` inline, keeping the status-only predicate
+  - **Files**: `frontend/tests/e2e/chaos-scenarios.spec.ts`
+  - **Satisfies**: FR-001, FR-002 (accepted-risk exception), FR-003, FR-006, FR-012
+  - **Acceptance criteria**:
+    1. Each of the three sites becomes promise-first inline:
+       `const r1 = page.waitForResponse((r) => r.url().includes('/api/') && r.status() === 503, { timeout: 15000 });`
+       then the fill(s), then `await r1;`.
+    2. The predicate is **byte-identical** to the original. It is NOT routed through the helper and
+       NOT narrowed to `/tickers/search` — that would change what the test asserts (FR-005, contract N3).
+    3. No query scoping is added. This is the FR-002 accepted-risk exception: under
+       `dynamodb_throttle`'s blanket 503 route any failing response legitimately signals "the API is
+       failing", which is what the health-monitor failure counter keys on. The commit message MUST
+       restate the residual risk: these waits confirm *a* failure occurred, not *this search's*
+       failure, so a regression making only one of three searches fail would still satisfy them.
+    4. `{ timeout: 15000 }` on every converted call (FR-006).
+    5. **FR-003 hold-out**: `chaos-scenarios.spec.ts:138` is left **byte-unchanged**. Its action is
+       `page.reload()`, the `lambda_cold_start` handler delays 3s before `route.continue()`, and an
+       `await expect(skeletons.first()).toBeVisible({ timeout: 2000 })` sits between them — leaving a
+       worst-case ordering margin of about **1s** (not the 2.8s an earlier draft claimed). The reason
+       is recorded in the commit message, and the scan continues to classify it `OTHER`.
+    6. `chaos-scenarios.spec.ts:251` (already correct) is left **byte-unchanged** (FR-004).
+
+- [ ] **T008** [US1] Convert the 3 `waitForEvent('requestfailed')` sites inline
+  - **Files**: `frontend/tests/e2e/chaos-scenarios.spec.ts` (depends on T007 — same file)
+  - **Site identification** (pre-sweep `:219/:222/:225`, which will have drifted by the time T007
+    lands): the three occurrences of the exact statement
+    `await page.waitForEvent('requestfailed', { timeout: 5000 });`
+    inside the test titled `'API timeout — errors communicated, no blank screens'`. There are
+    exactly three in the file and all three are in that test. Match on the statement text, not the
+    line.
+  - **Satisfies**: FR-001, FR-002 (accepted-risk exception), FR-006, FR-012
+  - **Acceptance criteria**:
+    1. Each becomes promise-first inline:
+       `const f1 = page.waitForEvent('requestfailed', { timeout: 15000 });` then the fill(s), then
+       `await f1;`.
+    2. These convert **inline, not through the helper** — `waitForEvent('requestfailed')` takes no
+       predicate at all, so there is nothing for the helper to parameterise (contract N3).
+    3. Per-call timeout is raised from the original `5000` to `15000` (FR-006). The change is
+       declared in the commit message as a diagnosability change, explicitly not the fix.
+    4. These sites fire under `api_timeout`'s `route.abort`, which collapses the action-to-listener
+       margin further than `route.fulfill` does — record that in the commit message as why they are
+       in the same class despite the different method name (AR#2 scope-definition lesson).
+    5. The scan (T001) reports all three as `PROMISE-FIRST`, proving the classifier covers
+       `waitForEvent`, not just `waitForResponse`. Verify by the scan's per-file count for
+       `chaos-scenarios.spec.ts`, not by the reported line numbers, which have drifted.
+
+- [ ] **T009** [US1] Add `test.setTimeout(60000)` to the two multi-wait tests in this file
+  - **Files**: `frontend/tests/e2e/chaos-scenarios.spec.ts` (depends on T007, T008)
+  - **Satisfies**: FR-006
+  - **Site identification**: by **test title**, not by line. Both tests have already been edited by
+    T007/T008, so their pre-sweep line numbers (`:88`, `:210`) are stale locators only.
+  - **Acceptance criteria**:
+    1. `test.setTimeout(60000)` is the first statement in the test titled
+       `'database throttle — health banner appears, cached data visible'`, which contains the three
+       converted status-503 waits from T007.
+    2. `test.setTimeout(60000)` is the first statement in the test titled
+       `'API timeout — errors communicated, no blank screens'`, which contains the three converted
+       `requestfailed` waits from T008.
+    3. No other test in this file receives one. Verify by walking every `test(` block in the file
+       and counting converted waits per block; each of the others holds at most one. Do not rely on
+       the pre-sweep block starts `:28`, `:123`, `:150`, `:240`.
+    4. Rationale comment on each: `playwright.config.ts` sets no top-level `timeout` (verified — the
+       `timeout` keys at `:67`/`:76` are `webServer` timeouts), so the cap is Playwright's default
+       30000ms, and a second hung 15000ms wait would blow the test cap before the per-call cap fires,
+       reporting opaquely — the exact outcome FR-006 exists to prevent.
+
+### C.4 — `chaos-degradation.spec.ts` (5 sites)
+
+- [ ] **T010** [US1] Convert `:131` and `:138` with their **original status-bearing predicates passed explicitly**, query-scoped
+  - **Files**: `frontend/tests/e2e/chaos-degradation.spec.ts`
+  - **Satisfies**: FR-001, FR-002, FR-005, FR-006, FR-012, US1 acceptance scenario 3
+  - **Acceptance criteria**:
+    1. `:131` becomes
+       `await searchAndAwaitResponse(page, searchInput, 'AAPL', { predicate: (r) => r.url().includes('/tickers/search') && r.url().includes('q=AAPL') && r.status() === 500 });`
+    2. `:138` becomes
+       `await searchAndAwaitResponse(page, searchInput, 'GOOG', { clearFirst: true, predicate: (r) => r.url().includes('/tickers/search') && r.url().includes('q=GOOG') && r.status() === 200 });`
+    3. **The default predicate MUST NOT be used at either site.** The default is URL-only and would
+       drop the `status() === 500` / `status() === 200` checks, **widening** the match — which FR-002
+       forbids and contract G3 explicitly refuses to protect against
+       (`contracts/helper-api.md:46-47`). A reviewer confirms by seeing an explicit `predicate:` on
+       both calls.
+    4. **Query scoping is mandatory here, and this is the highest-risk predicate change in the
+       feature.** This test's mock returns 500 on the first request and 200 on every later one, and
+       `providers.tsx:48` sets `retry: 1`, so the failed AAPL search fires a retry roughly 1s later.
+       A promise-first listener for `/tickers/search` + `status === 200` registered before
+       `fill('GOOG')` could match the **AAPL retry** instead of the GOOG response, and the test would
+       then assert on a state GOOG has not reached — passing for the wrong reason (spec Edge Cases,
+       research D4). The `q=` parameter name is verified at `frontend/src/lib/api/tickers.ts:28-31`;
+       input is upper-cased before it reaches the query (`ticker-input.tsx` `handleChange`), so the
+       literal matches the fill value with no case handling (spec C2).
+    5. The predicate change is **declared in the commit message** as a deliberate tightening under
+       FR-002, naming both sites and the retry it defends against.
+    6. The test at `:109` ('single failure does not trigger banner') contains exactly two converted
+       waits, so it does **not** get `test.setTimeout(60000)` (FR-006 applies above two).
+    7. Green under `--project="Desktop Chrome"`, and green under `--repeat-each=20 --workers=8` in
+       T023 — a mis-scoped predicate here shows up as a nondeterministic pass, not a clean failure,
+       so contention is the check that matters.
+
+- [ ] **T011** [US1] Convert the three AAPL/GOOG/MSFT waits to the default predicate, **declaring the narrowing**
+  - **Files**: `frontend/tests/e2e/chaos-degradation.spec.ts` (depends on T010 — same file)
+  - **Site identification** (pre-sweep `:178/:183/:188`, drifted by T010): the three occurrences of
+    `await page.waitForResponse((r) => r.url().includes('/tickers/search'));` inside the test titled
+    `'cross-endpoint success prevents banner despite other endpoint failures'`. That predicate text
+    with **no** status clause appears only in that test; the two in T010's test carry
+    `&& r.status() === 500` / `=== 200`. Match on the statement text plus the test title.
+  - **Satisfies**: FR-001, FR-002, FR-005, FR-006, FR-012
+  - **Acceptance criteria**:
+    1. Interaction 1 → `await searchAndAwaitResponse(page, searchInput, 'AAPL');`
+       Interaction 2 → `await searchAndAwaitResponse(page, searchInput, 'GOOG', { clearFirst: true });`
+       Interaction 3 → `await searchAndAwaitResponse(page, searchInput, 'MSFT', { clearFirst: true });`
+    2. **The narrowing is explicitly declared.** The original predicate is
+       `(r) => r.url().includes('/tickers/search')`; the default is
+       `(r) => r.url().includes('/api/v2/tickers/search')`. This **narrows** the match from any path
+       containing `/tickers/search` to the versioned API path only. Narrowing is permitted by FR-002
+       (it cannot weaken an assertion) but MUST be called out — the commit message names all three
+       sites and the exact before/after predicate strings
+       (`contracts/helper-api.md:48-50`, AR#2 D-06).
+    3. No query scoping is added at these three, and the justification is **stronger** than an
+       earlier draft claimed. That draft said "the 503s in this test come from the sentiment
+       endpoint, which the narrowed search-scoped predicate cannot match". That is false: **there
+       are no 503s in this test at all.** The route is
+       `page.route('**/api/v2/sentiment**', … 503)` (pre-sweep `chaos-degradation.spec.ts:153`), but
+       the app's sentiment URLs are `/api/v2/tickers/{ticker}/sentiment/history` and
+       `/api/v2/configurations/{id}/sentiment`. Neither contains the literal segment
+       `/api/v2/sentiment`, so the glob never matches and no 503 is ever produced. The test titled
+       `'cross-endpoint success prevents banner despite other endpoint failures'` therefore passes
+       **vacuously** today: nothing fails, so of course no banner appears.
+       What actually justifies skipping query scoping is the search route alone: it `route.fulfill`s
+       a **200** every time (pre-sweep `:162-171`), so `retry: 1` never fires and exactly one
+       matching response exists per interaction. The conversion is correct as written.
+       The dead route is **not** fixed here (FR-009 scope discipline, same class as the
+       `dynamodb_throttle` dead branch). It is carded by T027.
+    4. Green under `--project="Desktop Chrome"`.
+
+- [ ] **T012** [US1] Raise the test budget for multi-wait tests (FR-006)
+  - **Files**: `frontend/tests/e2e/chaos-degradation.spec.ts`, `frontend/tests/e2e/helpers/chaos-helpers.ts` (depends on T010, T011)
+  - **Design note**: the raise for `triggerHealthBanner`'s three waits goes **inside the helper**,
+    not into each caller. `chaos-helpers.ts` already imports from `@playwright/test`, so it imports
+    `test` and calls `test.setTimeout(60000)` on entry to `triggerHealthBanner`. This covers all
+    seven `triggerHealthBanner(page)` call sites at once, and keeps `chaos-cross-browser.spec.ts`
+    and `chaos-error-boundary.spec.ts` byte-unchanged. Per-caller raises were rejected: they grow
+    the diff from 5 files to 7 and leave the rule for a future caller to remember, which is the same
+    failure mode that produced this bug class.
+  - **Site identification**: by **function name** (`triggerHealthBanner` in
+    `helpers/chaos-helpers.ts`) and by **test title** (`'cross-endpoint success prevents banner
+    despite other endpoint failures'` in `chaos-degradation.spec.ts`). The pre-sweep `:148` locator
+    has drifted by T010/T011.
+  - **Acceptance criteria**:
+    1. `triggerHealthBanner` raises the cap as its first statement, and `chaos-helpers.ts` imports
+       `test` from `@playwright/test`. The call is
+       **`test.setTimeout(Math.max(test.info().timeout, 60000));`**, not a bare
+       `test.setTimeout(60000)`. A bare call is an unconditional override and would silently *lower*
+       a caller's deliberate cap: `chaos-accessibility.spec.ts:29` sets `test.setTimeout(30_000)` at
+       the describe level, and `chaos-accessibility.spec.ts` imports `triggerHealthBanner`. The
+       helper may only ever raise.
+    2. In `chaos-degradation.spec.ts`, `test.setTimeout(60000)` is the first statement of the test
+       titled `'cross-endpoint success prevents banner despite other endpoint failures'`, which
+       holds the three converted waits from T011 (cross-artifact finding CX-2: FR-006's rule catches
+       this test but its own enumeration omitted it).
+    3. `git diff --stat frontend/tests/e2e/chaos-cross-browser.spec.ts frontend/tests/e2e/chaos-error-boundary.spec.ts`
+       is **empty**. Those two files are affected but not modified. This is the criterion that
+       proves the helper-side design landed; a non-empty diff here means someone applied the
+       rejected per-caller design.
+    4. No test that already fits inside the 30s budget gets a raise. FR-006 applies only above two
+       converted waits; verify by counting per test.
+    5. `cd frontend && npx tsc --noEmit` passes. `helpers/chaos-helpers.ts` is imported by **six**
+       spec files (`chaos-cross-browser`, `chaos-cached-data`, `chaos-error-boundary`,
+       `chaos-degradation`, `chaos-accessibility`, `chaos-scenarios`), and two of them
+       (`chaos-cached-data.spec.ts`, `chaos-accessibility.spec.ts`) appear in **no** verification
+       command in this feature. A type check is the only thing that covers them.
+  - **Satisfies**: FR-006
+
+- [ ] **T013** [US1] Convert `triggerHealthBanner`'s 3 waits to promise-first, keeping status-only predicates
+  - **Files**: `frontend/tests/e2e/helpers/chaos-helpers.ts` (depends on T005–T012)
+  - **Site identification** (pre-sweep `:364/:367/:370`, drifted by T012's import and
+    `test.setTimeout` insertion): the three occurrences of the exact statement
+    `await page.waitForResponse((resp) => resp.status() === 503);` inside the function
+    `triggerHealthBanner`. Match on the function name plus the statement text.
+  - **Satisfies**: FR-001, FR-002 (accepted-risk exception), FR-005, FR-006, FR-012
+  - **Acceptance criteria**:
+    1. Each of the three becomes promise-first inline:
+       `const f1 = page.waitForResponse((resp) => resp.status() === 503, { timeout: 15000 });`
+       then the fill(s), then `await f1;`.
+    2. The predicates stay **status-only**. They are NOT narrowed to `/tickers/search` — that is
+       explicitly Out of Scope (spec Out of Scope, FR-005) and is the exact contradiction AR#1 F-04
+       resolved.
+    3. `triggerHealthBanner` does **not** call `searchAndAwaitResponse` (contract N3).
+    4. `{ timeout: 15000 }` on all three (FR-006).
+    5. **Sequenced last on purpose.** After this edit, re-run the full chaos suite — including the
+       two unedited callers — before committing:
+       `cd frontend && npx playwright test tests/e2e/chaos-degradation.spec.ts tests/e2e/chaos-scenarios.spec.ts tests/e2e/chaos-cross-browser.spec.ts tests/e2e/chaos-error-boundary.spec.ts --project="Desktop Chrome"`.
+       All green, or the change is reverted and re-analysed rather than patched forward.
+    6. The `dynamodb_throttle` dead branch (pre-sweep `chaos-helpers.ts:169-189`; identify it by the
+       byte-identical `if`/`else` inside the `dynamodb_throttle` scenario, both returning 503) is
+       **NOT** fixed here (FR-009). `git diff` shows no hunk touching that block. It is carded by
+       T027 instead.
+    7. `cd frontend && npx tsc --noEmit` passes. Same reason as T012 crit. 5: six spec files import
+       this module and two of them are exercised by no verification command here.
+
+- [ ] **T014** [US1] Soften the `triggerHealthBanner` docstring's determinism claim
+  - **Files**: `frontend/tests/e2e/helpers/chaos-helpers.ts` (depends on T013 — same file)
+  - **Satisfies**: FR-005 ("Consequence of the FR-002 exception")
+  - **Site identification**: the JSDoc block immediately above
+    `export async function triggerHealthBanner(page: Page): Promise<void>` in
+    `helpers/chaos-helpers.ts` (pre-sweep `:334-344`, drifted by T012 and T013), and the inline
+    comment inside that function beginning `// Wait for the 503 response after each search`
+    (pre-sweep `:360-362`). Match by function name and comment text.
+  - **Acceptance criteria**:
+    1. The docstring currently reads *"Uses `page.waitForResponse()` after each search interaction
+       (not `waitForTimeout`) to ensure the failure is recorded by the health monitor before
+       proceeding. This makes the trigger deterministic rather than timing-dependent."* Both
+       sentences are now false: "after each search interaction" describes the bug being removed, and
+       the determinism claim never held under a status-only predicate.
+    2. The replacement states what the predicate actually proves: **a** failing response was observed
+       before proceeding, not that **this particular search's** failure was recorded. Any of the three
+       searches, or a `retry: 1` retry, can satisfy it.
+    3. The inline comment ("Wait for the 503 response after each search to confirm the failure was
+       recorded") gets the same correction — it carries the identical false claim.
+    4. The replacement text records the residual risk verbatim from FR-002's exception: a regression
+       that made only one of three searches fail would still satisfy these waits.
+    5. **This edit is carried by its own task on purpose**, so it cannot be lost as an incidental
+       change inside T013 (FR-005 requires exactly this).
+    6. No behavioural change in this task. `git diff` shows comment/docstring lines only.
+
+### C.6 — Cross-cutting conversion guards
+
+- [ ] **T015** [P] [US1] Audit FR-010: no wait introduced where the query is cache-served
+  - **Files**: read-only across `frontend/tests/e2e/` (depends on T005–T014)
+  - **Satisfies**: FR-010
+  - **Acceptance criteria**:
+    1. Enumerate every converted site and confirm none repeats a query already issued within the same
+       test inside the 30s `staleTime` window (`ticker-input.tsx:38`).
+    2. `ticker-search-gaps.spec.ts:242-247` is byte-unchanged and still carries its comment
+       explaining why it deliberately asserts on the UI instead of waiting.
+    3. No `searchAndAwaitResponse` call and no new `waitForResponse` exists anywhere a wait did not
+       exist before the sweep. Diff the scan's site list against the T002 baseline: the post-sweep
+       site set is a subset of the baseline set plus the one helper-internal wait.
+    4. Any site found to be cache-served is reverted to a UI assertion following the
+       `:242-247` precedent, and the finding recorded.
+
+- [ ] **T016** [P] [US1] Audit FR-004: the 6 already-correct sites are byte-unchanged
+  - **Files**: read-only (depends on T005–T014)
+  - **Satisfies**: FR-004, spec C5
+  - **Acceptance criteria**:
+    1. `git diff main...HEAD -- frontend/tests/e2e/error-visibility-search.spec.ts` is **empty**.
+    2. `git diff` hunks for `chaos-degradation.spec.ts` touch no line in `:231-237`;
+       `chaos-scenarios.spec.ts` touches no line at `:251`; `ticker-search-gaps.spec.ts` touches no
+       line at `:231` or `:237`. (Line numbers shift with edits — verify by content, matching the
+       exact original statements.)
+    3. None of the six adopts the helper (spec C5: touching them adds diff surface with no defect
+       fixed, and blurs the CI signal this feature depends on).
+    4. The scan still classifies all six as `PROMISE-FIRST`.
+
+- [ ] **T017** [P] [US1] Audit FR-012: every converted wait is awaited on the success path
+  - **Files**: read-only (depends on T005–T014)
+  - **Satisfies**: FR-012
+  - **Acceptance criteria**:
+    1. Every inline promise-first conversion (T007, T008, T013 — 9 sites) has a matching `await`
+       of the stored promise on the success path. No promise is created and left unawaited.
+    2. `try/finally` is **NOT** added at the inline sites, and that is deliberate, not an omission.
+       An unhandled rejection can only occur when an intervening action throws, and an intervening
+       action that throws fails the test anyway, so the rejection rides an already-failing test
+       (FR-012, AR#2 N-05). Confirm no reviewer added one.
+    3. The helper's internal await (contract G2) covers all 18 helper-routed sites.
+    4. Total: 18 helper-routed + 9 inline = 27, matching FR-001.
+
+---
+
+## Phase D — Verification (SC-001 … SC-004)
+
+**Ordering**: scan first (cheapest, catches a miscount before burning suite time), then smoke, then
+fault injection, then contention. Injection precedes contention because it is the falsifiable step —
+if it fails to reproduce at a sound target, the diagnosis is wrong and contention results would be
+meaningless.
+
+- [ ] **T018** [US1] Post-sweep scan reports RACY 0 (SC-001)
+  - **Files**: none modified (depends on Phase C)
+  - **Satisfies**: SC-001, and verifies FR-001, FR-003, FR-011
+  - **How this gate is checked**: by **per-file counts** and **enclosing test or function names**.
+    Every expectation below is deliberately free of line numbers. Phase C is net line-additive, so
+    pinning post-sweep scan output to pre-sweep lines (`:102/105/108`, `:219/222/225`,
+    `:364/367/370`, `:138`) would report a failure that is not there. An implementer who checks
+    lines will conclude the sweep broke. Check counts.
+  - **Acceptance criteria**:
+    1. `source .venv/bin/activate && python scripts/scan-waitforresponse-race.py` reports exactly
+       `RACY 0 / PROMISE-FIRST 16 / OTHER 1`, total **17**.
+    2. Exit code is **0** (T002 recorded exit 1 — both branches of FR-011's exit contract are now
+       exercised).
+    3. `PROMISE-FIRST` distributes **per file** exactly as follows, and each row is checked against
+       the scan's own per-file output:
+
+       | File | PF count | What they are |
+       |---|---|---|
+       | `chaos-scenarios.spec.ts` | 7 | 3 status-503 conversions in `'database throttle — health banner appears, cached data visible'` + 3 `requestfailed` conversions in `'API timeout — errors communicated, no blank screens'` + 1 pre-existing (FR-004 protected) |
+       | `helpers/chaos-helpers.ts` | 3 | the 3 status-503 conversions inside `triggerHealthBanner` |
+       | `error-visibility-search.spec.ts` | 2 | both pre-existing, FR-004 protected, file byte-unchanged |
+       | `ticker-search-gaps.spec.ts` | 2 | both pre-existing, FR-004 protected |
+       | `chaos-degradation.spec.ts` | 1 | pre-existing, the merged #981 conversion, FR-004 protected |
+       | `helpers/search-helpers.ts` | 1 | the helper's own internal wait |
+       | `chart-edge-cases.spec.ts` | 0 | all 4 sites are now helper calls, so no inline wait remains |
+       | **Total** | **16** | 6 pre-existing + 6 status-only + 3 `requestfailed` + 1 helper-internal |
+
+    4. The single `OTHER` is in `chaos-scenarios.spec.ts`, inside the test titled
+       `'cold start — loading skeletons appear during delay'`. That is the `page.reload()` site held
+       back by FR-003. Its count for that file is **1**; no other file reports an `OTHER`. It appears
+       under the T001 crit. 10 "requires human triage" banner, which is expected and is not a
+       failure.
+    5. `RACY` is **0 in every file**, not merely 0 in total.
+    6. `grep -rn "searchAndAwaitResponse(" frontend/tests/e2e/ --include="*.spec.ts" | wc -l`
+       returns exactly **18**. The `--include="*.spec.ts"` filter is load-bearing: without it the
+       helper's own `export async function searchAndAwaitResponse(` definition line is counted and
+       the answer is 19. Flagged as CX-4.
+    7. The 18 distribute as `chart-edge-cases.spec.ts` 4 + `ticker-search-gaps.spec.ts` 9 +
+       `chaos-degradation.spec.ts` 5 = 18, across **3** spec files, not 4 (see CX-1). Check with
+       `grep -rc` per file, not by eye.
+
+- [ ] **T019** [US1] Smoke run (SC-002 — precondition only, non-evidential)
+  - **Files**: none modified (depends on T018)
+  - **Satisfies**: SC-002
+  - **Acceptance criteria**:
+    1. Runs the six-file command from `quickstart.md` section 2, including
+       `chaos-cross-browser.spec.ts` and `chaos-error-boundary.spec.ts` (in the helper's blast radius
+       via `triggerHealthBanner`).
+    2. All tests pass under `--project="Desktop Chrome"`.
+    3. The result is recorded as **"catches gross breakage from the conversions"** and explicitly
+       **NOT** as evidence the race is fixed. Pre-fix code passed this too (10/10 locally). Citing it
+       as evidence fails this task (SC-002 is labelled non-evidential for exactly this reason).
+
+- [ ] **T020** [US1] Fault injection against **pre-fix** code — MUST FAIL (SC-003a, the gate)
+  - **Files**: temporary uncommitted patch to `frontend/tests/e2e/ticker-search-gaps.spec.ts` and `frontend/tests/e2e/chart-edge-cases.spec.ts` (depends on T019)
+  - **Satisfies**: SC-003(a)
+  - **Restoring pre-fix content**: **do not `git stash`.** Every Phase C task commits, so the tree
+    is clean and `git stash` has nothing to stash. Check the pre-fix files out of the merge base
+    instead:
+    ```bash
+    BASE=$(git merge-base main HEAD)     # 8c27271 at time of writing
+    git checkout "$BASE" -- frontend/tests/e2e/ticker-search-gaps.spec.ts \
+                            frontend/tests/e2e/chart-edge-cases.spec.ts
+    # ... inject, run, record ...
+    git checkout HEAD -- frontend/tests/e2e/ticker-search-gaps.spec.ts \
+                         frontend/tests/e2e/chart-edge-cases.spec.ts
+    ```
+    Both files are self-contained at the base commit (neither imported `search-helpers.ts` before
+    this feature), so checking them out alone leaves a compiling tree.
+  - **Acceptance criteria**:
+    1. The two target files hold their merge-base content, restored by the `git checkout "$BASE" --`
+       command above. `git diff --stat` shows changes confined to those two files.
+    2. Inject `await new Promise((r) => setTimeout(r, 250));` **between** the triggering action and
+       the listener registration at:
+       - `ticker-search-gaps.spec.ts:22` → site `:38` (its mock returns a single 200 with empty
+         results; not an error, so `retry: 1` does not fire a second response), and
+       - `chart-edge-cases.spec.ts` → site `:72` (its `beforeEach` mock at `:32-40` `route.fulfill`s
+         a single 200 for ticker search).
+    3. `cd frontend && npx playwright test tests/e2e/ticker-search-gaps.spec.ts tests/e2e/chart-edge-cases.spec.ts --project="Desktop Chrome"` → **both injected tests FAIL**.
+    4. **These are the ONLY two valid injection targets.**
+       - `chaos-degradation.spec.ts:196` is **not** one: PR #981 (`8c27271`) already converted its
+         racy site; it is promise-first at `:231-237` and protected by FR-004, so restoring the
+         merge-base content cannot bring the old shape back, because the merge base already contains
+         that conversion (AR#2 D-02).
+       - The 6 status-only 503 sites and the 3 `requestfailed` sites are **unsound** targets:
+         `retry: 1` (`providers.tsx:48`) plus the blanket `page.route('**/api/**', …503)` keep
+         supplying a matching response, so the listener resolves however wide the gap. Their
+         non-reproduction is EXPECTED and falsifies nothing (AR#2 N-02).
+    5. **STOP CONDITION.** If either injected pre-fix test **passes**, the diagnosis is falsified.
+       Halt the feature, do not proceed to T021, and re-analyse. Recorded honestly in T022.
+
+- [ ] **T021** [US1] Same injection against **converted** code — MUST PASS (SC-003a)
+  - **Files**: temporary uncommitted patch to `frontend/tests/e2e/helpers/search-helpers.ts`
+    (depends on T020 passing its stop condition)
+  - **Satisfies**: SC-003(a)
+  - **The seam, named exactly.** Post-conversion, both injection targets are single
+    `await searchAndAwaitResponse(page, searchInput, ...);` calls. There is no "between the action
+    and the listener" position left in the spec file. The only position after the action visible
+    there is after the helper has already awaited its response. A delay placed there proves nothing
+    and passes trivially, which would let this half of the primary gate be marked green by an
+    implementation that tests nothing. So the patch goes **inside the helper**:
+    ```ts
+    // frontend/tests/e2e/helpers/search-helpers.ts (TEMPORARY, never committed)
+    await searchInput.fill(query);
+    await new Promise((r) => setTimeout(r, 250));   // <-- injected here, and only here
+    await responsePromise;
+    ```
+    That is the same 250ms gap T020 injected, moved to the one place it can still be observed: after
+    the triggering action, before the await. It passes only because the listener was registered
+    before the fill.
+  - **Acceptance criteria**:
+    1. The Phase C conversions are back in the tree:
+       `git checkout HEAD -- frontend/tests/e2e/ticker-search-gaps.spec.ts frontend/tests/e2e/chart-edge-cases.spec.ts`,
+       and `git status` shows those two files clean before the patch goes in.
+    2. `await new Promise((r) => setTimeout(r, 250));` is inserted into
+       `frontend/tests/e2e/helpers/search-helpers.ts`, on its own line **between** the
+       `await searchInput.fill(query);` line and the `await responsePromise;` line.
+    3. **The patched file MUST be `search-helpers.ts`.** A patch applied in a `.spec.ts` file does
+       **NOT** satisfy this task, regardless of what the run reports. Verify with
+       `git diff --name-only` before running: it must list `search-helpers.ts` and nothing else.
+    4. `cd frontend && npx playwright test tests/e2e/ticker-search-gaps.spec.ts tests/e2e/chart-edge-cases.spec.ts --project="Desktop Chrome"` → **both tests PASS**.
+    5. **Negative control, and it is a hard gate.** The same helper-side delay must *discriminate*
+       between the two shapes. Run it twice, changing only the helper's statement order:
+       - **PRE-FIX shape**: inside the helper, move `const responsePromise = page.waitForResponse(…)`
+         to *below* `await searchInput.fill(query);`, keeping the 250ms delay between them. The two
+         target tests MUST **FAIL**.
+       - **POST-FIX shape**: restore the promise-first order, keep the same 250ms delay. The two
+         target tests MUST **PASS**.
+
+       **If both runs pass, the injection is landing in the wrong place and the result is void.**
+       T021 is not satisfied, no pass is recorded, and the injection is re-sited and re-run. A delay
+       that cannot make the pre-fix shape fail is not measuring ordering.
+    6. Together with T020 this demonstrates the conversion **removes** the race rather than reducing
+       its probability — which a green contention run alone cannot show.
+    7. The injection patch is reverted:
+       `git checkout HEAD -- frontend/tests/e2e/helpers/search-helpers.ts`. `git status` is clean of
+       it before any commit.
+
+- [ ] **T022** [US1] Record the fault-injection result honestly, including the stop condition
+  - **Files**: `specs/001-waitforresponse-race-sweep/tasks.md` (`## Execution Log` section below) (depends on T020, T021)
+  - **Satisfies**: SC-003(a) — the falsifiability half
+  - **Acceptance criteria**:
+    1. The log records, for each of the two sound targets: the injected delay, the pre-fix result,
+       the post-fix result, and the exact command.
+    2. **If pre-fix code did NOT fail under injection at either sound target, that is written down as
+       a falsification of the diagnosis, the sweep is halted, and no "fixed" claim is made
+       anywhere** — not in the commit message, not on the board, not in the PR description. Reporting
+       green after a failed injection fails this task outright.
+    3. The log states plainly that the 6 status-only and 3 `requestfailed` sites were **not** validated
+       by injection and are covered by contention (T023) only, so a future reader does not mistake
+       partial coverage for full coverage.
+    4. No overstatement. The spec exists to correct an overstated board claim; an overstated result
+       here reproduces the exact failure mode (AR#1 self-defeat check).
+    5. `git status` confirms the injection patch was never committed, specifically that
+       `frontend/tests/e2e/helpers/search-helpers.ts` carries no injected delay and no flipped
+       statement order.
+
+- [ ] **T023** [US1] Contention run across every affected file (SC-003b)
+  - **Files**: none modified (depends on T021)
+  - **Satisfies**: SC-003(b)
+  - **Acceptance criteria**:
+    1. `cd frontend && npx playwright test tests/e2e/chaos-degradation.spec.ts tests/e2e/chaos-scenarios.spec.ts tests/e2e/chart-edge-cases.spec.ts tests/e2e/ticker-search-gaps.spec.ts tests/e2e/chaos-cross-browser.spec.ts tests/e2e/chaos-error-boundary.spec.ts --project="Desktop Chrome" --repeat-each=20 --workers=8`
+    2. **20/20 for every affected test.** A single flake fails this task; it is not retried away.
+    3. The file list **MUST** include `chaos-cross-browser.spec.ts` and
+       `chaos-error-boundary.spec.ts` — they call `triggerHealthBanner` (`:35`, `:63`) and are in the
+       helper's blast radius (AR#2 N-03) — and `chaos-scenarios.spec.ts`.
+    4. This is the **only** verification the 6 status-only and 3 `requestfailed` sites receive, since
+       injection is unsound on them. Record that scoping alongside the result.
+    5. A mis-scoped predicate from T010 surfaces here as a nondeterministic pass rather than a clean
+       failure — inspect the T010 sites specifically if any repeat is red.
+    6. **Record total wall-clock for the six-file run and compare it against the CI hard wall.**
+       `.github/workflows/pr-checks.yml` wraps the Playwright step in `timeout 900` (15 minutes) with
+       `timeout-minutes: 20` on the job, and this feature raises roughly ten tests from a 30s cap to
+       a 60s cap. Raised caps do not cost time on green runs, but they double the cost of every red
+       one, and the `timeout 900` kill is a silent, uninformative failure mode. Log the single-pass
+       wall-clock (not the `--repeat-each=20` total) alongside the contention result, and flag it if
+       it is within 30% of 900s. This is a recorded observation, not a pass/fail bar. The sweep is
+       not gated on it, but a future reader needs the number.
+
+- [ ] **T024** [P] [US1] Test-count parity (SC-004)
+  - **Files**: none modified (depends on T023)
+  - **Satisfies**: SC-004
+  - **Acceptance criteria**:
+    1. Post-sweep passed / failed / skipped tallies compared against the T003 baseline.
+    2. Identical **except** that failures become passes. Any drop in `passed`, any new `skipped`, or
+       any deleted test fails this task.
+    3. `git diff` shows no new `test.skip`, `test.fixme`, `test.only`, or deleted `test(` block
+       across `frontend/tests/e2e/`.
+    4. No assertion was weakened to reach green — cross-checked against T010/T011's declared
+       predicate changes, which are the only intentional predicate edits in the feature.
+
+- [ ] **T025** [P] [US1] Scope-confinement audit (FR-007)
+  - **Files**: none modified (depends on Phase C, Phase E)
+  - **Satisfies**: FR-007
+  - **Acceptance criteria**:
+    1. `git diff --name-only main...HEAD` lists **only**: paths under `frontend/tests/e2e/`,
+       `scripts/scan-waitforresponse-race.py`, `CLEANUP-BOARD.html`, and
+       `specs/001-waitforresponse-race-sweep/`.
+    2. **Zero** paths under `frontend/src/` — no product-code change to search, caching, or the
+       health banner.
+    3. No workflow file is touched. `.github/workflows/pr-checks.yml` is unchanged, so the Playwright
+       E2E job stays non-required (FR-009, Out of Scope).
+    4. No `package.json` / `package-lock.json` change — no new dependency (plan Technical Context).
+    5. Every commit on the branch is GPG-signed: `git log --show-signature main...HEAD` shows a good
+       signature on each, and no commit was made with `--no-verify`.
+
+---
+
+## Phase E — Board (FR-008, FR-009, SC-005, US3)
+
+**Method (all three tasks)**: JSON surgery, not regex. `raw_decode` the array after `const CARDS = `,
+mutate card-by-card in Python, re-dump with `json.dumps(..., ensure_ascii=False)` at default
+separators, splice back, then re-parse and re-count. The file is in git; a corrupt write is
+recoverable, a silently mangled card is not.
+
+- [ ] **T026** [P] [US3] Correct the two existing cards (FR-008)
+  - **Files**: `CLEANUP-BOARD.html`
+  - **Satisfies**: FR-008, US3 acceptance scenarios 1 and 2
+  - **Acceptance criteria**:
+    1. **Card "Playwright E2E red on every PR: chaos-degradation banner-reappear test times out"**:
+       - The claim *"fails on main and every PR (observed 2026-07-30 on the #977/#978/#979 runs)"* is
+         **removed**. It is false — Playwright was **green** on those main runs. The job is
+         intermittently red on PRs, not persistently red on main.
+       - Replaced with the verified rate and its sampling method: **5 of 25 runs (~20%)** attributable
+         to this race class, sampled from the 30 most recent `PR Checks` runs as of 2026-07-30, of
+         which 25 executed the Playwright job; 6 were red and 5 are attributable (the sixth,
+         `30460832567`, is the unrelated user-menu flake #950). The method MUST record that
+         `pr-checks.yml` runs with `--retries=0`, without which the rate is not re-derivable
+         (`nightly-e2e` does not pass it).
+       - The run/commit distinction is stated: `30512621168` is a `push` run whose sibling
+         `pull_request` run on the same commit (`30512623219`) passed, so ~20% describes **runs**,
+         not commits.
+       - Re-scoped from one test to **this sweep**: 27 sites across 5 files, not
+         `chaos-degradation.spec.ts:196` alone. That test's cited site `:229` was already fixed by
+         PR #981 (`8c27271`).
+       - `next_action` rewritten to point at this feature branch.
+    2. **Card "MASTER: CI/CD hygiene"**: its `evidence` children list currently ends with *"Playwright
+       pr-checks job red on every PR (chaos-degradation flake, non-required so silent)"*. That child
+       entry is rewritten to the same corrected framing (~20% attributable across sampled PR runs,
+       race-class sweep, main was green). The rest of the children list is left untouched.
+    3. **Card count is unchanged by this task** — both are in-place edits.
+    4. Rationale recorded in the commit message: the board is the campaign's ground truth, and a card
+       asserting "fails on main" when the cited main runs were green corrodes trust in every other
+       card (US3).
+
+- [ ] **T027** [US3] Add the two follow-up cards (FR-009)
+  - **Files**: `CLEANUP-BOARD.html` (depends on T026 — same file)
+  - **Satisfies**: FR-009
+  - **Acceptance criteria**:
+    1. **Card 1 — merge-required follow-up decision.** Records the owner's deferred decision on making
+       the Playwright E2E job merge-required. Evidence: the job's ~20% attributable false-red rate is
+       what blocks the decision; this sweep removes the blocker. Cites
+       `.github/workflows/pr-checks.yml` and this feature branch. `next_action`: revisit after the
+       sweep has been green across several PR runs. **This feature MUST NOT change the job's required
+       status** — the card records the decision, it does not make it.
+    2. **Card 2, dead chaos-mock traps (ONE card covering BOTH instances).** They are the same
+       class: a mock that does not do what its surrounding code claims, with tests passing because
+       of it rather than despite it. Keeping them on one card holds the count at 118 → 120.
+       - **Instance A, `dynamodb_throttle` dead branch.** `chaos-helpers.ts:169-189` has
+         byte-identical `if`/`else` branches, both returning 503, despite the `else` comment claiming
+         *"Read operations may still succeed (cached)"* (verified in tree). Three of the 27 swept
+         sites (`chaos-scenarios.spec.ts:102/105/108`) resolve **only** because that dead branch also
+         returns 503. If the comment-to-code mismatch is ever corrected so reads succeed, those three
+         waits break.
+       - **Instance B, dead sentiment route.** `chaos-degradation.spec.ts:153` registers
+         `page.route('**/api/v2/sentiment**', … 503)`, but the app's sentiment URLs are
+         `/api/v2/tickers/{ticker}/sentiment/history` and `/api/v2/configurations/{id}/sentiment`.
+         Neither contains the literal segment `/api/v2/sentiment`, so the glob **never matches** and
+         no 503 is ever produced. The test titled `'cross-endpoint success prevents banner despite
+         other endpoint failures'` therefore passes vacuously: it asserts no banner appears in a
+         scenario where nothing fails. Fixing the glob would make the test assert what its title
+         claims, and may well turn it red.
+       - `next_action`: fix both mocks in one change and re-verify the tests that depend on them:
+         the three `chaos-scenarios` waits for A, the cross-endpoint test for B.
+       - **This feature MUST NOT fix either one.** Both are recorded, not repaired (FR-009).
+    3. Both cards use the existing card schema keys: `title`, `lane`, `severity`, `evidence`,
+       `citation`, `next_action`, `source` (verified against the current array).
+    4. Card count goes **118 → 120**.
+
+- [ ] **T028** [US3] Validate the board (SC-005)
+  - **Files**: none modified (depends on T026, T027)
+  - **Satisfies**: SC-005
+  - **Acceptance criteria**:
+    1. The `CARDS` array literal still parses:
+       ```bash
+       python - <<'PY'
+       import json
+       s = open('CLEANUP-BOARD.html').read()
+       i = s.index('const CARDS = ') + len('const CARDS = ')
+       cards, _ = json.JSONDecoder().raw_decode(s[i:])
+       print('cards:', len(cards))
+       PY
+       ```
+       prints `cards: 120`.
+    2. Baseline confirmed: the pre-edit count is **118** (verified in tree at branch start).
+    3. The board opens in a browser and renders with **no console error** — a parse that succeeds in
+       Python but breaks the page's own JS still fails this task.
+    4. Spot-check the two edited cards render with their corrected text and the two new cards appear
+       in their lanes.
+    5. `git diff CLEANUP-BOARD.html` touches only the `CARDS` array — no incidental reformatting of
+       the surrounding HTML, CSS, or unrelated cards.
+
+---
+
+## Dependencies & Execution Order
+
+```
+Phase A (T001 → T002; T003 [P])
+        │
+        ▼
+Phase B (T004)
+        │
+        ▼
+Phase C, order MANDATORY:
+  T005 chart-edge-cases
+   └─► T006 ticker-search-gaps
+        └─► T007 → T008 → T009  chaos-scenarios
+             └─► T010 → T011 → T012  chaos-degradation (+ helper-side setTimeout)
+                  └─► T013 → T014  chaos-helpers  ◄── LAST (triggerHealthBanner precondition)
+                       └─► T015 [P] T016 [P] T017 [P]  guards
+        │
+        ▼
+Phase D (T018 → T019 → T020 → T021 → T022 → T023 → T024 [P] / T025 [P])
+        │
+Phase E (T026 → T027 → T028)  ── independent of Phase D, may run alongside
+```
+
+### Why the Phase C order is not negotiable
+
+`chaos-helpers.ts` (T013/T014) is last because `triggerHealthBanner` is a precondition of the whole
+chaos suite. Its blast radius is every chaos test in six importing files plus the two unedited
+callers, so it must be validated against **already-converted** callers. Converting it first would
+mean a chaos-suite failure could originate in the helper or in an unconverted caller, with no way to
+tell which. Everything above it is ordered smallest blast radius first: `chart-edge-cases` (4 sites,
+self-contained mocks) → `ticker-search-gaps` (9 sites, self-contained) → `chaos-scenarios`
+(6 sites, shared chaos scenarios) → `chaos-degradation` (5 sites, the highest-risk predicates).
+
+### Parallel Opportunities
+
+- **T003** with T001/T002 — no shared files.
+- **T015 / T016 / T017** — read-only audits over different concerns, after Phase C.
+- **T024 / T025** — read-only audits, after T023.
+- **Phase E (T026–T028)** with all of Phase D — disjoint files (`CLEANUP-BOARD.html` vs test sources).
+- **T005 and T006** touch disjoint files and have no code dependency, but the stated order is
+  preserved deliberately (blast-radius sequencing) and they are **not** marked `[P]`.
+
+---
+
+# Coverage Analysis
+
+Produced after task generation, non-destructively. Every claim below was checked against the working
+tree at `frontend/tests/e2e/` and `CLEANUP-BOARD.html`, not against the artifacts alone.
+
+## 1. Requirements coverage
+
+### Functional requirements
+
+| Req | Summary | Tasks | Status |
+|---|---|---|---|
+| FR-001 | All 27 racy sites converted | T005, T006, T007, T008, T010, T011, T013 (impl); T017 (27 = 18+9 count); T018 (verify RACY 0) | COVERED |
+| FR-002 | No weakening; tighten where the window widens; declare meaning changes | T005 (no widening, justified), T006 (no widening), T007 (exception, risk restated), T008 (exception), T010 (**tightening**, declared), T011 (**narrowing**, declared), T013 (exception) | COVERED |
+| FR-003 | `chaos-scenarios.spec.ts:138` left unconverted with recorded reason | T007 crit. 5 (byte-unchanged + reason recorded); T018 crit. 4 (scan reports `OTHER`) | COVERED |
+| FR-004 | 6 already-correct sites unmodified | T006 crit. 4, T007 crit. 6, T016 (dedicated audit) | COVERED |
+| FR-005 | Predicate-parameterised helper; `triggerHealthBanner` stays status-only; docstring corrected | T004 (helper + G3), T013 (status-only retained), T014 (**docstring**, its own task by requirement) | COVERED |
+| FR-006 | 15000ms per call + `test.setTimeout(60000)` above two waits | T004 crit. 5 (default), T005–T008/T010/T011/T013 (explicit 15000), T009 (chaos-scenarios), T012 (`chaos-degradation`'s cross-endpoint test + the helper-side `Math.max` raise covering all 7 `triggerHealthBanner` callers, leaving the 2 outside callers byte-unchanged) | COVERED |
+| FR-007 | No product code; confinement + named exceptions | T025 (dedicated audit) | COVERED |
+| FR-008 | Two existing board cards corrected | T026 | COVERED |
+| FR-009 | Two follow-up cards added; job stays non-required; dead branch not fixed | T027 (both cards), T013 crit. 6 (dead branch untouched), T025 crit. 3 (no workflow edit) | COVERED |
+| FR-010 | Cache-served sites identified and left alone | T006 crit. 3 (`:242-247` hold-out), T015 (dedicated audit) | COVERED |
+| FR-011 | Scan committed, rule documented in-script, both APIs, non-zero exit on RACY | T001 (all four obligations as separate criteria); T002 + T018 exercise both exit branches | COVERED |
+| FR-012 | Success-path await; helper's internal guarantee; no `try/finally` requirement at the inline sites | T004 crit. 3 (G2 as a checkable code shape: `try`/`finally` or `.catch` at creation), T017 (dedicated audit incl. the deliberate absence of `try/finally` inline) | COVERED |
+
+### Success criteria
+
+| Criterion | Summary | Verification tasks | Status |
+|---|---|---|---|
+| SC-001 | Scan reports RACY 0 / PF 16 / OTHER 1, total 17; exactly 18 helper call sites | **T002** (before: 27/6/1, total 34), **T018** (after, both halves) | COVERED |
+| SC-002 | Suite passes locally — precondition, non-evidential | **T019** (incl. an explicit criterion forbidding its citation as evidence) | COVERED |
+| SC-003(a) | Fault injection at the two sound targets; pre-fix FAILS, post-fix PASSES | **T020** (pre-fix + stop condition), **T021** (post-fix), **T022** (honest record) | COVERED |
+| SC-003(b) | Contention 20/20 across all affected files | **T023** (file list includes `chaos-cross-browser`, `chaos-error-boundary`, `chaos-scenarios`) | COVERED |
+| SC-004 | Test count unchanged; nothing skipped, deleted, or weakened | **T003** (baseline), **T024** (comparison) | COVERED |
+| SC-005 | `CARDS` parses, board renders, 118 → 120 | **T028** | COVERED |
+
+**Gaps found: 0.** Every FR-001…FR-012 has at least one implementing task and every SC-001…SC-005 has
+at least one dedicated verification task. Four requirements that are easy to lose as incidental edits
+were given **their own tasks** rather than being folded into a neighbour, because a criterion buried
+in another task's acceptance list is a criterion that gets skipped: T014 (docstring, required by
+FR-005 to be carried explicitly), T022 (honest injection record incl. the stop condition), T015
+(FR-010 cache-served audit), T017 (FR-012 await audit).
+
+## 2. Reverse check — tasks that trace to nothing
+
+Every task traces. No scope creep found.
+
+| Task | Traces to |
+|---|---|
+| T001, T002 | FR-011, SC-001 |
+| T003 | SC-004 (baseline half) |
+| T004 | FR-005, FR-006, FR-012, US2 |
+| T005–T008, T010, T011, T013 | FR-001, FR-002, FR-005, FR-006, FR-012 |
+| T009, T012 | FR-006 |
+| T014 | FR-005 ("Consequence of the FR-002 exception") |
+| T015 | FR-010 |
+| T016 | FR-004, spec C5 |
+| T017 | FR-012 |
+| T018–T024 | SC-001…SC-004 |
+| T025 | FR-007, FR-009 (job stays non-required) |
+| T026 | FR-008, US3 |
+| T027 | FR-009 |
+| T028 | SC-005 |
+
+Two tasks warrant a note because they sit closest to the scope-creep line:
+
+- **T012** touches exactly two files: `frontend/tests/e2e/chaos-degradation.spec.ts` and
+  `frontend/tests/e2e/helpers/chaos-helpers.ts`. It does **not** edit
+  `chaos-cross-browser.spec.ts` or `chaos-error-boundary.spec.ts`. The raise for
+  `triggerHealthBanner`'s three waits lives inside the helper, so all seven callers inherit it and
+  those two files stay byte-unchanged. T012 crit. 3 requires their diff to be empty. It traces to
+  FR-006's normative rule, not to creep. See CX-3.
+- **T022** produces a written record rather than code. It traces to SC-003(a), whose entire value is
+  the falsifiable stop condition — a gate with no recorded outcome is not a gate.
+
+## 3. Cross-artifact consistency check
+
+### Numbers that agree (verified against the tree, not just the documents)
+
+| Claim | Artifacts asserting it | Tree verification | Result |
+|---|---|---|---|
+| 27 racy sites | spec.md:83, plan.md:8/31, research.md:51, data-model.md:36 | 4 (`chart-edge-cases`) + 9 (`ticker-search-gaps`) + 5 (`chaos-degradation`) + 3 (`chaos-helpers`) + 3 + 3 (`chaos-scenarios`) = **27** | AGREE |
+| 34 total inline sites | spec.md:64-65, data-model.md:38, quickstart.md:12 | 41 grep hits − 7 comment lines = **34** | AGREE |
+| 18 helper-routed + 9 inline | spec.md:113, plan.md:8/106-109, research.md:48, contracts N3 | 4+9+5 = **18**; 3+3+3 = **9** | AGREE |
+| 6 already-correct, protected | spec.md:85-87 | `chaos-degradation:231`, `chaos-scenarios:251`, `error-visibility-search:142`/`:157`, `ticker-search-gaps:231`/`:237` = **6** | AGREE |
+| 1 triaged `OTHER` | spec.md:89, data-model.md:37 | `chaos-scenarios.spec.ts:138`, `page.reload()` then `expect(...).toBeVisible({timeout:2000})` then the wait — confirmed intervening assertion | AGREE |
+| Baseline 34 → target 17 | data-model.md:33-38, quickstart.md:12-13, SC-001 | 16 PF (6+6+3+1) + 1 OTHER = **17**; arithmetic closes | AGREE |
+| Board 118 → 120 | spec.md SC-005, plan.md:156, quickstart.md:122 | `raw_decode` on the live file returns **118** cards | AGREE |
+| 5 files converted | plan.md:31 | `chart-edge-cases`, `ticker-search-gaps`, `chaos-scenarios`, `chaos-degradation`, `chaos-helpers` = **5** | AGREE |
+| 24 `route.fulfill` + 3 `route.abort` | spec.md:20-24, research.md:25-27 | `dynamodb_throttle` and `triggerHealthBanner` both `route.fulfill`; `api_timeout` aborts → 24 + 3 = **27** | AGREE |
+| No top-level test timeout | spec.md:243, plan.md:28, research.md:90 | `frontend/playwright.config.ts` — the only `timeout` keys are at `:67`/`:76`, both under `webServer` | AGREE |
+| Both `triggerHealthBanner` outside callers | plan.md:92-93, quickstart.md:38 | `chaos-cross-browser.spec.ts:35`, `chaos-error-boundary.spec.ts:63` | AGREE |
+| `dynamodb_throttle` branches byte-identical | spec.md:361-364, FR-009 | `chaos-helpers.ts:169-189` — both branches fulfil 503 with the same body | AGREE |
+
+### Disagreements found — 4 (CX-1 and CX-3 now CLOSED in the artifacts, not just in tasks)
+
+- **CX-1 (MEDIUM), `contracts/helper-api.md:4`. CLOSED, no action left.** An earlier draft of the
+  contract stated *"Consumers: the 18 URL-scoped ticker-search wait sites across **4 spec files**."*
+  **The contract has already been corrected** and now reads "across 3 spec files". Nothing further is
+  required of any task. The reasoning is preserved below because the arithmetic is worth keeping:
+  there are **3** spec files, not 4:
+  `chart-edge-cases.spec.ts` (4) + `ticker-search-gaps.spec.ts` (9) + `chaos-degradation.spec.ts` (5)
+  = 18. The fourth file a reader would reach for is `chaos-scenarios.spec.ts`, whose 6 sites are
+  explicitly **inline** and explicitly **not** helper consumers by the same contract's own N3
+  (`contracts/helper-api.md:72-76`). The site count (18) was correct everywhere; only the file count
+  was wrong. **Closed twice over**: the contract line now reads "3 spec files", and T018 crit. 7
+  independently states "across **3** spec files, not 4".
+
+- **CX-2 (MEDIUM) — `spec.md:248-250` and `research.md:94-96`.** FR-006's normative rule is "any test
+  containing more than two converted waits MUST get an explicit `test.setTimeout(60000)`". Its
+  illustrative list then names only *"tests that call `triggerHealthBanner`"* and *"the three-search
+  sequences (`chaos-scenarios.spec.ts:102/105/108` and `:219/222/225`)"*. That list **omits
+  `chaos-degradation.spec.ts:148`** ('cross-endpoint success prevents banner despite other endpoint
+  failures'), which is itself a three-search sequence containing three converted waits at
+  `:178/:183/:188` (verified in tree). The rule captures it; the enumeration does not. A reader
+  implementing from the list alone would leave that test on the default 30s cap with three 15s
+  waits — the exact opaque-timeout outcome FR-006 exists to prevent. **Closed in tasks**: T012
+  crit. 1 and 2 add it and record that the rule governs the list.
+
+- **CX-3 (was HIGH), `plan.md:92-93` vs `spec.md:248-250`. RESOLVED BY DESIGN, no escalation
+  needed.** The apparent conflict was: the plan's Source Code tree labels `chaos-cross-browser.spec.ts`
+  and `chaos-error-boundary.spec.ts` **"UNCHANGED BUT AFFECTED"**, while FR-006 requires
+  `test.setTimeout(60000)` on tests that call `triggerHealthBanner`, and both files do (`:35`, `:63`).
+  Read as a per-caller obligation, both files would have to be edited and the labels would be wrong.
+
+  **The per-caller reading is superseded.** The raise goes **inside `triggerHealthBanner`** itself:
+  `chaos-helpers.ts` already imports from `@playwright/test`, so it imports `test` and calls
+  `test.setTimeout(Math.max(test.info().timeout, 60000))` on entry. All seven `triggerHealthBanner`
+  callers inherit the raised cap, and the two outside callers stay **byte-unchanged**. This is the
+  design recorded in spec.md FR-006 ("Where `test.setTimeout(60000)` goes") and in T012's Design
+  note; per-caller raises were explicitly rejected there because they grow the diff and leave the
+  rule for a future caller to remember.
+
+  Consequences:
+  - **`plan.md:92-93` is correct as written.** The "UNCHANGED BUT AFFECTED" labels stand. No plan
+    edit is required, and the earlier demand to restate the count as "7 modified files" is **wrong**
+    and is withdrawn. The modified-file count remains **5 converted + the 2 new files**, with
+    `chaos-cross-browser.spec.ts` and `chaos-error-boundary.spec.ts` outside it.
+  - **No owner escalation is needed.** The earlier note calling for "the plan correction or an owner
+    escalation before proceeding" referred to a T012 criterion that does not exist and to a plan
+    change that must not be made. Withdrawn.
+  - **T012 has FOUR original criteria plus a fifth added for the type check.** Its **crit. 3**
+    requires `git diff --stat` on those two files to be **empty**, the opposite of editing them.
+    That criterion is the check that the helper-side design actually landed. Any reference elsewhere
+    to "T012 crit. 3-6" or "crit. 5 requiring an owner escalation" is stale and has been deleted.
+
+  Downgraded from HIGH to CLOSED: the disagreement does not change the diff's shape, because the
+  design that removes it was already applied to the task body.
+
+- **CX-4 (LOW) — `quickstart.md:21` vs `spec.md:302` (SC-001).** SC-001 requires *"exactly 18
+  `searchAndAwaitResponse(` call sites MUST exist under `frontend/tests/e2e/`"*. The quickstart's
+  command scopes with `--include="*.spec.ts"`. That filter is **required**, not incidental: the
+  helper's own definition line `export async function searchAndAwaitResponse(` lives in
+  `helpers/search-helpers.ts` and matches the pattern, so an unfiltered grep over
+  `frontend/tests/e2e/` returns **19**, not 18. (Import lines do not match — they carry no open
+  paren.) The command is right and the SC wording is loose. Anyone verifying SC-001 literally from
+  the spec text will read a failure that is not there. **Closed in tasks**: T018 crit. 6 states the
+  filter is load-bearing and names the 19-vs-18 trap.
+
+### Consistency notes that are not disagreements
+
+- **FR-005 vs contract N3, mild tension.** FR-005 says the helper must accept a caller-supplied
+  predicate *"so that non-search callers are not forced onto a search-scoped one"*, which reads as
+  though non-search callers might use it. N3 says the helper *"is not used by the 9 non-search
+  sites"*. Both are true in outcome — the parameterisation exists so the helper **could** serve them,
+  and the design chooses inline conversion anyway. No task change needed; noted so a future reader
+  does not read N3 as a contradiction of FR-005.
+- **`.clear()` vs `fill('')` at `ticker-search-gaps.spec.ts:219`.** The contract's `clearFirst`
+  performs `fill('')` (`contracts/helper-api.md:26`); the original at that site uses
+  `searchInput.clear()`. **Not a behavioural change**: Playwright documents `locator.clear()` as
+  equivalent to `fill('')`. An earlier draft treated this as a substitution needing a declaration and
+  offered a keep-the-`.clear()` fallback; both were over-cautious and have been removed. T006 crit. 2
+  now carries it as a one-line commit-message note with no fallback.
+- **Stale test comment**, `ticker-search-gaps.spec.ts:37` — *"Wait for debounced search response"*.
+  Same false-debounce premise as the product comment at `ticker-input.tsx:33` that misled an earlier
+  spec draft (AR#1 F-09). The product comment is Out of Scope; this test comment disappears with the
+  conversion. Covered by T006 crit. 6, which forbids replacing it with another debounce claim.
+
+## 4. Summary
+
+**Gaps found: 0** across FR-001…FR-012 and SC-001…SC-005 — no requirement needed a task added to
+close a hole, because the four highest-drop-risk obligations were promoted to standalone tasks
+during generation (T014, T015, T017, T022) rather than left as sub-criteria.
+
+**Cross-artifact disagreements found: 4** (CX-1 through CX-4). All four are closed, and **none of
+them now requires an artifact edit or an owner decision**:
+
+1. **CX-1**: `contracts/helper-api.md:4` already reads "3 spec files". Corrected in the contract;
+   T018 crit. 7 states the same number independently. Nothing outstanding.
+2. **CX-3**: resolved by the helper-side `test.setTimeout` design, not by a plan edit.
+   `plan.md:92-93`'s "UNCHANGED BUT AFFECTED" labels are **correct as written** and must not be
+   changed. The modified-file count stays 5; no escalation is needed. See the rewritten CX-3 entry.
+3. **CX-2**: `spec.md`/`research.md`'s FR-006 enumeration omits `chaos-degradation`'s cross-endpoint
+   test. Safe to leave: T012 crit. 2 adds it and records that the rule, not the list, governs.
+4. **CX-4**: SC-001's grep wording is loose. Safe to leave: T018 crit. 6 names the filter and the
+   19-vs-18 trap.
+
+---
+
+## Execution Log
+
+*(populated during implementation — T002 baseline, T003 tally, T022 injection record)*
+
+| Task | Date | Result |
+|---|---|---|
+| T002 | | |
+| T003 | | |
+| T018 | | |
+| T020 | | |
+| T021 | | |
+| T022 | | |
+| T023 | | |
+| T024 | | |
+| T028 | | |
+
+---
+
+## Adversarial Review #3
+
+An independent implementation-readiness review, run against the task list rather than against the
+spec: the question was not "is the plan right" but "can someone execute this without guessing". Two
+design decisions were verified against Playwright's own source and against the tree rather than
+taken on trust. First, that `test.setTimeout()` called from a helper module resolves through
+`currentTestInfo()` and therefore affects only the currently running test, which is what makes the
+helper-side raise in T012 sound rather than a global side effect. Second, that both named
+fault-injection targets produce exactly one matching response, which is what makes T020's stop
+condition falsifiable instead of noisy. The review initially returned **BLOCKED**, on three grounds:
+stale line anchors that Phase C's own edits would invalidate, a Coverage Analysis generated against
+a superseded design decision, and a fault-injection task whose criteria could be satisfied by an
+implementation that tested nothing.
+
+### Findings
+
+| ID | Sev | Finding | Resolution |
+|---|---|---|---|
+| F-01 | CRITICAL | Line numbers cited by T008, T009, T011, T012, T013, T014 and T018 are pre-sweep. Phase C edits top-down and every conversion is net line-additive, so downstream lines drift before the task that cites them runs. T018 is the worst case: it pins **post**-sweep scan output to **pre**-sweep lines, so the SC-001 gate would read as a failure that is not there. | Standing note added near the top declaring all line numbers PRE-SWEEP locators against `8c27271`. Every affected task gained a **Site identification** block matching on file + quoted original statement + enclosing test or function name. T018 rewritten entirely as per-file counts plus enclosing names, with the line-pinning trap called out explicitly. |
+| F-02 | CRITICAL | Coverage Analysis contradicted the current T012. Section 2 said T012 edits `chaos-cross-browser.spec.ts` and `chaos-error-boundary.spec.ts`; CX-3 said "T012 applies the timeout to all four files", cited a nonexistent "crit. 3-6" and a "crit. 5" demanding owner escalation, and demanded plan.md be restated as "7 modified files". T012's body had already moved the raise inside `triggerHealthBanner`, and its crit. 3 requires those two files' diff to be **empty**. An implementer could act on either reading. | CX-3 rewritten: the helper-side raise supersedes the per-caller design, `plan.md:92-93` is correct as written, no owner escalation needed, and every reference to a T012 criterion number that does not exist is deleted. Section 2's file list corrected. CX-1 marked already closed (the contract already reads "3 spec files"). Section 4 summary rewritten to show zero outstanding artifact edits. |
+| F-03 | CRITICAL | T021 said "apply an equivalent 250ms delay after the action". Post-conversion both targets are single `searchAndAwaitResponse(...)` calls, so the only "after the action" position in the spec file is after the helper has already awaited. A delay there proves nothing and passes trivially, and half the primary gate could be marked green by an implementation that tests nothing. | T021 now names the file and the seam: patch `helpers/search-helpers.ts`, inserting the delay between `await searchInput.fill(query);` and `await responsePromise;`. Added an acceptance criterion that the patched file MUST be `search-helpers.ts` and that a `.spec.ts` patch does NOT satisfy the task, plus a negative control: the same delay must FAIL on the pre-fix shape and PASS on the post-fix shape, and if both pass the result is void. |
+| F-04 | HIGH | T020/T021 said "stash the Phase C conversions", but every Phase C task commits, so `git stash` has nothing to stash. The restoration step was inoperable. | Replaced with `git checkout $(git merge-base main HEAD) -- <files>` to get pre-fix content and `git checkout HEAD -- <files>` to restore, with the specific files named for each target. |
+| F-05 | HIGH | Contract G2 promised no dangling listener can become an unhandled rejection, but if `searchInput.fill()` throws inside the helper, `responsePromise` is never awaited, so the guarantee was unachievable as stated. T004 crit. 3 checked "awaited on every return path", vacuous where there is exactly one return path. | Contract G2 reworded to describe what the code delivers, and the Behaviour section now requires a `try { … } finally { }` shape or a `.catch(() => {})` attached at creation. T004 crit. 3 checks that shape specifically, and notes that the helper is new code so FR-004 is no obstacle to doing it properly. |
+| F-06 | HIGH | T011 crit. 3 stated a false fact: "the 503s in this test come from the sentiment endpoint". The route glob `**/api/v2/sentiment**` matches none of the app's sentiment URLs, so no 503 is ever produced and the cross-endpoint test passes vacuously. | T011 crit. 3 corrected: the conversion is right and needs no query scoping, on stronger grounds than claimed (the search route's unconditional 200). T027 extended to card the dead route alongside the `dynamodb_throttle` dead branch, as one card covering both dead-mock traps, holding the count at 118 → 120. |
+| F-07 | MEDIUM | T012 and T013 both touch `helpers/chaos-helpers.ts`, imported by six spec files, two of which (`chaos-cached-data.spec.ts`, `chaos-accessibility.spec.ts`) appear in no verification command in the feature. Nothing covered them. | `npx tsc --noEmit` added as an acceptance criterion to both tasks, with the reason recorded. |
+| F-08 | MEDIUM | FR-006's "explicit 15000ms on every converted call" is unauditable at the 18 helper-routed sites, which pass no `timeout` argument and rely on the helper default. | FR-006 reworded: explicitly 15000ms at the 9 inline sites, via the helper's documented `timeout` default at the 18 helper-routed sites. |
+| F-09 | MEDIUM | FR-011's trigger-action token list omitted `.evaluate(`, `.type(`, `.check(`, `.tap(`, `.setInputFiles(`, `.dispatchEvent(`. A live instance already exists at `error-visibility-search.spec.ts:158`, which triggers via `retryButton.evaluate((el) => el.click())`. Unclassifiable shapes were also invisible in the output. | Token list extended in spec.md FR-011, data-model.md's classification rule, and T001 crit. 3. New T001 criterion requires `OTHER` sites to print under a "requires human triage" banner so unclassified shapes are visible rather than silently counted as clean. |
+| F-10 | MEDIUM | No task recorded suite wall-clock against the CI hard wall, while roughly ten tests are being raised from a 30s to a 60s cap. `pr-checks.yml` wraps the run in `timeout 900` with `timeout-minutes: 20`, and a `timeout 900` kill is a silent, uninformative failure. | T023 crit. 6 added: record single-pass wall-clock for the six-file run, compare against the 900s wall, flag if within 30%. Recorded observation, not a pass/fail bar. |
+| F-11 | MEDIUM | T006 crit. 2 and the Coverage Analysis treated `.clear()` → `fill('')` as a behavioural change needing a commit-message declaration, with a fallback to keep `.clear()` outside the helper. Playwright documents `locator.clear()` as equivalent to `fill('')`. | Downgraded to a one-line commit-message note in T006 crit. 2; the fallback removed. Coverage Analysis note corrected to match. |
+| F-12 | MEDIUM | T012's helper-side `test.setTimeout(60000)` is an unconditional override. `chaos-accessibility.spec.ts:29` sets a deliberate `test.setTimeout(30_000)` suite cap and that file imports `triggerHealthBanner`, so a bare call would silently *lower* it in one direction and raise it in the other. | T012 crit. 1 now requires `test.setTimeout(Math.max(test.info().timeout, 60000))`, which can only raise. |
+| F-13 | LOW | `spec.md` FR-005 cited the `triggerHealthBanner` docstring at `chaos-helpers.ts:345`; `:345` is the `export async function` line and the docstring occupies `:334-344`. | Citation corrected to `chaos-helpers.ts:334-344`. |
+| F-14 | LOW | T001 did not require `scripts/scan-waitforresponse-race.py` to declare which dashboard it targets. Two existing scripts (`scripts/audit-e2e-skips.py`, `scripts/check-false-pass-patterns.sh`) default to the admin pytest suite, and the repo has a documented history of confusing the two dashboards. | T001 crit. 11 added: the module docstring carries `# Target: Customer Dashboard (Next.js/Amplify)` and `--help` names `frontend/tests/e2e/` as the scanned root. |
+
+### Highest-risk task
+
+**T012.** A late design decision (raise inside `triggerHealthBanner` rather than per caller) was
+applied to the task body but not to the Coverage Analysis, which had been generated against the old
+decision. The two readings demanded opposite diffs (edit two extra files, or prove their diff is
+empty), and an implementer could reasonably have acted on either. Now resolved by F-02.
+
+### Most likely to be silently wrong
+
+**T021.** Its criteria were satisfiable by an implementation that tests nothing: a delay placed after
+an already-awaited helper call passes trivially and looks like evidence. This is the failure mode the
+whole feature exists to correct, reproduced inside the feature's own gate. Now resolved by F-03's
+named seam and negative control.
+
+### Gate
+
+**READY FOR IMPLEMENTATION. 0 CRITICAL, 0 HIGH remaining.**

--- a/specs/001-waitforresponse-race-sweep/tasks.md
+++ b/specs/001-waitforresponse-race-sweep/tasks.md
@@ -70,13 +70,34 @@ the baseline, because a baseline taken after a conversion is worthless.
        which **7 are comments** (`error-visibility-search.spec.ts:141`, `helpers/chaos-helpers.ts:338`,
        `helpers/chaos-helpers.ts:392`, `ticker-search-gaps.spec.ts:37`, `:230`, `:236`, `:243`).
        The script MUST report **34**, not 41.
-    5. Output names every site as `file:line CLASSIFICATION` plus a summary line with the four counts.
-    6. `sys.exit(1)` when `RACY > 0`; `sys.exit(0)` otherwise. Assert both branches by running the
-       script before and after Phase C (T002 → exit 1; T018 → exit 0).
+    5. Output names every site as `file:line CLASSIFICATION`, **on stdout**, plus a summary line
+       carrying **five** numbers: RACY, PROMISE-FIRST, OTHER, total, and **files scanned**. When
+       `RACY > 0`, the output additionally carries remediation guidance: a literal corrected example
+       showing `const <name>Promise = page.waitForResponse(...)` positioned *before* the triggering
+       action, then awaited after it. A developer whose commit is refused must be able to act on the
+       message without opening the spec.
+       *(Requirements 5, 6, 8 and 12 are shaped by the dependent regression-guard feature, which
+       consumes this script as a contract. See `specs/002-waitforresponse-lint-guard/contracts/detector-cli.md`.
+       They were folded in before implementation so the guard needs no modification to the script.)*
+    6. `sys.exit(1)` when `RACY > 0`. `sys.exit(0)` **only** when the scan examined at least one
+       file and found no `RACY` site. A scan that examines **zero files** exits **non-zero**,
+       whatever the reason — root missing, root renamed, root present but empty. A guard whose
+       target has moved must fail loudly rather than report a clean tree. Assert the `RACY > 0` and
+       clean branches by running the script before and after Phase C (T002 → exit 1; T018 → exit 0),
+       and assert the zero-file branch against an empty temporary directory.
     7. It classifies `chaos-scenarios.spec.ts:138` as `OTHER` (an intervening
        `await expect(...).toBeVisible({ timeout: 2000 })` separates its `page.reload()` from the wait).
        If it reports `RACY` there, the adjacency rule is not implemented correctly.
-    8. Runs under the project venv: `source .venv/bin/activate && python scripts/scan-waitforresponse-race.py`.
+    8. **Standard library only.** No third-party import, so the script runs under a bare `python3`
+       with no virtualenv and no installed dependencies. Verify in a stdlib-only sandbox:
+       `python3 -I -S scripts/scan-waitforresponse-race.py` must behave identically to a normal run.
+       (`-I -S` is the correct sandbox here. Clearing `VIRTUAL_ENV` leaves `.venv/bin` on `PATH`, and
+       `/usr/bin/python3` is 3.12 on the dev machine and 3.10 per CLAUDE.md, so neither alternative
+       is a faithful test.) It must also still run under the project venv:
+       `source .venv/bin/activate && python scripts/scan-waitforresponse-race.py`. The stdlib
+       constraint exists because the CI job that will enforce this script installs no project
+       dependencies; a single `import yaml` would put the guard permanently red in an environment
+       nobody is blocked by, which is how guards get skip-listed.
     9. NOT wired into pre-commit or any workflow (spec C4). `grep -rn "scan-waitforresponse-race" .pre-commit-config.yaml .github/` returns nothing.
     10. `OTHER` sites are printed under an explicit **"requires human triage"** banner, not folded
         into the summary counts alone. A shape the classifier cannot place must be *visible*, or it
@@ -88,6 +109,18 @@ the baseline, because a baseline taken after a conversion is worthless.
         **admin** pytest suite under `tests/`, and this repo has a documented history of confusing
         the two dashboards (CLAUDE.md, "Two Dashboards"). A reader must not have to open the source
         to learn which suite this scans.
+    12. **The scan root is fixed; file arguments are ignored.** Invoked with arbitrary paths as
+        positional arguments, the script still walks `frontend/tests/e2e/` and scans nothing else.
+        It MUST NOT accept a file list that narrows the scan. This is load-bearing for the dependent
+        guard: its pre-commit hook runs `pass_filenames: false` against an **untracked** planted
+        file, which a file-list-driven detector would never be handed and would silently report
+        clean. If argparse is used, do not add a positional `paths` argument.
+    13. **Interpreter floor asserted in-script.** The first executable statement checks
+        `sys.version_info >= (3, 13)` and, if not, prints the required version and exits non-zero.
+        The guard invokes this script as a bare `python3`, which resolves from the committing
+        shell's `PATH` — verified to be 3.12.3 on the dev machine with the venv off `PATH`, and
+        documented as 3.10 system-wide in CLAUDE.md. Without this check the guard runs the detector
+        under an unvalidated interpreter and the result is silently untrustworthy.
 
 - [ ] **T002** [US1] Capture the pre-sweep scan baseline (depends on T001)
   - **Files**: none modified; output recorded in the T001/T002 commit message and pasted into this

--- a/specs/001-waitforresponse-race-sweep/tasks.md
+++ b/specs/001-waitforresponse-race-sweep/tasks.md
@@ -905,7 +905,7 @@ tree at `frontend/tests/e2e/` and `CLEANUP-BOARD.html`, not against the artifact
 | FR-008 | Two existing board cards corrected | T026 | COVERED |
 | FR-009 | Two follow-up cards added; job stays non-required; dead branch not fixed | T027 (both cards), T013 crit. 6 (dead branch untouched), T025 crit. 3 (no workflow edit) | COVERED |
 | FR-010 | Cache-served sites identified and left alone | T006 crit. 3 (`:242-247` hold-out), T015 (dedicated audit) | COVERED |
-| FR-011 | Scan committed, rule documented in-script, both APIs, non-zero exit on RACY | T001 (all four obligations as separate criteria); T002 + T018 exercise both exit branches | COVERED |
+| FR-011 | Scan committed, rule documented in-script, both APIs, non-zero exit on RACY, **plus the consumed-interface obligations** (stdlib-only, stdout, files-scanned, non-zero on a zero-file scan, remediation guidance, fixed root, interpreter floor) | T001 — every obligation is a separate criterion (1–13); T002 + T018 exercise the RACY exit branches; T001 crit. 6 exercises the zero-file branch | COVERED |
 | FR-012 | Success-path await; helper's internal guarantee; no `try/finally` requirement at the inline sites | T004 crit. 3 (G2 as a checkable code shape: `try`/`finally` or `.catch` at creation), T017 (dedicated audit incl. the deliberate absence of `try/finally` inline) | COVERED |
 
 ### Success criteria


### PR DESCRIPTION
Specification-only. No code, no behaviour change. Implementation is a separate PR.

## What this specs

~27 `waitForResponse` act-then-wait race sites in `frontend/tests/e2e/*.spec.ts`, where a listener is
registered *after* the action that triggers the request. The fix converts them to promise-first
(`const p = page.waitForResponse(...)` before the trigger, awaited after) behind a
`searchAndAwaitResponse()` helper, and commits a detector at
`scripts/scan-waitforresponse-race.py` so the result is reproducible rather than a shell-history
artifact.

Three adversarial reviews. The one that changed the shape of the work: the original classifier was
keyed on the **method name** `waitForResponse`, which hid three `waitForEvent('requestfailed')`
sites. The rule is now keyed on the **shape** (an awaited wait whose immediately preceding
non-comment, non-blank line performs a triggering action), across a 13-token trigger list.

## Artifacts

`spec.md` (13 FRs, adversarial-review appendices), `plan.md`, `research.md`, `data-model.md`,
`contracts/helper-api.md`, `quickstart.md`, `tasks.md` (T001-T027).

## The detector is a consumed interface

The dependent regression-guard feature wires this script into a pre-commit hook and the required CI
`Lint` job, so its invocation, output and exit codes are a contract. Its third review found that
T001's criteria did not merely omit that contract, they **contradicted** it: criterion 6 read
`sys.exit(0)` "otherwise", criterion 8 mandated venv invocation, and Clarification C4 promised the
guard could wire the script in "without modification". An implementer following this file literally
would have produced a detector that is inert in the feature that consumes it, discovered only after
this one merged.

Both features were still unimplemented, so the contract was folded in here rather than repaired
later: T001 criteria 5, 6 and 8 rewritten, 12 and 13 added, C4 amended to record the change, and the
same constraints waterfalled through FR-011, `plan.md` and `quickstart.md`.

## Verification

- `make test-unit`: 4083 passed, coverage 80.09%
- SAST: 478 rules, 164 files, 0 findings
- Open code-scanning alerts: none
- `make check-banned-terms` fails identically on `main` (15 pre-existing matches in
  `specs/1157-*`, `specs/1268-*`, `specs/archive/*`, `docs/cleanup/diagram-drift.md`,
  `.secrets.baseline`). This diff adds zero, and the target runs in no CI workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)