### PR TITLE
docs: remove the false Dependabot claim from the pre-push checklist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -618,7 +618,6 @@ When a user invokes `/speckit.specify`, ALWAYS follow the specify workflow - eve
 Before ANY push to remote, check these in order:
 
 ```bash
-# 1. Security alerts (CodeQL, Dependabot)
 gh api repos/{owner}/{repo}/code-scanning/alerts --jq '.[] | select(.state == "open") | {rule: .rule.id, file: .most_recent_instance.location.path}'
 
 # 2. Local validation


### PR DESCRIPTION
One line deleted. Nothing else.

The pre-push checklist labelled its first step
`# 1. Security alerts (CodeQL, Dependabot)`. The command underneath queries
`code-scanning/alerts` and never touches Dependabot at any point, so anyone
following the checklist believed they had checked something they had not.

Measured at the time of deletion: Dependabot corpus 175, 99 open, none of it
reachable from that command.

Deleted rather than annotated, so the line cannot keep reassuring the next reader.
No replacement comment, and no note anywhere describing the deletion.

The command itself is untouched. It has a separate defect (it filters `state`
client-side over a truncated 30-item page, so it reports 0 open while alerts are
open) and fixing that is its own piece of work, not a one-liner bolted onto this.

Draft on purpose.