### PR TITLE
docs(002): spec the waitForResponse regression guard

### DIFF
--- a/specs/002-waitforresponse-lint-guard/contracts/detector-cli.md
+++ b/specs/002-waitforresponse-lint-guard/contracts/detector-cli.md
@@ -1,0 +1,188 @@
+# Contract: detector CLI
+
+**Feature**: `002-waitforresponse-lint-guard` | **Satisfies**: spec FR-012
+**Subject**: `scripts/scan-waitforresponse-race.py`
+**Owner**: Feature `001-waitforresponse-race-sweep`, task T001
+**Consumer**: this feature's two enforcement points
+
+---
+
+## Why this contract exists
+
+The detector **does not exist yet**. Every task in `001/tasks.md` is unchecked. 002 is wiring
+against an interface that has been described in prose but never executed, so the interface is
+pinned here before any wiring is written. Discovering the real signature during verification, and
+quietly bending the wiring to fit it, is the failure this document prevents.
+
+002 **consumes** the detector. It does not own it. Any divergence between this contract and 001's
+delivered script is resolved by amending 001 T001, with the amendment recorded, not by editing the
+script from inside 002 (spec FR-010).
+
+---
+
+## C1 — Invocation
+
+```bash
+python3 scripts/scan-waitforresponse-race.py
+```
+
+| Property | Requirement |
+|---|---|
+| Interpreter | Any CPython 3.13 on `PATH` as `python3`. MUST NOT require `.venv`. |
+| Arguments | None required. The default invocation scans the full root. |
+| Working directory | Repository root. |
+| Imports | **Standard library only.** No import of anything in `requirements-dev.txt`, `requirements-ci.txt`, or `requirements.txt`. |
+| Executable bit | Not required. Invoked via the interpreter, so no shebang and no `chmod +x`. |
+
+**Amendment against 001 T001 criterion 8.** That criterion specifies invocation as
+`source .venv/bin/activate && python scripts/scan-waitforresponse-race.py`. That remains a valid way
+to run it. This contract adds that venv availability MUST NOT be a **precondition**, because the CI
+`Lint` job has no venv (`pr-checks.yml:35-65` installs only `ruff`). If 001's implementation
+introduces a third-party import, that is a defect against spec FR-005 and blocks 002.
+
+---
+
+## C2 — Exit codes
+
+| Code | Meaning | Required by |
+|---|---|---|
+| `0` | `RACY == 0` **and** at least one file was scanned | spec FR-013 |
+| `1` | `RACY > 0` | 001 T001 criterion 6 |
+| non-zero, not `1` | Any internal error: unreadable file, unparseable input, missing scan root, zero files scanned | spec FR-008, FR-013 |
+
+Hard constraints:
+
+- Exit `0` MUST NOT be reachable when the scan examined zero files. "No violations found" and "no
+  files found" are different facts and MUST NOT share an exit code. A renamed or moved scan root is
+  the cheapest possible route to a permanently green inert guard.
+- The detector MUST NOT catch a scanning exception and exit `0`. Swallowing an error into a pass is
+  the silent-failure pattern the constitution forbids and is a defect against spec FR-008.
+
+**Amendment against 001 T001 criterion 6**, which specifies only the `0` / `1` split. The
+zero-file and internal-error cases are new and originate in AR#1 finding F-13.
+
+---
+
+## C3 — Output
+
+### Findings, on stdout
+
+One line per call site:
+
+```
+frontend/tests/e2e/<file>.spec.ts:<line> <CLASSIFICATION>
+```
+
+`CLASSIFICATION` is one of `RACY`, `PROMISE-FIRST`, `OTHER`.
+
+### Summary, on stdout
+
+MUST report all **five** numbers:
+
+| Field | Note |
+|---|---|
+| `RACY` count | Drives the exit code |
+| `PROMISE-FIRST` count | — |
+| `OTHER` count | Does **not** affect the exit code |
+| **total** | Required by 001 T001 criterion 5, which says "a summary line with the **four** counts". 001 T002 ("total **34**") and T018 ("total **17**") are unverifiable without it. |
+| **files scanned** | **New in this contract** (spec FR-013). Not required by 001. |
+
+An earlier draft of this contract listed four fields and silently dropped `total`. Implementing that
+literally would have broken 001 T001 criterion 5 and made 001's own before/after gates
+unverifiable. Caught as AR#2 finding D-07.
+
+Expected summary on the post-001 tree: `RACY 0 / PROMISE-FIRST 16 / OTHER 1`, total **17**, across
+**48** files scanned. The total drops from 34 because 18 helper-routed sites cease to be inline wait
+call sites and the helper adds one internal wait (001 SC-001).
+
+### Triage banner
+
+`OTHER` sites MUST appear under an explicit **"requires human triage"** heading listing file,
+enclosing test or function name, and statement text (001 T001 criterion 10). This banner MUST NOT
+affect the exit code: a shape the classifier cannot place is a prompt for a human, not a blocked
+commit.
+
+### Remediation guidance
+
+On a `RACY` finding the output MUST include a literal corrected example, not only a count, so a
+contributor can act without opening the spec (spec FR-006). Verifiable by asserting the output
+contains a line matching `const <name>Promise = page.waitForResponse` positioned before the
+triggering action.
+
+**Amendment against 001 T001 criterion 5.** No 001 criterion requires remediation guidance;
+criterion 5 specifies `file:line CLASSIFICATION` lines plus a summary and nothing more. This is a
+third change request, filed here rather than absorbed silently into 002's wiring.
+
+**Amendment against 001 T001 criterion 5 (output stream).** 001 does not specify stdout versus
+stderr for findings. This contract requires stdout so the enforcement points can capture and assert
+on it. Fourth change request.
+
+---
+
+## C4 — Classification rule (reproduced, not redefined)
+
+The rule has exactly one definition site: the detector's module docstring (001 T001 criterion 3,
+spec FR-002). It is reproduced here for review convenience only. **If this section and the script
+disagree, the script wins and this document is wrong.**
+
+- **RACY** — an awaited `page.waitForResponse(...)` or
+  `page.waitForEvent('requestfailed'|'response')` whose immediately preceding non-comment,
+  non-blank line performs a triggering action.
+- **PROMISE-FIRST** — the wait is assigned to a variable before the triggering action and awaited
+  after it.
+- **OTHER** — neither shape. Requires human triage.
+
+Trigger-action tokens (13, as extended by 001 AR#3):
+
+```
+.fill(  .click(  .press(  .selectOption(  .clear(  .goto(  .reload(
+.evaluate(  .type(  .check(  .tap(  .setInputFiles(  .dispatchEvent(
+```
+
+`.evaluate(` is not hypothetical: `error-visibility-search.spec.ts:158` triggers via
+`retryButton.evaluate((el) => el.click())`. A token list stopping at `.reload(` misses it, which is
+how the list came to be extended in the first place.
+
+---
+
+## C5 — Scan root
+
+`frontend/tests/e2e/`, recursively, every `*.ts` file including `helpers/` (001 T001 criterion 1).
+
+This is the **customer** dashboard suite (Next.js/Amplify). It is not `tests/e2e/`, which is the
+admin HTMX suite. Two existing scripts (`scripts/audit-e2e-skips.py`,
+`scripts/check-false-pass-patterns.sh`) default to the admin suite, and CLAUDE.md records four
+separate incidents caused by confusing the two. 001 T001 criterion 11 requires the docstring and
+`--help` to name the root explicitly for this reason.
+
+The guard MUST NOT widen this root. Extending coverage to Playwright specs elsewhere is carded
+under spec FR-011(c).
+
+---
+
+## C6 — Verification of this contract
+
+Phase A of the implementation plan is a gate, not a formality. Before any wiring is written:
+
+| Check | Command | Expected |
+|---|---|---|
+| Stdlib-only, statically | `grep -nE '^\s*(import\|from) ' scripts/scan-waitforresponse-race.py` | Every module in the 3.13 standard library |
+| Stdlib-only, dynamically | `python3 -I -S scripts/scan-waitforresponse-race.py` | Runs; exit 0 on the post-001 tree |
+| Clean exit | `python3 scripts/scan-waitforresponse-race.py; echo $?` | `0`, with `RACY 0 / PROMISE-FIRST 16 / OTHER 1`, total 17, 48 files scanned |
+| Zero-file case | Temporarily rename the scan root, re-run | Non-zero exit, not `0` |
+| Summary completeness | Inspect output | **Five** numbers: RACY, PROMISE-FIRST, OTHER, total, files scanned |
+| Ignores any file list | Invoke with arbitrary file arguments | Scans its own root regardless; never narrows to the given list |
+
+**The dynamic check must use `-I -S`.** `env -u VIRTUAL_ENV python3 …` does **not** leave the venv:
+it clears a marker variable while `.venv/bin` stays on `PATH`, so `python3` still resolves to
+`.venv/bin/python3` with `sys.prefix` inside the venv. Verified in this repo. Scrubbing `PATH`
+instead selects the system interpreter, which is 3.12 or 3.10 on a CLAUDE.md-conformant machine and
+therefore tests the wrong version. `-I` (isolated) with `-S` (no `site`) keeps 3.13 and removes
+site-packages, which is precisely the FR-005 property. Caught as AR#2 finding N-01.
+
+The "ignores any file list" row exists because `pass_filenames: false` plus a filesystem-walking
+detector is what makes SC-003 work at all: after `git restore --staged`, the planted file is
+untracked and `pre-commit run --all-files` would not pass it to the hook. If the detector ever
+gains a "scan only the files given to me" mode, SC-003 goes inert with no other symptom (AR#2 N-17).
+
+Any failure here is an amendment against 001 T001, filed before proceeding to Phase B.

--- a/specs/002-waitforresponse-lint-guard/contracts/detector-cli.md
+++ b/specs/002-waitforresponse-lint-guard/contracts/detector-cli.md
@@ -4,6 +4,11 @@
 **Subject**: `scripts/scan-waitforresponse-race.py`
 **Owner**: Feature `001-waitforresponse-race-sweep`, task T001
 **Consumer**: this feature's two enforcement points
+**Status**: **ACCEPTED BY THE OWNER.** As of `3b86d9c`, every requirement below is carried by a
+001 T001 acceptance criterion (5, 6, 8, 12, 13), and 001's Clarification C4 records the amendment.
+This file remains the contract of record and the place to read the reasoning; 001 T001 is where an
+implementer will actually encounter it. See AR#3 G-01 in `../tasks.md` for why the split mattered:
+four of these requirements were not gaps in 001 but direct contradictions of its written criteria.
 
 ---
 

--- a/specs/002-waitforresponse-lint-guard/data-model.md
+++ b/specs/002-waitforresponse-lint-guard/data-model.md
@@ -1,0 +1,163 @@
+# Data Model: waitForResponse race regression guard
+
+**Feature**: `002-waitforresponse-lint-guard` | **Date**: 2026-07-30
+
+This feature persists nothing. There is no database, no file format, no serialized state, and no
+API payload. What follows is the vocabulary the guard operates on, recorded so that tasks.md and
+the adversarial reviews use the same words for the same things.
+
+---
+
+## Entities
+
+### Call site
+
+A single `page.waitForResponse(...)` or `page.waitForEvent('requestfailed'|'response')` occurrence
+in a `*.ts` file under `frontend/tests/e2e/`.
+
+| Attribute | Value |
+|---|---|
+| Identity | `file:line` |
+| Classification | `RACY` \| `PROMISE-FIRST` \| `OTHER` |
+| Population at `35d5f61` (pre-001) | **34** real sites across 6 files (41 naive grep hits minus 7 comment lines) |
+| Pre-001 distribution | `RACY 27` / `PROMISE-FIRST 6` / `OTHER 1`, total **34** |
+| Population post-001 | **17** |
+| Post-001 target | `RACY 0` / `PROMISE-FIRST 16` / `OTHER 1`, total **17** |
+
+Comment lines are excluded from the population. A guard that counts commented-out code produces
+false positives, and a guard that produces false positives gets disabled.
+
+**The population shrinks across 001, and this is the number most likely to be got wrong.** The
+naive expectation is 27 + 6 + 1 = 34 before and after. It is not: 001 FR-005 routes **18** of the 27
+racy sites through `searchAndAwaitResponse(...)`, and those sites stop being wait call sites
+altogether once they become helper calls. The helper contributes **one** internal wait in their
+place.
+
+```
+34  pre-001 population
+−18  helper-routed sites cease to be call sites
+ +1  the helper's own internal wait
+= 17  post-001 population
+
+PROMISE-FIRST 16 = 6 pre-existing (001 FR-004, byte-unchanged)
+                 + 6 status-503 inline conversions
+                 + 3 requestfailed inline conversions
+                 + 1 helper-internal
+OTHER          1 = chaos-scenarios.spec.ts:138, held back by 001 FR-003
+RACY           0
+```
+
+This reproduces 001 SC-001 and 001 T018 criterion 1 exactly. An implementer who sees the detector
+print `17` and "corrects" it to `34` has broken the check; the number to trust is 001's, not
+intuition's.
+
+### Classification
+
+| Value | Definition | Effect on exit code |
+|---|---|---|
+| `RACY` | Awaited wait whose immediately preceding non-comment, non-blank line performs a triggering action | **Exit 1** when count > 0 |
+| `PROMISE-FIRST` | Wait assigned to a variable before the triggering action, awaited after it | None |
+| `OTHER` | Neither shape; requires human triage | **None** — printed under a banner, never blocks |
+
+`OTHER` deliberately does not gate. A shape the classifier cannot place is a prompt for a human,
+not a blocked commit. The one known `OTHER` at `35d5f61` is `chaos-scenarios.spec.ts:138`, where an
+intervening `await expect(...).toBeVisible({ timeout: 2000 })` separates `page.reload()` from the
+wait.
+
+### Trigger-action token
+
+A method-call fragment whose presence on the preceding line makes a wait `RACY`. Thirteen tokens,
+defined **once**, in the detector's module docstring:
+
+```
+.fill(  .click(  .press(  .selectOption(  .clear(  .goto(  .reload(
+.evaluate(  .type(  .check(  .tap(  .setInputFiles(  .dispatchEvent(
+```
+
+**This list is not stable and must not be duplicated.** It grew from seven entries to thirteen during
+001's AR#3, when `.evaluate(` was found in live use at `error-visibility-search.spec.ts:158`
+(`retryButton.evaluate((el) => el.click())`). A second copy in another language would drift, and the
+drift's failure mode is a detector narrower than the defect — which is exactly how three
+`waitForEvent` sites hid behind a `waitForResponse`-only framing. Spec FR-002 and SC-009 exist to
+keep the count at one.
+
+`specs/001-.../tasks.md:61-63` enumerates all thirteen tokens as prose. That is documentation, not
+an executable second source of truth, which is why SC-009’s grep excludes `specs/`.
+
+### Scan run
+
+One execution of the detector.
+
+| Attribute | Notes |
+|---|---|
+| Files scanned | **48** on the tree the guard runs on (47 at `35d5f61` plus `helpers/search-helpers.ts`, added by 001 T004); 6 contain matches. Must be reported (contract C3) |
+| Counts | `RACY` / `PROMISE-FIRST` / `OTHER` / **total** — four numbers required by 001 T001 criterion 5, plus files-scanned added by contract C3 |
+| Exit code | Per contract C2 |
+| Runtime budget | Under 2 seconds, measured not estimated (SC-010) |
+
+A run that scanned zero files exits non-zero (FR-013). "Found no violations" and "found no files"
+must be distinguishable, or renaming the scan root silently turns the guard green forever.
+
+### Enforcement point
+
+An invocation of the detector wired into a developer or CI workflow.
+
+| Point | Location | Authority | Bypassable |
+|---|---|---|---|
+| Local hook | `.pre-commit-config.yaml`, `repo: local` | Refuses `git commit` | Yes — `SKIP=<hook-id>` |
+| Blocking step | `Lint` job, `pr-checks.yml` | Fails a **required** status check | No |
+| Advisory ride-along | `Pre-commit Hooks` job | None — job is not required | Irrelevant |
+| Local convenience | `make validate` | Developer-invoked | Trivially |
+
+Only the second row can stop a merge. That distinction is the feature's central design fact and is
+recorded here so it is not re-lost: `main`'s `required_status_checks.contexts` is
+`["Secrets Scan", "Lint", "Run Tests"]`.
+
+### Planted violation
+
+A temporary act-then-wait call site introduced solely as FR-007 evidence.
+
+| Attribute | Value |
+|---|---|
+| Lifetime | Exists only during Phase D verification |
+| Committed | **Never** — SC-015 asserts a clean tree |
+| Purpose | Prove non-zero exit in all four verification modes; prove zero exit after revert |
+
+The planted violation is the only thing that distinguishes "the guard is installed" from "the guard
+works". Without it, every success criterion could be satisfied by a guard that always exits 0.
+
+---
+
+## Relationships
+
+```
+Scan run ──scans──► 48 files ──contains──► 17 call sites   (post-001 steady state)
+                                             │
+                                     classified by
+                                             │
+                                             ▼
+                             Trigger-action token list (13, single definition site)
+                                             │
+                                        yields
+                                             ▼
+                              Classification ──RACY > 0──► exit 1
+                                             │
+                                     consumed by
+                                             ▼
+                        Enforcement points (local hook, required Lint step)
+                                             │
+                                    proven live by
+                                             ▼
+                                    Planted violation
+```
+
+## Non-entities
+
+Deliberately absent, each because its absence is a requirement rather than an omission:
+
+- **Suppression list / baseline file / allowlist** — forbidden by FR-009. A guard that ships
+  pre-suppressed is the thing it was meant to prevent.
+- **Violation history or trend data** — the guard is binary and stateless. Trend data would invite
+  "only 3 violations this week" framing where the correct number is zero.
+- **Per-file or per-test exemptions** — no mechanism, deliberately. FR-009 requires a future
+  violation be fixed, not exempted.

--- a/specs/002-waitforresponse-lint-guard/plan.md
+++ b/specs/002-waitforresponse-lint-guard/plan.md
@@ -1,0 +1,411 @@
+# Implementation Plan: waitForResponse race regression guard
+
+**Branch**: `002-waitforresponse-lint-guard` | **Date**: 2026-07-30 | **Spec**: [spec.md](./spec.md)
+**Depends on**: `001-waitforresponse-race-sweep` (must land first)
+
+## Summary
+
+Wire 001's committed detector, `scripts/scan-waitforresponse-race.py`, into two enforcement points
+so the act-then-wait race pattern cannot be reintroduced:
+
+1. a `repo: local` pre-commit hook, for fast local feedback on `git commit`;
+2. a step in the **required** `Lint` job of `pr-checks.yml`, which is the control that can actually
+   block a merge.
+
+No new detection logic is written. The classification rule keeps exactly one definition site. The
+feature’s real content is not code, it is the verification that the guard is not inert — four
+verification modes against a planted violation, covering the index-state, environment, real-CI, and
+job-authority axes on which guards in this repo have previously gone quiet.
+
+## Technical Context
+
+**Language/Version**: Python 3.13 (detector, owned by 001), YAML (pre-commit config, GitHub Actions),
+GNU Make (local target, FR-014)
+**Primary Dependencies**: none added. The detector must be **stdlib-only** (spec FR-005) because the
+CI `Lint` job installs only `ruff==0.15.14` on top of `actions/setup-python@v7`.
+**Storage**: N/A
+**Testing**: verification is by planted violation and exit-code assertion, not by a unit-test suite.
+There is no product code to test.
+**Target Platform**: developer workstations (Linux/WSL2) and `ubuntu-latest` GitHub Actions runners
+**Project Type**: repository tooling / CI configuration
+**Performance Goals**: detector completes the full scan root in under 2 seconds (spec SC-010); scan
+root is 48 `.ts` files on the post-001 tree (47 at `35d5f61` plus the helper 001 T004 adds), 6 of which contain matches
+**Constraints**: no `.venv` on the CI runner; no repository settings changes; detector is owned by
+001 and may only be amended through a recorded change request
+**Scale/Scope**: 2 enforcement points, 1 make target, 8 board cards, 2 stale-comment corrections, 0 lines of new
+detection logic
+
+### Version surface (recorded because it is skewed)
+
+| Surface | Pinned `pre-commit` |
+|---|---|
+| `requirements-dev.txt:37` | `4.6.1` |
+| `requirements-ci.txt:58` | `4.6.1` |
+| `.github/workflows/pr-checks.yml:218` | `4.6.0` |
+| project `.venv` | `4.5.1` |
+
+Stage-selection behaviour was confirmed identical across all three during AR#1. `stages: [pre-commit]`
+is valid on all of them. Reconciling the pins is out of scope and is not carded here because it
+belongs to whichever feature owns dependency pinning.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+The constitution governs the sentiment-analyzer service (ingestion, inference, admin API, secrets,
+DB access). This feature changes only repository tooling configuration and a board file.
+
+| Gate | Applicability | Status |
+|---|---|---|
+| Functional requirements (ingest, dedupe, sentiment, admin API) | Not touched | PASS (N/A) |
+| Availability / latency / throughput NFRs | Not touched | PASS (N/A) |
+| Auth on management endpoints | Not touched | PASS (N/A) |
+| Secrets not in source control | No secrets introduced | PASS |
+| TLS in transit | Not touched | PASS (N/A) |
+| SQL injection / unsafe DB access | No DB access | PASS (N/A) |
+| Log redaction | No logging changes | PASS (N/A) |
+
+Project-level gates that do apply:
+
+| Gate | Status |
+|---|---|
+| GPG-signed commits, bypass flags forbidden | Enforced by pre-commit and the global block-no-verify hook. This feature **adds** to that enforcement surface rather than weakening it. |
+| No new AWS resources | PASS — none |
+| Two-dashboard rule | PASS — the detector's scan root is `frontend/tests/e2e/`, the **customer** dashboard suite. 001 T001 criterion 11 already requires the script's docstring and `--help` to name that root explicitly, precisely because two existing scripts default to the admin pytest suite. This feature must not widen the root. |
+| No unjustified fallback patterns | PASS — the guard has no fallback. FR-008 forbids the only one that would be tempting (treating a missing or erroring detector as a pass). |
+| No silent failures | **This is the feature.** FR-008, FR-013, and FR-007's four-mode verification exist to make every failure path observable. |
+| Land green first (1400 FR-007a) | PASS by construction — FR-009 forbids landing before 001, so the guard is green on arrival. |
+| Never regress to decorative (1400 AR3-F2) | PASS — FR-009 forbids suppression lists, baselines, and non-gating modes. |
+
+**Result: PASS.** No violations, no complexity deviations to track.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/002-waitforresponse-lint-guard/
+├── spec.md              # Stage 1 + AR#1 appendix + Clarifications appendix
+├── plan.md              # this file + AR#2 appendix
+├── research.md          # decision record for the three design questions
+├── data-model.md        # no persistent data; documents the classification vocabulary
+├── contracts/
+│   └── detector-cli.md  # FR-012 interface contract against 001's script
+├── tasks.md             # Stage 7 + AR#3 appendix
+└── quickstart.md        # how to run and verify the guard
+```
+
+### Source Code (repository root)
+
+```text
+.pre-commit-config.yaml            # MODIFIED — one new repo:local hook
+.github/workflows/pr-checks.yml    # MODIFIED — one new step in the required `Lint` job
+Makefile                           # MODIFIED — target wired into `validate` (FR-014)
+CLEANUP-BOARD.html                 # MODIFIED — guard card + 7 deferred-item cards
+scripts/scan-waitforresponse-race.py   # OWNED BY 001 — not edited except by recorded amendment
+frontend/tests/e2e/**              # NOT MODIFIED — the guard's subject, never its patient
+```
+
+**Structure decision**: this feature adds no source directory and no new script. Its entire
+footprint is four configuration and documentation files. The deliberate asymmetry — a spec of
+several hundred lines producing a handful of config lines — is the point: the difficulty here is
+establishing that the wiring works, not writing it.
+
+## Design Decisions
+
+### D1 — Reuse 001's Python detector; do not write an ESLint rule
+
+**Decision**: the guard invokes `scripts/scan-waitforresponse-race.py`.
+
+**Rationale**: two independent reasons, either sufficient.
+
+1. *An ESLint rule would not execute.* `npm run lint` is `next lint`
+   (`frontend/package.json:9`), there is no `--dir` argument and no `eslint` block in
+   `next.config.js`, so it uses `ESLINT_DEFAULT_DIRS` =
+   `["app","pages","components","lib","src"]`
+   (`frontend/node_modules/next/dist/lib/constants.js:246-252`). `frontend/tests/` is not in that
+   list. The rule would be written, configured, committed, and never run against a target file.
+2. *It would fork the classification rule.* The trigger-action token list grew from seven entries to
+   thirteen during 001's AR#3, when `.evaluate(` was found live at
+   `error-visibility-search.spec.ts:158`. A JavaScript copy of an evolving Python list drifts, and
+   the failure mode of that drift is a detector narrower than the defect — exactly what let three
+   `waitForEvent` sites hide from an earlier `waitForResponse`-only framing.
+
+**Rejected alternative**: adopt `eslint-plugin-playwright`. It ships no rule for this pattern, and
+enabling it would flag unrelated violations suite-wide. Already Out of Scope in 001's spec.
+
+**Deferred**: editor-time feedback. Genuinely valuable and genuinely unavailable without changing
+the lint invocation. Carded under FR-011(b).
+
+### D2 — The blocking enforcement point is the `Lint` job, not the `Pre-commit Hooks` job
+
+**Decision**: add a `run:` step to the `Lint` job in `pr-checks.yml`, in addition to the pre-commit
+hook.
+
+**Rationale**: `main`'s branch protection lists `required_status_checks.contexts` =
+`["Secrets Scan", "Lint", "Run Tests"]`, with no rulesets. The `pre-commit` job's display name is
+`Pre-commit Hooks` (`pr-checks.yml:192`) and is absent from that list. A guard reaching CI only
+through the pre-commit config would be **advisory**: it could go red and `gh pr merge --auto
+--squash`, the repo's documented merge command, would merge anyway.
+
+This was AR#1 finding F-01 and it was the design's central defect. The original draft asserted "the
+CI pre-commit job is a blocking gate" from reading the workflow file. The workflow file cannot tell
+you that; only branch protection can.
+
+**Rejected alternative**: add `Pre-commit Hooks` to the required contexts. This is the "correct"
+fix in the abstract and completes 1400 FR-007 step (b), but it is a repository settings change
+requiring admin rights, and it would retroactively make **every** hook in the config a merge
+blocker — including `trivy-terraform`, which is documented as non-gating because 5 HIGH findings
+are outstanding. Far larger blast radius than this feature. Carded as an owner decision under
+FR-011(f).
+
+**Consequence accepted**: a Playwright race scan lives in a job named `Lint`. Slightly surprising
+to a reader. The step carries a comment explaining why, and correctness of the gate outranks
+tidiness of job naming.
+
+### D3 — `language: system` with a bare `python3` entry
+
+**Decision**: the pre-commit hook uses `language: system`, `entry: python3
+scripts/scan-waitforresponse-race.py`, `pass_filenames: false`, `always_run: true`,
+`stages: [pre-commit]`.
+
+**Rationale**, one clause at a time:
+
+| Choice | Why | What it avoids |
+|---|---|---|
+| `language: system` | No shebang, no `chmod +x`, no wrapper script | Keeps FR-010's file allowlist honest (AR#1 F-08) |
+| `python3`, not `.venv/bin/python3` | The CI `pre-commit` job installs no `.venv` (`pr-checks.yml:211-221`) | A hook that is red in CI forever, creating pressure to SKIP-list it (AR#1 F-02) |
+| `pass_filenames: false` + `always_run: true` | Whole-tree scan every invocation | The `--staged-only` inertness that makes `check-false-pass-patterns` a no-op in CI |
+| `stages: [pre-commit]`, stated explicitly | Modern stage name | The deprecated `commit` alias, which all installed pre-commit versions warn is scheduled for removal (AR#1 F-07) |
+| Never `stages: [push]` or `[manual]` | — | `check-error-log-assertions` is `stages: [push]` and looks like a template but fires on neither `git commit` nor `pre-commit run --all-files` (AR#1 F-04) |
+
+**Consequence**: the detector must be stdlib-only. That is a change request against 001 T001
+criterion 8, recorded in `contracts/detector-cli.md` rather than applied silently.
+
+### D4 — Verification is the deliverable
+
+**Decision**: four verification modes (spec FR-007), each with its own success criterion.
+
+**Rationale**: this repo contains a worked example of a guard that is present, unskipped, green, and
+inert, documented by its own authors at `pr-checks.yml:236-240`. The axes on which a guard can go
+quiet are: invocation mode, scan scope, hook stage, runtime environment, and whether the job it runs
+in has authority. A verification pass that covers one axis licenses a false conclusion about the
+other four.
+
+Mode (c) — `python3 -I -S`, site-packages disabled — is the one most likely to be pruned as
+redundant or "simplified" by a future maintainer, so its rationale and its two wrong alternatives
+are stated in the spec text, the quickstart, and contract C6 as well as here. Modes (a) and (b) both
+run where `.venv` is importable and therefore cannot detect a detector with a third-party
+dependency.
+
+The specific trap is worth restating because this feature fell into it once. AR#1 added mode (c) to
+close its own CRITICAL and wrote it as `env -u VIRTUAL_ENV python3 …`, which does nothing: it clears
+a marker variable while `.venv/bin` remains on `PATH`. AR#2 caught it. Scrubbing `PATH` instead is
+also wrong here — the system interpreter is 3.12 or 3.10 on a CLAUDE.md-conformant machine, so the
+test would run the wrong version and prove nothing about a 3.13 runner. `-I -S` is the only form
+that keeps the right interpreter while removing the dependency set.
+
+Mode (d) — the draft red-team PR — was added at AR#2 because modes (a) through (c) all test the
+*detector* and none of them tests the *wiring*. A hook can satisfy all three and still be attached
+to a job that cannot block, or guarded by an `if:` that never fires. 1400 T006 set the precedent.
+
+## Implementation Phases
+
+Phase ordering is dictated by one hard constraint: **nothing in Phase B may run before 001 has
+landed and the detector reports `RACY 0`.** A guard verified against a tree that still holds 27
+violations proves only that it can find violations, never that it can be green.
+
+| Phase | Purpose | Gate to enter |
+|---|---|---|
+| **A — Precondition check** | Confirm 001 landed; run the detector under `python3 -I -S`; confirm it satisfies all six rows of `contracts/detector-cli.md` C6; file amendments against 001 T001 for every divergence (four are already known: stdlib-only, files-scanned + non-zero-on-empty, remediation guidance, stdout stream) | 001 merged |
+| **B — Local enforcement point** | Add the `repo: local` hook per D3 | Phase A clean |
+| **C — Blocking enforcement point** | Add the `Lint` job step with `if: always()`; add the make target and wire it into `validate`; correct the two stale "BLOCKING gate" statements per FR-015 | Phase B green locally |
+| **D — Adversarial verification** | Plant a violation; assert non-zero in modes (a) `git commit`, (b) `pre-commit run --all-files` on a clean index, (c) `python3 -I -S`; revert and assert zero in all three; measure runtime; rename the scan root and assert non-zero; rename the detector and assert non-zero | Phases B and C complete |
+| **E — Real-CI verification** | Mode (d): draft red-team PR carrying the planted violation; observe the **required `Lint`** check fail; close the PR and delete the branch | Phase D clean |
+| **F — Board** | Guard card plus one card per FR-011 item (a)–(g); eight cards total, `source: 002-waitforresponse-lint-guard` | Phase E evidence recorded |
+
+Phases D and E are the only ones that can fail in an interesting way, and they are deliberately last
+so that they exercise the real wiring rather than a stand-in. Phase E is separated from D because it
+is the only step that leaves the local machine, needs a push, and produces evidence nobody can fake
+by rerunning a local command. It follows 1400 T006's draft red-team PR precedent.
+
+## Risks
+
+| # | Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|---|
+| R1 | 001's delivered detector diverges from `contracts/detector-cli.md` (imports a third-party module, omits files-scanned, exits 0 on an empty scan) | **High** — the script does not exist yet; every 001 task is unchecked | Rework in Phase A; possible amendment round-trip to 001 | Contract written before wiring; Phase A is a gate, not a formality; FR-010 permits amendment with a recorded change request |
+| R2 | `Lint` is removed from `main`'s required contexts | Low | The blocking enforcement point silently becomes advisory — the exact failure this design corrects | Recorded as the feature's single external Assumption; SC-008 asserts placement, and the Assumption names the condition so a future reader can re-check it |
+| R3 | A future `paths:` filter is added to `pr-checks.yml`'s `pull_request` trigger | Low | The `Lint` job stops running on some PRs | Verified absent at `35d5f61` (`:18-26`); noted as an Edge Case |
+| R4 | A pre-commit release removes the deprecated stage names, erroring the whole config | Low near-term, certain eventually | Every hook stops running, not just this one | This feature uses the modern name; config-wide migration carded FR-011(e) |
+| R5 | `SKIP=<hook-id> git commit` bypasses the local hook | Certain — this is not closable | Local gate skipped | Structural: the required `Lint` step is not a pre-commit hook and is unaffected |
+| R6 | Detector runtime grows as the suite grows, making commits sluggish | Low | Friction, then pressure to remove the hook | SC-010 sets a measured 2s budget rather than an assumption |
+
+R1 is the dominant risk and it is a **sequencing** risk, not a technical one. It is the direct cost
+of specifying 002 before 001 is implemented, which the battleplan does deliberately so that both
+features can be reviewed together before either is built.
+
+## Complexity Tracking
+
+No constitution violations. One complexity deviation worth naming explicitly:
+
+| Deviation | Why accepted | Simpler alternative rejected because |
+|---|---|---|
+| Two enforcement points invoking the same detector two different ways (pre-commit hook, workflow step) | The local hook gives fast feedback but cannot block a merge; the `Lint` step can block but gives no feedback until push | A single enforcement point in the `Lint` job alone would surrender local feedback; a single pre-commit hook alone would be advisory in CI (D2). Duplication is of *invocation*, not of *logic* — FR-002's single definition site is preserved |
+
+---
+
+## Adversarial Review #2
+
+Conducted by a second independent reviewer, distinct from AR#1's, against the full artifact suite
+(spec + plan + research + data-model + contracts + quickstart) cross-checked against 001's spec and
+tasks. Returned **2 CRITICAL, 6 HIGH, 15 MEDIUM, 9 LOW**.
+
+**Orchestrator re-verification.** Both CRITICAL findings were re-checked directly before acceptance.
+Both confirmed, and the second turned out to be worse than reported.
+
+| Re-checked claim | Command | Result |
+|---|---|---|
+| Post-001 distribution is 16/1, total 17 — not 33 | `sed -n '327,340p' 001/spec.md` | 001 SC-001 states **"RACY 0, PROMISE-FIRST 16, OTHER 1, total 17"** verbatim, with the derivation |
+| `env -u VIRTUAL_ENV` does not leave the venv | `source .venv/bin/activate; env -u VIRTUAL_ENV bash -c 'command -v python3'` | `/home/…/.venv/bin/python3`, `sys.prefix` = the venv. Confirmed no-op |
+| Scrubbing `PATH` is not the fix either | `env -i PATH=/usr/bin:/bin python3 --version` | **Python 3.12.3** — the wrong interpreter version, so this "fix" would test nothing about a 3.13 runner |
+| `-I -S` is the correct mechanism | `python3 -I -S -c "import sys; …"` then `python3 -I -S -c "import yaml"` | 3.13.0, `site-packages` absent from `sys.path`, `import yaml` → `ModuleNotFoundError`. Correct sandbox |
+
+### Drift findings
+
+Spec drift here was **caused by AR#1's own fixes**, which is the drift pattern this stage exists to
+catch. AR#1 renumbered and inserted requirements; the prose that cited them was not swept.
+
+| ID | Location | Drift | Resolution |
+|---|---|---|---|
+| D-01, D-02 | spec Edge Cases (2 sites) | Cited `FR-004a`, an id that never existed after AR#1's renumber | → `FR-004` |
+| D-03 | spec Context, failure-taxonomy paragraph | "**FR-006** verifies against all of them" — FR-006 became the failure-output requirement; the three-mode verification is FR-007. AR#1's own findings table said FR-007 while the body still said FR-006, so the fix was written into the ledger and not into the prose | → `FR-007` |
+| D-04 | research R6 taxonomy | Mapped "invocation mode" to FR-004; the whole-tree property is FR-003 | → FR-003 |
+| D-05 | research R6 taxonomy | Mapped "scan scope" to FR-012, whose contract table has **no scan-root row** — the axis 002 claimed to close was closed by nothing | → `contracts/detector-cli.md` C5 |
+| D-06 | spec FR-013 | Cited only 001 T001 criterion 5. Exiting non-zero on an empty scan **contradicts** criterion 6's `sys.exit(0)` "otherwise" branch | Now cites 5 (extends) **and** 6 (amends) |
+| D-07 | contracts C3 | Summary table listed four fields and **dropped `total`**. 001 T001 criterion 5 requires four counts including total; 001 T002 ("total 34") and T018 ("total 17") are unverifiable without it. Implementing C3 literally would have broken 001 | Summary now requires **five** numbers, with the regression noted in-line |
+| D-08 | spec SC, data-model, quickstart, plan, research | "47 `.ts` files" quoted as the operating figure. 001 T004 adds `helpers/search-helpers.ts`, and the guard only ever runs post-001 (FR-009) | → **48** at the operating sites; 47 retained where explicitly labelled pre-001 |
+
+### Cross-artifact inconsistencies
+
+| ID | Inconsistency | Resolution |
+|---|---|---|
+| X-01 | **CRITICAL.** data-model and quickstart claimed post-001 `RACY 0 / PROMISE-FIRST 33 / OTHER 1`, derived as 27 converted + 6 already-correct. 001 SC-001 says **16**, total **17** | Corrected in both, with the derivation spelled out and a warning against "correcting" it back |
+| X-02 | data-model's relationship diagram showed 47 files / 34 call sites with no era label, reading as steady state | → 48 files / 17 call sites, labelled post-001 |
+| X-03 | 47 vs 48 across five artifacts | Resolved with D-08 |
+| X-04 | "grew from **six** tokens to thirteen" in four artifacts. 001 AR#3 F-09 names the six tokens *added*, leaving a prior list of **seven** | → seven, in all four |
+| X-05 | plan Scale/Scope said "~6 board cards" against SC-014's count | → 8 |
+| X-06 | Clarification C2's card-key list omitted `milestone`, present on 3 of 118 cards, while claiming to be the observed vocabulary | Noted; C2's list is descriptive, and the eighth key is now acknowledged |
+| X-07 | SC-002 decided on `git commit` but quickstart's mode (a) ran `pre-commit run`, so the criterion had no procedure | quickstart mode (a) now runs `git commit -S` |
+
+### New findings
+
+| ID | Severity | Finding | Resolution |
+|---|---|---|---|
+| N-01 | **CRITICAL** | **FR-007 mode (c) was a no-op.** `env -u VIRTUAL_ENV python3 …` clears a marker variable while `.venv/bin` stays on `PATH`, so `python3` still resolved inside the venv. Mode (c) was the fix AR#1 added to close its own CRITICAL F-03, and it collapsed straight back into the environment it was meant to escape — on the default shell CLAUDE.md prescribes | Mode (c) is now `python3 -I -S`, which keeps 3.13 while removing site-packages. The mechanism and the two wrong alternatives are written into FR-007, quickstart, and contract C6 so it cannot be "simplified" back. New **SC-005** makes it a standing check rather than a one-time gate |
+| N-02 | HIGH | FR-006 (remediation guidance in output) and FR-012 (stdout stream) are requirements against 001's deliverable that no 001 criterion covers, yet Clarification C5 asserted "**two** amendments are already filed" | Two further amendment blocks added to contract C3. The ledger now reads four, plus 001 T001 criterion 9's intentional inversion |
+| N-03 | HIGH | `.pre-commit-config.yaml:190-192` still says the pre-commit job runs hooks "as a **BLOCKING** gate", and `pr-checks.yml:229` names the step "Run pre-commit (blocking)". **That sentence is what this feature's own Stage 1 draft read and repeated**, producing AR#1's CRITICAL F-01. The new hook lands a few lines below it | Promoted to **FR-015** rather than carded. Both files are already in the FR-010 allowlist; leaving the false claim next to a hook that depends on the opposite fact guarantees the next reader repeats F-01 |
+| N-04 | MEDIUM | `scripts/` is outside every **required** CI check — `Lint` runs ruff over `src/ tests/` only, bandit is `-r src/`, `make lint` is `src tests`. 002 promotes a `scripts/` file into the required merge path with no required check covering it | Carded FR-011(g) |
+| N-05 | MEDIUM | Nothing enforced FR-005 (stdlib-only) past a one-time Phase A inspection | New **SC-005**: `python3 -I -S …` exits 0 on a clean tree, failing the moment a third-party import appears |
+| N-06 | MEDIUM | The `Lint` step is placed last (C4) and Actions steps are fail-fast, so any ruff failure meant the guard never ran and produced no output | FR-004 now requires `if: always()`, with the reasoning stated |
+| N-07 | MEDIUM | SC-007's `specs/` exclusion was justified by `001/tasks.md:61-63` — a **Markdown** file the command's `--include` filters cannot reach. The exclusion is genuinely needed, for a different reason | Rewritten (now SC-009) to name the real hazard: `specs/` holds real `.ts` and `.yaml` files matching the filters |
+| N-08 | MEDIUM | SC-007 asserted "exactly one definition site" but counted grep **lines**. Any correct implementation holds the tokens in both the docstring (001 T001 criterion 3 requires them verbatim) and an executable list, returning ≥2 — a criterion that reads as failure on a correct build, which is 001's own CX-4 trap reproduced | Now counts **files** via `cut -d: -f1 \| sort -u \| wc -l` → 1 |
+| N-09 | MEDIUM | FR-014 was conditional ("if a make target is added") while C1 and plan Phase C made it mandatory, and no SC covered it | FR-014 made unconditional; new **SC-013** asserts `make validate` fails on a planted violation and that the target is on the `validate` dependency line |
+| N-10 | MEDIUM | FR-008 had no success criterion — "a missing detector must not read as a pass" was asserted by construction and checked by nobody | New **SC-012**: rename the detector, assert both enforcement points exit non-zero |
+| N-11 | MEDIUM | SC-010's "locatable by grep" specified no pattern, so it was satisfiable by any cards or none | Now **SC-014**: count cards whose `source` is `002-waitforresponse-lint-guard`, expect exactly 8 |
+| N-12 | MEDIUM | The fork-PR edge case concluded "no gap here today" having checked only for `paths:` filters. `pull_request` builds the fork's checkout, so a fork can edit the detector or delete the step from its copy of the workflow | Conclusion narrowed to what was checked; the fork-edits-the-detector case recorded as a review-mitigated residual |
+| N-13 | LOW | SC-006 named no command despite the section preamble promising one for each | Now **SC-008**, with an explicit grep |
+| N-14 | LOW | Contract C1 assumed `python3` is 3.13 everywhere; CLAUDE.md documents system Python as 3.10 and the symlink as apt-resettable | Resolved by N-01's `-I -S`, which uses whichever 3.13 is in play rather than reaching for a system interpreter |
+| N-15 | LOW | quickstart hardcoded an absolute path | → `cd "$(git rev-parse --show-toplevel)"` |
+| N-16 | LOW | quickstart's bare `git reset` unstages the developer's whole index | → `git restore --staged <file>` |
+| N-17 | LOW | Mode (b) works only because `pass_filenames: false` plus a filesystem-walking detector catches an untracked file; undocumented and load-bearing | Added as a row in contract C6 ("ignores any file list") with the SC-003 consequence stated |
+| N-18 | LOW | 001 T001 criterion 9 is permanently inverted by this feature and was absent from the amendment ledger | Added, marked as an intentional inversion |
+
+### SC renumbering
+
+Resolving N-05, N-09, N-10 and promoting the CI check inserted new criteria mid-sequence. The
+Success Criteria section went from 11 entries to 15. Mapping, for anyone reading AR#1's ledger,
+whose SC references are preserved as the historical record of what AR#1 said at the time:
+
+| AR#1 numbering | Current |
+|---|---|
+| SC-001 – SC-004 | unchanged in meaning; SC-004 now specifies `-I -S` |
+| SC-005 (wiring grep) | SC-007 |
+| SC-006 (`SKIP` placement) | SC-008 |
+| SC-007 (token single-source) | SC-009 |
+| SC-008 (runtime budget) | SC-010 |
+| SC-009 (scan-root rename) | SC-011 |
+| SC-010 (board cards) | SC-014 |
+| SC-011 (file allowlist) | SC-015 |
+| — | SC-005 (durable stdlib-only), SC-006 (real-CI check), SC-012 (detector rename), SC-013 (`make validate`) are new |
+
+### Scope-definition lesson
+
+AR#1 closed its self-defeat check by claiming the residual risk was "concentrated in one external
+condition rather than in the design". AR#2 falsified that twice over. The verification mode AR#1
+added to close its own CRITICAL did not work (N-01), and the arithmetic AR#1 never examined was
+wrong by 17 (X-01).
+
+The generalisable point is that **a review's fixes are not self-verifying**. AR#1 changed a design,
+renumbered a requirement set, and asserted a resolution for each finding; six of those resolutions
+were incompletely applied (D-01 through D-06) and one was applied in a form that did not do what it
+said (N-01). The AR#2 stage earns its place not by finding new categories of defect but by checking
+whether the previous stage's repairs actually landed.
+
+### Gate
+
+All CRITICAL and HIGH findings resolved, with both CRITICALs re-verified by the orchestrator against
+live command output rather than accepted from the reviewer's summary. Every MEDIUM was resolved or
+carded; every LOW was resolved.
+
+Design changes at this gate: verification grew from three modes to four (adding the real-CI draft PR,
+1400 T006's precedent); mode (c) changed mechanism entirely; the contract gained a fifth summary
+number and two more filed amendments; FR-014 became unconditional; FR-015 was added to correct the
+stale claim that misled this feature's own first draft.
+
+**0 CRITICAL, 0 HIGH remaining.**
+
+---
+
+## Plan Second Pass (Stage 6)
+
+Run because AR#2 found drift requiring realignment. This stage is not a re-plan from scratch; it is
+a sweep for artifact text that still described the pre-AR#2 design after the findings were resolved.
+
+**Realignment applied to this file:**
+
+| Location | Was | Now |
+|---|---|---|
+| Summary | "three invocation modes … index-state, environment, and job-authority axes" | four verification modes, adding the real-CI axis |
+| Technical Context | "GNU Make (optional local target)"; scan root "47 `.ts` files" | make target is required by FR-014; 48 files post-001 |
+| Scale/Scope | "1 optional make target, ~6 board cards" | 1 make target, 8 board cards, 2 stale-comment corrections |
+| Constitution Check | "FR-007's three-mode verification" | four-mode |
+| Project Structure | "optional target"; "6 deferred-item cards" | target wired into `validate` (FR-014); 7 deferred-item cards |
+| D1 | token list "grew from six entries" | seven entries (AR#2 X-04) |
+| D4 | "three verification modes"; mode (c) described as "clean environment, no `.venv`" | four modes; mode (c) restated as `python3 -I -S` with both wrong alternatives named, plus mode (d)'s rationale |
+| Implementation Phases | five phases A–E; Phase D asserted "all three modes" | six phases A–F; D splits local verification from E's real-CI draft PR; C gains `if: always()` and FR-015 |
+| Risk R2, R6 | cited SC-006, SC-008 | SC-008, SC-010 after the AR#2 renumber |
+
+**Realignment applied to sibling artifacts** (recorded here because Stage 6 owns the sweep):
+
+- `spec.md` — US2 acceptance scenario 3 rewritten from "no `.venv` and no project dependencies …
+  bare Python 3.13 interpreter" to the `-I -S` form, and a new scenario 4 added for the real-CI mode.
+  Two dangling `FR-004a` references corrected. One `FR-006` → `FR-007` in the Context taxonomy.
+- `research.md` — R6's failure-taxonomy table remapped: "invocation mode" now points at FR-003 (the
+  whole-tree property) rather than FR-004, and "scan scope" at `contracts/detector-cli.md` C5 rather
+  than FR-012, whose contract table has no scan-root row.
+- `data-model.md` — post-001 distribution corrected to `RACY 0 / PROMISE-FIRST 16 / OTHER 1`, total
+  17, with the derivation; relationship diagram relabelled to the post-001 steady state.
+- `contracts/detector-cli.md` — summary requirement raised from four numbers to five (`total`
+  restored); two further amendments filed; C6's dynamic check changed to `-I -S`.
+- `quickstart.md` — expected output corrected to 16/17/48 with an explicit warning not to "correct"
+  it back; mode (a) now runs `git commit`; mode (c) changed to `-I -S`; a new section 2b for the
+  draft red-team PR.
+
+**Constitution re-check after design changes: still PASS.** The additions (FR-014 mandatory make
+target, FR-015 comment corrections, mode (d) draft PR) touch no constitution gate. FR-015 edits two
+files already inside FR-010's allowlist. Mode (d) pushes a temporary branch and opens a draft PR,
+which is a process step rather than a repository change, and Phase E requires the branch be deleted
+and the PR closed.
+
+**No new complexity deviations.** The single tracked deviation (two enforcement points invoking one
+detector) is unchanged.

--- a/specs/002-waitforresponse-lint-guard/plan.md
+++ b/specs/002-waitforresponse-lint-guard/plan.md
@@ -29,7 +29,9 @@ There is no product code to test.
 **Target Platform**: developer workstations (Linux/WSL2) and `ubuntu-latest` GitHub Actions runners
 **Project Type**: repository tooling / CI configuration
 **Performance Goals**: detector completes the full scan root in under 2 seconds (spec SC-010); scan
-root is 48 `.ts` files on the post-001 tree (47 at `35d5f61` plus the helper 001 T004 adds), 6 of which contain matches
+root is 48 `.ts` files on the post-001 tree (47 at `35d5f61` plus the helper 001 T004 adds). Six
+files contain matches **pre-001**; the post-001 figure is not derived anywhere and is at least seven,
+since 001 T004's new `helpers/search-helpers.ts` contains a `page.waitForResponse` (AR#3 G-16)
 **Constraints**: no `.venv` on the CI runner; no repository settings changes; detector is owned by
 001 and may only be amended through a recorded change request
 **Scale/Scope**: 2 enforcement points, 1 make target, 8 board cards, 2 stale-comment corrections, 0 lines of new
@@ -217,10 +219,10 @@ violations proves only that it can find violations, never that it can be green.
 
 | Phase | Purpose | Gate to enter |
 |---|---|---|
-| **A — Precondition check** | Confirm 001 landed; run the detector under `python3 -I -S`; confirm it satisfies all six rows of `contracts/detector-cli.md` C6; file amendments against 001 T001 for every divergence (four are already known: stdlib-only, files-scanned + non-zero-on-empty, remediation guidance, stdout stream) | 001 merged |
-| **B — Local enforcement point** | Add the `repo: local` hook per D3 | Phase A clean |
-| **C — Blocking enforcement point** | Add the `Lint` job step with `if: always()`; add the make target and wire it into `validate`; correct the two stale "BLOCKING gate" statements per FR-015 | Phase B green locally |
-| **D — Adversarial verification** | Plant a violation; assert non-zero in modes (a) `git commit`, (b) `pre-commit run --all-files` on a clean index, (c) `python3 -I -S`; revert and assert zero in all three; measure runtime; rename the scan root and assert non-zero; rename the detector and assert non-zero | Phases B and C complete |
+| **A — Precondition check** | Confirm 001 landed; run the detector under `python3 -I -S`; confirm it satisfies all six rows of `contracts/detector-cli.md` C6, **including remediation guidance** (checked here against a throwaway violation, not deferred to Phase D — AR#3 G-07); assert non-zero on a zero-file scan for both a renamed root and an empty directory; record any divergence from 001 T001. The contract is folded into 001 T001 as of `3b86d9c`, so this phase is expected to pass | 001 merged |
+| **B — Local enforcement point** | Add the `repo: local` hook per D3; correct the two stale "BLOCKING gate" statements per FR-015 (tasks T005) | Phase A clean |
+| **C — Blocking enforcement point** | Add the `Lint` job step with `if: always()`; add the make target and wire it into `validate` | Phase B green locally |
+| **D — Adversarial verification** | Plant a violation; assert non-zero in modes (a) `git commit`, (b) `pre-commit run --all-files` on a clean index **with the failure attributed to this hook by name**, (c) `python3 -I -S`; revert and assert zero in all three; measure runtime; rename the detector and assert non-zero; assert an undecodable file under the scan root is not silently skipped | Phases B and C complete |
 | **E — Real-CI verification** | Mode (d): draft red-team PR carrying the planted violation; observe the **required `Lint`** check fail; close the PR and delete the branch | Phase D clean |
 | **F — Board** | Guard card plus one card per FR-011 item (a)–(g); eight cards total, `source: 002-waitforresponse-lint-guard` | Phase E evidence recorded |
 
@@ -314,7 +316,7 @@ catch. AR#1 renumbered and inserted requirements; the prose that cited them was 
 | N-11 | MEDIUM | SC-010's "locatable by grep" specified no pattern, so it was satisfiable by any cards or none | Now **SC-014**: count cards whose `source` is `002-waitforresponse-lint-guard`, expect exactly 8 |
 | N-12 | MEDIUM | The fork-PR edge case concluded "no gap here today" having checked only for `paths:` filters. `pull_request` builds the fork's checkout, so a fork can edit the detector or delete the step from its copy of the workflow | Conclusion narrowed to what was checked; the fork-edits-the-detector case recorded as a review-mitigated residual |
 | N-13 | LOW | SC-006 named no command despite the section preamble promising one for each | Now **SC-008**, with an explicit grep |
-| N-14 | LOW | Contract C1 assumed `python3` is 3.13 everywhere; CLAUDE.md documents system Python as 3.10 and the symlink as apt-resettable | Resolved by N-01's `-I -S`, which uses whichever 3.13 is in play rather than reaching for a system interpreter |
+| N-14 | LOW | Contract C1 assumed `python3` is 3.13 everywhere; CLAUDE.md documents system Python as 3.10 and the symlink as apt-resettable | ~~Resolved by N-01's `-I -S`~~ — **REOPENED AND PROPERLY RESOLVED at AR#3 (G-04)**. `-I -S` is verification mode (c), a manual command. The hook entry is `python3 scripts/...`, which resolves from the committing shell's `PATH` and was never addressed. Empirically: with the venv off `PATH`, `python3` here is **3.12.3**. Now closed by a new **001 T001 criterion 13** — an in-script `sys.version_info >= (3, 13)` floor that exits non-zero with the required version. This entry is left struck through rather than rewritten, because a resolution that names a real fix and applies it to the wrong mechanism is the failure mode this ledger exists to catch |
 | N-15 | LOW | quickstart hardcoded an absolute path | → `cd "$(git rev-parse --show-toplevel)"` |
 | N-16 | LOW | quickstart's bare `git reset` unstages the developer's whole index | → `git restore --staged <file>` |
 | N-17 | LOW | Mode (b) works only because `pass_filenames: false` plus a filesystem-walking detector catches an untracked file; undocumented and load-bearing | Added as a row in contract C6 ("ignores any file list") with the SC-003 consequence stated |

--- a/specs/002-waitforresponse-lint-guard/quickstart.md
+++ b/specs/002-waitforresponse-lint-guard/quickstart.md
@@ -1,0 +1,201 @@
+# Quickstart: waitForResponse race regression guard
+
+**Feature**: `002-waitforresponse-lint-guard`
+**Prerequisite**: Feature 001 has landed and `scripts/scan-waitforresponse-race.py` exists.
+
+---
+
+## Run the detector directly
+
+```bash
+cd "$(git rev-parse --show-toplevel)"
+python3 scripts/scan-waitforresponse-race.py; echo "exit=$?"
+```
+
+Expected on a healthy post-001 tree:
+
+```
+RACY 0 / PROMISE-FIRST 16 / OTHER 1, total 17   (48 files scanned)
+exit=0
+```
+
+**Do not "correct" the 16 or the 17.** The pre-001 tree holds 34 call sites (27 racy, 6
+promise-first, 1 other), and the intuitive expectation is that the total stays at 34 after the
+sweep. It does not. 001 routes 18 of the 27 through `searchAndAwaitResponse(...)`, and those cease
+to be wait call sites; the helper adds one internal wait back. `34 − 18 + 1 = 17`, of which 16 are
+promise-first. These figures come from 001 SC-001 and 001 T018 criterion 1. If the detector prints
+something else, the detector is wrong — not this document.
+
+No venv activation needed, and that is deliberate: the CI `Lint` job has no venv, so if this
+command needs one, the guard is broken in CI (spec FR-005).
+
+---
+
+## Run the local enforcement point
+
+```bash
+pre-commit run scan-waitforresponse-race --all-files
+```
+
+Or the whole config, the way CI does:
+
+```bash
+pre-commit run --all-files
+```
+
+---
+
+## Prove the guard actually works
+
+Installing a guard and observing green proves nothing. This repo contains a guard that is present,
+unskipped, green, and inert (`check-false-pass-patterns`, documented by its own authors at
+`pr-checks.yml:236-240`). The only evidence that matters is a planted violation.
+
+### 1. Plant a violation
+
+Create `frontend/tests/e2e/__scratch-race.spec.ts`:
+
+```ts
+// Target: Customer Dashboard (Next.js/Amplify)
+import { test } from '@playwright/test';
+
+test('planted violation - never commit this', async ({ page }) => {
+  await page.goto('/');
+  await page.getByRole('textbox').fill('AAPL');
+  // RACY: listener registered after the action that triggers the request
+  await page.waitForResponse((r) => r.url().includes('/api/v2/tickers'));
+});
+```
+
+### 2. Assert it fails in all local modes
+
+```bash
+# (a) local commit path, violation staged — this is what SC-002 decides
+git add frontend/tests/e2e/__scratch-race.spec.ts
+git commit -S -m "planted violation (should be refused)"; echo "mode-a exit=$?"
+                                                                     # expect non-zero, no commit created
+
+# (b) CI invocation shape: clean index, whole tree
+git restore --staged frontend/tests/e2e/__scratch-race.spec.ts
+pre-commit run --all-files; echo "mode-b exit=$?"                    # expect non-zero
+
+# (c) CI environment shape: no site-packages, stdlib only
+python3 -I -S scripts/scan-waitforresponse-race.py; echo "mode-c exit=$?"
+                                                                     # expect non-zero
+```
+
+**Mode (c) must be `-I -S`, not `env -u VIRTUAL_ENV`.** The obvious way to write "run it outside the
+venv" does not work and was caught in AR#2 as finding N-01. Unsetting `VIRTUAL_ENV` removes a
+marker variable but leaves `.venv/bin` on `PATH`, so `python3` still resolves inside the venv:
+
+```
+$ source .venv/bin/activate
+$ env -u VIRTUAL_ENV bash -c 'command -v python3'
+/home/…/sentiment-analyzer-gsk/.venv/bin/python3      # still the venv
+```
+
+Scrubbing `PATH` instead is worse: `/usr/bin/python3` on a CLAUDE.md-conformant machine is 3.12 or
+3.10, so the test would run the wrong interpreter and its result would say nothing about the CI
+runner. `-I` (isolated) plus `-S` (no `site`) keeps the 3.13 interpreter while removing
+site-packages entirely, which is exactly the property FR-005 requires. Confirmed locally: under
+`-I -S`, stdlib imports succeed and `import yaml` raises `ModuleNotFoundError`.
+
+Mode (c) is not redundant with (b). Modes (a) and (b) both run in a shell where `.venv` exists and
+is importable, so neither can detect a detector that quietly depends on a third-party package. That
+was AR#1 finding F-03; N-01 is the same trap one level down, which is why the mechanism is spelled
+out here rather than left to the reader.
+
+### 2b. Assert it fails in the real CI environment
+
+Local modes prove the detector's properties. Only CI proves the wiring.
+
+```bash
+git checkout -b tmp/gate-red-team
+git add -f frontend/tests/e2e/__scratch-race.spec.ts
+git commit -S -m "DO NOT MERGE [gate red-team] planted violation"
+git push -u origin HEAD
+gh pr create --draft --title "DO NOT MERGE [gate red-team]" --body "Verifies 002 guard fails a required check."
+gh pr checks --watch
+```
+
+Expect the **`Lint`** check to report failure. Close the PR and delete the branch afterwards. This
+mirrors Feature 1400's T006, which used the same draft red-team PR to prove a gate could actually
+fail rather than assuming it.
+
+### 3. Revert and assert green
+
+```bash
+rm frontend/tests/e2e/__scratch-race.spec.ts
+pre-commit run --all-files; echo "clean exit=$?"                    # expect 0
+git status --short                                                   # expect empty
+```
+
+The planted violation is **never committed** (SC-015).
+
+### 4. Prove an empty scan root fails
+
+```bash
+mv frontend/tests/e2e /tmp/e2e-parked
+python3 scripts/scan-waitforresponse-race.py; echo "empty-root exit=$?"   # expect non-zero
+mv /tmp/e2e-parked frontend/tests/e2e
+```
+
+If this exits 0, a future directory rename silently disables the guard forever (spec FR-013).
+
+### 5. Measure the cost
+
+```bash
+time python3 scripts/scan-waitforresponse-race.py
+```
+
+Record the real figure. Budget is under 2 seconds (SC-010). An estimate does not satisfy the
+criterion; the Stage 1 draft's "roughly ten files" guess was wrong by 5x, which is why measurement
+is required.
+
+---
+
+## Where the guard runs
+
+| Point | Trigger | Blocks a merge? |
+|---|---|---|
+| `repo: local` pre-commit hook | `git commit` | No — bypassable with `SKIP=` |
+| Step in the **`Lint`** job | Every PR to `main` | **Yes** — `Lint` is a required status check |
+| `Pre-commit Hooks` job (ride-along) | Every PR to `main` | No — job is not in the required contexts |
+| `make validate` | Manual | No |
+
+`main`'s required contexts are `["Secrets Scan", "Lint", "Run Tests"]`. Verify with:
+
+```bash
+gh api repos/traylorre/sentiment-analyzer-gsk/branches/main/protection \
+  --jq '.required_status_checks.contexts'
+```
+
+If `Lint` ever leaves that list, this guard becomes advisory and the enforcement point must move.
+That is the feature's single external dependency.
+
+---
+
+## When the guard fires on your commit
+
+Do not suppress it. There is no allowlist, no baseline, and no exemption mechanism, deliberately
+(spec FR-009). Fix the ordering:
+
+```ts
+// Before — RACY: the request can complete before the listener exists
+await searchInput.fill('AAPL');
+await page.waitForResponse((r) => r.url().includes('/api/v2/tickers'));
+
+// After — PROMISE-FIRST
+const responsePromise = page.waitForResponse(
+  (r) => r.url().includes('/api/v2/tickers'),
+  { timeout: 15000 }
+);
+await searchInput.fill('AAPL');
+await responsePromise;
+```
+
+Playwright's own documentation states the rule: *"Ensure the promise is initiated before the action
+that triggers the request."*
+
+If your shape is legitimately neither — an intervening assertion, say — the detector classifies it
+`OTHER`, prints it under the "requires human triage" banner, and does **not** block your commit.

--- a/specs/002-waitforresponse-lint-guard/quickstart.md
+++ b/specs/002-waitforresponse-lint-guard/quickstart.md
@@ -109,14 +109,35 @@ out here rather than left to the reader.
 
 Local modes prove the detector's properties. Only CI proves the wiring.
 
+Two things about this block are deliberate and easy to get wrong.
+
+**Branch from the feature branch, not `main`.** GitHub builds `pull_request` runs from the merge
+commit, so the `Lint` job contains the guard step only if this branch descends from
+`002-waitforresponse-lint-guard`. Cut it from `main` and the check goes green against a workflow
+that does not contain the thing under test.
+
+**The commit needs `SKIP=`.** By this point the local hook is installed and step 2a has already
+proved it refuses this exact file. `--no-verify` is forbidden by CLAUDE.md and denied by the global
+`block-no-verify` hook. `SKIP=` is the one bypass this design accepts, and needing it here is itself
+evidence the local hook fires. The required `Lint` job is not a pre-commit hook, so `SKIP=` has no
+effect on the gate under test.
+
 ```bash
+git checkout 002-waitforresponse-lint-guard
 git checkout -b tmp/gate-red-team
-git add -f frontend/tests/e2e/__scratch-race.spec.ts
-git commit -S -m "DO NOT MERGE [gate red-team] planted violation"
+git merge-base --is-ancestor 002-waitforresponse-lint-guard tmp/gate-red-team   # must succeed
+git add frontend/tests/e2e/__scratch-race.spec.ts
+SKIP=scan-waitforresponse-race git commit -S -m "DO NOT MERGE [gate red-team] planted violation"
 git push -u origin HEAD
 gh pr create --draft --title "DO NOT MERGE [gate red-team]" --body "Verifies 002 guard fails a required check."
 gh pr checks --watch
 ```
+
+The branch should also carry a **deliberate ruff violation** under `src/` or `tests/`. Without one,
+the ruff steps pass and the guard step runs whether or not `if: always()` is present, so the run
+cannot tell you the flag works. With one, the `Lint` log must show *both* failures in the same run.
+That is the only observation that distinguishes `if: always()` from its absence, and it is the
+flag's entire justification in FR-004.
 
 Expect the **`Lint`** check to report failure. Close the PR and delete the branch afterwards. This
 mirrors Feature 1400's T006, which used the same draft red-team PR to prove a gate could actually

--- a/specs/002-waitforresponse-lint-guard/research.md
+++ b/specs/002-waitforresponse-lint-guard/research.md
@@ -1,0 +1,221 @@
+# Research: waitForResponse race regression guard
+
+**Feature**: `002-waitforresponse-lint-guard` | **Date**: 2026-07-30
+
+All findings checked against the working tree at `35d5f61` unless the entry says otherwise.
+
+---
+
+## R1 — Is there an upstream lint rule for this pattern?
+
+**Question**: can an off-the-shelf rule detect act-then-wait `waitForResponse`?
+
+**Finding**: no.
+
+*Carried from 001's research, not re-verified here*: `eslint-plugin-playwright@2.11.0` ships 59
+rules, none of which covers request-listener ordering. The nearest names,
+`no-wait-for-navigation` and `no-wait-for-selector`, target deprecated APIs rather than the
+act-then-wait shape.
+
+*Verified here*: the published version is still `2.11.0` (`npm view eslint-plugin-playwright
+version`), and the plugin is **not installed** — `frontend/node_modules/eslint-plugin-playwright`
+does not exist.
+
+**Decision**: no upstream option. Detection must be repo-owned.
+
+**Secondary finding**: adopting the plugin wholesale is separately undesirable. 001's spec places it
+Out of Scope because its default rule set would flag unrelated violations
+(`no-conditional-in-test`, `no-networkidle`) across the existing suite, converting a targeted guard
+into a suite-wide cleanup project.
+
+---
+
+## R2 — Would a custom ESLint rule actually run?
+
+**Question**: if we wrote one, would it execute against `frontend/tests/e2e/*.spec.ts`?
+
+**Finding**: **no**, and this is decisive.
+
+Evidence chain:
+
+1. `frontend/package.json:9` — `"lint": "next lint"`. This is the only lint script.
+2. `frontend/.eslintrc.json` — a single `extends: "next/core-web-vitals"` line. No `overrides`, no
+   `ignorePatterns`.
+3. `frontend/next.config.js` — contains only `reactStrictMode` and `images`. No `eslint` block, so
+   no `dirs` override.
+4. No `--dir` argument anywhere in the npm scripts.
+5. Therefore `next lint` falls through to Next.js's built-in default:
+   `frontend/node_modules/next/dist/lib/constants.js:246-252` defines
+   `ESLINT_DEFAULT_DIRS = ["app", "pages", "components", "lib", "src"]`.
+6. `frontend/tests/` is not in that list.
+
+**Consequence**: a custom rule would be authored, registered, committed, reviewed, and silently
+never applied to a single file it was written for. It would present as working — `npm run lint`
+exits 0 — while detecting nothing. That is the same failure shape the feature exists to prevent,
+which makes it a particularly poor choice of mechanism.
+
+**Additional friction, secondary to the above**: the frontend runs ESLint 8 with a legacy
+`.eslintrc.json`. Local custom rules under legacy config require either a resolvable
+`eslint-plugin-*` module, the `eslint-plugin-local-rules` shim, or `--rulesdir`, none of which
+`next lint` exposes cleanly. This alone would not have been disqualifying; point 6 is.
+
+**Decision**: defer editor-time feedback. Carded FR-011(b). Revisit if the lint invocation is ever
+changed to cover `frontend/tests/`.
+
+---
+
+## R3 — Where should enforcement live so that it can actually block a merge?
+
+**Question**: which CI job, if any, has the authority to stop a bad merge?
+
+**Finding**: only three jobs do, and the obvious candidate is not among them.
+
+```
+gh api repos/traylorre/sentiment-analyzer-gsk/branches/main/protection \
+  --jq '.required_status_checks.contexts'
+→ ["Secrets Scan", "Lint", "Run Tests"]
+
+gh api repos/traylorre/sentiment-analyzer-gsk/rulesets --jq 'length'
+→ 0
+```
+
+The `pre-commit` job's display name is `Pre-commit Hooks` (`pr-checks.yml:192`). It is **absent**
+from the required contexts and there are no rulesets supplying an alternative path. A red
+`Pre-commit Hooks` job does not prevent `gh pr merge --auto --squash`, which is the merge command
+CLAUDE.md documents.
+
+**This inverted the design.** The Stage 1 draft asserted "the CI pre-commit job is a blocking gate"
+on the strength of having read the workflow file. The workflow file describes what runs; branch
+protection decides what matters. Reading one and concluding the other is the methodological error
+at the centre of AR#1 finding F-01.
+
+**Candidate hosts evaluated**:
+
+| Host | Required? | Environment | Verdict |
+|---|---|---|---|
+| `Pre-commit Hooks` job | **No** | pre-commit 4.6.0, checkov, bc-detect-secrets, trivy; **no `.venv`** | Advisory only. Reached for free via the hook config, so keep it — but it cannot be the control. |
+| `Lint` job | **Yes** | `actions/setup-python@v7`, `PYTHON_VERSION: '3.13'` (`:29`), installs only `ruff==0.15.14` | **Chosen.** Has a 3.13 interpreter, needs no new dependency for a stdlib-only script, and can block. |
+| `Run Tests` job | Yes | Full `requirements-dev.txt` install | Would work, but it is the slowest job and this check needs no dependencies. Wrong altitude. |
+| `Secrets Scan` job | Yes | gitleaks | Unrelated purpose. Rejected. |
+| New dedicated job | — | — | Would require adding it to required contexts: a repo settings change, admin-gated. Same blocker as the alternative below. |
+| Add `Pre-commit Hooks` to required contexts | — | — | Correct in the abstract, completes 1400 FR-007(b). Rejected here: admin rights needed, and it would retroactively make every hook merge-blocking, including `trivy-terraform`, documented as non-gating with 5 outstanding HIGH findings. Carded FR-011(f). |
+
+**Decision**: `Lint` job step (blocking) **plus** the pre-commit hook (local feedback, and it rides
+along in the advisory `Pre-commit Hooks` job at no cost).
+
+---
+
+## R4 — Does the CI runner have the project venv?
+
+**Question**: can a hook invoke `.venv/bin/python3`, as the repo's existing pytest hook does?
+
+**Finding**: **no**. `pr-checks.yml:211-221` installs `pre-commit==4.6.0`, `checkov==3.2.508`,
+`bc-detect-secrets==1.5.45`, and the trivy binary. There is no `.venv`, no `requirements-*.txt`
+install, and no bootstrap step.
+
+The existing precedent is `.pre-commit-config.yaml:139`:
+
+```yaml
+- id: pytest
+  entry: bash -c '.venv/bin/python3 -m pytest tests/unit -x --tb=short -q'
+```
+
+with the comment *"pre-commit runs in its own subprocess and doesn't inherit an activated venv"*.
+That hook is `stages: [push]`, so it never runs in CI and its `.venv` dependency has never been
+tested there.
+
+**Consequence**: copying that entry form into a commit-stage hook would put the guard permanently
+red in CI. Under R3's finding that the job is advisory, nobody would be blocked by it, so the
+pressure would be to SKIP-list it — landing precisely on 1400 AR3-F2's forbidden outcome.
+
+**Decision**: `entry: python3 scripts/scan-waitforresponse-race.py`, and require the detector be
+stdlib-only (FR-005). Filed as a change request against 001 T001 criterion 8, which currently
+specifies venv invocation. Venv invocation remains valid; venv *availability* must not be a
+precondition.
+
+---
+
+## R5 — pre-commit stage semantics and the deprecation clock
+
+**Question**: does `pre-commit run --all-files` run commit-stage hooks, and are the config's stage
+names safe?
+
+**Finding**: yes it does, and no they are not.
+
+*Empirically confirmed during AR#1 across pre-commit `4.5.1`, `4.6.0`, and `4.6.1`*: under
+`default_stages: [commit]` (`.pre-commit-config.yaml:36`), a stage-less hook runs under
+`pre-commit run --all-files`; a `stages: [push]` hook does not. All three versions emit:
+
+```
+[WARNING] ... uses deprecated stage names ... which will be removed in a future version.
+          run: `pre-commit migrate-config`
+```
+
+Three pins coexist: `4.6.1` (`requirements-dev.txt:37`, `requirements-ci.txt:58`), `4.6.0`
+(`pr-checks.yml:218`), `4.5.1` (project `.venv`). Behaviour is identical across all three, so the
+skew is harmless today and is recorded rather than fixed.
+
+**Decision**: state `stages: [pre-commit]` explicitly on the new hook. It is valid on all three
+installed versions and does not add to the deprecation debt. The config-wide migration
+(`pre-commit migrate-config`) touches every hook in the file and is carded FR-011(e).
+
+---
+
+## R6 — What does a guard in this repo look like when it fails?
+
+**Question**: are there worked examples of guards going inert here?
+
+**Finding**: yes, one, and its authors documented it themselves.
+
+`check-false-pass-patterns` (`.pre-commit-config.yaml:181-188`) is not in the CI `SKIP` list, so it
+runs in the `pre-commit` job. It does nothing there. Its `--staged-only` branch reads
+`git diff --cached --name-only --diff-filter=ACM` (`scripts/check-false-pass-patterns.sh:39-41`);
+`actions/checkout` leaves the index matching `HEAD`, so the diff is empty and it prints
+`No test files to check` and exits 0 (`:47-49`).
+
+Feature 1400 wrote this down in the job's own `env:` block at `pr-checks.yml:236-240`:
+
+> *"check-false-pass-patterns uses --staged-only and thus NO-OPS in CI (nothing is staged) — it
+> gates local commits only; not claimed as CI coverage here (honesty, per this feature's whole
+> point)."*
+
+**Second axis, not covered by that note**: the script's filter is `^tests/.*\.py$` (`:41`) and its
+non-staged branch is `find tests/e2e -name "*.py"` (`:44`). Both target the **admin** pytest suite.
+It could never have covered `frontend/tests/e2e/*.ts` under any invocation, so its scope was never
+this class of defect either.
+
+**Third example, adjacent**: `check-error-log-assertions` (`:170-177`) is `stages: [push]`. It looks
+like a structural twin of `check-false-pass-patterns` but fires on neither `git commit` nor
+`pre-commit run --all-files`. `pr-checks.yml:236-238` says so explicitly.
+
+**Generalised failure taxonomy** — a guard in this repo can be present, unskipped, green, and inert
+via any of:
+
+| Axis | Example | Countered by |
+|---|---|---|
+| Invocation mode | `--staged-only` on an empty CI index | FR-003 whole-tree scan (`pass_filenames: false`, `always_run: true`) |
+| Scan scope | filter targets the wrong suite | `contracts/detector-cli.md` C5 pins the scan root |
+| Hook stage | `stages: [push]` never runs on commit or `--all-files` | FR-003 forbids it |
+| Runtime environment | `.venv/bin/python3` absent on the runner | FR-005 stdlib-only, bare `python3` |
+| Job authority | job is not a required status check | FR-004 uses the required `Lint` job |
+| Empty target | scan root renamed, zero files, exit 0 | FR-013 non-zero on zero files |
+
+**Decision**: FR-007's four verification modes plus SC-011’s rename test cover all six rows. This
+taxonomy is the feature's actual contribution; the YAML is incidental.
+
+---
+
+## R7 — Scan cost
+
+**Question**: is a whole-tree scan on every commit affordable?
+
+**Finding**: the scan root holds **47** `.ts` files (`find frontend/tests/e2e -name "*.ts" | wc -l`),
+of which 6 contain `waitForResponse` or `waitForEvent` matches. A naive
+`grep -rn "waitForResponse\|waitForEvent"` over the root returns 41 lines, 7 of which are comments,
+leaving 34 real call sites (001 T001 criterion 4).
+
+The Stage 1 draft asserted "roughly ten files", which was wrong by roughly 5x and was an estimate
+presented as a fact in a section claiming verification.
+
+**Decision**: no estimate. SC-010 requires a **measured** figure with a 2-second budget, so the
+criterion can fail rather than being satisfied by assertion.

--- a/specs/002-waitforresponse-lint-guard/spec.md
+++ b/specs/002-waitforresponse-lint-guard/spec.md
@@ -682,8 +682,9 @@ detector rather than duplicate logic, so the single-definition property (FR-002)
 
 ### C2 — What lane, severity, and source should 002's board cards carry?
 
-**Answer**: the guard card lands in `done` at severity `medium`. The six FR-011 deferred cards land
-in `track` at severity `low`, except FR-011(d) and FR-011(f), which are `medium`.
+**Answer**: the guard card lands in `done` at severity `medium`. The seven FR-011 deferred cards,
+(a) through (g), land in `track` at severity `low`, except FR-011(d) and FR-011(f), which are
+`medium`.
 
 **Evidence**: `CLEANUP-BOARD.html` currently holds **118** cards
 (`raw_decode` on the text following `const CARDS = `). Its vocabularies are:

--- a/specs/002-waitforresponse-lint-guard/spec.md
+++ b/specs/002-waitforresponse-lint-guard/spec.md
@@ -418,16 +418,20 @@ list. Exactly one definition site exists.
   (f) the owner decision on whether `Pre-commit Hooks` should be added to `main`'s required status
   checks, completing 1400 FR-007 step (b) for that job;
   (g) `scripts/` is outside every **required** CI check. Verified: the `Lint` job runs
-  `ruff format --check src/ tests/`, `ruff check src/ tests/`, and `ruff check src/ --select S`;
+  `ruff format --check --diff src/ tests/`, `ruff check src/ tests/`, and `ruff check src/ --select S`;
   the bandit hook is `-r src/`; `make sast` scans `src/`; `make lint` is `ruff check src tests`. The
   detector is linted only by the `ruff-check` / `ruff-format` pre-commit hooks, which in CI run
   solely in the **non-required** `Pre-commit Hooks` job. This feature promotes a `scripts/` file into
   the required merge path without any required check covering it.
 
-- **FR-015**: This feature MUST correct the two in-repo statements that the `pre-commit` job is a
-  blocking gate:
-  `.pre-commit-config.yaml:190-192` (*"runs these hooks on every PR to main as a **BLOCKING**
-  gate"*) and the step name at `pr-checks.yml:229` (*"Run pre-commit (blocking)"*). Both are false
+- **FR-015** *(out of numeric order: FR-012, FR-013 and FR-014 follow this entry. FR-015 was added
+  during AR#1 and appended next to the FR-010/FR-011 scope block it belongs with. Do not stop
+  reading here — FR-012 carries the detector interface contract, AR#3 G-17)*: This feature MUST
+  correct the two in-repo statements that the `pre-commit` job is a blocking gate:
+  the comment block in `.pre-commit-config.yaml` reading *"runs these hooks on every PR to main as a
+  **BLOCKING** gate"* (at `:190-192` today, but locate it by that string — the new hook is inserted
+  into the same file first and shifts it, AR#3 G-10) and the step name at `pr-checks.yml:229`
+  (*"Run pre-commit (blocking)"*). Both are false
   against `main`'s verified `required_status_checks.contexts`, and both files are already inside
   FR-010's allowlist.
 
@@ -457,9 +461,12 @@ list. Exactly one definition site exists.
 - **FR-013**: The detector MUST report the number of files scanned, and a scan that examines **zero**
   files MUST exit non-zero. "No violations found" and "no files found" MUST NOT share an exit code.
   This closes the cheapest route to a permanently green inert guard: renaming or moving
-  `frontend/tests/e2e/`. This **extends** 001 T001 criterion 5 (which requires four counts but not
-  files-scanned) and **amends** criterion 6 (whose `sys.exit(0)` "otherwise" branch would return 0
-  on an empty scan). Both are filed under FR-010's amendment clause.
+  `frontend/tests/e2e/`. A zero-file scan MUST exit non-zero whether the root is **missing, renamed,
+  or present but empty** — testing only the rename passes a detector that raises on a missing
+  directory and returns 0 on an empty one (AR#3 G-08). This requirement is now carried by 001 T001
+  criteria 5 and 6 directly, folded in at `3b86d9c`. It was originally filed as an amendment against
+  criterion 5 (four counts, no files-scanned) and criterion 6 (whose `sys.exit(0)` "otherwise"
+  branch returned 0 on an empty scan); both criteria have since been rewritten.
 
 - **FR-014**: The guard MUST be exposed through a `make` target, that target MUST
   shell out to the same detector rather than duplicating any logic, and MUST be added to the
@@ -504,8 +511,10 @@ Each criterion names the command that decides it.
 - **SC-007**: `grep -rn "scan-waitforresponse-race" .pre-commit-config.yaml .github/` returns hits in
   **both** `.pre-commit-config.yaml` and `.github/workflows/pr-checks.yml`, inverting 001's T001
   criterion 9.
-- **SC-008**: `grep -A3 'SKIP:' .github/workflows/pr-checks.yml | grep -c scan-waitforresponse-race`
-  returns `0`, and the guard's step under `jobs.lint.steps` has a `run:` key (not a `uses:` or a
+- **SC-008**: `! grep -A3 'SKIP:' .github/workflows/pr-checks.yml | grep -q scan-waitforresponse-race`
+  succeeds — written as a negated `grep -q`, not `grep -c ... = 0`, because `grep -c` exits 1 on a
+  zero count and the success case would report as a failure (AR#3 G-19) — and the guard's step under
+  `jobs.lint.steps` has a `run:` key (not a `uses:` or a
   `pre-commit` invocation), so the `pre-commit` job's `SKIP` cannot reach it.
 - **SC-009**:
   `grep -rn "setInputFiles" --include='*.py' --include='*.js' --include='*.ts' --include='*.yaml' . | grep -v node_modules | grep -v '^./specs/' | cut -d: -f1 | sort -u | wc -l`
@@ -537,7 +546,11 @@ Each criterion names the command that decides it.
   two follow-up cards) → **128**. Counting by `source` rather than "locatable by grep" is
   deliberate: an unspecified grep pattern is satisfied by any eight cards, or by none.
 - **SC-015**: No file outside the FR-010 allowlist is modified, verified by `git diff --stat` against
-  the branch point, and the planted violation appears in no commit on any branch.
+  the branch point; and, after Phase E completes, the planted violation exists in no commit on
+  `main` and on no surviving branch or open PR. It necessarily exists on the temporary
+  `tmp/gate-red-team` branch while FR-007 mode (d) runs, which is what that mode tests. The earlier
+  absolute wording ("no commit on any branch") contradicted mode (d) and was unsatisfiable alongside
+  it (AR#3 G-11). FR-007's phrasing is the one of record.
 
 ## Out of Scope
 

--- a/specs/002-waitforresponse-lint-guard/spec.md
+++ b/specs/002-waitforresponse-lint-guard/spec.md
@@ -1,0 +1,776 @@
+# Feature Specification: waitForResponse race regression guard
+
+**Feature Branch**: `002-waitforresponse-lint-guard`
+**Created**: 2026-07-30
+**Status**: Draft
+**Depends on**: `001-waitforresponse-race-sweep` (hard dependency — see Context)
+**Input**: Add a repository guard that prevents reintroduction of the act-then-wait `waitForResponse`
+race pattern in Playwright E2E tests, enforced in both pre-commit and CI.
+
+## Context
+
+Feature 001 converts 27 racy `waitForResponse` / `waitForEvent` call sites in
+`frontend/tests/e2e/` from act-then-wait to promise-first. It fixes the sites that exist today. It
+does nothing about the 28th.
+
+The interesting question is not "how did 27 sites become racy" but "how did 27 sites become racy
+without anything noticing". The answer is that nothing was looking. The pattern is legal
+TypeScript, `tsc` accepts it, no lint rule in this repo examines it, and it reads naturally
+top-to-bottom in review. It fails only under load, in CI, in **5 of the 25 sampled PR-Checks runs
+where Playwright executed** (001 spec, "Confirmed CI failures"). That ~20% figure describes *runs*,
+not commits, and 001 states it that way deliberately. Every one of those 27 sites was written by
+someone who believed they were writing a correct test, and they were all correct in the only ways
+the toolchain could measure.
+
+So 001 pays down the debt and 002 stops it re-accruing. This feature adds the missing detector to
+the gate.
+
+### The dependency is not stylistic
+
+002 cannot land before 001. A guard that gates on "zero racy sites" would, on the pre-001 tree,
+fail immediately on all 27 existing violations. Landing it there would either block every commit in
+the repository or force it to ship with a suppression list, and a guard that ships pre-suppressed
+is the thing it was meant to prevent.
+
+This is settled repo doctrine, not a judgment call. The `trivy-terraform` hook in
+`.pre-commit-config.yaml:111-124` carries an in-line record of the same decision: Feature 1400
+intended to flip it to `--exit-code 1`, found 5 pre-existing HIGH findings, and left it non-gating
+with a `TODO` rather than born-red the gate. The comment's own words are *"Flipping now would
+born-red the pre-commit gate, violating the 'land green first' rule (FR-007)"* (`:114-115`) and
+*"Escape hatch per AR3-F2: never regress to decorative once green"* (`:117`).
+
+1400's FR-007 is worth quoting precisely, because its second clause is the one this feature nearly
+repeated. `specs/1400-validator-gating/spec.md:77-80` requires a gate to land **in two steps**:
+*"(a) job added and observed green on main (baseline must be clean BEFORE the job exists) … then
+(b) job marked as a required status check."* Step (b) is not decoration. See the next section.
+
+### What 001 hands over
+
+001 commits `scripts/scan-waitforresponse-race.py` (001 task T001) as a runnable artifact. It is
+already shaped as a guard's hook point, and was specified that way deliberately:
+
+| Property (001 T001 acceptance criteria) | Why 002 depends on it |
+|---|---|
+| Scans every `*.ts` under `frontend/tests/e2e/`, spec files **and** `helpers/` | The scan root is already the right one |
+| Classifies **both** `page.waitForResponse(...)` and `page.waitForEvent('requestfailed'\|'response')` | The method-name-only framing is what hid 3 of the 27 sites (001 AR#2 N-01) |
+| Documents the classification rule in its own module docstring | The rule is auditable without reading the parser |
+| Excludes comment lines from the call-site population (34 real sites, not the naive grep's 41) | A guard that counts comments produces false positives and gets disabled |
+| Adjacency rule: an intervening statement makes a site `OTHER`, not `RACY` | Verified against `chaos-scenarios.spec.ts:138` |
+| Prints `OTHER` sites under an explicit "requires human triage" banner | A shape the classifier cannot place stays visible instead of counting as clean by omission |
+| `sys.exit(1)` when `RACY > 0`, `sys.exit(0)` otherwise | This is the entire gating contract, already implemented |
+
+001 clarification **C4** (`001/spec.md:509-515`) states the split explicitly: the scan is committed
+as a runnable artifact only, is deliberately **not** wired into pre-commit or any workflow, and
+enforcement belongs to this feature. 001 task T001 criterion 9 asserts that
+`grep -rn "scan-waitforresponse-race" .pre-commit-config.yaml .github/` returns nothing. This
+feature makes that grep return something.
+
+**The detector does not exist yet.** Every task in `001/tasks.md` is unchecked. 002 is therefore
+specifying against an interface that has been described but never executed, which is why FR-012
+pins that interface down as an explicit contract rather than discovering it during verification.
+
+### Verified facts about the enforcement surface
+
+Each bullet names its evidence source. Items checked against the working tree at `35d5f61` say so;
+items carried from 001's research say that instead.
+
+- **No upstream rule exists.** *Source: 001 research, not re-verified here.* 001's spec records that
+  `eslint-plugin-playwright@2.11.0` ships 59 rules and none covers this pattern, the nearest
+  neighbours (`no-wait-for-navigation`, `no-wait-for-selector`) being about deprecated APIs rather
+  than ordering. *Checked at `35d5f61`:* the package version is current
+  (`npm view eslint-plugin-playwright version` → `2.11.0`) and the plugin is **not installed**
+  (`frontend/node_modules/eslint-plugin-playwright` does not exist). 001 places adopting it
+  wholesale in Out of Scope because it would flag unrelated violations (`no-conditional-in-test`,
+  `no-networkidle`) suite-wide.
+- **The frontend lint invocation cannot see the target files.** *Checked at `35d5f61`.*
+  `frontend/package.json:9` defines `"lint": "next lint"`. `frontend/.eslintrc.json` carries a
+  single `extends` line and nothing else. There is no `--dir` argument and no `eslint` block in
+  `frontend/next.config.js`, so `next lint` falls back to Next.js's `ESLINT_DEFAULT_DIRS`, which is
+  `["app", "pages", "components", "lib", "src"]`
+  (`frontend/node_modules/next/dist/lib/constants.js:246-252`). `frontend/tests/` is not in that
+  list. A custom ESLint rule added today would be committed, configured, and never executed against
+  a single file it was written for.
+- **The repo already guards frontend E2E test files.** *Checked at `35d5f61`.* `make validate`
+  depends on `check-test-target-headers` (`Makefile:42`), whose recipe (`:45-54`) greps
+  `frontend/tests/e2e/*.spec.ts` **and** `tests/e2e/test_*.py` for a `Target:` header. Repo-level
+  guards over this exact directory are established practice.
+- **The `Lint` job is a required status check; the `Pre-commit Hooks` job is not.** *Checked at
+  `35d5f61` via the GitHub API.*
+  `repos/traylorre/sentiment-analyzer-gsk/branches/main/protection` reports
+  `required_status_checks.contexts` = `["Secrets Scan", "Lint", "Run Tests"]`, and
+  `repos/.../rulesets` is empty. The `pre-commit` job's display name is `Pre-commit Hooks`
+  (`pr-checks.yml:192`), which is absent from that list. **A red `Pre-commit Hooks` job does not
+  block a merge**, and CLAUDE.md's documented workflow is `gh pr merge --auto --squash`, which waits
+  only on required checks. 1400 FR-007 step (b) has not been performed for this job.
+- **The required `Lint` job can host the detector as-is.** *Checked at `35d5f61`.*
+  `pr-checks.yml:35-65` runs `actions/setup-python@v7` with `PYTHON_VERSION: '3.13'` (`:29`) and
+  then `pip install ruff==0.15.14`. It has a Python 3.13 interpreter on `PATH` and installs nothing
+  else. A stdlib-only script runs there with no new dependency.
+- **The CI `pre-commit` job installs no project dependencies.** *Checked at `35d5f61`.*
+  `pr-checks.yml:211-221` installs `pre-commit==4.6.0`, `checkov`, `bc-detect-secrets`, and the
+  trivy binary. There is **no `.venv`** on the runner and no `requirements-*.txt` install. The
+  repo's only Python-invoking local hook is `pytest` (`.pre-commit-config.yaml:139`), wired as
+  `entry: bash -c '.venv/bin/python3 -m pytest …'` and carrying the comment *"pre-commit runs in its
+  own subprocess and doesn't inherit an activated venv"*. That hook is `stages: [push]`, so it never
+  runs in CI. Copying its `.venv/bin/python3` entry form into a commit-stage hook would put the
+  guard permanently red in CI.
+- **Two local pre-commit hooks look like a structural template; only one of them is.** *Checked at
+  `35d5f61`.* `check-error-log-assertions` (`.pre-commit-config.yaml:170-177`) and
+  `check-false-pass-patterns` (`:181-188`) are both `repo: local`, `language: script`,
+  `types: [python]`, `pass_filenames: false`, `always_run: true`. But
+  `check-error-log-assertions` is **`stages: [push]`** (`:177`) and therefore never runs on commit
+  and never runs under `pre-commit run --all-files`. Only `check-false-pass-patterns`
+  (`stages: [commit]`, `:188`) is a valid structural model, and only for its wiring shape.
+- **Stage names in this config are deprecated.** *Checked at `35d5f61`.* `.pre-commit-config.yaml:36`
+  sets `default_stages: [commit]`, and hooks use the legacy `commit` / `push` / `manual` names. All
+  installed pre-commit versions accept them while printing
+  `[WARNING] … uses deprecated stage names … which will be removed in a future version`.
+- **`--no-verify` is blocked; `SKIP=` is not.** *Checked at `35d5f61`.* A global
+  `block-no-verify.sh` PreToolUse hook denies `git … --no-verify` and `commit -n`. It matches on
+  those strings only, so `SKIP=<hook-id> git commit` bypasses any pre-commit hook without tripping
+  it, as does running git outside that harness entirely.
+- **`page.waitForRequest` has zero uses** in `frontend/tests/` (*checked at `35d5f61`*; grep returns
+  matches only under `node_modules/`), so it is a live *future* risk rather than a present gap.
+
+### The precedent this feature is correcting, and who found it
+
+`check-false-pass-patterns` is wired as `entry: ./scripts/check-false-pass-patterns.sh
+--staged-only`, `stages: [commit]`. It is not in the CI job's `SKIP` list, so it runs in the
+`pre-commit` job. In that job it does nothing.
+
+The script's `--staged-only` branch resolves its file list from
+`git diff --cached --name-only --diff-filter=ACM` (`scripts/check-false-pass-patterns.sh:39-41`).
+On a CI runner, `actions/checkout` leaves the index matching `HEAD`, so that diff is empty, the
+script prints `No test files to check`, and exits 0 (`:47-49`).
+
+**This was not discovered by this feature.** It is documented in the repo already, in the
+`pre-commit` job's own `env:` block at `pr-checks.yml:236-240`: *"check-false-pass-patterns uses
+--staged-only and thus NO-OPS in CI (nothing is staged) — it gates local commits only; not claimed
+as CI coverage here (honesty, per this feature's whole point)."* Feature 1400 found it and chose to
+write it down rather than paper over it. 002 inherits the lesson, not the credit.
+
+There is a second axis 1400's note does not call out: the script's file filter is `^tests/.*\.py$`
+(`:41`) and its non-staged branch is `find tests/e2e -name "*.py"` (`:44`). Both target the **admin**
+pytest suite. It could never have covered `frontend/tests/e2e/*.ts` under any invocation, so its
+scope was never this class of defect either.
+
+The operative conclusion for 002 is that a guard can be *present*, *not skipped*, *green*, and
+*inert*, and that the failure has more than one axis: invocation mode, scan scope, hook stage,
+runtime environment, and whether the job it runs in can block anything. FR-007 verifies against all
+of them rather than one.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - A reintroduced race is caught before it lands (Priority: P1)
+
+A contributor adds a Playwright test that fills a search box and then awaits
+`page.waitForResponse(...)` on the following line. They commit.
+
+**Why this priority**: this is the entire feature. Everything else is supporting structure.
+
+**Independent Test**: plant that exact shape in a scratch file under `frontend/tests/e2e/`, stage
+it, and attempt a commit. The commit is refused with a message naming the file, the line, and the
+correct promise-first shape.
+
+**Acceptance Scenarios**:
+
+1. **Given** a clean post-001 tree where the guard reports zero racy sites, **When** a contributor
+   stages a new test containing an act-then-wait `page.waitForResponse`, **Then** the commit is
+   refused and the output names `file:line` and states the required promise-first ordering.
+2. **Given** the same violation reaching a pull request without a local hook run, **When** the PR's
+   **`Lint`** job runs, **Then** that job fails. Because `Lint` is a required status check, the PR
+   cannot be merged, including by `gh pr merge --auto --squash`.
+3. **Given** a contributor writes the promise-first shape correctly, **When** they commit, **Then**
+   the guard passes and adds no friction.
+4. **Given** a contributor writes an act-then-wait `page.waitForEvent('requestfailed')`, **When**
+   they commit, **Then** it is refused identically. Coverage is by shape, not by method name.
+
+---
+
+### User Story 2 - The guard is provably not decorative (Priority: P1)
+
+A maintainer six months from now needs to know whether the green check means anything.
+
+**Why this priority**: co-equal P1 with US1. A guard whose effectiveness is unverified is
+indistinguishable from no guard, and this repo has a live, self-documented example of exactly that
+failure. Shipping US1 without US2 ships a claim, not a control.
+
+**Independent Test**: run the guard in every invocation mode against a planted violation and record
+each non-zero exit as evidence.
+
+**Acceptance Scenarios**:
+
+1. **Given** a planted violation in the working tree, **When** the guard runs in the local
+   pre-commit invocation, **Then** it exits non-zero.
+2. **Given** the same planted violation present, **When** `pre-commit run --all-files` runs on a
+   checkout whose index matches `HEAD`, **Then** it exits non-zero. An empty staged diff MUST NOT be
+   able to produce a pass.
+3. **Given** the same planted violation present, **When** the detector is invoked with
+   **site-packages disabled** (`python3 -I -S`), **Then** it exits non-zero. This approximates the
+   CI `Lint` job's dependency set, where only ruff is installed.
+4. **Given** the same planted violation present on a draft pull request, **When** CI runs, **Then**
+   the **`Lint`** required check fails. This is the only scenario that exercises the wiring rather
+   than the detector.
+5. **Given** the planted violation is reverted, **When** every invocation is repeated, **Then** all
+   exit zero.
+5. **Given** the detector script is missing, renamed, or unrunnable, **When** any enforcement point
+   runs, **Then** it fails loudly rather than passing.
+
+---
+
+### User Story 3 - The classification rule has exactly one home (Priority: P2)
+
+Someone adds a new triggering-action idiom to the suite and needs to teach the detector about it.
+
+**Why this priority**: correctness over time. 001's AR#3 found `.evaluate(` in live use at
+`error-visibility-search.spec.ts:158` after an earlier seven-token list had already been called
+complete. The token list will need editing again, and it must be editable in one place.
+
+**Independent Test**: grep the executable surface of the repository for the trigger-action token
+list. Exactly one definition site exists.
+
+**Acceptance Scenarios**:
+
+1. **Given** the guard is installed, **When** a maintainer greps outside `specs/` for a trigger
+   token such as `setInputFiles`, **Then** the only definition-site hit is 001's scan script.
+2. **Given** a maintainer adds a token to that list, **When** they re-run the guard, **Then** every
+   enforcement point picks up the new token with no second edit anywhere.
+
+---
+
+### User Story 4 - The board reflects the closed loop (Priority: P3)
+
+**Why this priority**: bookkeeping, and it depends on 001's board edits landing first.
+
+**Independent Test**: grep `CLEANUP-BOARD.html` for the named card titles and confirm each exists.
+
+**Acceptance Scenarios**:
+
+1. **Given** 001's board edits have landed, **When** 002 lands, **Then** `CLEANUP-BOARD.html`
+   contains a card recording the guard as the closing half of the race-class work, plus one card per
+   FR-011 deferred item.
+
+### Edge Cases
+
+- **A contributor legitimately needs a shape the classifier calls `OTHER`.** `OTHER` does not fail
+  the gate (only `RACY` does), but it is printed under 001's "requires human triage" banner. The
+  guard must not convert that banner into a hard failure, or every novel-but-correct shape becomes
+  a blocked commit.
+- **A commit touches no test files at all.** With `always_run: true` and a whole-tree scan, the
+  guard still runs. That is intended: it means a violation cannot arrive via a merge, a rebase, or a
+  revert that stages nothing under `frontend/tests/e2e/`.
+- **`SKIP=<hook-id> git commit`.** A known, unclosable local bypass. `block-no-verify.sh` matches
+  `--no-verify` and `commit -n` only, so `SKIP=` passes it, as does running git outside that
+  harness. This is precisely why FR-004 puts the blocking enforcement point in a **required CI
+  job** rather than relying on the local hook. The local hook is a fast-feedback convenience; the
+  required job is the control.
+- **`SKIP=` set in the workflow.** FR-004's `Lint` step is a plain `run:` step, not a pre-commit
+  hook, so the `pre-commit` job's `SKIP` env cannot disable it.
+- **The scan script is deleted in the same commit that would introduce a violation.** FR-008 covers
+  the detector being absent; every enforcement point must fail rather than pass.
+- **`frontend/tests/e2e/` is empty, missing, or renamed.** Covered by FR-013: zero files scanned is
+  itself a failure, because "found no violations" and "found no files" are the same exit code
+  otherwise, and a directory rename would silently turn the guard green forever.
+- **Someone adds Playwright specs outside `frontend/tests/e2e/`.** Out of the detector's root, so
+  silently unguarded. Carded under FR-011(c) rather than solved here.
+- **A violation is introduced by a machine, not a person** — a codemod or an AI-assisted edit that
+  never runs a local hook. The required-job enforcement point is the one that catches this.
+- **Fork PRs and path filters.** *Checked at `35d5f61`:* `pr-checks.yml:18-26` declares
+  `pull_request: branches: [main]` with **no `paths:` filter**, so the `Lint` job runs on every PR
+  to `main` including from forks. No gap here today; a future `paths:` filter would introduce one.
+- **The deprecated stage names are removed by a future pre-commit release.** `default_stages:
+  [commit]` and `stages: [push]` are already warned as scheduled for removal. FR-003 requires the
+  new hook use the modern `pre-commit` stage name so this feature does not add to that debt, and
+  FR-011(e) cards the config-wide migration.
+- **Six months unattended.** The three failure modes are: the detector is renamed (FR-008), the scan
+  root is renamed (FR-013), and the `Lint` job's Python is bumped past what a stdlib-only script
+  tolerates (low risk, and the job fails loudly rather than silently if so).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The guard MUST refuse a commit locally, and MUST fail a **required** CI status check,
+  when any file under `frontend/tests/e2e/` contains an awaited `page.waitForResponse(...)` or
+  `page.waitForEvent('requestfailed'|'response')` whose immediately preceding non-comment,
+  non-blank line performs a triggering action. This is the `RACY` classification from 001 FR-011,
+  reused verbatim rather than restated.
+
+- **FR-002**: The guard MUST reuse `scripts/scan-waitforresponse-race.py` from 001 as its detector.
+  It MUST NOT reimplement the classification rule in a second language or a second file. The
+  trigger-action token list, the comment-exclusion rule, the adjacency rule, and the
+  `waitForEvent` coverage all have exactly one definition site, and it is that script.
+
+  Rationale, since this is the feature's central decision: a second implementation is a second
+  truth. 001's history shows the token list is not stable — it grew from seven tokens to thirteen when
+  `.evaluate(` was found live during AR#3 — and a JavaScript copy of an evolving Python list is a
+  drift generator. It would reproduce the precise class of miss (a detector whose framing is
+  narrower than the defect) that let 3 sites hide.
+
+- **FR-003 (local enforcement point)**: The guard MUST be wired as a `repo: local` hook in
+  `.pre-commit-config.yaml` with `pass_filenames: false`, `always_run: true`, and
+  `stages: [pre-commit]` stated explicitly.
+
+  Constraints, each closing an observed failure mode:
+  - It MUST use `language: system` with an entry of the form
+    `python3 scripts/scan-waitforresponse-race.py`. This requires no shebang and no mode change on
+    the detector, keeping FR-010's file allowlist honest, and it avoids the `.venv/bin/python3`
+    entry form that would fail on a CI runner.
+  - It MUST NOT use `stages: [push]` or `stages: [manual]`. `check-error-log-assertions` is
+    `stages: [push]` and is therefore **not** a valid template despite looking like one; a push-stage
+    hook fires on neither `git commit` nor `pre-commit run --all-files`, which would defeat US1 and
+    US2 simultaneously while producing no output to notice.
+  - It MUST use the modern `pre-commit` stage name rather than the deprecated `commit` alias, so the
+    guard does not depend on a name its own tooling has announced for removal.
+  - It MUST NOT be added to the `SKIP` list of the `pre-commit` job in `pr-checks.yml`.
+
+- **FR-004 (blocking enforcement point)**: The guard MUST additionally run as a step in the
+  **`Lint`** job of `.github/workflows/pr-checks.yml`, invoking the same detector directly.
+
+  This is the requirement that makes FR-001's "MUST fail CI" true. `Lint` is one of the three
+  required status checks on `main` (`["Secrets Scan", "Lint", "Run Tests"]`); the `Pre-commit Hooks`
+  job is not, so a guard reaching CI only through the pre-commit config would be advisory and could
+  not stop `gh pr merge --auto --squash`. The `Lint` job already provides Python 3.13 via
+  `actions/setup-python@v7` and installs only ruff, so the step adds no dependency.
+
+  This does **not** duplicate the detector, only its invocation, so FR-002's single-source-of-truth
+  property is preserved. The alternative — adding `Pre-commit Hooks` to the required contexts — is a
+  repository settings change requiring admin rights and is deliberately **out of scope**, recorded
+  as an owner decision under FR-011(f).
+
+  The step MUST carry `if: always()`. GitHub Actions steps are fail-fast, and the guard is placed
+  last in the job (Clarification C4), so without it any of the three preceding ruff steps failing
+  means the guard never runs and produces no output at all. A PR that is both ruff-dirty and
+  race-dirty would report only the ruff failure, and the contributor would discover the race on a
+  second round trip. With `if: always()` the job still fails; both failures surface in one run.
+
+  The step MUST be a plain `run:` step, not a `pre-commit` invocation, so the `pre-commit` job's
+  `SKIP` environment variable cannot reach it.
+
+- **FR-005**: The detector MUST be runnable with the standard library alone, under a bare
+  `python3` (3.13) interpreter, with no `.venv`, no `pip install`, and no import of anything in
+  `requirements-*.txt`.
+
+  This is a **change request against 001 task T001**, whose criterion 8 specifies invocation under
+  the project venv. Venv invocation remains valid and is unaffected; this requirement adds that
+  venv availability MUST NOT be a precondition, because the `Lint` job has no venv. If 001's
+  implementation introduces a third-party import, that is a defect against this requirement and must
+  be reconciled before 002 can land.
+
+- **FR-006**: The guard's failure output MUST name each offending `file:line` and MUST include a
+  literal corrected example showing the promise-first ordering, so a contributor can act on it
+  without opening this spec. Verifiable by asserting the output contains the offending `file:line`
+  and a line matching `const <name>Promise = page.waitForResponse` before the triggering action.
+
+- **FR-007**: The guard MUST be verified against a **deliberately planted violation** in all four
+  modes before it is accepted:
+  (a) the local commit path on a staged violation (`git commit`, not merely `pre-commit run`);
+  (b) `pre-commit run --all-files` against a checkout whose index matches `HEAD`;
+  (c) a **site-packages-free** invocation, `python3 -I -S scripts/scan-waitforresponse-race.py`;
+  (d) a real CI run: a draft pull request carrying the planted violation, on which the **`Lint`**
+  required check is observed to fail.
+  Each MUST exit non-zero with the violation present and zero with it absent. The planted violation
+  MUST NOT be merged, and MUST NOT survive on any branch after verification.
+
+  Mode (c) MUST use `-I -S` and MUST NOT use `env -u VIRTUAL_ENV`. Unsetting `VIRTUAL_ENV` clears a
+  marker variable while leaving `.venv/bin` on `PATH`, so `python3` still resolves inside the venv —
+  verified in this repo, where `env -u VIRTUAL_ENV bash -c 'command -v python3'` returns
+  `.venv/bin/python3`. Scrubbing `PATH` instead selects the system interpreter, which is 3.12 or
+  3.10 on a CLAUDE.md-conformant machine and so tests the wrong version. `-I` with `-S` keeps 3.13
+  and removes site-packages, which is exactly the FR-005 property.
+
+  Modes (c) and (d) are not redundant with (b). The `check-false-pass-patterns` precedent went inert
+  on the *invocation mode* axis; verifying only that axis repeats the spec's own error one level up,
+  because (a) and (b) both run where `.venv` is importable and neither can detect a detector with a
+  third-party dependency. Mode (d) is the only one that exercises the wiring rather than the
+  detector, and it follows 1400 T006's draft red-team PR precedent. Local green on an unmodified
+  tree is not evidence at all — the pre-001 tree also went green on `npm run lint` while holding 27
+  violations.
+
+- **FR-008**: Every enforcement point MUST fail loudly if the detector is absent, unrunnable, or
+  exits non-zero for any reason other than `RACY > 0`. A missing detector, an unresolvable
+  interpreter, or an internal exception MUST NOT be reported as a pass. The detector MUST NOT catch
+  a scanning exception and exit 0; any such swallow is a defect against this requirement.
+
+- **FR-009**: The guard MUST be introduced only on a tree where 001's sweep has already landed, so
+  it is green on arrival. It MUST NOT ship with a suppression list, a baseline file, an allowlist,
+  or a non-gating mode. Per 1400 AR3-F2, once green it MUST NOT be softened to decorative; a future
+  violation is fixed, not exempted.
+
+- **FR-010**: No product-code changes and no changes to test assertions. This feature adds
+  enforcement wiring and verification evidence only. The set of files it may modify is
+  `.pre-commit-config.yaml`, `.github/workflows/pr-checks.yml`, `Makefile`, `CLEANUP-BOARD.html`,
+  and this spec directory. It MUST NOT edit `scripts/scan-waitforresponse-race.py` except where
+  FR-005 or FR-012 reveals a mismatch with 001's delivered implementation, and any such edit MUST be
+  recorded as a change against 001's T001 acceptance criteria rather than made silently.
+
+- **FR-011**: Deferred items MUST be recorded as cards in `CLEANUP-BOARD.html` rather than dropped:
+  (a) `page.waitForRequest` coverage, currently zero-use and therefore a future risk;
+  (b) editor-time feedback via a custom ESLint rule, which today would require changing the
+  `next lint` invocation to reach `frontend/tests/`;
+  (c) extending the scan root beyond `frontend/tests/e2e/` if Playwright specs are ever added
+  elsewhere;
+  (d) the `check-false-pass-patterns` CI inertness and its admin-suite-only scope, already
+  documented at `pr-checks.yml:236-240` and belonging to that feature to fix;
+  (e) migrating `.pre-commit-config.yaml` off deprecated stage names
+  (`pre-commit migrate-config`), which affects every hook in the file and so is not this feature's
+  to perform;
+  (f) the owner decision on whether `Pre-commit Hooks` should be added to `main`'s required status
+  checks, completing 1400 FR-007 step (b) for that job;
+  (g) `scripts/` is outside every **required** CI check. Verified: the `Lint` job runs
+  `ruff format --check src/ tests/`, `ruff check src/ tests/`, and `ruff check src/ --select S`;
+  the bandit hook is `-r src/`; `make sast` scans `src/`; `make lint` is `ruff check src tests`. The
+  detector is linted only by the `ruff-check` / `ruff-format` pre-commit hooks, which in CI run
+  solely in the **non-required** `Pre-commit Hooks` job. This feature promotes a `scripts/` file into
+  the required merge path without any required check covering it.
+
+- **FR-015**: This feature MUST correct the two in-repo statements that the `pre-commit` job is a
+  blocking gate:
+  `.pre-commit-config.yaml:190-192` (*"runs these hooks on every PR to main as a **BLOCKING**
+  gate"*) and the step name at `pr-checks.yml:229` (*"Run pre-commit (blocking)"*). Both are false
+  against `main`'s verified `required_status_checks.contexts`, and both files are already inside
+  FR-010's allowlist.
+
+  This is not scope creep, and the distinction matters. `.pre-commit-config.yaml:190-192` is
+  **the sentence this feature's own Stage 1 draft read and believed**, producing AR#1's CRITICAL
+  finding F-01 and a design that would have shipped an advisory guard. The new hook lands a few
+  lines below it. Leaving the claim in place while adding a hook that depends on the opposite fact
+  guarantees the next reader repeats the error, and this feature would have fixed its own text while
+  leaving the source of the mistake intact. The correction is two comment edits.
+
+- **FR-012 (detector interface contract)**: Because the detector does not exist yet, 002 pins the
+  interface it wires against. The detector MUST satisfy:
+
+  | Aspect | Contract |
+  |---|---|
+  | Invocation | `python3 scripts/scan-waitforresponse-race.py`, no required arguments, runnable from the repo root |
+  | Exit 0 | `RACY == 0` **and** at least one file was scanned |
+  | Exit 1 | `RACY > 0` |
+  | Exit non-zero, non-1 | any internal error; MUST NOT be 0 |
+  | Findings output | `file:line CLASSIFICATION` per site, on stdout |
+  | Summary output | counts for `RACY` / `PROMISE-FIRST` / `OTHER` **and** the number of files scanned |
+  | Triage banner | `OTHER` sites listed under an explicit "requires human triage" heading; does not affect exit code |
+
+  Any divergence between this table and 001's delivered script MUST be reconciled as an amendment to
+  001 T001, not absorbed silently into 002's wiring.
+
+- **FR-013**: The detector MUST report the number of files scanned, and a scan that examines **zero**
+  files MUST exit non-zero. "No violations found" and "no files found" MUST NOT share an exit code.
+  This closes the cheapest route to a permanently green inert guard: renaming or moving
+  `frontend/tests/e2e/`. This **extends** 001 T001 criterion 5 (which requires four counts but not
+  files-scanned) and **amends** criterion 6 (whose `sys.exit(0)` "otherwise" branch would return 0
+  on an empty scan). Both are filed under FR-010's amendment clause.
+
+- **FR-014**: The guard MUST be exposed through a `make` target, that target MUST
+  shell out to the same detector rather than duplicating any logic, and MUST be added to the
+  `validate` target's dependency list, consistent with how `check-test-target-headers` is wired at
+  `Makefile:42`.
+
+### Key Entities
+
+- **Detector**: `scripts/scan-waitforresponse-race.py`, owned by 001, contracted by FR-012.
+  Classifies every call site as `RACY` / `PROMISE-FIRST` / `OTHER`. 002 consumes it, does not own it,
+  and files amendments rather than edits.
+- **Local gate**: a `repo: local` pre-commit hook (FR-003). Fast feedback. Bypassable via `SKIP=`.
+- **Blocking gate**: a step in the required `Lint` job (FR-004). Not bypassable by a contributor.
+- **Planted violation**: a temporary act-then-wait site used solely as FR-007 evidence. Never
+  committed.
+
+## Success Criteria *(mandatory)*
+
+Each criterion names the command that decides it.
+
+- **SC-001**: On the post-001 tree with the guard installed, `pre-commit run --all-files` exits 0,
+  and the detector reports `RACY 0 / PROMISE-FIRST 16 / OTHER 1`, total **17**, across **48** files
+  scanned. The 16/17 figures are 001's (SC-001, T018 criterion 1), not this feature's, and MUST NOT
+  be adjusted to match whatever the detector happens to print — that would discard the only
+  independent check that it counted the right things.
+- **SC-002**: With a planted violation staged, `git commit -S` is **refused** (non-zero, no commit
+  object created) and the output contains the planted `file:line`. Asserted with `git commit`, not
+  `pre-commit run`, because the commit path is what US1 promises.
+- **SC-003**: With the same planted violation present but **unstaged**, `pre-commit run --all-files`
+  on a checkout whose index matches `HEAD` exits non-zero. This is the assertion that distinguishes
+  this guard from `check-false-pass-patterns`.
+- **SC-004**: With the same planted violation present,
+  `python3 -I -S scripts/scan-waitforresponse-race.py` exits non-zero. `-I -S` is required; see
+  FR-007 mode (c) for why `env -u VIRTUAL_ENV` does not test what it appears to.
+- **SC-005**: On the post-001 tree **without** a planted violation,
+  `python3 -I -S scripts/scan-waitforresponse-race.py` exits **0**. This is the durable FR-005
+  check: it fails the moment anyone adds a third-party import to the detector, rather than relying
+  on a one-time Phase A inspection.
+- **SC-006**: A draft pull request carrying the planted violation shows the **`Lint`** required
+  check as failed (`gh pr checks`). This is the only criterion that exercises the wiring rather than
+  the detector.
+- **SC-007**: `grep -rn "scan-waitforresponse-race" .pre-commit-config.yaml .github/` returns hits in
+  **both** `.pre-commit-config.yaml` and `.github/workflows/pr-checks.yml`, inverting 001's T001
+  criterion 9.
+- **SC-008**: `grep -A3 'SKIP:' .github/workflows/pr-checks.yml | grep -c scan-waitforresponse-race`
+  returns `0`, and the guard's step under `jobs.lint.steps` has a `run:` key (not a `uses:` or a
+  `pre-commit` invocation), so the `pre-commit` job's `SKIP` cannot reach it.
+- **SC-009**:
+  `grep -rn "setInputFiles" --include='*.py' --include='*.js' --include='*.ts' --include='*.yaml' . | grep -v node_modules | grep -v '^./specs/' | cut -d: -f1 | sort -u | wc -l`
+  returns **1**, and that file is `scripts/scan-waitforresponse-race.py`.
+
+  Two things about this command are deliberate. It counts **files, not lines**: any real
+  implementation holds the thirteen tokens both in the module docstring (001 T001 criterion 3
+  requires them verbatim there) and in an executable list, so a line count returns ≥2 on a correct
+  build and the criterion would read as a false failure — the same trap 001 hit with its own
+  `searchAndAwaitResponse` grep. And the `specs/` exclusion is needed because `specs/` contains real
+  `.ts` and `.yaml` files that the `--include` filters match. It is *not* needed for
+  `001/tasks.md:61-63`, which is Markdown and unreachable by these filters; an earlier draft gave
+  that as the reason, which would have led the next reader to delete the exclusion as unnecessary.
+- **SC-010**: The detector's wall-clock runtime on the full scan root (**48** `.ts` files
+  post-001, of which 6 contain matches) is measured with `time` and recorded, and is **under 2
+  seconds**. A measured figure is required; an estimate does not satisfy this.
+- **SC-011**: With `frontend/tests/e2e/` temporarily renamed, the detector exits non-zero rather
+  than reporting a clean scan.
+- **SC-012**: With `scripts/scan-waitforresponse-race.py` temporarily renamed, **both** the
+  pre-commit hook and the `Lint` job's command shape exit non-zero. This is FR-008's only
+  verification; without it, "a missing detector must not read as a pass" is asserted by construction
+  and checked by nobody.
+- **SC-013**: `make validate` exits non-zero with a planted violation present, and
+  `grep -n 'check-waitforresponse-race' Makefile` shows the target on the `validate` dependency
+  line.
+- **SC-014**: All required cards exist in `CLEANUP-BOARD.html`, verified by counting cards whose
+  `source` field is `002-waitforresponse-lint-guard`: exactly **8** — one guard card plus one per
+  FR-011 item (a) through (g), which is seven items. Total board count goes 118 → 120 (after 001's
+  two follow-up cards) → **128**. Counting by `source` rather than "locatable by grep" is
+  deliberate: an unspecified grep pattern is satisfied by any eight cards, or by none.
+- **SC-015**: No file outside the FR-010 allowlist is modified, verified by `git diff --stat` against
+  the branch point, and the planted violation appears in no commit on any branch.
+
+## Out of Scope
+
+- Fixing the 27 existing racy sites. That is 001.
+- Adopting `eslint-plugin-playwright` wholesale. It has no rule for this pattern and would flag
+  unrelated violations suite-wide; 001's spec already places it out of scope.
+- Writing a custom ESLint rule now. Deferred under FR-011(b) because `next lint` does not reach
+  `frontend/tests/`, so the rule would not execute.
+- Changing what any test asserts, or any product code.
+- Making the Playwright E2E job a required merge check. The owner explicitly deferred that decision
+  to after the sweep lands and the job shows a clean streak.
+- Adding `Pre-commit Hooks` to `main`'s required status checks. This is a repository settings change
+  needing admin rights and it would retroactively make every currently-non-blocking hook blocking, a
+  much larger blast radius than this feature. Carded under FR-011(f) as an owner decision.
+- Remediating the `check-false-pass-patterns` CI inertness or its admin-suite-only scope. Carded
+  under FR-011(d).
+- Migrating the whole config off deprecated stage names. Carded under FR-011(e).
+- Extending the detector to `page.waitForRequest`. Zero current uses; carded under FR-011(a).
+
+## Assumptions
+
+- 001 lands before 002. Every requirement here assumes `scripts/scan-waitforresponse-race.py` exists,
+  satisfies FR-012, and reports `RACY 0` on the tree 002 is applied to.
+- `Lint` remains a required status check on `main`. If it is removed from
+  `required_status_checks.contexts`, FR-004's blocking property is lost and the enforcement point
+  must move. This is the single external condition the feature's correctness depends on.
+- **pre-commit version skew is accepted, with evidence.** Three pins exist:
+  `requirements-dev.txt:37` and `requirements-ci.txt:58` pin `4.6.1`, `pr-checks.yml:218` pins
+  `4.6.0`, and the project `.venv` currently runs `4.5.1`. Stage-selection behaviour was confirmed
+  identical across all three during AR#1: a stage-less hook under `default_stages: [commit]` runs
+  under `pre-commit run --all-files`, a `stages: [push]` hook does not, and all three emit the
+  deprecation warning without erroring. FR-003's explicit `stages: [pre-commit]` is valid on all
+  three. Reconciling the pins is not this feature's work.
+- FR-004 places the blocking check in `Lint`, a job whose name describes linting. A reader may find a
+  Playwright race scan there surprising. Accepted deliberately: correctness of the gate outranks
+  tidiness of job naming, and the alternative requires an owner-gated settings change. The step MUST
+  carry a comment explaining why it lives there.
+
+---
+
+## Adversarial Review #1
+
+Conducted by an independent reviewer against the Stage 1 draft, then re-verified by the
+orchestrator. The reviewer was instructed to check every factual claim and line-number citation in
+Context against the live tree rather than assess plausibility. It returned 3 CRITICAL, 5 HIGH,
+6 MEDIUM, 3 LOW.
+
+**Orchestrator re-verification.** Per the project's refuter standard the reviewer's highest-impact
+claims were re-checked directly rather than accepted from its summary. All four load-bearing claims
+verified TRUE:
+
+| Re-checked claim | Command | Result |
+|---|---|---|
+| `Pre-commit Hooks` is not a required status check | `gh api repos/traylorre/sentiment-analyzer-gsk/branches/main/protection --jq '.required_status_checks.contexts'` | `["Secrets Scan","Lint","Run Tests"]`; rulesets count `0` |
+| The false-pass CI no-op was already documented | `sed -n '230,245p' .github/workflows/pr-checks.yml` | Documented verbatim at `:236-240` |
+| `check-error-log-assertions` is `stages: [push]` | `sed -n '168,189p' .pre-commit-config.yaml` | Confirmed at `:177` |
+| Scan root holds 47 `.ts` files, not "roughly ten" | `find frontend/tests/e2e -name "*.ts" \| wc -l` | `47` |
+
+Two further checks were run to validate the *resolutions* rather than the findings: the `Lint` job's
+environment (`pr-checks.yml:35-65` — `setup-python@v7`, `PYTHON_VERSION: '3.13'`, installs only
+ruff) and SC-007's grep, which returns empty on the pre-001 tree as expected and must return exactly
+one hit once the detector lands.
+
+### Findings
+
+| ID | Severity | Finding | Resolution |
+|---|---|---|---|
+| F-01 | CRITICAL | "The CI pre-commit job is a blocking gate" is **false**. `Pre-commit Hooks` is not in `main`'s required contexts, so US1 AS2's "the PR is blocked" was false on day one and the whole CI enforcement point was advisory. 1400 FR-007 step (b) was never performed for that job. | Design changed. New **FR-004** puts the blocking check in the **`Lint`** job, which *is* required, needs no repo-settings change, and already has Python 3.13. Every "blocking gate" claim in Context rewritten to the verified branch-protection state. Adding `Pre-commit Hooks` to required contexts moved to Out of Scope and carded as an owner decision, FR-011(f). |
+| F-02 | CRITICAL | The CI `pre-commit` job installs no `.venv` and no project deps. The repo's only Python-hook precedent uses `entry: bash -c '.venv/bin/python3 …'`; copying it would put the guard permanently red in CI, which under F-01 nobody is blocked by, so it would get SKIP-listed. | New **FR-005** requires the detector be stdlib-only and runnable under a bare `python3`, filed as an explicit change request against 001 T001 criterion 8. **FR-003** mandates `language: system` with a `python3 …` entry, never `.venv/bin/python3`. |
+| F-03 | CRITICAL | FR-006(b) claimed `pre-commit run --all-files` on a clean index "reproduces the CI condition". It reproduces the *index state* only, not the *environment*. Both original verification modes run where a `.venv` exists, so neither could detect an environment-dependent guard. The spec applied its own lesson to one axis and stopped. | **FR-007** now requires three modes, adding (c): a clean environment with no `.venv` and no project dependencies. New **SC-004** asserts it. The rationale is stated in-line so the third mode is not later pruned as redundant. |
+| F-04 | HIGH | FR-003 named `check-error-log-assertions` as a structural template. It is `stages: [push]`, so copying it yields a hook that fires on neither `git commit` nor `pre-commit run --all-files` — defeating US1 and US2 at once, silently. | Removed from the template. FR-003 now cites only `check-false-pass-patterns` for wiring shape and **explicitly forbids** `stages: [push]` and `stages: [manual]`. Context now flags the trap by name. |
+| F-05 | HIGH | `SKIP=<hook-id> git commit` bypasses any pre-commit hook. The global block-no-verify guard matches only the bypass flag and `commit -n`. With F-01 unfixed, neither enforcement leg held. | Added as an Edge Case naming the bypass. The resolution is structural: FR-004's required-job step is not a pre-commit hook and is unaffected by `SKIP`. The local hook is now described as fast feedback, the required job as the control. |
+| F-06 | HIGH | Three different `pre-commit` pins exist (`4.6.1` in both requirements files, `4.6.0` in the workflow, `4.5.1` in `.venv`); the spec named one. | Assumptions now name all three and record the reviewer's empirical result that stage-selection behaviour is identical across all of them. Reconciling the pins is explicitly not this feature's work. |
+| F-07 | HIGH | `default_stages: [commit]` and `stages: [push]` are deprecated with removal announced; building the guard's activation on a legacy alias is a time bomb. | **FR-003** requires the new hook state `stages: [pre-commit]` explicitly. Config-wide migration carded as FR-011(e) rather than performed here, since it touches every hook in the file. |
+| F-08 | HIGH | FR-010's allowlist forbade the file changes FR-003's `language: script` shape would require (shebang, `chmod +x`, or a wrapper), and 001 T001 has no criterion making the detector executable. | Resolved by choosing `language: system` with `entry: python3 scripts/...`, which needs no shebang, no mode change, and no wrapper. `.github/workflows/pr-checks.yml` added to the FR-010 allowlist for FR-004. |
+| F-09 | MEDIUM | Context claimed "Checked against the working tree, not recalled" while carrying at least three unchecked items, including the eslint-plugin rule count and the "blocking gate" claim — the same epistemic failure the spec diagnoses in the 27 sites. | Every Context bullet now names its evidence source and distinguishes *checked at `35d5f61`* from *carried from 001 research*. The claim that this feature discovered the false-pass inertness is **withdrawn**: it is documented at `pr-checks.yml:236-240` and the credit is now attributed to Feature 1400 in the spec text. |
+| F-10 | MEDIUM | "the scan reads roughly ten files" was wrong by ~5x (47 `.ts` files) and contradicted SC-007's demand for measurement. | Estimate deleted. **SC-008** now carries the verified count (47 files, 6 with matches), requires a measured figure, and sets a 2-second budget so the criterion can fail. |
+| F-11 | MEDIUM | FR-005/FR-008/SC-006/SC-007 were unfalsifiable as written, and SC-006's literal grep would have failed against `001/tasks.md:61-63`, which enumerates all thirteen tokens. | **FR-006** now names the exact strings the output must contain. **FR-008** adds "exits non-zero for any reason other than `RACY > 0`" and forbids swallowing exceptions. **SC-007** carries the exact command including a `specs/` exclusion, with the exclusion justified in-line rather than left as a dodge. **SC-008** gets a threshold. |
+| F-12 | MEDIUM | The detector does not exist — every 001 task is unchecked — yet FR-002 mandated reuse of a file with no signature, no exit-code table, and no defined output stream. | New **FR-012** pins the interface as an explicit contract table (invocation, four exit-code cases, findings output, summary output, triage banner) and requires any divergence be reconciled as an amendment to 001 T001. Context now states plainly that the detector does not exist yet. |
+| F-13 | MEDIUM | The "scan root empty or missing" edge case had no FR or SC. A directory rename would silently turn the guard green forever — the cheapest possible route to inertness. | New **FR-013**: the detector must report files-scanned and exit non-zero on a zero-file scan. New **SC-009** renames the directory and asserts the failure. |
+| F-14 | MEDIUM | US4 and FR-011 had no success criterion, and US4's precondition ("001's board edits have landed") was untestable from inside 002. | New **SC-010** requires one greppable card for the guard plus one per FR-011 item (a)–(f). US4's Independent Test is now a grep. |
+| F-15 | LOW | `frontend/.eslintrc.json` is 3 lines, not 2 — in the paragraph claiming verification. | Reworded to "a single `extends` line and nothing else". |
+| F-16 | LOW | The `check-false-pass-patterns` post-mortem was incomplete: beyond the empty staged diff, its filter is `^tests/.*\.py$` targeting the **admin** pytest suite, so it could never have covered `frontend/tests/e2e/*.ts` under any invocation. | Added to Context as a second axis, and the operative conclusion generalised: a guard can go inert via invocation mode, scan scope, hook stage, runtime environment, or a job that cannot block. FR-007 verifies against all of them. |
+| F-17 | LOW | `make validate` was never named as an enforcement point despite `Makefile` being in the allowlist and `check-test-target-headers` being the cited precedent for guarding this directory. | **FR-014** now requires that if a make target is added it be wired into `validate`, matching `Makefile:42`. |
+
+Two claims in the Stage 1 draft were outright false and load-bearing (F-01, and the credit claim
+corrected under F-09); two were false but cosmetic (F-15, F-10). The reviewer confirmed the 001
+T001 dependency table, the C4 citation, the Next.js `ESLINT_DEFAULT_DIRS` chain, and the
+`check-false-pass-patterns:39-41 / 47-49` post-mortem as accurate.
+
+### Self-defeat check
+
+The reviewer's central question was whether this feature could ship, report green, and be inert —
+reproducing the defect it exists to correct. It found three routes, one of which required no
+implementation error at all:
+
+1. **Live on day one (F-01).** The specified CI enforcement point could not block a merge. Ship as
+   drafted and a red guard is merged over by `gh pr merge --auto --squash`. Closed by FR-004 moving
+   the blocking check into the required `Lint` job.
+2. **One-word implementation error (F-04).** Copying the `stages: [push]` template produces a hook
+   that runs nowhere and prints nothing, which reads as a pass. Closed by forbidding the stage and
+   naming the trap.
+3. **Opposite polarity (F-02).** Copying the `.venv/bin/python3` entry form produces a hook that is
+   red in CI forever, creating pressure to SKIP-list it. Closed by FR-005 and FR-003's entry form.
+
+The residual risk is now concentrated in one external condition rather than in the design: **the
+`Lint` job must remain a required status check.** That is recorded as an explicit Assumption rather
+than buried, because it is the single thing whose change would silently make this guard advisory
+again.
+
+### Gate
+
+All CRITICAL and HIGH findings resolved in-spec, with the resolutions verified against the live tree
+rather than asserted. The feature's design changed materially at this gate: the blocking enforcement
+point moved from the `Pre-commit Hooks` job to the required `Lint` job, and the detector acquired a
+stdlib-only constraint plus an explicit interface contract.
+
+**0 CRITICAL, 0 HIGH remaining.**
+
+---
+
+## Clarifications
+
+Five ambiguities were identified at Stage 4. **All five were answerable from the codebase or from
+existing artifacts; none required owner input.** Each answer records the evidence that supports it
+so a reader can overturn it by checking the same source rather than by re-litigating the judgment.
+
+### C1 — Should a `make` target be added, and how should it be wired?
+
+**Answer**: yes. Add `check-waitforresponse-race` and add it to the `validate` target's dependency
+list.
+
+**Evidence**: `Makefile:42` reads
+`validate: fmt lint security sast check-banned-terms check-test-target-headers`.
+`check-test-target-headers` is the existing precedent for a repo-level guard over
+`frontend/tests/e2e/*.spec.ts`, and it is wired as a `validate` dependency rather than left
+free-floating. Following that shape costs one line and keeps `make validate` an honest name.
+
+A target that exists but is not in `validate` would be a fourth invocation nobody runs, which is the
+decorative outcome this feature is built to avoid. Spec FR-014 requires the target shell out to the
+detector rather than duplicate logic, so the single-definition property (FR-002) is unaffected.
+
+### C2 — What lane, severity, and source should 002's board cards carry?
+
+**Answer**: the guard card lands in `done` at severity `medium`. The six FR-011 deferred cards land
+in `track` at severity `low`, except FR-011(d) and FR-011(f), which are `medium`.
+
+**Evidence**: `CLEANUP-BOARD.html` currently holds **118** cards
+(`raw_decode` on the text following `const CARDS = `). Its vocabularies are:
+
+| Field | Observed values |
+|---|---|
+| `lane` | `track` (53), `done` (29), `fix` (18), `nice` (13), `probe` (5) |
+| `severity` | `low` (42), `medium` (41), `high` (19), `info` (10), `critical` (6) |
+| card keys | `title`, `lane`, `severity`, `evidence`, `citation`, `next_action`, `source` — plus an optional eighth, `milestone`, present on 3 of the 118 |
+
+`source` is free text and existing features use their own spec directory name, e.g.
+`001-lambda-log-visibility cards.md` (6 cards). 002 follows that convention with
+`002-waitforresponse-lint-guard`, which is what makes SC-014 countable.
+
+Severity reasoning: the guard itself is `medium` because it prevents a recurring CI-signal defect
+rather than a user-facing or security one. FR-011(d) is `medium` because it records a *live* inert
+guard in the repository. FR-011(f) is `medium` because it is an unresolved owner decision about
+merge-gate authority. The rest are genuine `low` future-risk items.
+
+Card count arithmetic: 118 today, **120** after 001's two follow-up cards, **128** after 002's
+**eight** (one guard card plus seven FR-011 cards, (a) through (g)). This figure moved during AR#2:
+FR-011 grew a seventh item when the `scripts/`-outside-required-checks gap was found, and the count
+was originally written as seven cards / 127.
+
+### C3 — What should the pre-commit hook id be?
+
+**Answer**: `scan-waitforresponse-race`, matching the detector's filename stem.
+
+**Evidence**: every local hook in `.pre-commit-config.yaml` uses an id identical to its script stem:
+`check-error-log-assertions` → `scripts/check-error-log-assertions.sh`,
+`check-false-pass-patterns` → `scripts/check-false-pass-patterns.sh`,
+`check-branch-collision` → `scripts/check-branch-collision.sh`. Following the convention makes
+SC-007's grep (`grep -rn "scan-waitforresponse-race" .pre-commit-config.yaml .github/`) match the
+hook id, the entry, and the workflow step with one pattern, which is why the success criterion was
+written that way.
+
+Note the deliberate departure from the `check-` prefix: the detector is named `scan-` by 001 and the
+id follows the file, not the prefix convention. Renaming the script to `check-` would be an edit to
+a file this feature does not own (FR-010).
+
+### C4 — Where in the `Lint` job should the step go?
+
+**Answer**: last, after the three existing ruff steps, carrying an explanatory comment.
+
+**Evidence**: the `Lint` job (`pr-checks.yml:35-65`) runs checkout → setup-python → install ruff →
+`ruff format --check` → `ruff check src/ tests/` → `ruff check src/ --select S`. Its identity is
+Python linting. A Playwright race scan is a genuine outlier there, placed in that job solely because
+it is one of the three required status checks
+(`["Secrets Scan", "Lint", "Run Tests"]`), which the `Pre-commit Hooks` job is not.
+
+Placing it last preserves the job's readable narrative and means a ruff failure — the far more
+common case — still surfaces first. The comment is not optional: a future maintainer tidying the
+`Lint` job would otherwise reasonably move this step out and silently convert the guard back to
+advisory. Plan assumption 3 and design decision D2 both record this.
+
+The step must be a plain `run:` step, not a pre-commit invocation, so the `pre-commit` job's `SKIP`
+environment variable cannot reach it (SC-008).
+
+### C5 — What happens if 001's delivered detector diverges from `contracts/detector-cli.md`?
+
+**Answer**: 002 blocks at Phase A and files an amendment against 001 T001. It does not adapt its
+wiring to fit, and it does not edit the script.
+
+**Evidence**: spec FR-010 confines 002's edits to four files and permits touching
+`scripts/scan-waitforresponse-race.py` only via a recorded change request. Two amendments are
+**already** filed by this feature and are known divergences from 001's current task text, not
+hypotheticals:
+
+| Amendment | Against | Reason |
+|---|---|---|
+| Detector must be stdlib-only and runnable under bare `python3`; venv must not be a precondition | 001 T001 criterion 8, which specifies venv invocation | The CI `Lint` job has no `.venv` (`pr-checks.yml:35-65` installs only ruff) |
+| Detector must report files-scanned and exit non-zero on a zero-file scan | 001 T001 criteria 5 and 6, which specify three counts and a `0`/`1` split only | A renamed scan root would otherwise exit 0 forever (AR#1 F-13) |
+
+The reason this is a real risk rather than a formality: **the detector does not exist yet.** Every
+task in `001/tasks.md` is unchecked. 002 is wiring against prose. Plan risk R1 rates this **High**
+likelihood and identifies it as a sequencing cost accepted deliberately so that both features can be
+reviewed together before either is built.
+
+Adapting the wiring to whatever 001 happens to produce is the failure mode being guarded against
+here: it would let a detector that exits 0 on an empty scan, or one that needs a venv, pass through
+unremarked and land a guard that is green in CI for the wrong reason.
+
+### Deferred to the Phase 2 summary
+
+**None from this stage.** All five questions were resolved from repository evidence.
+
+One pre-existing item is carried forward for owner visibility rather than as a clarification:
+FR-011(f), whether `Pre-commit Hooks` should be added to `main`'s required status checks. That is a
+repository settings change requiring admin rights, it is explicitly Out of Scope for this feature,
+and it is the unfinished step (b) of 1400 FR-007. It is carded, not blocking.

--- a/specs/002-waitforresponse-lint-guard/tasks.md
+++ b/specs/002-waitforresponse-lint-guard/tasks.md
@@ -19,14 +19,40 @@
 | Every commit GPG-signed; bypass flags forbidden | CLAUDE.md | Security policy violation |
 | Mode (c) is `python3 -I -S`, never `env -u VIRTUAL_ENV`, never a scrubbed `PATH` | FR-007, AR#2 N-01 | The verification that proves the guard works is itself a no-op |
 
-**Known amendments already filed against 001 T001** (contract C1/C2/C3). Phase A confirms each;
-it does not discover them:
+**Detector contract: FOLDED INTO 001 BEFORE IMPLEMENTATION** (AR#3 G-01). These were originally
+filed as amendments for Phase A to *discover*. AR#3 established that they were not gaps in 001 but
+direct contradictions — 001 T001 criterion 6 read `sys.exit(0)` "otherwise", criterion 8 mandated
+venv invocation, and 001 Clarification C4 promised the guard could wire the script in "without
+modification". A 001 implementer following 001's own tasks.md would have produced a detector failing
+at least three T002 criteria, discovered at the *second* task of this feature, with no task, branch,
+or FR-010 allowlist entry authorising the repair.
 
-1. stdlib-only, runnable under bare `python3` — amends criterion 8 (venv invocation)
-2. report files-scanned; exit non-zero on a zero-file scan — extends criterion 5, amends criterion 6
-3. remediation guidance in the failure output — extends criterion 5
-4. findings on stdout — criterion 5 does not specify a stream
-5. criterion 9 (`grep` returns nothing) is **intentionally inverted** by SC-007 — not a defect
+Both features were still unimplemented, so the contract was folded into 001 at commit `3b86d9c`:
+
+| # | Requirement | Now carried by |
+|---|---|---|
+| 1 | stdlib-only, runnable under bare `python3`, verified with `-I -S` | 001 T001 crit. 8 (rewritten) |
+| 2 | five summary numbers including files-scanned | 001 T001 crit. 5 (extended) |
+| 3 | non-zero on a zero-file scan — missing, renamed, **or empty** root | 001 T001 crit. 6 (rewritten) |
+| 4 | remediation guidance in the failure output | 001 T001 crit. 5 (extended) |
+| 5 | findings on **stdout** | 001 T001 crit. 5 (extended) |
+| 6 | fixed scan root; file arguments ignored | 001 T001 crit. 12 (**new**) |
+| 7 | in-script `sys.version_info >= (3, 13)` floor | 001 T001 crit. 13 (**new**) |
+
+Items 6 and 7 were not in the original ledger. Item 6 was a contract C6 row backed by no 001
+criterion at all (AR#3 G-06); item 7 closes AR#3 G-04. 001 C4 now records the amendment rather
+than silently promising the old contract.
+
+**Consequence for Phase A**: T002 is now expected to **pass**, and T003 is expected to record an
+empty divergence log. Phase A remains a real gate — it verifies the fold-in landed rather than
+assuming it — but a T002 failure now means 001 was implemented against its own written criteria
+incorrectly, not that the criteria were wrong.
+
+One item stays an inversion, not an amendment:
+
+- 001 T001 criterion 9 (`grep -rn "scan-waitforresponse-race" .pre-commit-config.yaml .github/`
+  returns nothing) is **intentionally inverted** by SC-007. Wiring the detector in is this
+  feature's entire purpose. Not a defect in either feature.
 
 ---
 
@@ -64,13 +90,26 @@ unchecked. This is where prose meets a running program.
        call sites, while the helper adds one internal wait. `34 − 18 + 1 = 17`. If the detector
        prints something else, that is a finding against 001, recorded in T003.
     4. **Five summary numbers** present: RACY, PROMISE-FIRST, OTHER, total, files scanned.
-    5. **Zero-file case**: with the scan root temporarily renamed, the detector exits **non-zero**.
-       Restore the root immediately afterwards and confirm `git status --short` is empty.
+    5. **Zero-file case, both shapes** (AR#3 G-08). (i) With the scan root temporarily renamed, the
+       detector exits **non-zero**; restore the root immediately afterwards and confirm
+       `git status --short` is empty. (ii) Pointed at an **empty temporary directory**, it also
+       exits non-zero. Testing only the rename would pass a detector that raises on a missing root
+       but returns 0 on an existing-but-empty one, which is the likelier real-world shape and is
+       exactly what FR-013 forbids.
     6. **Ignores any file list**: invoked with arbitrary file arguments, it still scans its own root.
        This property is load-bearing for SC-003, where the planted file is untracked and
        `pre-commit run --all-files` would not pass it to the hook.
-    7. **Remediation guidance**: deferred to T009, which is the first point a `RACY` finding exists
-       to produce output from.
+    7. **Remediation guidance, verified here** (AR#3 G-07). Plant a throwaway violation under the
+       scan root, run the detector **standalone**, capture the output, delete the violation, and
+       confirm `git status --short` is empty. The output must carry a literal corrected example
+       matching `const <name>Promise = page.waitForResponse` positioned before the triggering
+       action. This was previously deferred to T009, which sits in Phase D — *after* T004–T007 have
+       landed the hook, the workflow step and the make target. Deferring it guaranteed that a
+       contract requirement would be discovered after the gate whose entire purpose is to prevent
+       wiring-before-verification. Nothing is wired at T002, so the check belongs here.
+    8. **Gate completeness**: with criterion 7 moved in, every requirement in
+       `contracts/detector-cli.md` is now observable from Phase A. Phase A is a complete contract
+       gate, which is what plan Phase A claims it is.
 
 - [ ] **T003** Record contract divergences as amendments against 001 T001 (depends on T002)
   - **Files**: `specs/002-waitforresponse-lint-guard/contracts/detector-cli.md` (amendment log only)
@@ -78,8 +117,14 @@ unchecked. This is where prose meets a running program.
   - **Acceptance criteria**:
     1. Every T002 criterion that failed is written up naming the 001 T001 criterion it contradicts,
        the observed behaviour, and the required behaviour.
-    2. `scripts/scan-waitforresponse-race.py` is **not** edited by this feature. If a fix is needed,
-       it is made as a change to 001 and re-verified from T002.
+    2. `scripts/scan-waitforresponse-race.py` is **not** edited by this feature. Since the contract
+       is folded into 001 T001 (see the ground rules above), a T002 failure means the delivered
+       script diverges from 001's own written criteria. **The repair route, which must exist before
+       it is needed** (AR#3 G-01): open a branch off `main` named `fix/detector-contract-<crit>`,
+       amend `scripts/scan-waitforresponse-race.py` to satisfy the 001 T001 criterion it violates,
+       cite that criterion in the commit message, merge it, then re-run T002 in full. This is a
+       change to 001's deliverable and is deliberately outside FR-010's allowlist, which is why it
+       gets its own branch and PR rather than riding along in this feature.
     3. If T002 passed in full, state that explicitly. An empty amendment log must be distinguishable
        from an unperformed check.
     4. **Blocking**: Phase B does not start while any T002 criterion is failing.
@@ -110,8 +155,12 @@ unchecked. This is where prose meets a running program.
   - **Files**: `.pre-commit-config.yaml`, `.github/workflows/pr-checks.yml`
   - **Satisfies**: FR-015
   - **Acceptance criteria**:
-    1. `.pre-commit-config.yaml:190-192` no longer claims the `pre-commit` job runs hooks "as a
-       BLOCKING gate". Replacement states the verified position: the job runs on every PR to `main`,
+    1. The comment block in `.pre-commit-config.yaml` containing the literal text
+       **"as a BLOCKING gate"** no longer claims it. Locate it by that string, not by line number:
+       it sits at `:190-192` today, but T004 inserts roughly ten lines of hook YAML into the same
+       file *earlier in the dependency graph*, shifting it to about `:200` before T005 runs
+       (AR#3 G-10). This follows 001's own "PRE-SWEEP locators" discipline
+       (`001/tasks.md:17-21`). Replacement states the verified position: the job runs on every PR to `main`,
        and is **not** among `main`'s `required_status_checks.contexts`
        (`["Secrets Scan", "Lint", "Run Tests"]`).
     2. The step name at `pr-checks.yml:229`, "Run pre-commit (blocking)", is corrected or annotated.
@@ -199,8 +248,16 @@ unchecked. This is where prose meets a running program.
     1. `git restore --staged frontend/tests/e2e/__scratch-race.spec.ts` — unstage **only** the
        planted file, never a bare `git reset`, which would unstage unrelated work (AR#2 N-16).
     2. `git diff --cached --name-only` is empty, reproducing the CI index state.
-    3. `pre-commit run --all-files` exits non-zero.
-    4. This is the criterion that distinguishes the guard from `check-false-pass-patterns`, which is
+    3. `pre-commit run --all-files` exits non-zero, **and the failure is attributable to this hook**
+       (AR#3 G-03): pre-commit reports `scan-waitforresponse-race` as `Failed` **by name**, and its
+       output names `frontend/tests/e2e/__scratch-race.spec.ts:<line>`. A bare non-zero exit is not
+       sufficient — that config runs roughly twenty hooks including trivy, checkov, bandit and
+       detect-secrets, any one of which satisfies a bare exit-code assertion while this guard sits
+       inert. Shipping SC-003 in that form would reproduce this feature's own thesis defect inside
+       its own verification.
+    4. Isolated form as corroboration: `pre-commit run scan-waitforresponse-race --all-files` exits
+       non-zero.
+    5. This is the criterion that distinguishes the guard from `check-false-pass-patterns`, which is
        green in CI for exactly this input.
 
 - [ ] **T011** Mode (c): site-packages-free invocation (depends on T008)
@@ -224,7 +281,12 @@ unchecked. This is where prose meets a running program.
        scan-waitforresponse-race --all-files` exits **non-zero**.
     2. The same rename makes the `Lint` job's command shape (`python3 scripts/...`) exit non-zero.
     3. Restore the name; `git status --short` is empty.
-    4. A missing detector must never read as a pass. Without this task FR-008 is asserted by
+    4. **Unreadable-file case** (AR#3 G-14). FR-008 forbids the detector catching a *scanning*
+       exception and exiting 0. The rename case above only covers "detector absent". Write an
+       undecodable byte sequence into a `.ts` file under the scan root, confirm the detector exits
+       non-zero rather than skipping the file silently, then delete it and confirm
+       `git status --short` is empty. Without this, half of FR-008 stays asserted by construction.
+    5. A missing detector must never read as a pass. Without this task FR-008 is asserted by
        construction and checked by nobody.
 
 - [ ] **T013** Revert and re-assert green (depends on T009–T012)
@@ -232,10 +294,18 @@ unchecked. This is where prose meets a running program.
   - **Satisfies**: FR-007, SC-001, SC-005, SC-015
   - **Acceptance criteria**:
     1. Delete `__scratch-race.spec.ts`.
-    2. `pre-commit run --all-files` exits **0**.
+    2. **Pass/fail**: `pre-commit run scan-waitforresponse-race --all-files` exits **0**, and
+       `make check-waitforresponse-race` exits **0**.
     3. `python3 -I -S scripts/scan-waitforresponse-race.py` exits **0** (SC-005 — the durable
        stdlib-only check, which fails the moment anyone adds a third-party import).
-    4. `make validate` exits 0.
+    4. **Advisory, not pass/fail** (AR#3 G-15): run `pre-commit run --all-files` and `make validate`
+       and record the result. Neither is a criterion, because neither is a property of this feature.
+       `pre-commit run --all-files` rides on trivy's daily-updating vulnerability database
+       (`pr-checks.yml:187-189` documents that it can go red with no repo diff), checkov, and
+       detect-secrets. `make validate` runs `fmt`, which executes `ruff format src tests` and is
+       **mutating**, so "tree clean afterwards" is not a stable assertion; it also hard-requires
+       semgrep on `PATH` and runs `pip-audit`. A red result here is investigated, not treated as a
+       guard failure.
     5. `git status --short` is empty and `git stash list` is empty.
 
 - [ ] **T014** `make validate` fails on a violation (depends on T007, T013)
@@ -277,8 +347,10 @@ unchecked. This is where prose meets a running program.
   - **Acceptance criteria**:
     1. `grep -rn "scan-waitforresponse-race" .pre-commit-config.yaml .github/` returns hits in
        **both** files, inverting 001 T001 criterion 9.
-    2. `grep -A3 'SKIP:' .github/workflows/pr-checks.yml | grep -c scan-waitforresponse-race`
-       returns **0**.
+    2. `! grep -A3 'SKIP:' .github/workflows/pr-checks.yml | grep -q scan-waitforresponse-race`
+       succeeds. Written as a negated `grep -q`, **not** `grep -c ... = 0` (AR#3 G-19): `grep -c`
+       exits **1** when the count is zero, so the success case reports as a failure under `set -e`
+       or a naive `&&` chain. Same shape as the trap AR#2 caught in N-08.
     3. The guard's step under `jobs.lint.steps` has a `run:` key and an `if: always()` key.
 
 ---
@@ -293,15 +365,37 @@ never fires.
   - **Files**: temporary branch only; **nothing merged**
   - **Satisfies**: FR-007(d), SC-006
   - **Acceptance criteria**:
-    1. Branch `tmp/gate-red-team` carrying the planted violation, PR opened as **draft**, titled
-       `DO NOT MERGE [gate red-team]`. Follows 1400 T006's precedent.
-    2. `gh pr checks` shows the **`Lint`** check as **failed**.
-    3. The failure output in the `Lint` job log names the planted `file:line`, confirming the step
-       ran rather than the job failing for another reason.
-    4. Confirm the guard step executed even though it is last: check the step's log is present.
-    5. **Cleanup**: PR closed, remote branch deleted, local branch deleted. Verified with
+    1. Branch `tmp/gate-red-team` **cut from `002-waitforresponse-lint-guard`**, not from `main`
+       (AR#3 G-12). GitHub builds `pull_request` runs from the merge commit, so the guard step is
+       present in the `Lint` job only if the branch descends from the feature branch. Cut from
+       `main` and the check goes green against a workflow that does not contain the thing under
+       test. Confirm with
+       `git merge-base --is-ancestor 002-waitforresponse-lint-guard tmp/gate-red-team`.
+    2. **Creating the commit requires the one bypass this design accepts** (AR#3 G-02). By this
+       point T004's hook is installed and T009 has *proved* that committing this exact file is
+       refused with no commit object created. `--no-verify` and `commit -n` are forbidden by
+       CLAUDE.md policy and denied by the global `block-no-verify` hook. Use:
+       `SKIP=scan-waitforresponse-race git commit -S -m "DO NOT MERGE [gate red-team] planted violation"`.
+       This is deliberate and recorded. It is the bypass the spec already names as the local gate's
+       known weakness (spec Edge Cases), and its necessity here is itself evidence the local hook
+       fires. The point of mode (d) is that the required `Lint` job is **not** a pre-commit hook and
+       is unaffected by `SKIP=`.
+    3. The branch **also carries a deliberate ruff violation** under `src/` or `tests/`
+       (AR#3 G-05). Without it the three ruff steps pass, the guard step runs regardless, and
+       criterion 6 cannot fail — `if: always()` would be verified in the one environment where its
+       absence makes no difference. FR-004's entire justification for the flag is that a failing
+       ruff step would otherwise skip the guard, so that is the condition mode (d) must create.
+    4. PR opened as **draft**, titled `DO NOT MERGE [gate red-team]`. Follows 1400 T006's precedent.
+    5. `gh pr checks` shows the **`Lint`** check as **failed**.
+    6. The `Lint` job log shows **both** the ruff failure **and** the guard step's failure in the
+       same run, and the guard's output names the planted `file:line`. This is the assertion that
+       distinguishes `if: always()` from its absence: a skipped guard step leaves only the ruff
+       failure in the log.
+    7. **Cleanup**: PR closed, remote branch deleted, local branch deleted. Verified with
        `gh pr list --state open` and `git branch -a`.
-    6. The planted violation exists in no commit on `main` and no open branch.
+    8. After cleanup, the planted violation exists in **no commit on `main`**, and on no surviving
+       branch or open PR. It necessarily existed on `tmp/gate-red-team` while the mode ran — that is
+       what mode (d) tests. See SC-015, reworded to match (AR#3 G-11).
 
 ---
 
@@ -359,19 +453,19 @@ T001 ─► T002 ─► T003 ──┐   (Phase A gate — blocks everything)
                        │      │
                        │      └─► T006 ─► T007   (Phase C)
                        │                   │
-                       └───────────────────┴─► T008 ─┬─► T009 ─► T010
-                                                     ├─► T011
-                                                     ├─► T012
-                                                     └─► T013 ─┬─► T014
-                                                               ├─► T015
-                                                               ├─► T016
-                                                               └─► T017
-                                                                     │
-                                                                     ▼
-                                                                   T018   (Phase E, real CI)
-                                                                     │
-                                                                     ▼
-                                                              T019 ─► T020 (Phase F)
+                       └───────────────────┴─► T008   (Phase D begins)
+                                                 │
+                                                 ▼
+              T009 ─► T010 ─► T011 ─► T012 ─► T013 ─► T014 ─► T015 ─► T016 ─► T017
+                                                 ▲
+                        T013 deletes the planted fixture that T011 and T012 both
+                        require, so Phase D is a STRICT CHAIN, not a fan-out.
+                                                 │
+                                                 ▼
+                                               T018   (Phase E, real CI)
+                                                 │
+                                                 ▼
+                                        T019 ─► T020   (Phase F)
 ```
 
 **Serialisation notes.** T003 gates everything: wiring against an unverified interface is the
@@ -423,8 +517,9 @@ of four small files. Concurrency here buys nothing and risks two agents editing 
 | SC-014 eight cards, `source` field | T019 |
 | SC-015 file allowlist honoured, nothing planted committed | T013 crit. 5, T018 crit. 6, T020 |
 
-**Every FR maps to ≥1 task. Every SC maps to exactly one deciding task.** No orphans in either
-direction.
+**Every FR maps to ≥1 task. Every SC maps to ≥1 deciding task.** No orphans in either direction.
+The table above deliberately shows SC-001 and SC-015 decided by more than one criterion (AR#3 G-18);
+the earlier "exactly one" wording contradicted the table printed directly above it.
 
 ---
 
@@ -436,3 +531,95 @@ check result, and the final board count go here)*
 | Task | Date | Result | Evidence |
 |---|---|---|---|
 | | | | |
+
+---
+
+## Adversarial Review #3 (Stage 8)
+
+Independent reviewer over `spec.md` + `plan.md` + `tasks.md` + `contracts/` together, briefed on
+implementation readiness rather than correctness: can T001–T020 be executed in order without
+stopping, where is rework most likely, and which acceptance criteria could pass while the guard is
+inert. Every load-bearing finding below was re-verified against the repository by the orchestrator
+before the resolution was written. **21 findings: 2 CRITICAL / 5 HIGH / 8 MEDIUM / 6 LOW.**
+
+### Findings and resolutions
+
+| ID | Severity | Finding | Resolution |
+|---|---|---|---|
+| G-01 | CRITICAL | **T003 had no executable path and was near-certain to fire.** The four amendments filed against 001 T001 were not gaps but direct contradictions: 001 crit. 6 read `sys.exit(0)` "otherwise"; crit. 8 mandated venv invocation; crit. 5 specified output as sites plus four counts with no stream, no files-scanned, no remediation text. 001 Clarification C4 closed with *"the guard can wire it in **without modification**"* — the prerequisite feature explicitly promising the opposite of this one's contract. A 001 implementer following 001's own tasks.md produces a detector failing ≥3 T002 criteria, discovered at the **second task** of this feature, with no task, branch, or FR-010 allowlist entry authorising the repair. | **Folded the contract into 001 before implementation** (commit `3b86d9c`). 001 T001 crit. 5, 6, 8 rewritten; new crit. 12 and 13 added; C4 amended to record the change rather than silently promising the old contract. Both features were still paper, so this cost one edit instead of an out-of-scope repair PR against a merged feature. T003 gains an explicit repair route for the residual case. Ground-rules ledger rewritten from "amendments Phase A discovers" to "contract folded in; Phase A verifies it landed". |
+| G-02 | CRITICAL | **T018 was not executable.** It requires a branch carrying the planted violation, but by then T004's hook is installed and T009 has *proved* that commit is refused with no commit object created. `--no-verify` and `commit -n` are forbidden by CLAUDE.md and denied by the global `block-no-verify` hook. The only route is the `SKIP=` bypass the spec itself names as the local gate's known weakness, and no artifact mentioned it. An engineer stops here and asks. | T018 crit. 2 now states the exact command and frames it as the one deliberate, recorded use of the accepted bypass — noting that needing it is itself evidence the local hook fires, and that the required `Lint` job is not a pre-commit hook and is unaffected. Mirrored in quickstart §2b. |
+| G-03 | HIGH | **T010 could pass with the guard completely inert.** Crit. 3 was a bare *`pre-commit run --all-files` exits non-zero*. That config runs ~20 hooks; any one going red satisfies it. T010 is the sole decider for SC-003, which the spec calls "the assertion that distinguishes this guard from `check-false-pass-patterns`". It distinguished nothing. This feature's own thesis defect, reproduced inside its own verification. | Crit. 3 now requires pre-commit to report `scan-waitforresponse-race` as `Failed` **by name** and its output to name the planted `file:line`; new crit. 4 adds the isolated single-hook run as corroboration. |
+| G-04 | HIGH | **An AR#2 resolution was applied to the wrong mechanism.** N-14 raised that `python3` is not 3.13 everywhere and recorded the fix as *"Resolved by N-01's `-I -S`"* — but `-I -S` is verification mode (c), a manual command. The hook entry is `python3 scripts/...`, resolved from the committing shell's `PATH`, and was never touched. Verified: with the venv off `PATH`, `python3` here is **3.12.3**. Third instance in this feature of a ledger resolution naming a real fix and applying it elsewhere. | New **001 T001 crit. 13**: in-script `sys.version_info >= (3, 13)` floor exiting non-zero with the required version. N-14 left struck through in the AR#2 ledger rather than rewritten, because misapplied resolutions are what that ledger exists to catch. |
+| G-05 | HIGH | **`if: always()` was asserted but never exercised.** T018's red-team PR carried only a `.ts` violation, so the ruff steps pass and the guard step runs with or without the flag. The property was verified in the one environment where it cannot fail — and FR-004's whole justification for the flag is a *failing* preceding step. | T018 crit. 3 adds a deliberate ruff violation under `src/` or `tests/`; crit. 6 requires the `Lint` log to show **both** failures in one run. Mirrored in quickstart §2b. |
+| G-06 | HIGH | **A sixth requirement on 001's deliverable was un-filed.** Contract C6 row 6 ("ignores any file list; still scans its own root") had no backing 001 T001 criterion and was absent from the amendment ledger, which claimed five items and that "Phase A confirms each; it does not discover them". The property is load-bearing: `pass_filenames: false` plus an **untracked** planted file means only a filesystem-walking detector makes SC-003 work at all. Same class as AR#2's N-02, fixed for two of three cases. | Filed as **001 T001 crit. 12**, worded to forbid a narrowing positional `paths` argument. Ledger corrected to seven items. |
+| G-07 | HIGH | **Phase A structurally could not verify the contract it gates.** T002 crit. 7 deferred remediation-guidance verification to T009 — in Phase D, after the hook, workflow step and make target have all landed. So one contract requirement was *guaranteed* to be discovered after the gate that exists to prevent wiring-before-verification, and T009 said to record it "per T003", a Phase A task already closed. Plan Phase A asserted the opposite invariant. | Moved into T002 as crit. 7: plant a throwaway violation, run the detector **standalone**, capture output, revert. Nothing is wired at T002. New crit. 8 states that Phase A is now a complete contract gate. Plan phase table corrected to match. |
+| G-08 | MEDIUM | **FR-013's test covered the wrong failure mode.** FR-013 requires non-zero when the scan examines zero files; T002 crit. 5, SC-011 and quickstart tested only a *renamed* root. A detector that raises on a missing root but exits 0 on an existing-but-empty one satisfies every criterion while violating the requirement. | T002 crit. 5 now tests both shapes. 001 T001 crit. 6 worded as "files-scanned == 0 ⇒ non-zero, whether missing, renamed, or empty" rather than "root missing ⇒ non-zero". |
+| G-09 | MEDIUM | plan.md and tasks.md disagreed on phase membership: FR-015's corrections were Phase C in the plan and Phase B (T005) in tasks; the scan-root rename was Phase D in the plan and Phase A in tasks. Stage 6 claims to have swept exactly this. | Plan phase table realigned to tasks.md, the executable artifact. |
+| G-10 | MEDIUM | **T005's line citations go stale before T005 runs.** It targets `.pre-commit-config.yaml:190-192`, but T004 precedes it in the dependency graph and inserts ~10 lines of hook YAML into the same file, shifting the block to ~`:200`. | T005 crit. 1 and FR-015 now locate the block by its unique string *"as a BLOCKING gate"*, following 001's own PRE-SWEEP-locator discipline. |
+| G-11 | MEDIUM | **SC-015 contradicted T018.** SC-015 said the planted violation "appears in no commit on any branch"; mode (d) *requires* committing it on `tmp/gate-red-team`. FR-007's wording was correct, T020 crit. 4 had a third variant. | SC-015 reworded to FR-007's form: no commit on `main`, no surviving branch or open PR after Phase E. T018 crit. 8 matched. |
+| G-12 | MEDIUM | **T018 never stated the branch point.** `pull_request` runs build from the merge commit, so branching `tmp/gate-red-team` from `main` yields a `Lint` job with no guard step, a green check, and a recorded result about a workflow that does not contain the thing under test. | T018 crit. 1 requires the cut from `002-waitforresponse-lint-guard` and a `git merge-base --is-ancestor` confirmation. Mirrored in quickstart. |
+| G-13 | MEDIUM | **The dependency graph contradicted T013 and would destroy T011/T012's fixture.** The graph drew T013 as a sibling of T011/T012; T013 crit. 1 deletes `__scratch-race.spec.ts`, which both require. The header said "depends on T009–T012". | Graph redrawn as a strict Phase D chain with the reason stated inline. |
+| G-14 | MEDIUM | **FR-008's exception clause was unverified.** FR-008 forbids the detector swallowing a *scanning* exception and exiting 0; T012 covered only "detector absent". The named swallow was asserted by construction — the remaining half of AR#2's own N-10. | New T012 crit. 4: undecodable bytes in a `.ts` file under the scan root must produce non-zero, not a silent skip. |
+| G-15 | MEDIUM | **Two green-state criteria depended on tooling this feature does not control.** T013 crit. 2 (`pre-commit run --all-files` exits 0) rides on trivy's daily-updating vulnerability DB — which `pr-checks.yml:187-189` documents can go red with no repo diff — plus checkov and detect-secrets. T013 crit. 4 / T014 crit. 3 (`make validate` exits 0, tree clean) run `fmt`, which is **mutating**, plus semgrep and pip-audit. "Tree clean after `make validate`" is not a property of this feature. | Pass/fail narrowed to the single-hook run and `make check-waitforresponse-race`. The full-config and full-validate runs are retained as **advisory**, explicitly not criteria. |
+| G-16 | LOW | "6 of which contain matches" is a pre-001 figure presented as post-001. 001 T004 adds `helpers/search-helpers.ts`, which contains a `page.waitForResponse`, so the post-sweep figure is ≥7. The paired 47→48 file count was carefully corrected at AR#2 D-08; this one was not. | Labelled pre-001 and the derivation gap stated, matching how 47 is labelled. |
+| G-17 | LOW | Requirement ordering is non-monotonic: FR-015 sits between FR-011 and FR-012, so a reader scanning for the last requirement stops there and misses FR-012 (the detector interface contract), FR-013 and FR-014. | Annotated in place with a forward pointer. Left in position because the block belongs with the FR-010/FR-011 scope material it was appended to. |
+| G-18 | LOW | tasks.md asserted "Every SC maps to exactly one deciding task" directly below a table where SC-001 maps to two and SC-015 to three. | Reworded to "≥1 deciding task" with the contradiction noted. |
+| G-19 | LOW | T017 crit. 2 used `grep -c ... ` expecting `0`, but `grep -c` **exits 1** when the count is zero, so the success case reports as failure under `set -e`. Same shape as the trap AR#2 caught in N-08. | Rewritten as a negated `grep -q`. |
+| G-20 | LOW | quickstart used `git add -f` on the planted file, which is not gitignored (`git check-ignore` exits 1). An unexplained force flag in the one procedure that deliberately commits a violation invites a reader to assume an override is expected. | Dropped. |
+| G-21 | LOW | FR-011(g) quoted the `Lint` job as running `ruff format --check src/ tests/`; the actual step is `ruff format --check --diff src/ tests/`. The load-bearing claim — that `scripts/` is outside every required check — is TRUE. | Quoted exactly. |
+
+### Reviewer's factual audit
+
+The reviewer independently re-checked roughly thirty specific assertions across these artifacts:
+branch-protection contexts, job and step names, workflow line numbers, hook stages, pre-commit pin
+skew, file counts, the 001 SC-001 arithmetic, the `next lint` directory constants, and every
+`CLEANUP-BOARD.html` count. **Two were wrong**, both cosmetic and both fixed above (G-16, G-21).
+Two claims the artifacts made *about the environment* were falsified and mattered: `python3` off the
+venv is 3.12.3, not 3.13 (G-04), and the planted file is not gitignored (G-20).
+
+It also confirmed empirically, in a scratch repository, the two mechanisms this design rests on:
+that `stages: [pre-commit]` fires correctly under `default_stages: [commit]` on pre-commit 4.5.1 for
+both `git commit` and `run --all-files`, and that an untracked planted file survives
+`pre-commit run --all-files` and is seen by a filesystem-walking detector — the mechanism SC-003
+depends on.
+
+### Highest-risk task
+
+**T003**, and the reviewer rated it higher than plan risk R1 did, having read 001's actual criteria
+rather than this feature's summary of them. That risk is now **retired**: the contract is folded into
+001 at `3b86d9c`, so T002 is expected to pass and T003 to record an empty log. Phase A remains a real
+gate — a T002 failure now means the delivered script diverges from 001's own written criteria, which
+is a different and much cheaper problem, and T003 crit. 2 carries the repair route.
+
+The highest remaining risk is **T018**. It is the only task that depends on GitHub's behaviour rather
+than the local tree, it now carries three separate preconditions that were each individually capable
+of silently invalidating it (branch point, the bypass, the co-planted ruff violation), and it is the
+only task whose failure mode is a *green* check.
+
+### Most likely source of rework
+
+The boundary between what Phase A can observe and what only Phases D and E can. Three properties the
+contract treated as gated at Phase A were unobservable there: remediation guidance (G-07), `if:
+always()` behaviour (G-05), and the hook's interpreter resolution (G-04). Each, on failure, sent work
+backwards past a gate the plan describes as one-way. Compounding it, the two criteria most likely to
+be run first — T010's bare "exits non-zero" and T013's bare "exits 0" — were both satisfiable by
+unrelated hooks, so a run could look conclusive in either direction while saying nothing about the
+guard. All three are now observable in the phase that claims to gate them, and both bare exit-code
+criteria are attributed.
+
+### Gate
+
+**READY FOR IMPLEMENTATION.**
+
+The reviewer returned **BLOCKED** on four findings (G-01, G-02, G-03, G-04) plus three strongly
+recommended (G-05, G-06, G-07). All seven are resolved above, along with the remaining fourteen. The
+four blocking ones were each re-verified against primary sources before being accepted — 001's T001
+criteria and C4 read directly, T009/T010/T018's criteria read directly, and plan.md's N-14 row read
+directly — rather than taken from the review's summary.
+
+One resolution reached outside this feature: G-01 required editing `specs/001-waitforresponse-race-sweep/`,
+which is committed on its own branch. It was made there (`3b86d9c`) and 002 rebased onto it, because a
+fix landing only on 002's branch would not be visible to a 001 implementation and would not have been
+a fix at all. **This is a cross-feature change and is flagged for the owner at the Phase 2 pause.**
+
+Phase 3 remains gated on owner approval. No implementation has been performed.

--- a/specs/002-waitforresponse-lint-guard/tasks.md
+++ b/specs/002-waitforresponse-lint-guard/tasks.md
@@ -1,0 +1,438 @@
+# Tasks: waitForResponse race regression guard
+
+**Feature**: `002-waitforresponse-lint-guard` | **Branch**: `002-waitforresponse-lint-guard`
+**Depends on**: `001-waitforresponse-race-sweep` — **must be merged before T001 runs**
+**Input**: [spec.md](./spec.md), [plan.md](./plan.md), [research.md](./research.md),
+[data-model.md](./data-model.md), [contracts/detector-cli.md](./contracts/detector-cli.md),
+[quickstart.md](./quickstart.md)
+
+---
+
+## Ground rules
+
+| Rule | Source | Consequence if broken |
+|---|---|---|
+| Nothing starts until 001 is merged and the detector reports `RACY 0` | FR-009, 1400 FR-007a | The guard is born red and either blocks every commit or ships pre-suppressed |
+| The detector is owned by 001. Divergences are **amendments**, not edits | FR-010, FR-012 | 002 silently absorbs a broken interface and the guard passes for the wrong reason |
+| Files this feature may modify: `.pre-commit-config.yaml`, `.github/workflows/pr-checks.yml`, `Makefile`, `CLEANUP-BOARD.html`, `specs/002-*/` | FR-010, SC-015 | Scope creep |
+| The planted violation is never committed or merged | FR-007, SC-015 | A deliberate race lands in the suite |
+| Every commit GPG-signed; bypass flags forbidden | CLAUDE.md | Security policy violation |
+| Mode (c) is `python3 -I -S`, never `env -u VIRTUAL_ENV`, never a scrubbed `PATH` | FR-007, AR#2 N-01 | The verification that proves the guard works is itself a no-op |
+
+**Known amendments already filed against 001 T001** (contract C1/C2/C3). Phase A confirms each;
+it does not discover them:
+
+1. stdlib-only, runnable under bare `python3` — amends criterion 8 (venv invocation)
+2. report files-scanned; exit non-zero on a zero-file scan — extends criterion 5, amends criterion 6
+3. remediation guidance in the failure output — extends criterion 5
+4. findings on stdout — criterion 5 does not specify a stream
+5. criterion 9 (`grep` returns nothing) is **intentionally inverted** by SC-007 — not a defect
+
+---
+
+## Phase A — Precondition gate (FR-005, FR-012, FR-013)
+
+**Purpose**: prove the detector satisfies the contract *before* any wiring exists. Phase A is a
+gate, not a formality: 002 was specified against prose, because at authoring time every 001 task was
+unchecked. This is where prose meets a running program.
+
+- [ ] **T001** Confirm 001 has landed and the tree is clean
+  - **Files**: none modified
+  - **Satisfies**: FR-009 precondition
+  - **Acceptance criteria**:
+    1. `git log --oneline -1` on `main` includes 001's sweep commit, and
+       `scripts/scan-waitforresponse-race.py` exists.
+    2. `git status --short` is empty.
+    3. `find frontend/tests/e2e -name "*.ts" | wc -l` returns **48** (47 pre-001 plus
+       `helpers/search-helpers.ts` from 001 T004). If it returns 47, 001's T004 did not land and
+       this phase stops.
+
+- [ ] **T002** Verify the detector against `contracts/detector-cli.md` C6, all six rows
+  - **Files**: none modified
+  - **Satisfies**: FR-005, FR-012, FR-013
+  - **Acceptance criteria**:
+    1. **Stdlib-only, statically**: `grep -nE '^\s*(import|from) ' scripts/scan-waitforresponse-race.py`
+       lists only Python 3.13 standard-library modules.
+    2. **Stdlib-only, dynamically**: `python3 -I -S scripts/scan-waitforresponse-race.py` runs and
+       exits **0**.
+    3. **Clean exit and counts**: `python3 scripts/scan-waitforresponse-race.py` exits 0 and reports
+       `RACY 0 / PROMISE-FIRST 16 / OTHER 1`, total **17**, across **48** files scanned.
+
+       These figures are 001's (SC-001, T018 criterion 1). **Do not adjust them to match the
+       detector's output.** The naive expectation is that the total stays at 34; it does not,
+       because 18 of the 27 sites become `searchAndAwaitResponse(...)` calls and stop being wait
+       call sites, while the helper adds one internal wait. `34 − 18 + 1 = 17`. If the detector
+       prints something else, that is a finding against 001, recorded in T003.
+    4. **Five summary numbers** present: RACY, PROMISE-FIRST, OTHER, total, files scanned.
+    5. **Zero-file case**: with the scan root temporarily renamed, the detector exits **non-zero**.
+       Restore the root immediately afterwards and confirm `git status --short` is empty.
+    6. **Ignores any file list**: invoked with arbitrary file arguments, it still scans its own root.
+       This property is load-bearing for SC-003, where the planted file is untracked and
+       `pre-commit run --all-files` would not pass it to the hook.
+    7. **Remediation guidance**: deferred to T009, which is the first point a `RACY` finding exists
+       to produce output from.
+
+- [ ] **T003** Record contract divergences as amendments against 001 T001 (depends on T002)
+  - **Files**: `specs/002-waitforresponse-lint-guard/contracts/detector-cli.md` (amendment log only)
+  - **Satisfies**: FR-010's amendment clause, FR-012
+  - **Acceptance criteria**:
+    1. Every T002 criterion that failed is written up naming the 001 T001 criterion it contradicts,
+       the observed behaviour, and the required behaviour.
+    2. `scripts/scan-waitforresponse-race.py` is **not** edited by this feature. If a fix is needed,
+       it is made as a change to 001 and re-verified from T002.
+    3. If T002 passed in full, state that explicitly. An empty amendment log must be distinguishable
+       from an unperformed check.
+    4. **Blocking**: Phase B does not start while any T002 criterion is failing.
+
+---
+
+## Phase B — Local enforcement point (FR-003)
+
+- [ ] **T004** Add the `scan-waitforresponse-race` hook to `.pre-commit-config.yaml`
+  - **Files**: `.pre-commit-config.yaml`
+  - **Satisfies**: FR-003, FR-004's `SKIP` constraint
+  - **Acceptance criteria**:
+    1. Added under the existing `repo: local` block, adjacent to `check-false-pass-patterns`.
+    2. `id: scan-waitforresponse-race` (Clarification C3 — the id follows the detector's filename
+       stem, as every other local hook does).
+    3. `language: system`, `entry: python3 scripts/scan-waitforresponse-race.py`.
+       **Not** `language: script` (would need a shebang and `chmod +x` on a file this feature does
+       not own, AR#1 F-08). **Not** `.venv/bin/python3` (the CI runner has no venv, AR#1 F-02).
+    4. `pass_filenames: false` and `always_run: true`.
+    5. `stages: [pre-commit]`, stated explicitly. **Not** the deprecated `commit` alias, and
+       **never** `push` or `manual`. `check-error-log-assertions` is `stages: [push]` and looks like
+       a template but fires on neither `git commit` nor `pre-commit run --all-files` (AR#1 F-04).
+    6. A comment records why the entry is `python3` and not the venv path, so the next maintainer
+       does not "fix" it toward the `pytest` hook's form.
+    7. `pre-commit run scan-waitforresponse-race --all-files` exits 0 on the clean tree.
+
+- [ ] **T005** Correct the two stale "BLOCKING gate" statements
+  - **Files**: `.pre-commit-config.yaml`, `.github/workflows/pr-checks.yml`
+  - **Satisfies**: FR-015
+  - **Acceptance criteria**:
+    1. `.pre-commit-config.yaml:190-192` no longer claims the `pre-commit` job runs hooks "as a
+       BLOCKING gate". Replacement states the verified position: the job runs on every PR to `main`,
+       and is **not** among `main`'s `required_status_checks.contexts`
+       (`["Secrets Scan", "Lint", "Run Tests"]`).
+    2. The step name at `pr-checks.yml:229`, "Run pre-commit (blocking)", is corrected or annotated.
+    3. The replacement text names how to re-check the claim
+       (`gh api repos/traylorre/sentiment-analyzer-gsk/branches/main/protection`), so it can be
+       falsified rather than trusted.
+    4. Nothing else in either comment block is altered. The `detect-secrets` / `gitleaks` SKIP
+       rationale and the `stages:[push]` NO-OP note at `:236-240` are accurate and stay.
+  - **Why this is in scope**: `.pre-commit-config.yaml:190-192` is the sentence this feature's own
+    Stage 1 draft read and believed, producing AR#1's CRITICAL F-01 and a design that would have
+    shipped an advisory guard. T004's hook lands a few lines below it. Leaving the false claim in
+    place while adding a hook that depends on the opposite fact guarantees the next reader repeats
+    the error.
+
+---
+
+## Phase C — Blocking enforcement point (FR-004, FR-014)
+
+- [ ] **T006** Add the guard step to the required `Lint` job
+  - **Files**: `.github/workflows/pr-checks.yml`
+  - **Satisfies**: FR-004
+  - **Acceptance criteria**:
+    1. A new step in `jobs.lint.steps`, placed **last**, after `ruff check src/ --select S`
+       (Clarification C4).
+    2. It is a plain `run:` step invoking `python3 scripts/scan-waitforresponse-race.py`. Not a
+       `uses:`, not a `pre-commit` invocation — so the `pre-commit` job's `SKIP` env cannot reach it
+       (SC-008).
+    3. It carries `if: always()`. Actions steps are fail-fast, and the guard is last, so without
+       this any ruff failure means the guard never runs and produces no output (AR#2 N-06). The job
+       still fails; both failures surface in one run.
+    4. It carries a comment explaining why a Playwright race scan lives in a job named `Lint`:
+       `Lint` is one of `main`'s three required status checks and `Pre-commit Hooks` is not, so this
+       is the only place the guard can actually block a merge. Without the comment, a maintainer
+       tidying the job would reasonably move the step out and silently make the guard advisory.
+    5. No new `pip install` is added. The job already provides Python 3.13 via
+       `actions/setup-python@v7` (`pr-checks.yml:29`, `:46-50`) and the detector is stdlib-only.
+    6. The `Lint` job's existing steps are unchanged.
+
+- [ ] **T007** Add the `check-waitforresponse-race` make target and wire it into `validate`
+  - **Files**: `Makefile`
+  - **Satisfies**: FR-014, Clarification C1
+  - **Acceptance criteria**:
+    1. New target `check-waitforresponse-race` whose recipe shells out to
+       `python3 scripts/scan-waitforresponse-race.py`. It duplicates no logic (FR-002).
+    2. Added to the `validate` dependency list at `Makefile:42`, alongside
+       `check-test-target-headers` — the existing precedent for a repo-level guard over
+       `frontend/tests/e2e/`.
+    3. Carries a `##` help comment, matching the style of neighbouring targets.
+    4. `make check-waitforresponse-race` exits 0 on the clean tree.
+
+---
+
+## Phase D — Local adversarial verification (FR-006, FR-007 modes a–c, FR-008)
+
+**Purpose**: prove the guard is not decorative. Everything before this phase is assertion.
+
+**Nothing in this phase may be committed.** The planted violation exists only as evidence.
+
+- [ ] **T008** Plant the violation
+  - **Files**: `frontend/tests/e2e/__scratch-race.spec.ts` (temporary, never committed)
+  - **Satisfies**: prerequisite for T009–T013
+  - **Acceptance criteria**:
+    1. Contains an act-then-wait `page.waitForResponse` whose immediately preceding line is a
+       `.fill(` — the canonical `RACY` shape.
+    2. Carries the `// Target: Customer Dashboard (Next.js/Amplify)` header so it does not trip
+       `check-test-target-headers` and confuse the evidence with an unrelated failure.
+    3. `python3 scripts/scan-waitforresponse-race.py` now reports `RACY 1` and exits 1.
+
+- [ ] **T009** Mode (a): the local commit path refuses the commit (depends on T008)
+  - **Files**: none modified
+  - **Satisfies**: FR-007(a), FR-006, SC-002
+  - **Acceptance criteria**:
+    1. `git add frontend/tests/e2e/__scratch-race.spec.ts && git commit -S -m "..."` exits non-zero.
+    2. **No commit object is created** — `git log -1` is unchanged. Asserted with `git commit`, not
+       `pre-commit run`, because the commit path is what US1 promises (AR#2 X-07).
+    3. Output names the planted `file:line`.
+    4. Output contains a literal corrected example, matching
+       `const <name>Promise = page.waitForResponse` positioned before the triggering action
+       (FR-006). If it does not, that is amendment 3 from the ground rules, recorded per T003.
+
+- [ ] **T010** Mode (b): whole-tree scan with a clean index (depends on T009)
+  - **Files**: none modified
+  - **Satisfies**: FR-007(b), SC-003
+  - **Acceptance criteria**:
+    1. `git restore --staged frontend/tests/e2e/__scratch-race.spec.ts` — unstage **only** the
+       planted file, never a bare `git reset`, which would unstage unrelated work (AR#2 N-16).
+    2. `git diff --cached --name-only` is empty, reproducing the CI index state.
+    3. `pre-commit run --all-files` exits non-zero.
+    4. This is the criterion that distinguishes the guard from `check-false-pass-patterns`, which is
+       green in CI for exactly this input.
+
+- [ ] **T011** Mode (c): site-packages-free invocation (depends on T008)
+  - **Files**: none modified
+  - **Satisfies**: FR-007(c), FR-005, SC-004
+  - **Acceptance criteria**:
+    1. `python3 -I -S scripts/scan-waitforresponse-race.py` exits non-zero.
+    2. The command **must** be `-I -S`. `env -u VIRTUAL_ENV` is forbidden: it clears a marker
+       variable while `.venv/bin` stays on `PATH`, so `python3` still resolves inside the venv.
+       Verified: `env -u VIRTUAL_ENV bash -c 'command -v python3'` returns `.venv/bin/python3`.
+    3. A scrubbed `PATH` is also forbidden: `/usr/bin/python3` is 3.12 or 3.10 on a
+       CLAUDE.md-conformant machine, so it would test the wrong interpreter version.
+    4. Record the interpreter actually used: `python3 -I -S -c "import sys; print(sys.version)"`
+       must report **3.13.x**, matching the `Lint` job's `PYTHON_VERSION`.
+
+- [ ] **T012** Detector-absent case (depends on T008)
+  - **Files**: none modified (temporary rename only)
+  - **Satisfies**: FR-008, SC-012
+  - **Acceptance criteria**:
+    1. With `scripts/scan-waitforresponse-race.py` temporarily renamed, `pre-commit run
+       scan-waitforresponse-race --all-files` exits **non-zero**.
+    2. The same rename makes the `Lint` job's command shape (`python3 scripts/...`) exit non-zero.
+    3. Restore the name; `git status --short` is empty.
+    4. A missing detector must never read as a pass. Without this task FR-008 is asserted by
+       construction and checked by nobody.
+
+- [ ] **T013** Revert and re-assert green (depends on T009–T012)
+  - **Files**: none modified
+  - **Satisfies**: FR-007, SC-001, SC-005, SC-015
+  - **Acceptance criteria**:
+    1. Delete `__scratch-race.spec.ts`.
+    2. `pre-commit run --all-files` exits **0**.
+    3. `python3 -I -S scripts/scan-waitforresponse-race.py` exits **0** (SC-005 — the durable
+       stdlib-only check, which fails the moment anyone adds a third-party import).
+    4. `make validate` exits 0.
+    5. `git status --short` is empty and `git stash list` is empty.
+
+- [ ] **T014** `make validate` fails on a violation (depends on T007, T013)
+  - **Files**: none modified
+  - **Satisfies**: FR-014, SC-013
+  - **Acceptance criteria**:
+    1. Re-plant the violation; `make validate` exits non-zero.
+    2. `grep -n 'check-waitforresponse-race' Makefile` shows the target on the `validate` dependency
+       line.
+    3. Remove the violation; `make validate` exits 0; tree clean.
+
+- [ ] **T015** Measure the scan cost (depends on T013)
+  - **Files**: evidence recorded in the Execution Log below
+  - **Satisfies**: SC-010
+  - **Acceptance criteria**:
+    1. `time python3 scripts/scan-waitforresponse-race.py`, real elapsed time recorded.
+    2. Under **2 seconds**.
+    3. A **measured** figure is written down. An estimate does not satisfy this: the Stage 1 draft's
+       "roughly ten files" guess was wrong by ~5x against the real 47, which is why the criterion
+       demands measurement.
+
+- [ ] **T016** Single-definition-site check (depends on T013)
+  - **Files**: none modified
+  - **Satisfies**: FR-002, SC-009
+  - **Acceptance criteria**:
+    1. `grep -rn "setInputFiles" --include='*.py' --include='*.js' --include='*.ts' --include='*.yaml' . | grep -v node_modules | grep -v '^./specs/' | cut -d: -f1 | sort -u | wc -l`
+       returns **1**, and that file is `scripts/scan-waitforresponse-race.py`.
+    2. Count **files, not lines**. A correct implementation holds the tokens both in the module
+       docstring (001 T001 criterion 3 requires them verbatim) and in an executable list, so a line
+       count returns ≥2 and would read as a false failure — 001 hit the same trap with its own
+       `searchAndAwaitResponse` grep (AR#2 N-08).
+    3. The `specs/` exclusion is required because `specs/` holds real `.ts` and `.yaml` files the
+       `--include` filters match. It is **not** for `001/tasks.md`, which is Markdown and
+       unreachable by these filters.
+
+- [ ] **T017** Wiring assertions (depends on T004, T006)
+  - **Files**: none modified
+  - **Satisfies**: SC-007, SC-008
+  - **Acceptance criteria**:
+    1. `grep -rn "scan-waitforresponse-race" .pre-commit-config.yaml .github/` returns hits in
+       **both** files, inverting 001 T001 criterion 9.
+    2. `grep -A3 'SKIP:' .github/workflows/pr-checks.yml | grep -c scan-waitforresponse-race`
+       returns **0**.
+    3. The guard's step under `jobs.lint.steps` has a `run:` key and an `if: always()` key.
+
+---
+
+## Phase E — Real-CI verification (FR-007 mode d)
+
+**Purpose**: Phase D proves properties of the *detector*. Only CI proves the *wiring*. A hook can
+pass every local mode and still be attached to a job that cannot block, or guarded by an `if:` that
+never fires.
+
+- [ ] **T018** Draft red-team PR (depends on Phase D complete)
+  - **Files**: temporary branch only; **nothing merged**
+  - **Satisfies**: FR-007(d), SC-006
+  - **Acceptance criteria**:
+    1. Branch `tmp/gate-red-team` carrying the planted violation, PR opened as **draft**, titled
+       `DO NOT MERGE [gate red-team]`. Follows 1400 T006's precedent.
+    2. `gh pr checks` shows the **`Lint`** check as **failed**.
+    3. The failure output in the `Lint` job log names the planted `file:line`, confirming the step
+       ran rather than the job failing for another reason.
+    4. Confirm the guard step executed even though it is last: check the step's log is present.
+    5. **Cleanup**: PR closed, remote branch deleted, local branch deleted. Verified with
+       `gh pr list --state open` and `git branch -a`.
+    6. The planted violation exists in no commit on `main` and no open branch.
+
+---
+
+## Phase F — Board (FR-011, US4)
+
+- [ ] **T019** Add eight cards to `CLEANUP-BOARD.html` (depends on T018)
+  - **Files**: `CLEANUP-BOARD.html`
+  - **Satisfies**: FR-011, US4, SC-014
+  - **Acceptance criteria**:
+    1. Board count goes from **120** (118 today plus 001's two follow-up cards) to **128**.
+    2. All eight carry `"source": "002-waitforresponse-lint-guard"`, matching the convention set by
+       `001-lambda-log-visibility cards.md`. SC-014 counts by this field rather than by an
+       unspecified grep pattern, which any eight cards or none would satisfy.
+    3. Cards, with lane and severity per Clarification C2:
+
+       | # | Subject | Lane | Severity |
+       |---|---|---|---|
+       | 1 | The guard itself: race regression guard landed, two enforcement points | `done` | `medium` |
+       | 2 | FR-011(a) `page.waitForRequest` coverage — zero uses today, future risk | `track` | `low` |
+       | 3 | FR-011(b) editor-time ESLint rule — blocked on `next lint` not reaching `frontend/tests/` | `track` | `low` |
+       | 4 | FR-011(c) scan root beyond `frontend/tests/e2e/` if specs are added elsewhere | `track` | `low` |
+       | 5 | FR-011(d) `check-false-pass-patterns` is inert in CI and admin-suite-scoped | `track` | `medium` |
+       | 6 | FR-011(e) migrate `.pre-commit-config.yaml` off deprecated stage names | `track` | `low` |
+       | 7 | FR-011(f) owner decision: add `Pre-commit Hooks` to required contexts (1400 FR-007b) | `track` | `medium` |
+       | 8 | FR-011(g) `scripts/` is outside every required CI check | `track` | `low` |
+
+    4. Card 5's evidence quotes `pr-checks.yml:236-240`, where Feature 1400 documented the no-op
+       itself. 002 inherits the lesson, not the credit.
+    5. Each card uses the existing key set (`title`, `lane`, `severity`, `evidence`, `citation`,
+       `next_action`, `source`). Note the board also carries an eighth key, `milestone`, on 3 of 118
+       cards; it is optional and not used here.
+    6. `python3 -c "import json; ..."` `raw_decode` on the text after `const CARDS = ` parses
+       cleanly and returns 128.
+
+- [ ] **T020** Final scope and cleanliness check (depends on T019)
+  - **Files**: none modified
+  - **Satisfies**: SC-015
+  - **Acceptance criteria**:
+    1. `git diff --stat` against the branch point touches only: `.pre-commit-config.yaml`,
+       `.github/workflows/pr-checks.yml`, `Makefile`, `CLEANUP-BOARD.html`,
+       `specs/002-waitforresponse-lint-guard/**`.
+    2. `scripts/scan-waitforresponse-race.py` is **unmodified** by this branch.
+    3. `frontend/tests/e2e/**` is unmodified.
+    4. No `__scratch-race.spec.ts` anywhere in history on this branch.
+    5. All commits GPG-signed: `git log --show-signature` clean.
+
+---
+
+## Dependency graph
+
+```
+T001 ─► T002 ─► T003 ──┐   (Phase A gate — blocks everything)
+                       │
+                       ├─► T004 ─► T005          (Phase B)
+                       │      │
+                       │      └─► T006 ─► T007   (Phase C)
+                       │                   │
+                       └───────────────────┴─► T008 ─┬─► T009 ─► T010
+                                                     ├─► T011
+                                                     ├─► T012
+                                                     └─► T013 ─┬─► T014
+                                                               ├─► T015
+                                                               ├─► T016
+                                                               └─► T017
+                                                                     │
+                                                                     ▼
+                                                                   T018   (Phase E, real CI)
+                                                                     │
+                                                                     ▼
+                                                              T019 ─► T020 (Phase F)
+```
+
+**Serialisation notes.** T003 gates everything: wiring against an unverified interface is the
+sequencing risk the plan rates **High**. T008 must follow T006 and T007, or Phase D would verify a
+partially-wired guard and the green result would mean less than it appears. T018 must follow the
+whole of Phase D, because a red-team PR is expensive and should not be spent discovering something
+a local run would have caught.
+
+**No task is parallelisable.** Every task either gates on a prior verification result or edits one
+of four small files. Concurrency here buys nothing and risks two agents editing the same YAML.
+
+---
+
+## Requirement coverage
+
+| Requirement | Covered by | Status |
+|---|---|---|
+| FR-001 (refuse locally, fail a required check) | T004, T006, T009, T018 | COVERED |
+| FR-002 (single detector, no second implementation) | T004 crit. 3, T007 crit. 1, T016 | COVERED |
+| FR-003 (local hook shape) | T004 (all criteria) | COVERED |
+| FR-004 (`Lint` job step, `if: always()`, plain `run:`) | T006, T017 crit. 3 | COVERED |
+| FR-005 (stdlib-only, bare `python3`) | T002 crit. 1–2, T011, T013 crit. 3 | COVERED |
+| FR-006 (actionable failure output) | T009 crit. 3–4 | COVERED |
+| FR-007 (four verification modes) | T009 (a), T010 (b), T011 (c), T018 (d) | COVERED |
+| FR-008 (fail loudly on missing/erroring detector) | T012 | COVERED |
+| FR-009 (land green, no suppression) | T001, T013 crit. 2 | COVERED |
+| FR-010 (file allowlist, amendments not edits) | T003, T020 | COVERED |
+| FR-011 (seven deferred cards) | T019 crit. 3 rows 2–8 | COVERED |
+| FR-012 (detector interface contract) | T002, T003 | COVERED |
+| FR-013 (files-scanned, non-zero on empty scan) | T002 crit. 4–5 | COVERED |
+| FR-014 (make target wired into `validate`) | T007, T014 | COVERED |
+| FR-015 (correct the stale BLOCKING claims) | T005 | COVERED |
+
+| Success criterion | Decided by |
+|---|---|
+| SC-001 clean tree green, correct counts | T002 crit. 3, T013 crit. 2 |
+| SC-002 `git commit` refused, names `file:line` | T009 |
+| SC-003 `--all-files` on a clean index fails | T010 |
+| SC-004 `-I -S` fails on a violation | T011 |
+| SC-005 `-I -S` passes on a clean tree | T013 crit. 3 |
+| SC-006 `Lint` required check fails on a draft PR | T018 |
+| SC-007 wiring grep hits both files | T017 crit. 1 |
+| SC-008 not in `SKIP`, is a `run:` step | T017 crit. 2–3 |
+| SC-009 exactly one definition file | T016 |
+| SC-010 runtime measured, under 2s | T015 |
+| SC-011 scan-root rename exits non-zero | T002 crit. 5 |
+| SC-012 detector rename exits non-zero | T012 |
+| SC-013 `make validate` fails on a violation | T014 |
+| SC-014 eight cards, `source` field | T019 |
+| SC-015 file allowlist honoured, nothing planted committed | T013 crit. 5, T018 crit. 6, T020 |
+
+**Every FR maps to ≥1 task. Every SC maps to exactly one deciding task.** No orphans in either
+direction.
+
+---
+
+## Execution Log
+
+*(populated during implementation — Phase A output, T015's measured runtime, T018's PR number and
+check result, and the final board count go here)*
+
+| Task | Date | Result | Evidence |
+|---|---|---|---|
+| | | | |


### PR DESCRIPTION
Specification-only. No code, no behaviour change. Depends on #982 (merged). Implementation is a
separate PR and is not yet approved.

## What this specs

The regression guard for #982's sweep. It wires that feature's detector into two enforcement points
so a reintroduced act-then-wait race fails a check instead of merging:

- a `repo: local` pre-commit hook, for fast local feedback
- a step in the CI `Lint` job, which is the part that can actually block

## The finding that changed the design

The first draft put the blocking check in the `Pre-commit Hooks` CI job, on the strength of a
comment in `.pre-commit-config.yaml` describing it as a BLOCKING gate. That comment is false.
`main`'s required contexts are exactly `Secrets Scan`, `Lint`, `Run Tests` (rulesets: 0), so a red
`Pre-commit Hooks` job still merges under `gh pr merge --auto --squash`. The guard would have
shipped advisory.

The general lesson, which cost two of the three reviews' top findings: reading a workflow file tells
you a job exists; only branch protection tells you it can block a merge.

FR-015 corrects the two in-repo statements that caused the error, including the one this feature's
own draft read and believed.

## Three adversarial reviews

AR#1 3 CRITICAL / 5 HIGH / 6 MED / 3 LOW. AR#2 2 CRITICAL / 6 HIGH / 15 MED / 9 LOW. AR#3 2 CRITICAL
/ 5 HIGH / 8 MED / 6 LOW. All resolved; ledgers are appended to `spec.md`, `plan.md` and `tasks.md`.

Two patterns worth carrying forward:

**A review's fixes are not self-verifying.** AR#2 found six of AR#1's resolutions incompletely
applied, and one applied in a form that did not do what it claimed. AR#3 then found the same class
in AR#2's own ledger (N-14, now struck through rather than rewritten).

**Three acceptance criteria could not fail.** T010 asserted `pre-commit run --all-files` exits
non-zero as the criterion distinguishing this guard from an inert one, but ~20 hooks run under that
command and any red one satisfied it. `if: always()` was verified on a branch where no preceding
step fails. The hook's interpreter was never checked in the only environment where it is wrong
(`python3` off the venv is 3.12.3 here). A guard feature shipping criteria that pass while the guard
is inert is the thesis failing on itself.

## Cross-feature

Only shared file with #982 is `CLEANUP-BOARD.html` (that feature +2 cards, this one +8, 118 -> 128).
Merge order was forced by this feature's T001 precondition and is already satisfied.

Gate: **READY FOR IMPLEMENTATION**. Phase 3 remains owner-gated.

## Verification

- `make test-unit`: 4083 passed, coverage 80.09%
- SAST: 478 rules, 164 files, 0 findings
- Open code-scanning alerts: none
- `make check-banned-terms` fails identically on `main` (15 pre-existing matches, none in this
  diff); the target runs in no CI workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)