### PR TITLE
fix(001): stop the ingestion handler logging Secrets Manager ARNs

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1776,6 +1776,17 @@
         "is_removed": false
       }
     ],
+    "specs/001-ingestion-arn-logging/research.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "specs/001-ingestion-arn-logging/research.md",
+        "hashed_secret": "847927bc7415677cbe34396ee5a0e1cb58b2df64",
+        "is_verified": false,
+        "line_number": 133,
+        "is_added": false,
+        "is_removed": false
+      }
+    ],
     "specs/072-market-data-ingestion/contracts/news-item.schema.json": [
       {
         "type": "Hex High Entropy String",
@@ -2506,5 +2517,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-30T20:35:06Z"
+  "generated_at": "2026-07-31T19:03:09Z"
 }

--- a/specs/001-ingestion-arn-logging/checklists/requirements.md
+++ b/specs/001-ingestion-arn-logging/checklists/requirements.md
@@ -1,0 +1,60 @@
+# Specification Quality Checklist: Stop Ingestion Handler Logging Secret ARNs
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-30
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- CodeQL, GitHub, the rule id `py/clear-text-logging-sensitive-data` and the alert numbers 148,
+  149 and 150 are named plainly throughout. That matches existing repository convention: 20 spec
+  files under `specs/` already say CodeQL and 168 say GitHub, and the sibling spec
+  `001-oauth-provider-taint/spec.md` opens with "Close CodeQL alert 144". These are the
+  vocabulary of the problem being solved, not leaked implementation detail.
+- SC-002 names the `refs/heads` branch analysis and the GitHub code scanning alerts API as the
+  evidence source rather than a pull request check. This is a deliberate verification constraint:
+  CodeQL runs diff-informed analysis on pull requests in this repository, and PR #990 was green
+  with five alerts open.
+- SC-002 is keyed to the file path plus the rule id, never to alert numbers 148, 149 and 150.
+  Adversarial Review #1 established that the engine can close those three and open fresh numbers
+  at the same path in the same run, so a number-keyed criterion was satisfiable while the
+  disclosure persisted. SC-002a adds the companion constraint that `fixed_at` is the field that
+  proves repair, because `state` conflates dismissal with repair.
+- Two candidate code shapes exist in the repository's own history for this rule. FR-004 selects
+  the strip from context shape, cites both commits by SHA, and goes one step stricter by
+  excluding the exception message as well. FR-003 correspondingly forbids calling the existing
+  sanitizer from these three sites, because the source identity here is statically known at the
+  call site and no sanitized value is needed. Choosing between the shapes is not an open question.
+- FR-013 locks file scope to the ingestion handler, its tests, and this feature's own
+  `specs/001-ingestion-arn-logging/` directory (the directory carve-out was added by Clarification
+  Q4, so that FR-011's convention artifact and FR-008a's handoff artifact are writable).
+  `src/lambdas/shared/secrets.py`
+  is explicitly off limits, since four dismissed alerts on that file still carry a null
+  `fixed_at` and editing those lines risks re-fingerprinting them into fresh open alerts.
+- Adversarial Review #1 is recorded at the end of spec.md: 1 CRITICAL, 7 HIGH, 3 MEDIUM resolved
+  by edit; 2 LOW carded. Gate is 0 CRITICAL, 0 HIGH remaining.

--- a/specs/001-ingestion-arn-logging/codeql-logging-convention.md
+++ b/specs/001-ingestion-arn-logging/codeql-logging-convention.md
@@ -1,0 +1,174 @@
+# Convention: handling CodeQL `py/clear-text-logging-sensitive-data`
+
+**Owner**: feature `001-ingestion-arn-logging` | **Date**: 2026-07-30
+**Satisfies**: FR-011, SC-006. Written to be cited by `001-oauth-provider-taint` and by any later
+feature working this rule, so nobody re-derives it.
+
+This document is self-contained on purpose. A reader who has never seen the feature should get the
+decision rule, the dismissal wording, and the verification caveat from this file alone.
+
+---
+
+## 1. Decision rule: rewrite or dismiss
+
+Work the list in order and stop at the first branch that applies.
+
+**Step 1. Is the flagged value's meaning knowable at the call site without reading it?**
+
+If the site is `if not tiingo_adapter:` then yes, the author already knows the source is Tiingo.
+Write the literal and drop the value entirely. This is the preferred outcome and it is what
+`001-ingestion-arn-logging` did at all three of its sites. No helper, no sanitizer, no truncation.
+
+**Step 2. If not, can the record carry a non-derived discriminator instead?**
+
+A counter, an enum, an error type, an index into a fixed list. Anything that identifies the failing
+case without being a function of the sensitive value. Prefer this over any transformation of the
+value.
+
+**Step 3. Only if neither works, sanitize.**
+
+Be aware this shape has failed in this repository. `0e7a375` (PR #321, 2025-12-09) introduced an
+intermediate sanitized variable and CodeQL still flagged it. `ebcc2f4` (PR #322, same day) removed
+every secret-derived value from the log context and that is the shape that took. Read the outcome
+from `fixed_at`: alerts 22 through 25 are the four sanitize-in-place sites and their `fixed_at` is
+null to this day; alerts 26 and 27 are the two stripped sites and both carry a non-null `fixed_at`.
+A sanitized value is still a value derived from the sensitive one, so expect the alert to survive
+and expect to land in step 4.
+
+**Step 4. Alert survives a genuine remediation. Now dismiss, with the wording in section 2.**
+
+Never suppress with an inline comment as a first move (constitution §10), and never rename a
+variable to dodge the detector. Both read as detection avoidance, and neither is a fix.
+
+**Always**, whichever branch you land on: leave an inline comment at the site naming the rule id and
+the reason the value was removed. Unconditionally, including on sites where the fix worked cleanly.
+Without it, a later refactor reintroduces the interpolation and nothing objects.
+
+---
+
+## 2. Dismissal wording pattern
+
+Three elements. All three are required.
+
+1. **What the value actually is.** State that it is a resource identifier, not a credential value.
+   Name it.
+2. **Which convention was applied.** Name the shape used: value stripped from message, context and
+   exception; or discriminator substituted; or sanitized to a bare name.
+3. **Why CodeQL still reports the flow.** This element is new. None of the seven existing dismissals
+   of this rule in this repository states it, and their silence is exactly what makes them
+   impossible to re-evaluate later. Say what the engine is still seeing: the taint source reaching a
+   sink through a path the remediation did not sever, an inter-procedural flow through a helper, a
+   dataflow the engine models conservatively.
+
+Template:
+
+> The value reaching this sink is `<name>`, an AWS resource identifier (`<what it identifies>`), not
+> a credential value. It contains no secret material; possessing it does not grant access to
+> anything. Convention applied per `specs/001-ingestion-arn-logging/codeql-logging-convention.md`:
+> `<step 1 / 2 / 3 shape, stated concretely>`. CodeQL continues to report the flow because
+> `<concrete reason: e.g. the engine models the whole return value of get_secret() as tainted and
+> the remaining reference is inside the same dataflow path, regardless of what is now logged>`.
+> Re-evaluate this dismissal if `<the condition that would make it wrong>`.
+
+Do not paste the template as-is. The third element and the re-evaluation trigger must be specific to
+the site, otherwise the dismissal is no better than the seven that came before it.
+
+---
+
+## 3. Verification caveats
+
+Three traps. Each has burned somebody in this repository.
+
+**Trap 1: `state` is not `fixed_at`.** Dismissal is sticky and survives a later genuine repair, so
+`state` conflates "a human dismissed this" with "the code was fixed". Alerts 26 and 27 read
+`dismissed` and carry a non-null `fixed_at`, meaning repaired. Alerts 22 through 25 also read
+`dismissed` and have `fixed_at` null, meaning never repaired. Key every claim about repair on
+`fixed_at`, and require it to be dated at or after the change.
+
+**Trap 2: alert numbers are not stable identities.** CodeQL can close a number as fixed and open a
+brand new number at the same location in the same run. Alert 117 on
+`src/lambdas/shared/auth/oauth_state.py` carries `fixed_at` `2026-01-20T22:34:56Z` and alert 144 on
+the same file was created at that identical timestamp. Alerts 107, 110 and 111 spawned and closed
+within hours during the 2025-12-09 secrets remediation. Therefore: **key success on path plus rule
+id, never on the alert number**. "Alert N is no longer open" is not the criterion. "Zero open alerts
+of this rule at this path" is.
+
+**Trap 3: a green PR CodeQL check is not evidence.** CodeQL runs diff-informed analysis on pull
+requests here. PR runs report `results_count: 0` while the corresponding `refs/heads` run reports 9;
+PR #990 was green with five alerts open. Read closure from the default-branch analysis or from the
+code scanning alerts API, on a commit that includes the change. The useful inverse: when the change
+edits the exact flagged lines, the diff-scoped PR result is directly informative, so a survivor there
+is a real survivor.
+
+Query shape:
+
+```bash
+gh api "repos/<owner>/<repo>/code-scanning/alerts?state=open&per_page=100" \
+  --jq '.[] | select(.rule.id == "py/clear-text-logging-sensitive-data")
+        | select(.most_recent_instance.location.path == "<path>")
+        | {number, state, fixed_at, line: .most_recent_instance.location.start_line}'
+```
+
+Empty output is the pass condition. Drop `state=open` and read `fixed_at` per number to distinguish
+repaired from dismissed.
+
+---
+
+## 4. Blast radius rule
+
+Do not edit a file that carries alerts of this rule unless that file is your feature's target.
+Editing lines that hold a live-behind-dismissal finding (`state: dismissed`, `fixed_at: null`) can
+re-fingerprint it into a fresh open alert. That is what happened to `src/lambdas/shared/secrets.py`
+on 2025-12-09, and it is why `001-ingestion-arn-logging` refused to reuse that file's sanitizing
+helper even though reuse looked like the tidier option.
+
+Known live-behind-dismissal sites as of 2026-07-30: alerts 22, 23, 24 and 25 on
+`src/lambdas/shared/secrets.py`. Treat that file as off limits unless it is your target.
+
+---
+
+## 5. Two states that are neither done nor failed
+
+### 5a. You cannot yet verify: `PENDING-BRANCH-ANALYSIS`
+
+This is the normal ending, not an edge case. Closure is read from the default-branch analysis
+(section 3, trap 3), and no such analysis can exist while the change sits on a feature branch. So at
+the end of implementation the feature is not `DONE` (closure unevaluated), not `DONE (dismissed)` (no
+survivor observed yet), and not blocked on permission (nothing has been attempted).
+
+Terminate in `PENDING-BRANCH-ANALYSIS` when the code change and its regression tests are complete
+and green but no qualifying analysis exists. Record the exact verification query from section 3,
+filled in with your own path, so the check is mechanical the moment the analysis lands. Report it as
+neither done nor failed.
+
+### 5b. You cannot dismiss: `BLOCKED-ON-OWNER`
+
+**Check the permission with a read-only probe. Never establish it by attempting a dismissal**, which
+mutates alert state and cannot be cleanly reverted.
+
+The probe is the token's scope list read together with the repository's visibility and the actor's
+repository permissions:
+
+```bash
+gh auth status                                  # token scopes
+gh api repos/<owner>/<repo> --jq '{visibility, permissions}'
+```
+
+**A missing `security_events` scope is not by itself a blocker.** GitHub's
+update-code-scanning-alert endpoint requires `security_events` only on **private** repositories. On a
+**public** repository `public_repo` suffices, and the `repo` scope includes `public_repo`. This
+repository is public, so a token carrying `repo` plus a repository role of push or above can dismiss.
+Probed on 2026-07-30 the local environment satisfies exactly that, which means
+`BLOCKED-ON-OWNER` is **not** the expected outcome here. Reading `gh auth status` alone and
+concluding "no `security_events`, therefore blocked" is the specific mistake this paragraph exists to
+prevent; `001-ingestion-arn-logging` made it once and corrected it in its Clarification Q2.
+
+If the probe genuinely shows the permission absent, do not leave the feature hanging and do not
+report it failed. Terminate in `BLOCKED-ON-OWNER` and write a handoff artifact into your feature's
+directory carrying: the exact alert numbers observed at the path, the exact justification text for
+each (section 2), and the exact API call or UI steps to apply them. The code change is independently
+complete and mergeable at that point. Only the dismissal is outstanding.
+
+The two states are distinct. `PENDING-BRANCH-ANALYSIS` means no observation is possible yet.
+`BLOCKED-ON-OWNER` means a survivor has already been observed and permission to dismiss it is
+absent.

--- a/specs/001-ingestion-arn-logging/codeql-logging-convention.md
+++ b/specs/001-ingestion-arn-logging/codeql-logging-convention.md
@@ -77,7 +77,7 @@ the site, otherwise the dismissal is no better than the seven that came before i
 
 ## 3. Verification caveats
 
-Three traps. Each has burned somebody in this repository.
+Four traps. Each has burned somebody in this repository.
 
 **Trap 1: `state` is not `fixed_at`.** Dismissal is sticky and survives a later genuine repair, so
 `state` conflates "a human dismissed this" with "the code was fixed". Alerts 26 and 27 read
@@ -100,17 +100,66 @@ code scanning alerts API, on a commit that includes the change. The useful inver
 edits the exact flagged lines, the diff-scoped PR result is directly informative, so a survivor there
 is a real survivor.
 
-Query shape:
+**Trap 4: an absence is only evidence once the read is proven live.** This is the trap that makes the
+other three survivable, and it has two independent failure modes.
+
+*Truncation.* The alerts endpoint pages at 100 and defaults to 30. This repository held 137 alerts
+across all states on 2026-07-30, and one unpaginated page covered alert numbers 59 to 180 only, so
+every number below 59 was silently absent. That range includes alert 1 on `src/lambdas/shared/errors.py`
+and alerts 22 to 27 on `src/lambdas/shared/secrets.py`, which are exactly the alerts a blast-radius
+check has to see. An unpaginated all-states query returns nothing for them and reads as clean. Always
+pass `--paginate`, and never pass `--jq` alongside it: `gh` applies the filter once per page, so a
+`.[0]` expression prints one row per page rather than one row. Write to a file, then run `jq` standalone.
+
+*A wrong field path.* `jq` does not distinguish "no match" from "could not read". A mistyped path such
+as `.most_recent_instance.locatio.path` returns `null` for every alert, does not error, and exits `0`.
+A corpus-count floor does not catch it, because the floor is computed from `.rule.id`, a different
+field the typo never touches. Reproduced on the live corpus 2026-07-30: under the typo the filtered
+count for a given path evaluated to `0`, which is the PASS value of the gate it was guarding. So a
+floor plus an exit code is **necessary and not sufficient**. Add a positive anchor: assert that no
+alert has a null path, and that a known-present path returns its known count, both read **through the
+same field path the gate filters on**. (Contrast `grep`, which exits 1 on "no match" and 2 on "could
+not read"; that asymmetry is why `grep`-based absence checks are safe and `jq`-based ones are not.)
+
+Query shape, in this order: exit code, then corpus floor, then positive anchor, then read the absence.
 
 ```bash
-gh api "repos/<owner>/<repo>/code-scanning/alerts?state=open&per_page=100" \
-  --jq '.[] | select(.rule.id == "py/clear-text-logging-sensitive-data")
-        | select(.most_recent_instance.location.path == "<path>")
-        | {number, state, fixed_at, line: .most_recent_instance.location.start_line}'
+gh api --paginate "repos/<owner>/<repo>/code-scanning/alerts?per_page=100" > /tmp/alerts.json
+rc=$?
+[ "$rc" -eq 0 ] || { echo "READ FAILED: gh exit $rc"; exit 1; }
+
+# Proof of read 1: the rule is present in the corpus at all.
+total=$(jq -s 'add | map(select(.rule.id=="py/clear-text-logging-sensitive-data")) | length' /tmp/alerts.json)
+[ "$total" -ge "<known floor>" ] || { echo "READ FAILED / TRUNCATED: only $total"; exit 1; }
+
+# Proof of read 2 (positive anchor): the PATH field is being read, through the
+# same expression the gate below filters on. Without this the gate can pass blind.
+null_paths=$(jq -s 'add | map(select(.most_recent_instance.location.path==null)) | length' /tmp/alerts.json)
+[ "$null_paths" -eq 0 ] || { echo "BLIND READ: $null_paths alerts have a null path"; exit 1; }
+anchor=$(jq -s 'add | map(select(.most_recent_instance.location.path=="<known-present path>")) | length' /tmp/alerts.json)
+[ "$anchor" -ge "<its known count>" ] || { echo "BLIND READ: anchor returned $anchor"; exit 1; }
+
+# Only now is the absence below evidence of anything.
+open_at_path=$(jq -s 'add | map(select(
+    .rule.id=="py/clear-text-logging-sensitive-data"
+    and .state=="open"
+    and .most_recent_instance.location.path=="<path>")) | length' /tmp/alerts.json)
+echo "total=$total null_paths=$null_paths anchor=$anchor open_at_path=$open_at_path"
 ```
 
-Empty output is the pass condition. Drop `state=open` and read `fixed_at` per number to distinguish
-repaired from dismissed.
+The pass condition is `open_at_path == 0` **and** `rc == 0` **and** `total >= floor` **and**
+`null_paths == 0` **and** `anchor >= its known count`. `open_at_path == 0` on its own is not a pass;
+it is the value a completely blind read also returns.
+
+The snapshot is written without a `state` filter on purpose, so the same file answers the `fixed_at`
+question in section 3 trap 1. Read `fixed_at` per number from it to distinguish repaired from
+dismissed; do not re-query with `state=open`, which cannot see a dismissal at all.
+
+One more caveat for anyone diffing two snapshots: `rule@path` is **not** a unique key. On this
+repository one such key held 24 alerts, and this rule at `src/lambdas/shared/secrets.py` held 16. A
+set-diff keyed on `rule@path` reports only whether the key still exists, so 15 of those 16 could
+vanish and it would print nothing. Build `{key: count}` on each side and diff the **counts**,
+reporting three buckets (`disappeared`, `appeared`, `changed`) so a partial loss has somewhere to land.
 
 ---
 

--- a/specs/001-ingestion-arn-logging/plan.md
+++ b/specs/001-ingestion-arn-logging/plan.md
@@ -1,0 +1,409 @@
+# Implementation Plan: Stop Ingestion Handler Logging Secret ARNs
+
+**Branch**: `001-ingestion-arn-logging` | **Date**: 2026-07-30 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/001-ingestion-arn-logging/spec.md`
+
+## Summary
+
+Three logging calls in `src/lambdas/ingestion/handler.py` pass Secrets Manager ARNs into the
+logging sink: line 264 interpolates both ARNs into an f-string message that is also reused as a
+`RuntimeError` message, and lines 271 and 276 attach an ARN as a structured context value via
+`extra=`. CodeQL flags all three under `py/clear-text-logging-sensitive-data` as alerts 148, 149
+and 150.
+
+The technical approach is the shape proven by `ebcc2f4` (PR #322): carry no secret-derived value
+in the message, in the structured context, or in the raised exception. The source identity at
+these three sites is statically known at the call site, so the diagnostic value of each record is
+preserved with fixed literal text (`Tiingo`, `Finnhub`) and nothing is read from `config` for
+logging purposes. No sanitizer, no helper, no formatter, no filter. The change is a deletion at
+all three sites plus a reword at the first one, guarded by a new unit test module that asserts
+over both the rendered message and the record's structured attributes.
+
+## Technical Context
+
+**Language/Version**: Python 3.13 (`requires-python = ">=3.13"`; Lambda runtime `python3.13`)
+**Primary Dependencies**: Python standard-library `logging` only for the mechanism. `src/lambdas/ingestion/handler.py:119` uses `logging.getLogger(__name__)`, not a structured-logging wrapper, and the handler's logging mechanism is retained unchanged per FR-012. Tests use pytest 8.x with the built-in `caplog` fixture, plus `unittest.mock.patch` and `moto` (`mock_aws`) already present in `tests/unit/lambdas/ingestion/test_handler.py`. No dependency is added, removed or upgraded.
+**Storage**: N/A. No data store is read or written by this change.
+**Testing**: pytest, `tests/unit/lambdas/ingestion/`, run under the project venv (`source .venv/bin/activate`). Unit tests only; all AWS access is mocked with `moto` and all external APIs with `MagicMock`, per the constitution's LOCAL/DEV row.
+**Target Platform**: AWS Lambda (`{env}-sentiment-ingestion`), EventBridge-triggered, logging to CloudWatch Logs.
+**Project Type**: Single project. Backend Lambda source under `src/lambdas/`, tests under `tests/`.
+**Performance Goals**: N/A. Removing string interpolation from two branches that run at most once per invocation has no measurable effect.
+**Constraints**: FR-013 locks the writable file set to `src/lambdas/ingestion/handler.py`, its tests, and this feature's own `specs/001-ingestion-arn-logging/` directory (the directory carve-out was added by Clarification Q4 so that `codeql-logging-convention.md` and, if FR-008a fires, `dismissal-handoff.md` can be written at all). `src/lambdas/shared/secrets.py` must not be touched (alerts 22 through 25 sit there with `fixed_at` null). FR-012 forbids new cloud resources and any logging-framework change. SC-004 forbids loosening or removing any existing assertion; test changes must be additions only.
+**Scale/Scope**: 3 log call sites in 1 source file (about 20 lines net), 1 new test module (about 5 tests), 1 convention artifact. No runtime behaviour change beyond message text.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Checked against `.specify/memory/constitution.md` v1.6.
+
+| Constitution clause | Applies | Status | Evidence / note |
+|---|---|---|---|
+| §3 Security: "do not write raw user-provided text into logs or dashboard fields without redaction" and "Protect logs" | Yes | PASS, this feature is the enforcement | The change removes account topology from the log sink entirely. |
+| §6 Observability: "Emit structured logs for requests ... without logging raw input text by default" | Yes | PASS | Records keep their level, their trigger condition and their source identity. Only the ARN leaves. |
+| §7 Implementation Accompaniment Rule: every modified module needs unit tests covering happy path and at least one error path | Yes | PASS | New module `tests/unit/lambdas/ingestion/test_handler_arn_logging.py` covers all three failure branches plus the outer exception path. |
+| §7 Environment matrix: LOCAL/DEV run unit tests only, all AWS and external APIs mocked | Yes | PASS | `moto` for DynamoDB, `MagicMock` for adapters, `patch` for `get_api_key`. No preprod test is added. |
+| §7 Functional Integrity: never make tests pass by weakening fixtures | Yes | PASS | SC-004 already forbids loosening any existing assertion. Test changes are additions only. |
+| §7 Deterministic Time Handling | No | N/A | No date or time value appears anywhere in this change. |
+| §7 Coverage: 80% minimum for new code | Yes | PASS | The changed lines are exactly the lines the new tests execute. |
+| §8 Git Workflow: ruff check, ruff format, GPG-signed commit, feature branch, no `--no-verify` | Yes | PASS, applies at implementation | Standard. Nothing in this feature needs a bypass. |
+| §10 Local SAST: bandit pre-commit, `make sast` / `make validate` before push | Yes | PASS | The change deletes a CWE-532 pattern rather than introducing one. `make validate` runs before push as usual. |
+| §10 "DO NOT suppress without documented justification" and "DO NOT rename variables just to avoid detection" | Yes | PASS | The fix is removal at source, not suppression and not renaming. FR-003 explicitly forbids the sanitize-in-place shape that would look like detection avoidance. FR-008/FR-009 attach a written justification to any dismissal that remains. |
+| §9 Tech Debt Tracking: registry entry for "security shortcuts with documented acceptance criteria". The registry is `docs/reference/TECH_DEBT_REGISTRY.md`; constitution §9 cites the stale flat path `docs/TECH_DEBT_REGISTRY.md`, corrected by commit `f8db8d2` (PR #668) and independently noted by sibling `001-ruff-bump-forward` | Conditionally | **DEVIATION** | Triggers only on the dismissal branch, which is post-merge and therefore unevaluable during implementation. See Complexity Tracking below and Clarification Q1. |
+
+**Initial gate result: PASS with one recorded deviation (§9).**
+
+**Post-design re-check: unchanged. PASS with the same single deviation.** The Phase 1 design adds
+no new module, no new dependency, no new resource and no new interface, so no additional clause
+comes into play.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/001-ingestion-arn-logging/
+├── spec.md                        # Input (with Adversarial Review #1 appendix)
+├── plan.md                        # This file
+├── research.md                    # Phase 0 output: decisions D1 to D7
+├── codeql-logging-convention.md   # Phase 1 output: the FR-011 / SC-006 reusable artifact
+├── checklists/
+│   └── requirements.md            # Existing
+├── dismissal-handoff.md           # CONDITIONAL, created at implementation time only if FR-008a fires
+└── tasks.md                       # Phase 2 output (/speckit.tasks, NOT created here)
+```
+
+### Source Code (repository root)
+
+Only two files **outside this feature's specification directory** are writable under FR-013. Per
+Clarification Q4, `specs/001-ingestion-arn-logging/` is itself inside the writable set; everything
+else in the repository is not:
+
+```text
+src/lambdas/ingestion/
+└── handler.py                     # MODIFIED: 3 log sites at lines 258-277 (+ the RuntimeError message)
+
+tests/unit/lambdas/ingestion/
+├── test_handler.py                # UNCHANGED (SC-004: no existing assertion loosened or removed)
+└── test_handler_arn_logging.py    # NEW: the FR-007 regression guard
+```
+
+Explicitly not touched: `src/lambdas/shared/secrets.py` (FR-013, SC-005),
+`src/lambdas/shared/logging_config.py`, `src/lambdas/shared/logging_utils.py`, any Terraform,
+any workflow.
+
+**Structure Decision**: Single project, existing repository layout, no new directory. The feature
+is a defect fix inside one existing Lambda handler plus one new sibling test module placed next to
+the handler's existing test file. Nothing about this feature motivates a structural change, and
+FR-013 forbids one.
+
+## Phase 0: Research
+
+See [research.md](./research.md). No `NEEDS CLARIFICATION` markers were carried into Technical
+Context, so Phase 0 resolved no unknowns. It records seven decisions that were already settled by
+the spec and its adversarial review, so implementation does not re-derive them:
+
+- **D1** Code shape: strip the value, do not sanitize it (`ebcc2f4` over `0e7a375`).
+- **D2** Evidence field: `fixed_at`, never `state`.
+- **D3** Why lines 271 and 276 stay in scope even though nothing renders `extra` today.
+- **D4** Test assertion surface: the `LogRecord`'s attributes, not `caplog.text`.
+- **D5** Forbidden-string enumeration and the fixture ARN chosen to make each component unambiguous.
+- **D6** Verification path: default-branch analysis or the alerts API, keyed on path plus rule.
+- **D7** Terminal state when dismissal permission is absent.
+
+## Phase 1: Design
+
+### Interface contracts
+
+**Skipped, deliberately.** This feature exposes no interface. It changes no HTTP route, no event
+schema, no DynamoDB item shape, no function signature and no module export. `lambda_handler`'s
+input event and its returned response dict are byte-identical before and after, which FR-006
+requires. Generating a `contracts/` directory here would produce a file describing an unchanged
+API, which is padding, so none is written.
+
+### Data model
+
+**Skipped, deliberately.** There are no entities. The only data touched is two environment-sourced
+strings that the corrected code stops reading at these sites. Writing a `data-model.md` for a log
+statement would be noise.
+
+### Quickstart
+
+**Skipped as a separate file.** The only "getting started" content this feature has is the
+verification procedure, which is load-bearing for SC-002, SC-002a and SC-005 and is therefore
+recorded inline below rather than in a satellite document a reader might miss.
+
+### Agent context update
+
+**Not run.** `.specify/scripts/bash/update-agent-context.sh claude` writes to the repository-root
+`CLAUDE.md`, which is outside this feature's writable scope, and three sibling agents share this
+worktree. The script would also have nothing to add: this feature introduces no new technology
+(stdlib `logging` and pytest are both long-standing entries).
+
+### Code change design
+
+All three sites are inside the `if not tiingo_adapter and not finnhub_adapter:` region at
+`src/lambdas/ingestion/handler.py:256-277`.
+
+**Site 1, lines 259-265 (the definitely-rendered one).** `error_msg` is built by f-string from
+both ARNs, passed to `logger.error()`, then reused verbatim as the `RuntimeError` message. Both
+uses are sinks. Replace with a fixed literal that names both sources, satisfying FR-002 (this is
+the site that currently identifies its sources only through the interpolated key names) and
+FR-004 (the exception message is now clean, which is what makes FR-005 hold for the outer
+`except` at line 572). The `logger.error` call and the `raise RuntimeError` stay, same level, same
+branch, same exception type, per FR-006. Add the FR-010 inline comment naming the rule id.
+
+**Sites 2 and 3, lines 268-277 (the structured-context ones).** Delete the `extra={...}` argument
+outright. The message already carries the literal source name, so the record loses nothing an
+on-call engineer uses. Add the FR-010 inline comment at each. Do not replace `extra` with a
+sanitized value: that is the `0e7a375` shape and FR-003 forbids it.
+
+Net effect on `config`: `config["tiingo_secret_arn"]` and `config["finnhub_secret_arn"]` remain
+read exactly once each, at lines 249-250, where they are passed to `get_api_key()`. That is a
+legitimate non-logging use and is untouched.
+
+### Test design
+
+New file `tests/unit/lambdas/ingestion/test_handler_arn_logging.py`. Additions only; nothing in
+`test_handler.py` is edited, which satisfies SC-004 mechanically.
+
+**Fixture ARNs.** Deliberately richer than the ones in `test_handler.py`'s `env_vars` fixture,
+which lack an environment segment and use `us-east-1`, the same region the handler's unrelated
+`aws_region` config carries. A region collision would make a region assertion ambiguous, so the
+new fixture uses a region that appears nowhere else in the handler's config:
+
+```
+arn:aws:secretsmanager:eu-west-2:218795110243:secret:preprod/sentiment-analyzer/tiingo-AbCdEf
+arn:aws:secretsmanager:eu-west-2:218795110243:secret:preprod/sentiment-analyzer/finnhub-GhIjKl
+```
+
+**Fixture isolation (FR-007, added by Clarification Q3).** The region is not the only value that
+can collide. `_get_config()` at `src/lambdas/ingestion/handler.py:585-605` also loads
+`sns_topic_arn` and `alert_topic_arn`, both of which legitimately contain an account identifier. If
+the fixture put `218795110243` into either of them, a record carrying an SNS ARN would fail the
+account assertion for a reason unrelated to the secret ARN, and a passing assertion would stop being
+evidence. So the fixture MUST keep every enumerated forbidden string unique to the two secret ARNs:
+
+- `SNS_TOPIC_ARN` keeps the existing fixture's unrelated account (`123456789`) and must not contain
+  `218795110243`, `eu-west-2` or `preprod/sentiment-analyzer`.
+- `ALERT_TOPIC_ARN` is unset by the existing fixture and defaults to `""`. If the new fixture sets
+  it, the same three constraints apply.
+- `AWS_REGION` stays `us-east-1`. **`CLOUD_REGION` must be explicitly cleared or pinned to
+  `us-east-1` as well**: `_get_config()` reads `CLOUD_REGION` first and only falls back to
+  `AWS_REGION` (`handler.py:589-590`), so an inherited `CLOUD_REGION` in the runner's environment
+  would silently defeat the region isolation. Neither Q3 nor the existing `env_vars` fixture covers
+  this variable.
+
+The single-source cases (2 and 3) are the ones that reach `_get_sns_client` and
+`_create_failure_tracker`, so this is where the isolation matters. Case 1 raises at
+`handler.py:265` before either is called.
+
+**Forbidden strings (FR-007's enumeration, five classes).** Asserted per record, each on its own:
+the full ARN value; the prefix `arn:aws:secretsmanager`; the account identifier `218795110243`
+alone; the region `eu-west-2` alone; and the environment or secret path segment
+`preprod/sentiment-analyzer` alone. The random suffixes `AbCdEf` and `GhIjKl` are added as a
+sixth for completeness. A single-marker check on the prefix would pass while the account
+identifier leaked by itself, which is why the enumeration is the operative part of SC-001.
+
+**Assertion surface (FR-007, closes the false-negative edge case).** For each captured record the
+haystack is built from `record.getMessage()` **plus every value in `record.__dict__`**, not from
+`caplog.text`. Probe result recorded in research.md D4: with the current unfixed code
+`caplog.text` does not contain the ARN while `record.tiingo_secret_arn` holds it in full, so a
+rendered-text assertion passes against unfixed code and proves nothing. A helper in the test
+module builds that haystack once and every test uses it.
+
+**Cases.**
+
+1. Both credentials unavailable: `get_api_key` patched to return `None` for both ARNs. Assert a
+   record at `ERROR` exists, that its message contains the literal `Tiingo` and the literal
+   `Finnhub` (FR-002), and that it is clean against the full enumeration.
+2. Tiingo only unavailable: `get_api_key` given a `side_effect` keyed on the ARN argument so it
+   returns `None` for the Tiingo ARN and a key for the Finnhub ARN. Assert the `WARNING` record
+   still names Tiingo and is clean against the enumeration, including its structured attributes.
+3. Finnhub only unavailable: mirror of case 2.
+4. Outer exception path (Acceptance Scenario 4): with both credentials unavailable the
+   `RuntimeError` propagates to the `except` at line 572, which logs via
+   `get_safe_error_info(e)`. That helper returns `{"error_type": ...}` only, so the record is
+   clean by construction, but the test pins it so a future change to either the helper or the
+   exception message cannot reintroduce the leak silently.
+5. Sweep: assert **every** record captured across the whole invocation in case 1 is clean, not
+   just the three targeted ones. Cheap, and it catches a leak that migrates to a fourth site.
+
+**Mechanics.** Follow the existing pattern in `test_handler.py`: `@mock_aws`, the `env_vars`
+fixture shape with the new ARNs, `_create_table_with_gsi` plus one active configuration so the
+handler reaches line 249, and `patch` on `src.lambdas.ingestion.handler.get_api_key`,
+`.TiingoAdapter`, `.FinnhubAdapter`, `._get_sns_client`, `.emit_metrics_batch`. The handler logger
+is `src.lambdas.ingestion.handler` with `propagate` left at default, so
+`caplog.at_level(logging.WARNING, logger="src.lambdas.ingestion.handler")` captures cleanly. The
+`reset_caches` autouse fixture from `test_handler.py` must be duplicated in the new module,
+otherwise `_active_tickers_cache` leaks between modules.
+
+### Verification procedure
+
+Local, before push:
+
+```bash
+source .venv/bin/activate
+pytest tests/unit/lambdas/ingestion/ -v          # new module green, existing module unchanged
+make validate                                    # ruff + bandit + semgrep (constitution §10)
+```
+
+Closure evidence, after merge, once a default-branch analysis has run on a commit that includes
+the change. Keyed on path plus rule, never on the numbers 148, 149, 150:
+
+```bash
+gh api "repos/traylorre/sentiment-analyzer-gsk/code-scanning/alerts?state=open&per_page=100" \
+  --jq '.[] | select(.rule.id == "py/clear-text-logging-sensitive-data")
+        | select(.most_recent_instance.location.path == "src/lambdas/ingestion/handler.py")
+        | {number, state, fixed_at, line: .most_recent_instance.location.start_line}'
+```
+
+Empty output satisfies SC-002. Any number returned, including one that did not exist before, is a
+survivor under Acceptance Scenario 2 and is worked, not dismissed as unrelated.
+
+For SC-002a, re-query without the `state` filter and read `fixed_at` on each of 148, 149 and 150.
+Non-null and dated at or after the change means repaired. `state` of `dismissed` or `closed` with
+`fixed_at` null does not count.
+
+For SC-005, run the same query filtered to `src/lambdas/shared/secrets.py` and to
+`src/lambdas/shared/auth/oauth_state.py` before and after, and diff. Alert 144 must be untouched;
+alerts 22 through 25 must still read `dismissed` with `fixed_at` null; no new number may appear on
+`secrets.py`.
+
+Do not accept a green PR CodeQL check as closure evidence (SC-002). The useful inverse still
+holds: because this change edits the exact flagged lines, the diff-informed PR result is directly
+informative, so an alert that survives the PR run is a genuine survivor worth investigating
+immediately rather than waiting for the branch analysis.
+
+### Terminal states
+
+- **DONE**: tests green, zero open alerts of the rule at the handler path on the default-branch
+  analysis, SC-005 diff clean.
+- **DONE (dismissed)**: a survivor exists, is dismissed as a false positive with the FR-009
+  three-element justification from `codeql-logging-convention.md`, SC-003 satisfied by the
+  dismissal comment.
+- **PENDING-BRANCH-ANALYSIS** (FR-008b): the code change and the FR-007 tests are complete and
+  green, but no default-branch CodeQL analysis on a commit containing the change exists yet. This is
+  the **expected ending of implementation**, not an edge case, because SC-002 and SC-002a are only
+  evaluable after the change reaches the default branch and this agent tree performs no git
+  operations. Reaching this state requires recording the exact verification query above (the `gh api`
+  block under "Closure evidence") so the check is mechanical when the analysis lands; the query in
+  this plan satisfies that, and no separate artifact is required. Per FR-008b this is reported as
+  neither done nor failed.
+- **BLOCKED-ON-OWNER** (FR-008a): a survivor exists **and** a read-only capability probe shows the
+  implementing agent cannot dismiss it. The probe is mandatory and must run before any dismissal is
+  attempted, because a dismissal that succeeds mutates alert state and cannot be cleanly reverted,
+  which SC-005 treats as a breach. The probe is `gh auth status` (token scopes) read together with
+  `gh api repos/traylorre/sentiment-analyzer-gsk --jq '{visibility, permissions}'`. **A missing
+  `security_events` scope alone does not establish the block**: that scope is required only for
+  private repositories, this repository is public, and `public_repo` (which `repo` includes) plus a
+  push-or-above role suffices. Probed 2026-07-30 the local environment satisfies this, so
+  `BLOCKED-ON-OWNER` is not the expected outcome. If the probe does show the permission absent,
+  write `specs/001-ingestion-arn-logging/dismissal-handoff.md` carrying the observed alert numbers,
+  the exact justification text per alert, and the exact `gh api` call to apply each. The code change
+  is independently complete and mergeable at that point. Per FR-008a this is reported as blocked,
+  never as done and never as failed.
+
+`PENDING-BRANCH-ANALYSIS` and `BLOCKED-ON-OWNER` are distinct: the first means no observation is
+possible yet, the second means a survivor has already been observed and permission to act on it is
+absent.
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| Constitution §9 requires a `docs/reference/TECH_DEBT_REGISTRY.md` entry for a security finding accepted with documented criteria. If FR-008 fires and an alert ends dismissed rather than repaired, that is such an acceptance, and no registry entry will be written. | The registry exists (`TD-001` through `TD-023`); the constitution's flat path is stale. Two reasons the entry is not written here. First, the trigger is conditional on the dismissal branch, which is only knowable after a default-branch analysis, so it cannot be evaluated during implementation (FR-008b). Second, FR-013 locks the writable set to `src/lambdas/ingestion/handler.py`, its tests and this feature's spec directory; the shared registry is outside it, sibling `001-ruff-bump-forward` task T016 already claims the next sequential identifier, and three sibling agents share this worktree. | Writing the registry entry anyway breaches FR-013 and races the sibling for `TD-024`. The mitigation kept: the justification is recorded twice, in the GitHub dismissal comment (FR-009, SC-003) and in `codeql-logging-convention.md` under this feature's directory (FR-011, SC-006), so the acceptance is documented and discoverable, just not in the central registry. A follow-up registry entry is carded for the owner and is a one-line addition once the alert outcome is known. |
+
+## Carded, not done here
+
+Recorded so they are not silently lost. All are already in the spec's Out of Scope.
+
+- Adjacent account topology values near these sites (`sns_topic_arn`, `alert_topic_arn`) carry the
+  same account identifier and are not flagged by this rule. Separate triage.
+- A repository-wide lint rule blocking ARN interpolation into logging calls. The FR-007 test
+  guards these three sites only.
+- Making CodeQL a required status check. Today the required contexts are exactly `Secrets Scan`,
+  `Lint`, `Run Tests` and `Playwright E2E Tests`.
+- The `docs/reference/TECH_DEBT_REGISTRY.md` entry described in Complexity Tracking, if the
+  dismissal path fires. The identifier is allocated when the entry is written, never pre-reserved
+  here.
+
+## Adversarial Review #2
+
+Reviewer did not author any artifact under review and did not participate in Adversarial Review #1
+or in the clarification session. Scope of this pass is **post-clarification drift** and
+**cross-artifact consistency**, not a re-run of AR#1. Every claim below was checked against
+`src/lambdas/ingestion/handler.py`, `src/lambdas/shared/logging_utils.py`,
+`src/lambdas/shared/logging_config.py`, `tests/unit/lambdas/ingestion/test_handler.py`,
+`docs/reference/TECH_DEBT_REGISTRY.md`, `scripts/check-banned-terms.sh`, and against the live GitHub
+code scanning alerts API on 2026-07-30.
+
+### The structural cause
+
+The clarify stage writes its answers into `spec.md` only. It does not revisit `plan.md`,
+`research.md`, `codeql-logging-convention.md` or `checklists/requirements.md`. Clarifications Q2,
+Q3 and Q4 each changed a requirement that those four documents had already encoded, so each left a
+stale copy behind. Q2 is the worst case: its own answer text quotes the plan's Terminal States
+section as evidence of the gap and then does not fix it, so the plan was left literally documenting
+the state the clarification was raised to remove.
+
+### Findings
+
+| # | Severity | Finding | Caused by | Stale artifact | Correction |
+|---|---|---|---|---|---|
+| C1 | **CRITICAL** | `codeql-logging-convention.md:132` asserted "Dismissing requires `security-events: write`." That is false for this repository and it directly contradicts the spec, which was corrected: `spec.md:114` (Assumption) and `spec.md:270-280` (Q2) both establish that `security_events` is a **private**-repository requirement and that `public_repo`, which `repo` includes, suffices here. This is the one document feature `001-oauth-provider-taint` inherits by citation, and its token carries the same scope list (`gist`, `read:org`, `repo`, `workflow`, no `security_events`). Following section 5 as written, feature B reads its own scope list, concludes it is blocked, and terminates in `BLOCKED-ON-OWNER` while holding the permission it needs. The convention would have propagated the exact error the spec caught and corrected. | Q2 | `codeql-logging-convention.md:132` vs `spec.md:114,270-280` | **Fixed.** Section 5 rewritten. The scope claim is corrected, the "missing `security_events` alone does not establish the block" trap is stated explicitly, and the read-only probe (`gh auth status` plus repository visibility and permissions) is made mandatory with the reason a dismissal-attempt probe is unacceptable. |
+| H1 | **HIGH** | `plan.md` Terminal States listed exactly three states and omitted `PENDING-BRANCH-ANALYSIS`. FR-008b is therefore a spec requirement with **no reachability from the plan at all**, and the plan asserted a closed set of endings that excludes the one the implementation will actually hit. Q2's own answer names this section as the evidence for the gap. | Q2 | `plan.md:255-266` vs `spec.md:91` (FR-008b) | **Fixed.** `PENDING-BRANCH-ANALYSIS` added as a first-class terminal state, marked as the expected ending, with the FR-008b recording obligation pointed at the plan's existing `gh api` block so no new artifact is implied. A closing sentence distinguishes it from `BLOCKED-ON-OWNER`. |
+| H2 | **HIGH** | `plan.md:262` keyed `BLOCKED-ON-OWNER` on lacking `security-events: write` and carried no capability probe. Same false premise as C1, plus the omission of FR-008a's hard requirement that the permission be determined by a read-only probe and never by attempting a dismissal. An implementer following the plan alone would either self-block wrongly or probe by attempting, which SC-005 makes a breach. | Q2 | `plan.md:262` vs `spec.md:90` (FR-008a) and `spec.md:114` | **Fixed.** Rewritten with the mandatory probe, the two concrete commands, the public-repository correction, and the note that `BLOCKED-ON-OWNER` is not the expected outcome on this environment. |
+| H3 | **HIGH** | `research.md` D7 carried the same false `security-events: write` premise, described only one terminal state, and mentioned no probe. Research is the document the plan cites to avoid re-deriving decisions, so a stale D7 re-arms C1 and H2 even after they are fixed downstream. | Q2 | `research.md:187-197` vs `spec.md:90,91,114` | **Fixed.** D7 retitled and rewritten to cover both states, to record the corrected permission model explicitly as a decision that was gotten wrong and why, and to state the read-only probe constraint. |
+| H4 | **HIGH** | Q4 widened FR-013 to carve out `specs/001-ingestion-arn-logging/`. `plan.md` was left internally contradictory: `plan.md:31` (Constraints) and `plan.md:78` ("Only two files are writable under FR-013") kept the pre-Q4 two-file reading, while `plan.md:272` (Complexity Tracking) already used the widened form. An implementer reading the narrow statement refuses to write `dismissal-handoff.md`, which is precisely the failure Q4 was raised to close, and the plan contradicts itself about it. | Q4 | `plan.md:31` and `plan.md:78` vs `plan.md:272` and `spec.md:96` (FR-013) | **Fixed.** Both sites restated with the directory carve-out and a pointer to Q4. |
+| H5 | **HIGH** | Q3 added a fixture-isolation constraint to FR-007 covering `SNS_TOPIC_ARN`, `ALERT_TOPIC_ARN` and `AWS_REGION`. The plan's Test design, which is the operative instruction the implementer follows, justified **only** the region choice and never stated the account-identifier constraint. The plan then told the implementer to follow "the `env_vars` fixture shape" (`plan.md:210`), which does not set `ALERT_TOPIC_ARN` at all. A fixture that sets `ALERT_TOPIC_ARN` using account `218795110243` makes every account-identifier assertion fail for a reason unrelated to the secret ARN, and a passing assertion stops being evidence. | Q3 | `plan.md` Test design (fixture paragraph) vs `spec.md:88` (FR-007) | **Fixed.** A "Fixture isolation" subsection added stating the constraint per variable, plus the note that case 1 raises at `handler.py:265` before the SNS path and cases 2 and 3 are where it matters. |
+| H6 | **HIGH** | `codeql-logging-convention.md` had no terminal state for "cannot yet verify". Q2 called that hole "the larger one" for this feature; the convention passes the identical hole to feature B, whose closure criteria are keyed to the same default-branch analysis and which will finish implementation in exactly the same unclassifiable position. | Q2 | `codeql-logging-convention.md` section 5 vs `spec.md:91` (FR-008b) | **Fixed.** Section 5 split into 5a `PENDING-BRANCH-ANALYSIS` and 5b `BLOCKED-ON-OWNER`, written generically so feature B can cite it without substitution beyond its own path. |
+| M1 | MEDIUM | `research.md:130` gave the second fixture ARN as `...:secret:finnhub-GhIjKl` followed by a prose arrow, missing the `preprod/sentiment-analyzer/` path segment. It contradicts `plan.md:175` and defeats D5's own stated rationale at `research.md:141-145`, which is that the existing fixture is rejected precisely because it "has no environment or secret path segment, so one of the five required classes has nothing to assert against". | Pre-existing, surfaced by cross-artifact comparison | `research.md:130` vs `plan.md:175` | **Fixed** (single line). Full path restored, prose arrow removed. |
+| M2 | MEDIUM | `plan.md:284` (Carded) used the stale flat path `docs/TECH_DEBT_REGISTRY.md`, contradicting `plan.md:272` and Clarification Q1, which established the file is at `docs/reference/TECH_DEBT_REGISTRY.md` and that the constitution's flat path is the stale one. Q1 corrected the Constitution Check and Complexity Tracking rows and missed the Carded list. | Q1 | `plan.md:284` vs `plan.md:272` and `spec.md:219-228` | **Fixed** (single line). Path corrected and a no-pre-reservation clause added. |
+| M3 | MEDIUM | `checklists/requirements.md:53` stated FR-013 as "the ingestion handler and its tests", pre-Q4. The checklist is the quality-gate record for the spec, so a stale scope statement there is a false attestation, not just a stale note. The checklist also carries no note at all about the clarification session or FR-008b. | Q4 | `checklists/requirements.md:53` vs `spec.md:96` | **Partly fixed** (single line). Scope statement corrected. The missing clarification-session note is left recorded, not written, since the checklist is a Stage 1 artifact and adding sections to it is out of this pass's remit. |
+| M4 | MEDIUM | Q3's isolation reasoning, and therefore FR-007's constraint list, omits `CLOUD_REGION`. `_get_config()` at `handler.py:589-590` reads `CLOUD_REGION` first and only falls back to `AWS_REGION`, so an inherited `CLOUD_REGION` in the runner's environment silently defeats the region isolation that Q3 relies on. The existing `env_vars` fixture does not set or clear it. | Q3 (incomplete answer, not drift) | `spec.md:88` (FR-007 names three variables) | **Fixed in the plan only** (the plan's new Fixture isolation subsection requires `CLOUD_REGION` be cleared or pinned). FR-007's enumeration in `spec.md` still names three variables rather than four. Recorded, not edited, because `spec.md` is the clarification stage's output and amending its requirement text is the owner's call. |
+| M5 | MEDIUM | FR-008b (`spec.md:91`) requires "the exact verification query from the plan to be recorded" without saying **where**. Read literally it implies a new artifact; read loosely it is already satisfied by the plan. Ambiguity in the reaching-condition of a terminal state is the same defect class FR-008a was added to fix. | Q2 | `spec.md:91` | **Resolved in the plan** by stating that the plan's own `gh api` block satisfies the recording obligation and no separate artifact is required. The spec wording is left as-is. |
+| L1 | LOW | `spec.md:240` (Q1) says "both features would claim `TD-024`". Three sibling specs currently contain `TD-024`: `001-oauth-provider-taint`, `001-codeql-coverage` and (per Q1's own citation of task T016) `001-ruff-bump-forward`. The contention is worse than stated, which strengthens rather than weakens Q1's conclusion. | Q1 | `spec.md:240` | Recorded, not fixed. The conclusion is unaffected. |
+| L2 | LOW | `research.md:125` says "Six explicit forbidden strings", `plan.md` says five classes plus a sixth for completeness, and FR-007 enumerates five. All three are reconcilable (the suffix is the sixth) but three phrasings of one enumeration invite an implementer to assert the wrong count. | Pre-existing | `research.md:125` vs `plan.md:178-183` vs `spec.md:88` | Recorded, not fixed. No behavioural difference. |
+
+### Checks run that found nothing
+
+Recorded so a later reviewer does not repeat them.
+
+- **Banned terms in this feature's directory**: clean. No occurrence of any term on the
+  `scripts/check-banned-terms.sh` list under `specs/001-ingestion-arn-logging/`.
+- **`plan.md` line 21 placeholder**: not applicable here. This plan's Technical Context begins at
+  line 22 with `Primary Dependencies` filled in at line 25, so the template's seeded placeholder was
+  never inherited.
+- **Success criteria keyed on alert numbers**: SC-002 and the plan's verification query are keyed on
+  path plus rule id, correctly. SC-002a names 148, 149 and 150 but only as a companion
+  anti-fraud check on `fixed_at`; it cannot be used to claim success on its own. No violation.
+- **Tests that would pass on unfixed code**: the plan's assertion surface is
+  `record.getMessage()` plus every value in `record.__dict__`, not `caplog.text`. Correct, and D4
+  records the probe that proves it matters. One implementation note for the implementer, not a
+  finding: `record.__dict__` holds non-string values, so the haystack builder must coerce with
+  `str()` or the membership test will raise.
+- **Overstated `extra` impact**: none found. `spec.md:16`, `research.md` D3 and the plan all
+  correctly separate the definitely-rendered site 1 from the two latent `extra` sites, and none
+  claims the latter reach CloudWatch today.
+- **Tech-debt id pre-reservation by this feature**: none. Both mentions of `TD-024` in this
+  feature's artifacts are arguments for *not* claiming it.
+- **Live alert state**, queried 2026-07-30: alerts 148 (line 264), 149 (271) and 150 (276) open at
+  `src/lambdas/ingestion/handler.py`, all with `fixed_at` null; alert 144 open at
+  `src/lambdas/shared/auth/oauth_state.py:104`. Matches every artifact's claim.
+- **Handler line references**: `error_msg` at 259-265, `raise` at 265, warnings at 269-272 and
+  274-277, `_get_sns_client` at 280, outer `except` at 572 with its `logger.error` at 573. All plan
+  references check out.
+- **`get_safe_error_info` returns type only**: confirmed at
+  `src/lambdas/shared/logging_utils.py:106-131`. The plan's case 4 reasoning holds.
+- **Logger propagation**: `handler.py:119-120` uses `logging.getLogger(__name__)` with `propagate`
+  at its default, and `configure_lambda_logging` sets levels only. `caplog` captures cleanly, as the
+  plan states.
+
+### Gate
+
+**GATE: 0 CRITICAL, 0 HIGH remaining.**
+
+1 CRITICAL and 6 HIGH found, all fixed by edit. 5 MEDIUM found: M1, M2 and M3 fixed as single-line
+corrections, M4 fixed in the plan with the spec-side gap recorded, M5 resolved in the plan with the
+spec wording left as-is. 2 LOW recorded without fix.

--- a/specs/001-ingestion-arn-logging/research.md
+++ b/specs/001-ingestion-arn-logging/research.md
@@ -1,0 +1,233 @@
+# Phase 0 Research: Stop Ingestion Handler Logging Secret ARNs
+
+**Feature**: `001-ingestion-arn-logging` | **Date**: 2026-07-30 | **Plan**: [plan.md](./plan.md)
+
+No `NEEDS CLARIFICATION` marker was carried into the plan's Technical Context, so this phase
+resolved no open unknowns. Its purpose is different: the spec and its Adversarial Review #1 settled
+seven questions that are expensive to re-derive and easy to get wrong. They are recorded here so
+implementation cites them instead of rediscovering them, and so a reviewer can check the reasoning
+without reading GitHub.
+
+---
+
+## D1: Code shape is "strip the value", not "sanitize the value"
+
+**Decision**: At all three sites, carry no secret-derived value at all. Not in the message, not in
+`extra`, not in the raised exception message.
+
+**Rationale**: The repository has run this experiment already, on the same CodeQL rule, two weeks
+apart on the same file.
+
+- `0e7a375` (PR #321, 2025-12-09) broke the taint flow with an intermediate sanitized variable and
+  kept the sanitized name inside the log context. CodeQL still flagged it.
+- `ebcc2f4` (PR #322, 2025-12-09) removed every secret-derived value from the log context. That
+  worked.
+
+The empirical read, from `fixed_at` and not from `state` (see D2): alerts 22, 23, 24 and 25 are the
+four sites that kept a sanitized value inside `extra`, and their `fixed_at` is null to this day.
+Alerts 26 and 27 are the two sites rewritten to exception-message-only, and both carry a non-null
+`fixed_at`.
+
+**Alternatives considered**:
+
+- *Call the existing `_sanitize_secret_id_for_log()` helper from the three sites.* Rejected. This is
+  the `0e7a375` shape, it has already failed here, and FR-003 forbids it. It would also mean
+  importing from or touching `src/lambdas/shared/secrets.py`, which FR-013 forbids for an unrelated
+  and stronger reason (D6 tail).
+- *Keep the ARN and add a redacting `logging.Filter` or formatter.* Rejected by FR-012. It also does
+  not remove the flow at source, so the alert would likely survive and the repository would carry a
+  new logging mechanism for three lines.
+- *Suppress with a `# nosec` or CodeQL inline suppression.* Rejected by constitution §10 ("DO NOT
+  suppress without documented justification", "DO NOT rename variables just to avoid detection") and
+  by the fact that a real fix is available and cheap.
+
+**Why no sanitizer is needed here at all**: in `src/lambdas/shared/secrets.py` the identifier
+arrives as a runtime argument, so identifying which secret failed genuinely requires deriving
+something from that argument. At these three ingestion sites the source identity is statically known
+at the call site. `"Tiingo"` and `"Finnhub"` are literals the author can type. Nothing is lost by
+dropping the value entirely, which is what makes FR-004 stricter than its own precedent without
+costing any diagnostic power.
+
+---
+
+## D2: Read `fixed_at`, never `state`
+
+**Decision**: Every judgement about whether a site was repaired keys on the `fixed_at` field of the
+code scanning alert. `state` is not evidence.
+
+**Rationale**: Dismissal is sticky and can predate a later genuine repair, so `state` conflates "a
+human dismissed this" with "the code was fixed". In this repository:
+
+- Alerts 26 and 27 read `dismissed` and both carry a non-null `fixed_at`. Repaired.
+- Alerts 22 through 25 also read `dismissed` and have `fixed_at` null. Never repaired.
+
+A reviewer reading `state` alone would put all six in the same bucket and draw the opposite
+conclusion about which code shape works. That is exactly the error Adversarial Review #1 caught in
+the spec's own first draft.
+
+**Alternatives considered**: reading `state` only (rejected, above); reading the alert's `html_url`
+timeline by hand (rejected, not scriptable and not reproducible in CI or in a report).
+
+---
+
+## D3: Lines 271 and 276 stay in scope even though nothing renders `extra` today
+
+**Decision**: Fix all three sites. Do not narrow the change to line 264 on the grounds that the
+other two do not currently reach CloudWatch.
+
+**Rationale**: `configure_lambda_logging()` in `src/lambdas/shared/logging_config.py` is a
+level-setter only. Its own docstring says it "never attaches handlers or formatters". The root
+handler installed by the Lambda runtime renders `record.getMessage()`, so a value passed only via
+`extra=` is currently attached to the record and not printed. Line 264 interpolates directly into
+the message string and therefore definitely leaks today.
+
+Three reasons the other two stay in:
+
+1. The value is passed to the sink. Whether the sink prints it is a property of the currently
+   installed formatter, not of the code.
+2. It arms itself the moment any structured or JSON formatter is attached, which is a change one
+   line long that nobody would think of as security-relevant.
+3. CodeQL flags the flow regardless of rendering, so leaving them means leaving two open alerts,
+   which fails SC-002 outright.
+
+**Alternatives considered**: fixing only line 264 and dismissing 149 and 150 as non-rendering.
+Rejected. It trades a two-line deletion for two permanent dismissals plus a latent leak, and the
+dismissal justification would be false the day someone adds a formatter.
+
+---
+
+## D4: Tests assert over the `LogRecord`, not over `caplog.text`
+
+**Decision**: The forbidden-string assertions run against `record.getMessage()` plus every value in
+`record.__dict__`. `caplog.text` is not an acceptable assertion surface for this feature.
+
+**Rationale**: Probe result against the current unfixed code: `arn:aws:` is absent from
+`caplog.text`, while `record.tiingo_secret_arn` holds the full ARN. A test written against rendered
+text passes today against two of the three unfixed sites. It would be a permanent false negative and
+would not satisfy FR-007. Adversarial Review #1 raised this as a HIGH finding for exactly that
+reason.
+
+Scanning all of `record.__dict__` rather than a hand-listed set of extra keys is deliberate: it
+catches `msg`, `args`, and any future `extra` key without the test needing to know its name.
+
+**Alternatives considered**:
+
+- Asserting on `record.__dict__` keys by name (`assert not hasattr(record, "tiingo_secret_arn")`).
+  Rejected: it passes if someone renames the key.
+- Installing a JSON formatter inside the test so `caplog.text` becomes representative. Rejected: it
+  is more machinery than the direct read, and it makes the test depend on a formatter the production
+  code does not have.
+
+---
+
+## D5: The forbidden-string enumeration, and why the fixture ARN is not the existing one
+
+**Decision**: Six explicit forbidden strings per record, and a fixture ARN with a region and an
+environment path that appear nowhere else in the handler's configuration:
+
+```
+arn:aws:secretsmanager:eu-west-2:218795110243:secret:preprod/sentiment-analyzer/tiingo-AbCdEf
+arn:aws:secretsmanager:eu-west-2:218795110243:secret:preprod/sentiment-analyzer/finnhub-GhIjKl
+```
+
+Forbidden: the full value; `arn:aws:secretsmanager`; `218795110243`; `eu-west-2`;
+`preprod/sentiment-analyzer`; and the random suffix.
+
+**Rationale**: FR-007 requires the enumeration rather than a single marker because an assertion on
+the ARN prefix alone would pass while the account identifier leaked by itself, and the account
+identifier is the highest-value component of the disclosure.
+
+The existing `env_vars` fixture in `tests/unit/lambdas/ingestion/test_handler.py` uses
+`arn:aws:secretsmanager:us-east-1:123456789:secret:tiingo`. Two problems for this feature: it has no
+environment or secret path segment, so one of the five required classes has nothing to assert
+against; and its region `us-east-1` is also the value of `AWS_REGION`, which the handler legitimately
+logs elsewhere, so a region assertion could fail for an innocent reason or pass for the wrong one.
+Choosing `eu-west-2` makes any region match unambiguous evidence of an ARN leak.
+
+**Alternatives considered**: reusing the existing fixture and dropping the region and path
+assertions. Rejected: it drops two of the five classes FR-007 names.
+
+---
+
+## D6: Closure evidence comes from the default-branch analysis or the alerts API, keyed on path plus rule
+
+**Decision**: Success is "zero open alerts for rule `py/clear-text-logging-sensitive-data` whose
+location path is `src/lambdas/ingestion/handler.py`", read after a default-branch analysis on a
+commit containing the change. Never keyed on the numbers 148, 149, 150.
+
+**Rationale**: two independent traps.
+
+*Alert numbers are not stable identities.* CodeQL can close a number as fixed and open a fresh number
+at the same location in the same run. Documented here: alert 117 on
+`src/lambdas/shared/auth/oauth_state.py` has `fixed_at` `2026-01-20T22:34:56Z` and alert 144 on the
+same file was created at that identical timestamp. During the 2025-12-09 secrets remediation, alerts
+107, 110 and 111 were created and closed within hours at lines a remediation attempt had just
+rewritten. A criterion asking only whether three numbers stopped being open is satisfiable while the
+disclosure sits open under three fresh numbers.
+
+*A green PR check is not evidence.* CodeQL runs diff-informed analysis on pull requests in this
+repository. PR #990 was green with all five of its alerts still open; PR runs report
+`results_count: 0` while `refs/heads` runs report 9. The one useful inverse: because this change
+edits the exact flagged lines, the diff-scoped PR result is directly informative here, so an alert
+surviving the PR run is a genuine survivor.
+
+**Related constraint on blast radius**: SC-005 requires alerts outside the handler to be unchanged in
+both count and `fixed_at`. This is the reason FR-013 forbids editing `src/lambdas/shared/secrets.py`
+even to reuse its helper: alerts 22 through 25 sit on lines in that file with `fixed_at` null,
+meaning live findings behind a dismissal, and editing those lines risks re-fingerprinting them into
+fresh open alerts. That is precisely what happened to that file on 2025-12-09.
+
+**Alternatives considered**: waiting for a required-check signal. Rejected, because there is none.
+CodeQL is not a required status check on this repository; the required contexts are exactly
+`Secrets Scan`, `Lint`, `Run Tests` and `Playwright E2E Tests`. Nothing blocks a merge on a CodeQL
+result, which is why the spec defines its own completion gate.
+
+---
+
+## D7: Two terminal states exist that are neither done nor failed
+
+**Decision**: The feature has two non-terminal-looking but defined endings, and they are different
+things.
+
+*`PENDING-BRANCH-ANALYSIS` (FR-008b).* The code change and the FR-007 tests are complete and green
+but no default-branch CodeQL analysis containing the change exists yet. This is the expected ending
+of implementation, not an edge case, because SC-002 and SC-002a are keyed to a default-branch
+analysis (D6) which cannot exist while the change sits on a feature branch. Reaching it requires the
+plan's verification query to be on record so the check is mechanical when the analysis lands.
+
+*`BLOCKED-ON-OWNER` (FR-008a).* A survivor alert exists and a read-only capability probe shows the
+implementing agent cannot dismiss it. Then `dismissal-handoff.md` is written into this feature's
+directory. Reported as blocked, never as done and never as failed.
+
+**The permission claim this decision originally got wrong.** The first draft of D7 said dismissal
+requires `security-events: write`. That is false for this repository. GitHub's
+update-code-scanning-alert endpoint requires `security_events` only on **private** repositories; on a
+public repository `public_repo` suffices, and the `repo` scope includes `public_repo`. This
+repository is public and the actor holds push or above, so dismissal is available and
+`BLOCKED-ON-OWNER` is **not** the expected path. Corrected by Clarification Q2.
+
+**The probe is mandatory and must be read-only.** Establishing the permission by attempting a
+dismissal and reading the failure is not acceptable: a dismissal that succeeds mutates alert state,
+cannot be cleanly reverted, and SC-005 treats unintended alert-state change as a breach. The probe is
+`gh auth status` (scopes) read together with `gh api repos/<owner>/<repo>` (visibility and the
+actor's permissions).
+
+**Rationale**: FR-008a and FR-008b. Without these states the feature is permanently incomplete
+whenever the agent cannot dismiss or cannot yet verify, with no deliverable and no way to tell a
+blocked feature from a failed one. The handoff artifact carries the observed alert numbers, the exact
+justification text per alert, and the exact API call or UI steps to apply them, so the owner's action
+is mechanical. The code change is independently complete and mergeable in both states.
+
+**Alternatives considered**: leaving the alert open and unexplained (rejected by FR-008); marking the
+feature failed (rejected, it misreports a complete and correct code change); collapsing the two
+states into one (rejected, they call for different owner actions, one is "wait for the analysis" and
+the other is "apply this dismissal").
+
+---
+
+## Cross-references
+
+- The reusable convention distilled from D1, D2 and D6, for the sibling feature
+  `001-oauth-provider-taint`, lives in [codeql-logging-convention.md](./codeql-logging-convention.md)
+  as FR-011 and SC-006 require.
+- The concrete code and test design derived from these decisions is in [plan.md](./plan.md).

--- a/specs/001-ingestion-arn-logging/spec.md
+++ b/specs/001-ingestion-arn-logging/spec.md
@@ -1,0 +1,390 @@
+# Feature Specification: Stop Ingestion Handler Logging Secret ARNs
+
+**Feature Branch**: `001-ingestion-arn-logging`
+**Created**: 2026-07-30
+**Status**: Draft
+**Input**: User description: "Stop `src/lambdas/ingestion/handler.py` from writing full AWS Secrets Manager ARNs into CloudWatch logs. Closes CodeQL alerts 148, 149, 150 (`py/clear-text-logging-sensitive-data`) at handler.py lines 264, 271, 276."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Diagnose a missing API key without leaking account topology (Priority: P1)
+
+An on-call engineer sees the ingestion job return no articles. They open the ingestion log group and need to know which upstream credential is unavailable, Tiingo or Finnhub or both. Today the log tells them by printing the full Secrets Manager ARN, which also hands any log reader the AWS account ID, the region, the environment name, the secret path, and the random AWS suffix. The engineer needs the same diagnostic answer without the log carrying that extra topology.
+
+**Why this priority**: This is the actual defect. The disclosure is real and CloudWatch log access is broader than Secrets Manager access. Severity is low and recon grade, not a credential leak, but the fix is cheap.
+
+Precision on blast radius, because the three sites are not equivalent. One site interpolates both ARNs directly into the message string, so it is rendered by any formatter and definitely reaches CloudWatch. The other two attach the ARN as a structured context value rather than putting it in the message text, and whether a structured context value is rendered depends on the formatter active at runtime. The handler configures log levels only and installs no formatter of its own, so the spec does not assert that those two are emitted today. They are still in scope and still must be fixed: the value is passed to the logging call, it is reachable the moment a formatter that serialises structured context is introduced, and the analysis engine flags the flow regardless of rendering.
+
+**Independent Test**: Force each of the three conditions (both adapters unavailable, Tiingo only unavailable, Finnhub only unavailable), capture the emitted log records, and confirm each record still names the affected source while carrying no ARN component in either its rendered message or its structured context.
+
+**Acceptance Scenarios**:
+
+1. **Given** both credentials are unavailable, **When** the ingestion handler runs, **Then** the error record names Tiingo and Finnhub as fixed literal text, and neither its rendered message nor its structured context contains the account identifier, the region, the environment or secret path, the random AWS suffix, or the ARN prefix.
+2. **Given** only the Tiingo credential is unavailable, **When** the ingestion handler runs, **Then** the degraded-mode warning still says Tiingo is the unavailable source, and its structured context carries no value derived from the configuration ARN.
+3. **Given** only the Finnhub credential is unavailable, **When** the ingestion handler runs, **Then** the degraded-mode warning still says Finnhub is the unavailable source, and its structured context carries no value derived from the configuration ARN.
+4. **Given** both credentials are unavailable, **When** the raised failure propagates to the handler's outer exception path, **Then** the record written there still carries no ARN component in message or structured context.
+
+---
+
+### User Story 2 - Prove closure from branch state, not from a PR check (Priority: P2)
+
+A security reviewer needs to confirm that the three flagged sites in `src/lambdas/ingestion/handler.py` are genuinely free of open findings for rule `py/clear-text-logging-sensitive-data`, and to see a written justification for any finding that remains open by decision rather than by oversight.
+
+**Why this priority**: Two separate traps make the naive check wrong.
+
+First, a green CodeQL check on the pull request is not evidence. CodeQL runs diff-informed analysis on pull requests in this repository, so a pull request check only reasons about changed lines. PR #990 was green with all five of its alerts still open. Closure has to be read from the `refs/heads` branch analysis or from the GitHub code scanning alerts API.
+
+Second, and more dangerous, alert numbers are not stable identities. When a flagged line is rewritten, the engine can close the old number as fixed and open a brand new number at the same location in the same run. This is documented in this repository, not hypothetical. Alert 117 on `src/lambdas/shared/auth/oauth_state.py` carries `fixed_at` of `2026-01-20T22:34:56Z`, and alert 144 on the same file was created at that identical timestamp. During the 2025-12-09 remediation of the shared secrets module, alerts 107, 110 and 111 were all created and then closed within hours at lines a remediation attempt had just rewritten. A criterion that asks only whether three specific numbers stopped being open can therefore be fully satisfied while the disclosure sits open under three fresh numbers.
+
+The same trap applies to reading alert `state`. Dismissal is sticky and survives a later genuine fix, so `state` conflates "a human dismissed this" with "the code was repaired". Alerts 26 and 27 read `dismissed` but both carry a non-null `fixed_at`. Alerts 22, 23, 24 and 25 also read `dismissed` and have `fixed_at` null to this day, meaning those four sites were never repaired. `fixed_at` is the load-bearing field, not `state`.
+
+**Independent Test**: After the default branch analysis completes on a commit that includes the change, query the GitHub code scanning alerts API for every alert of this rule whose location path is `src/lambdas/ingestion/handler.py`, in any state, and confirm the set of open ones is empty regardless of alert number.
+
+**Acceptance Scenarios**:
+
+1. **Given** the change has landed on the default branch and its CodeQL analysis has completed on a commit that includes the change, **When** the GitHub code scanning alerts API is queried for all alerts of this rule located in `src/lambdas/ingestion/handler.py`, **Then** no alert at that path is in the open state, whether or not its number is 148, 149 or 150.
+2. **Given** alerts 148, 149 or 150 have moved out of the open state, **When** a new alert number for this rule appears at the same path, **Then** the change is classified as not yet successful and the new alert is worked as a survivor, not treated as an unrelated finding.
+3. **Given** an alert for this rule at this path ends in the dismissed state, **When** its GitHub dismissal record is read, **Then** it carries a justification that names the value logged, the convention applied, and why CodeQL still reports it.
+4. **Given** only the pull request CodeQL check is green, **When** closure is claimed on that basis alone, **Then** the claim is rejected as insufficient evidence.
+5. **Given** a claim that the site was repaired, **When** the evidence offered is an alert reading `dismissed` or `closed`, **Then** the claim is rejected unless that alert also carries a non-null `fixed_at` dated at or after the change.
+
+---
+
+### User Story 3 - Leave a convention the next feature can reuse (Priority: P3)
+
+The next feature working CodeQL rule `py/clear-text-logging-sensitive-data`, namely `001-oauth-provider-taint`, needs a single written convention to follow instead of re-deriving one. This repository already carries seven dismissals of this rule, and their reasoning lives only in GitHub dismissal comments.
+
+**Why this priority**: Value is real but deferred. The fix stands on its own without it. Skipping it means the next feature repeats the same investigation.
+
+**Independent Test**: A reader who has never seen this feature can find, in one place, the decision rule for when to rewrite the log site and when to dismiss, plus the wording pattern for the dismissal.
+
+**Acceptance Scenarios**:
+
+1. **Given** a new site is flagged by `py/clear-text-logging-sensitive-data`, **When** an engineer consults the recorded convention, **Then** it tells them which code shape to attempt first and what to do if the alert survives.
+
+---
+
+### Edge Cases
+
+- The configuration value is a bare secret name or a slash separated path rather than an ARN, which happens in local and development setups. Because the corrected design derives nothing from the configuration value for logging purposes, the log output is identical in that case and no shape handling is required. This edge case is closed by the design, not handled at runtime.
+- The configuration value is absent entirely. Configuration loading already fails earlier in that case, so the log sites must not be written as though a well formed ARN is guaranteed. Again, the corrected design does not read the value at these sites at all.
+- Only one of the two sources is degraded. Both single source paths must remain distinguishable in the logs.
+- Line numbers shift as the file changes, so CodeQL may report a finding at a new line for the same site. Verification must key on the file path and the rule id, not on the line number.
+- **CodeQL closes 148, 149 and 150 and opens fresh numbers at the same file.** This is the failure mode most likely to produce a false claim of success, and it is documented in this repository (alert 117 closing and alert 144 opening at the same timestamp on the same file; alerts 107, 110 and 111 spawning during the 2025-12-09 secrets remediation). It counts as not yet successful.
+- **The default branch analysis has not re-run, or the result predates the change.** A result whose commit does not include the change decides nothing. Classification must wait.
+- **A test asserts on rendered log text only.** Structured context values attached to a logging call are not rendered into the formatted message under the default formatter, so an assertion that only inspects rendered text passes today against two of the three unfixed sites. Any test written that way is a false negative and does not satisfy FR-007.
+- **The dismissal step cannot be performed by the implementing agent.** Permission to dismiss may be absent. The feature must have a defined terminal state in that case rather than hanging indefinitely.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The ingestion handler MUST NOT write a full Secrets Manager ARN, or any of its account identifier, region, environment path, secret path or random suffix components, into any log record. This covers both the rendered message and the structured context attached to the logging call, since the second is a sink whether or not the active formatter renders it.
+- **FR-002**: Each affected log record MUST still identify which upstream source is unavailable, using fixed literal text chosen at the call site. The two degraded mode warnings already carry literal source names and MUST keep them. The both keys missing error currently identifies the sources only through the interpolated configuration key names, so it MUST be reworded to name Tiingo and Finnhub as literal text. Deriving the source label from the configuration value in any way is prohibited by FR-004.
+- **FR-003**: No new sanitizing helper may be introduced, and the repository's existing ARN to bare name convention MUST NOT be called from any of the three sites. The source identity at these sites is statically known at the call site, unlike the shared secrets module where the identifier arrives as a runtime argument, so no sanitizing is required to satisfy FR-002. A sanitized value is still a value derived from the ARN and is therefore prohibited by FR-004; this is precisely the shape that failed in the `0e7a375` precedent below.
+- **FR-004**: No value derived from the configuration ARN may appear in the log message, in the structured context, or in the raised exception message. This is stricter than the closest precedent, which retained a sanitized name in the exception message only because the identifier there was a runtime argument. Here nothing is lost by dropping it entirely, and dropping it removes the taint flow at its source. The two commits that establish the precedent: `0e7a375` (PR #321, 2025-12-09) tried breaking the taint flow with an intermediate sanitized variable and CodeQL still flagged it, then `ebcc2f4` (PR #322, 2025-12-09) removed every secret derived value from the log context. Read the evidence via the `fixed_at` field, not via `state`, because dismissal is sticky and survives a later genuine repair: the two sites rewritten to drop the value from the log context are alerts 26 and 27, which both carry a non-null `fixed_at` despite still reading `dismissed`, whereas the four sanitize in place sites are alerts 22, 23, 24 and 25, whose `fixed_at` is null to this day.
+- **FR-005**: The failure raised when both credentials are missing MUST NOT reintroduce the ARN into logs through any downstream handler, including the outer exception path. Since FR-004 keeps the ARN out of the exception message entirely, this holds regardless of what a downstream handler chooses to log.
+- **FR-006**: Runtime behaviour MUST be otherwise unchanged, scoped precisely as: the same conditions trigger the same log levels at the same three sites, the same exception type is raised from the same branch, and the same response is returned. The text of the messages themselves is explicitly permitted to change, and FR-002 requires it to change on the both keys missing path. FR-006 does not override FR-002.
+- **FR-007**: Automated tests MUST cover all three paths by capturing emitted log records and asserting, for each record, that no ARN component appears in either the rendered message or the record's structured context attributes. Asserting only on rendered text is insufficient and MUST NOT be accepted: structured context values are not rendered into the formatted message under the default formatter, so such a test passes today against two of the three unfixed sites and proves nothing. The forbidden strings MUST be enumerated rather than represented by a single marker: the full ARN fixture value, the ARN prefix, the account identifier alone, the region alone, and the environment or secret path segment alone. An assertion on the ARN prefix alone would pass while the account identifier leaks by itself. The test module's own environment fixture MUST additionally keep every enumerated string unique to the two secret ARNs: no other environment value the fixture sets, in particular `SNS_TOPIC_ARN`, `ALERT_TOPIC_ARN` and `AWS_REGION`, may contain the account identifier, the region or the path segment being asserted. Without that isolation a record that legitimately carries one of those unrelated values fails the assertion for the wrong reason, and a passing assertion stops being evidence about the ARN. See Clarification Q3.
+- **FR-008**: If any alert for `py/clear-text-logging-sensitive-data` remains open at `src/lambdas/ingestion/handler.py` after the code change and after a completed default branch analysis, that alert MUST be dismissed in GitHub as a false positive with a written justification, and MUST NOT be left open and unexplained. This applies to any alert number at that path, not only to 148, 149 and 150.
+- **FR-008a**: If the implementing agent lacks permission to dismiss, the feature MUST reach the defined terminal state `BLOCKED-ON-OWNER` rather than remaining indefinitely incomplete. Reaching that state requires delivering, in this feature's directory, a handoff artifact containing the exact alert numbers observed at the path, the exact dismissal justification text for each, and the exact API call or UI steps needed to apply them. The code change is independently complete and mergeable at that point; only the dismissal is outstanding. A feature blocked this way MUST NOT be reported as done, and MUST NOT be reported as failed. Whether the permission is present MUST be determined by a read-only capability probe before any dismissal is attempted, never by attempting a dismissal and observing the result: a dismissal that succeeds cannot be cleanly undone and would itself mutate alert state. The probe is the token's scope list read together with the repository's visibility and the actor's repository permissions. See Clarification Q2.
+- **FR-008b**: The feature MUST also have a defined terminal state for the case where the code change is complete and locally verified but no default-branch CodeQL analysis containing the change exists yet, which is the normal state at the end of implementation because SC-002 and SC-002a are only evaluable after the change reaches the default branch. That state is `PENDING-BRANCH-ANALYSIS`. Reaching it requires the code change and the FR-007 tests to be complete and green, and requires the exact verification query from the plan to be recorded so the check is mechanical when the analysis lands. Like `BLOCKED-ON-OWNER`, it MUST NOT be reported as done and MUST NOT be reported as failed. It is distinct from `BLOCKED-ON-OWNER`, which is about permission to dismiss a survivor that has already been observed.
+- **FR-009**: Each dismissal justification MUST state three things: that the logged value is a resource identifier and not a credential value, which convention is applied, and why CodeQL still reports the flow. The first two elements match the wording on the seven existing dismissals of this rule in the repository; the third element is new and is deliberately stronger, because none of the existing seven states it and their silence on that point is what made them impossible to re-evaluate later.
+- **FR-010**: All three sites MUST carry an inline comment naming the rule id `py/clear-text-logging-sensitive-data` and the reason the value was removed, regardless of whether the resulting alerts end fixed or dismissed. Restricting the comment to dismissed sites would leave the successful path unmarked and let a later refactor silently reintroduce the interpolation.
+- **FR-011**: The wording pattern used for the dismissal justification, together with the decision rule for when to rewrite versus when to dismiss and the `fixed_at` versus `state` caveat, MUST be recorded in this feature's artifacts so `001-oauth-provider-taint`, which works the same CodeQL rule, can cite it instead of inventing its own.
+- **FR-012**: No new cloud resources may be introduced, and the handler's existing logging mechanism is retained. No logging framework migration, no new filter or formatter.
+- **FR-013**: No file outside `src/lambdas/ingestion/handler.py`, its tests, and this feature's own `specs/001-ingestion-arn-logging/` directory may be modified. The directory carve-out is explicit because FR-011 and SC-006 require a convention artifact there and FR-008a requires a handoff artifact there, and a literal reading of the earlier wording forbade writing either. Nothing in the carve-out relaxes the prohibition on source, test, infrastructure or documentation files elsewhere in the repository. See Clarification Q4. In particular `src/lambdas/shared/secrets.py` MUST NOT be edited. Four dismissed alerts (22 through 25) sit on lines in that file whose `fixed_at` is null, meaning the findings are still live behind a dismissal. Editing those lines risks re-fingerprinting them into fresh open alerts, which is exactly what happened to that file on 2025-12-09, and would breach SC-005.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Across all three failure paths, zero captured log records contain any of the enumerated forbidden strings from FR-007, checked against both the rendered message and the record's structured context attributes. The enumeration is the operative part: a check for the ARN prefix alone is not sufficient evidence for this criterion.
+- **SC-002**: The count of open alerts for rule `py/clear-text-logging-sensitive-data` whose location path is `src/lambdas/ingestion/handler.py` is zero, read from the `refs/heads` default branch CodeQL analysis or the GitHub code scanning alerts API after an analysis whose commit includes the change has completed. This criterion is keyed to the path and the rule, never to the numbers 148, 149 and 150, because the engine can close those three and open fresh numbers at the same path in the same run. A passing pull request CodeQL check is explicitly not accepted as evidence, because CodeQL runs diff-informed analysis on pull requests and PR #990 was green with five alerts open. The one useful inverse: because this change edits the exact lines flagged today, the diff scoped pull request result is directly informative here, and an alert that survives it is a genuine survivor.
+- **SC-002a**: For each of alerts 148, 149 and 150 that is reported as repaired rather than dismissed, `fixed_at` is non-null and dated at or after the change. A `state` of `dismissed` or `closed` with a null `fixed_at` does not satisfy this criterion, because dismissal is sticky and can mask a site that was never repaired, as alerts 22 through 25 demonstrate.
+- **SC-003**: Every alert for this rule at this path that ends dismissed rather than repaired has a non-empty GitHub dismissal comment containing all three elements required by FR-009. If the dismissal is pending an owner action under FR-008a, this criterion is satisfied instead by the handoff artifact containing the exact text that will be applied, and the feature status reads `BLOCKED-ON-OWNER` rather than complete.
+- **SC-004**: The existing ingestion test suite passes with no assertion loosened or removed, the only test change being additions.
+- **SC-005**: Alerts for `py/clear-text-logging-sensitive-data` outside `src/lambdas/ingestion/handler.py` are unchanged in both count and `fixed_at` value. In particular alert 144 on `src/lambdas/shared/auth/oauth_state.py`, owned by feature `001-oauth-provider-taint`, stays untouched, and alerts 22 through 25 on `src/lambdas/shared/secrets.py` remain dismissed with `fixed_at` null. Any new alert number appearing on `src/lambdas/shared/secrets.py` is a breach of this criterion and of FR-013.
+- **SC-006**: A reader can locate the dismissal wording pattern, the decision rule, and the `fixed_at` versus `state` caveat in a single artifact under this feature's directory, without reading dismissal comments in GitHub.
+
+## Assumptions
+
+- The configuration values are populated with full ARNs in the deployed environments, because infrastructure wires the secret ARN outputs straight into them. Non-ARN forms occur locally. Neither shape matters to the corrected design, because nothing derived from the value reaches a log or an exception message.
+- The existing sanitizing helper is private to its module and stays that way. It is not called from the ingestion handler and is not promoted, wrapped or otherwise touched. See FR-003 and FR-013.
+- Dismissing a CodeQL alert requires write access to code scanning alerts. On this repository, which is public, that is satisfied by a token carrying `public_repo` (which `repo` includes) together with a repository role of push or above; the `security_events` scope is what a private repository would require. Probed on 2026-07-30 the local environment satisfies this, so `BLOCKED-ON-OWNER` is not the expected path. It remains the defined terminal state under FR-008a if the implementing agent's environment differs. See Clarification Q2.
+- CodeQL is not a required status check on this repository. The required contexts are `Secrets Scan`, `Lint`, `Run Tests` and `Playwright E2E Tests`. Nothing therefore prevents this change from merging while alerts remain open. The completion definition in this spec is the only gate, which is why FR-008a defines a terminal state instead of relying on a merge block.
+- Best case is that the code change alone clears the site with no dismissal needed. The spec covers the dismissal path because the repository's own history shows this rule surviving a sanitize in place fix, not because dismissal is the expected outcome. Attempting the real fix is the primary path.
+
+## Out of Scope
+
+- Alert 144 on `src/lambdas/shared/auth/oauth_state.py`, the other open `py/clear-text-logging-sensitive-data` alert. That belongs to sibling feature `001-oauth-provider-taint`.
+- The seven existing dismissals of `py/clear-text-logging-sensitive-data` on the shared secrets and errors modules, alerts 1 and 22 through 27. They are not re-litigated here.
+- Migrating the ingestion handler to a different logging library, or adding a redacting filter or formatter anywhere.
+- Building a repository wide registry of CodeQL dismissals. The wording pattern is recorded in this feature's artifacts only.
+- Changing what infrastructure injects into the environment, or the shape of the secrets themselves.
+- Any change whatsoever to `src/lambdas/shared/secrets.py`, including the sanitizing helper's truncation behaviour on hyphenated names and its visibility. Forbidden by FR-013.
+- Other account topology values handled near these sites, such as the SNS topic ARN and the alert topic ARN. They carry the same account identifier but are not flagged by this rule and are not part of this feature. Carded for separate triage.
+- Making CodeQL a required status check, or adding a lint rule that blocks ARN interpolation into logging calls repository wide. The FR-007 test is the regression guard for these three sites only. A repository wide guard is carded.
+
+## Adversarial Review #1
+
+Reviewer did not author the spec. Every claim below was checked against the code at
+`src/lambdas/ingestion/handler.py`, `src/lambdas/shared/secrets.py`,
+`src/lambdas/shared/logging_config.py`, `src/lib/metrics.py`, and against the live GitHub code
+scanning alerts API on `refs/heads/main`.
+
+### Findings
+
+| Severity | Finding | Resolution |
+|---|---|---|
+| CRITICAL | SC-002 was keyed to alert numbers 148, 149 and 150. CodeQL can close those three and open fresh numbers at the same lines in the same run, so the criterion was satisfiable while the disclosure stayed open. Proven in this repository: alert 117 carries `fixed_at` `2026-01-20T22:34:56Z` and alert 144 was created at that exact timestamp on the same file; alerts 107, 110 and 111 spawned and closed within hours during the 2025-12-09 secrets remediation. | Fixed. SC-002 rewritten to require zero open alerts of this rule at path `src/lambdas/ingestion/handler.py`, any number. New acceptance scenario 2 in User Story 2 classifies a fresh number at the same path as not yet successful. New edge case added. |
+| HIGH | FR-003 and FR-004 contradicted each other. FR-003 required source identification to reuse the existing ARN to bare name sanitizer; FR-004 forbade carrying any secret derived value in the log message or context. A sanitized value is still ARN derived, so the two could not both hold in the log path. | Fixed. FR-003 inverted: the sanitizer MUST NOT be called from these three sites, because the source identity is statically known at the call site here, unlike the shared secrets module where it arrives as a runtime argument. FR-004 tightened to exclude the exception message too, which removes the taint at source and makes the helper unnecessary anywhere in the handler. |
+| HIGH | Assumption 2 authorised promoting or wrapping the private helper in `src/lambdas/shared/secrets.py`. That file holds alerts 22 through 25, which read `dismissed` but have `fixed_at` null, meaning the findings are still live behind a dismissal. Editing those lines risks re-fingerprinting them into fresh open alerts, the exact churn that file suffered on 2025-12-09, breaching SC-005. | Fixed. New FR-013 forbids editing any file other than the handler and its tests, naming `src/lambdas/shared/secrets.py` explicitly. Assumption rewritten. Out of Scope extended. SC-005 strengthened to check `fixed_at` and to treat any new alert on that file as a breach. |
+| HIGH | FR-007 and SC-001 were satisfiable by a test that passes against unfixed code. Structured context values attached to a logging call are not rendered into the formatted message under the default formatter, so an assertion over rendered text alone passes today against the two sites at lines 271 and 276. Verified by probe: rendered text does not contain the ARN, the record attribute does. | Fixed. FR-007 now requires assertion over both the rendered message and the record's structured context attributes, and explicitly rejects rendered-text-only tests. SC-001 follows. New edge case added. |
+| HIGH | FR-007 and SC-001 said "no ARN marker" without defining it. Asserting absence of the ARN prefix alone would pass while the account identifier leaked by itself, which is the highest value component of the disclosure. | Fixed. FR-007 now enumerates five required forbidden strings: the full fixture value, the ARN prefix, the account identifier alone, the region alone, and the environment or secret path segment alone. |
+| HIGH | FR-002 required the both keys missing error to name its sources, but that message currently names them only through the interpolated configuration key names, so satisfying FR-002 requires adding literal text. FR-006 said "the same conditions trigger the same error and warnings", readable as forbidding that text change. Contradiction between a requirement and its own compatibility clause. | Fixed. FR-002 now states which sites already carry literals and which must gain them. FR-006 scoped precisely to log level, branch, exception type and response, with message text explicitly permitted to change and FR-002 declared to win. |
+| HIGH | FR-004's precedent citation inverted part of its own evidence and rested on the wrong field. It cited "alerts 22 through 26" as the surviving sanitize in place sites. Alert 26 carries `fixed_at` `2025-12-03`, so it is a repaired site and is evidence for the preferred shape, not against it. More broadly, `state` conflates dismissal with repair: alerts 26 and 27 read `dismissed` while carrying non-null `fixed_at`, and dismissal predates the fix by two weeks. | Fixed. FR-004 corrected to 22 through 25, and rewritten to key on `fixed_at` rather than `state`. New SC-002a rejects a `dismissed` or `closed` state with null `fixed_at` as evidence of repair. New acceptance scenario 5 in User Story 2. |
+| HIGH | The dismissal handoff had no terminal state. FR-008, SC-003 and Assumption 3 together left the feature permanently incomplete whenever the implementing agent lacked `security-events: write`, with no defined deliverable and no way to distinguish a blocked feature from a failed one. | Fixed. New FR-008a defines terminal state `BLOCKED-ON-OWNER`, requires a handoff artifact carrying the observed alert numbers, the exact justification text and the exact steps, and states the code change is independently mergeable. SC-003 amended to accept the artifact when dismissal is pending. |
+| MEDIUM | FR-009 claimed its three element wording "follows the pattern already used on the seven existing dismissals". It does not. All seven existing comments carry two elements (the value is not a credential, a sanitizing convention is applied) and none states why CodeQL still reports the flow. | Fixed. FR-009 now claims only the first two elements as precedent and states the third is deliberately new, with the reason. |
+| MEDIUM | User Story 1 asserted the disclosure "is written on every degraded run". True for the site that interpolates into the message string, unverified for the two that attach the ARN as structured context, since the handler installs no formatter and only sets levels. Over-claiming impact weakens the spec against a reviewer who checks. | Fixed. User Story 1 now separates the three sites by rendering certainty and keeps all three in scope on the correct grounds: the value is passed to the sink, it becomes reachable the moment a serialising formatter is introduced, and the engine flags the flow regardless. |
+| MEDIUM | No regression guard on the success path. FR-010 required the inline comment only on sites behind a dismissed alert, so if the fix worked cleanly all three sites would end unmarked and a later refactor could reintroduce the interpolation silently. | Fixed. FR-010 made unconditional across all three sites regardless of outcome. Repository wide guard recorded as out of scope and carded. |
+| LOW | Adjacent account topology values are handled a few lines away and carry the same account identifier: `sns_topic_arn`, `alert_topic_arn`. Not flagged by this rule, not surveyed by the spec. | Out of scope, carded. Recorded in Out of Scope. |
+| LOW | CodeQL is not a required status check here, so nothing mechanically prevents merging with all three alerts open. The spec's completion definition is the only gate. | Out of scope, carded. Recorded as an assumption so the reliance is explicit, and mitigated by FR-008a defining a terminal state rather than depending on a merge block. |
+
+Counts: 1 CRITICAL, 7 HIGH, 3 MEDIUM, 2 LOW. All CRITICAL and HIGH resolved by edit. All MEDIUM
+resolved by edit because each was a wording fix inside existing scope. Both LOW carded without fix.
+
+### Edits made
+
+1. User Story 1 rationale rewritten to separate the one definitely-rendered site from the two whose
+   rendering depends on the active formatter, without weakening the case for fixing all three.
+2. User Story 1 independent test and all four acceptance scenarios rewritten to cover the structured
+   context, not only the rendered message, and to name the disclosure components explicitly.
+3. User Story 2 rewritten around two traps rather than one: diff-informed pull request analysis, and
+   alert number instability. Both documented with in-repository evidence.
+4. User Story 2 acceptance scenarios expanded from three to five, adding the fresh-number case and
+   the `fixed_at` versus `state` case.
+5. Edge cases: two sanitizer shape cases retired as closed by design, four added covering alert
+   renumbering, stale analysis, rendered-text-only tests, and the missing dismissal permission.
+6. FR-001 extended to name the structured context as a sink in its own right.
+7. FR-002 rewritten to require fixed literal source names and to state which site must gain them.
+8. FR-003 inverted from "reuse the sanitizer" to "do not call the sanitizer", with the reason.
+9. FR-004 tightened to exclude the exception message, corrected from "22 through 26" to
+   "22 through 25", and re-keyed onto `fixed_at`.
+10. FR-005 given its reason now that the exception message is clean.
+11. FR-006 scoped to control flow, level, exception type and response; message text change permitted.
+12. FR-007 rewritten to require structured context assertions and to enumerate five forbidden strings.
+13. FR-008 re-keyed from three alert numbers to any alert at the path.
+14. FR-008a added: `BLOCKED-ON-OWNER` terminal state plus handoff artifact contents.
+15. FR-009 provenance claim corrected.
+16. FR-010 made unconditional across all three sites.
+17. FR-011 extended to record the decision rule and the `fixed_at` caveat, not just the wording.
+18. FR-013 added: file scope lock, with `src/lambdas/shared/secrets.py` named.
+19. SC-001 re-keyed onto the FR-007 enumeration and the structured context.
+20. SC-002 re-keyed onto path plus rule, never onto alert numbers.
+21. SC-002a added: `fixed_at` must be non-null and dated at or after the change.
+22. SC-003 amended to accept the handoff artifact when dismissal is pending.
+23. SC-005 strengthened to check `fixed_at` and to treat any new alert on the shared secrets module
+    as a breach.
+24. SC-006 extended to require the `fixed_at` caveat be recorded.
+25. Assumptions: sanitizer promotion assumption struck and replaced with a prohibition; blocked
+    completion assumption re-pointed at FR-008a; new assumption recording that CodeQL is not a
+    required check.
+26. Out of Scope: shared secrets module edits, adjacent topology ARNs, and a repository wide lint
+    guard all added.
+
+### Gate
+
+**0 CRITICAL, 0 HIGH remaining.**
+
+## Clarifications
+
+### Session 2026-07-30
+
+Four questions were raised. All four were answered from the repository, the constitution, the live
+GitHub API and git history. **None is deferred to the owner.** The count is four rather than five
+because the spec's adversarial review and planning pass had already closed the rest; a fifth
+question would have been manufactured.
+
+---
+
+**Q1: Constitution §9 requires a `TD-XXX` registry entry when a security finding is accepted by
+dismissal. Is this feature blocked by that requirement, and what is the minimal correct response?**
+
+**A: Not blocked. The premise that the registry does not exist is wrong, the obligation is
+conditional and post-merge, and the correct response is a carded follow-up at the corrected path.**
+
+Three findings, in order of importance.
+
+First, the registry exists. It is `docs/reference/TECH_DEBT_REGISTRY.md`, not
+`docs/TECH_DEBT_REGISTRY.md`. Constitution §9(a) at `.specify/memory/constitution.md:527` cites the
+flat path, and §9's Acceptance Criteria at line 569 repeats it, but the file was moved under
+`docs/reference/` by commit `f8db8d2` ("feat(docs): Reorganize documentation into categorical
+subdirectories", PR #668), planned at `specs/1210-documentation-reorganization/plan.md:71`. The
+constitution was never updated. Sibling feature `001-ruff-bump-forward` reached the same conclusion
+independently and recorded it as its adversarial finding F3 at `plan.md:109`. Sibling feature
+`001-codeql-coverage` did not, and states at its `plan.md:59` that the file "does not exist in this
+repository", which is false. This spec's own `plan.md` Constitution Check row and Complexity
+Tracking row both carried the stale path and have been corrected.
+
+Second, the obligation is conditional, and the condition cannot be evaluated during implementation.
+§9's trigger list at constitution lines 553 to 558 includes "Security shortcuts with documented
+acceptance criteria". A dismissal under FR-008 is such a shortcut. A clean repair under FR-001 is
+not, and creates no debt at all. Which of the two occurs is only knowable after a default-branch
+CodeQL analysis, which is post-merge (see Q2). So no registry entry can be authored during
+implementation even if the file were writable.
+
+Third, FR-013 keeps the registry outside the writable set, and that reason survives the path
+correction. The registry is a shared, append-only, single-source-of-truth file, and sibling feature
+`001-ruff-bump-forward` already has task T016 queued to add "the next sequential TD entry" to it.
+The highest existing identifier is `TD-023`, so both features would claim `TD-024` and collide.
+Three sibling agents share this worktree, which makes that collision likely rather than theoretical.
+
+**Minimal correct response**: no change to scope. The §9 deviation already recorded in
+`plan.md`'s Complexity Tracking stands, with its path corrected to
+`docs/reference/TECH_DEBT_REGISTRY.md` and its rationale restated as conditional-and-post-merge
+rather than file-does-not-exist. The acceptance remains documented in two places under this
+feature's own directory (FR-009 dismissal text, FR-011 convention artifact), so it is discoverable.
+The registry entry itself is carded for the owner, to be written at the next free identifier at the
+time it is written, not pre-reserved as `TD-024`.
+
+*Evidence*: `docs/reference/TECH_DEBT_REGISTRY.md` (exists, `TD-001` through `TD-023`);
+`.specify/memory/constitution.md:527,553-558,569`; commit `f8db8d2`;
+`specs/1210-documentation-reorganization/plan.md:71`; `specs/001-ruff-bump-forward/plan.md:109` and
+`tasks.md:36`; `specs/001-codeql-coverage/plan.md:59`.
+
+---
+
+**Q2: FR-008a defines `BLOCKED-ON-OWNER` for the case where the implementing agent cannot dismiss.
+Does that fully cover the case?**
+
+**A: No. Two holes. One is a missing detection procedure, the other is a missing terminal state for
+a different and far more likely blocker. Both are now closed in the spec.**
+
+*Hole 1, no capability probe.* FR-008a as written told the agent what to do when it "lacks
+permission to dismiss" but never said how to establish that. The obvious method, attempting the
+dismissal and reading the failure, is unacceptable here: a dismissal that succeeds mutates alert
+state and cannot be cleanly reverted, and SC-005 makes unintended alert-state change a breach.
+A read-only probe exists and was run. `gh auth status` reports the active token's scopes as `gist`,
+`read:org`, `repo`, `workflow`, with no `security_events`. On its own that reads as blocked, and
+the spec's Assumption 3 said exactly that. It is wrong. GitHub's update-code-scanning-alert endpoint
+requires `security_events` only for private repositories; `public_repo` suffices for public ones,
+and `repo` includes `public_repo`. This repository is public:
+`gh api repos/traylorre/sentiment-analyzer-gsk` returns `"private": false`, `"visibility":
+"public"`, and permissions `admin: true, maintain: true, push: true`. Read access is already
+demonstrated: the alerts API returns the four open alerts of this rule (148, 149, 150 at
+`src/lambdas/ingestion/handler.py` lines 264, 271 and 276, plus 144 at
+`src/lambdas/shared/auth/oauth_state.py:104`, which is the sibling feature's and stays untouched
+per SC-005). So on this environment dismissal is available and `BLOCKED-ON-OWNER` is not the
+expected outcome. FR-008a now names the probe, and Assumption 3 has been rewritten from the false
+`security-events: write` claim to the actual requirement.
+
+*Hole 2, and this is the larger one: nothing covered "cannot yet verify".* SC-002 and SC-002a are
+both keyed to a default-branch CodeQL analysis on a commit that includes the change. Such an
+analysis cannot exist while the change sits on a feature branch, so at the end of implementation
+the feature is neither `DONE` (SC-002 unevaluated), nor `DONE (dismissed)` (no survivor observed
+yet), nor `BLOCKED-ON-OWNER` (permission is present and no dismissal is pending). The plan's
+Terminal States section lists exactly those three. This is not an edge case, it is the normal
+ending, and it is made certain here because this agent tree performs no git operations at all. The
+spec's edge case "The default branch analysis has not re-run" said only "Classification must wait",
+which is not a terminal state and reproduces precisely the ambiguity that FR-008a was added to
+remove.
+
+**Resolution**: new **FR-008b** adds terminal state `PENDING-BRANCH-ANALYSIS`, reached when the code
+change and the FR-007 tests are complete and green but no qualifying analysis exists. Like
+`BLOCKED-ON-OWNER` it is reported as neither done nor failed, and it is explicitly distinguished
+from it: `BLOCKED-ON-OWNER` is about permission to dismiss a survivor already observed,
+`PENDING-BRANCH-ANALYSIS` is about no observation being possible yet.
+
+*Evidence*: `gh auth status` scope list, 2026-07-30; `gh api repos/traylorre/sentiment-analyzer-gsk`
+visibility and permissions; `gh api .../code-scanning/alerts?state=open` returning 148, 149, 150 and
+144; spec SC-002, SC-002a; `plan.md` "Terminal states".
+
+---
+
+**Q3: The plan uses a richer local fixture instead of the shared `env_vars` fixture. Does any other
+test depend on the values chosen, and is each forbidden string actually assertable against it?**
+
+**A: No other test depends on them. Each string is assertable, but only under an isolation
+constraint the plan stated for the region and omitted for the account identifier. FR-007 now carries
+that constraint.**
+
+*Dependency sweep, all clean.* `eu-west-2` appears in exactly one test module,
+`tests/unit/test_dynamodb_helpers.py`, which sets its own region and shares no fixture with the
+ingestion tests. `218795110243` appears in `tests/unit/test_sentiment.py` at lines 748, 803, 843 and
+906, always as the S3 bucket name `sentiment-analyzer-models-218795110243`, again a different module
+with no shared fixture. `preprod/sentiment-analyzer` appears in no test at all; its only
+non-specification occurrence is a comment in `infrastructure/terraform/ci-user-policy.tf:285`. The
+existing `env_vars` fixture at `tests/unit/lambdas/ingestion/test_handler.py:42-68` is not modified
+and not shared, so SC-004 is unaffected.
+
+*On using the real account identifier.* `218795110243` is this project's real AWS account. It is
+already committed to the repository in `CLAUDE.md` and in `tests/unit/test_sentiment.py`, so the
+fixture introduces no disclosure that is not already public in a public repository, and no secret
+scanner treats it as a finding. Keeping it is therefore acceptable and matches existing test
+precedent. A synthetic identifier would work equally well and is the tidier choice if the
+implementer prefers it; nothing in FR-007 or SC-001 depends on the value being real.
+
+*Assertability, one string at a time, against the handler's actual configuration.* The full ARN,
+the suffixes `AbCdEf` and `GhIjKl`, and the path segment `preprod/sentiment-analyzer` are unique to
+the two secret ARNs by construction; the fixture's `ENVIRONMENT` is `test`, so `preprod` does not
+collide. The prefix `arn:aws:secretsmanager` is safe because the only other ARN in the
+configuration is `SNS_TOPIC_ARN`, which is `arn:aws:sns`; note that a bare `arn:aws:` assertion
+would have collided and must not be used. `eu-west-2` is safe only because `AWS_REGION` stays
+`us-east-1`, which the plan states. The account identifier is the gap: `_get_config()` at
+`src/lambdas/ingestion/handler.py:585-605` also loads `sns_topic_arn` and `alert_topic_arn`, and
+both legitimately contain an account identifier. If the new fixture reused `218795110243` in either
+of those, a record carrying an SNS ARN would fail the account assertion for a reason that has
+nothing to do with the secret ARN, and conversely a passing assertion would stop being evidence.
+The existing fixture already uses `123456789` for `SNS_TOPIC_ARN`, so keeping that separation is
+sufficient. FR-007 now states the constraint for all three of `SNS_TOPIC_ARN`, `ALERT_TOPIC_ARN`
+and `AWS_REGION` rather than for the region alone.
+
+*One non-issue checked and cleared.* The plan's sweep case, which asserts every record from the
+both-keys-missing invocation is clean, cannot trip over the SNS or alert topic ARN, because that
+path raises at `handler.py:265` before `_get_sns_client` and `_create_failure_tracker` are reached.
+The single-source cases do run that code, which is why the fixture isolation matters there.
+
+*Evidence*: `tests/unit/test_dynamodb_helpers.py`; `tests/unit/test_sentiment.py:748,803,843,906`;
+`tests/unit/lambdas/ingestion/test_handler.py:42-68`; `src/lambdas/ingestion/handler.py:256-277` and
+`585-605`; `infrastructure/terraform/ci-user-policy.tf:285`; `CLAUDE.md`.
+
+---
+
+**Q4: FR-013 forbids modifying any file outside the handler and its tests. FR-011, SC-006 and
+FR-008a all require artifacts under `specs/001-ingestion-arn-logging/`. Which wins?**
+
+**A: A real contradiction, not a reading quibble. FR-013 has been given an explicit carve-out for
+this feature's own specification directory.**
+
+As written, FR-013 forbade writing `codeql-logging-convention.md`, which FR-011 and SC-006 require
+and which already exists, and forbade writing `dismissal-handoff.md`, which FR-008a requires as the
+sole deliverable of the `BLOCKED-ON-OWNER` state. An implementing agent obeying FR-013 literally
+would refuse to produce the one artifact that distinguishes a blocked feature from a failed one,
+which is the exact failure FR-008a was added to prevent. The plan already assumed the carve-out, at
+`plan.md:65-74`, without the spec granting it.
+
+The carve-out is narrow on purpose. FR-013's real target is source, test, infrastructure and shared
+documentation files, and above all `src/lambdas/shared/secrets.py`, whose alerts 22 through 25 read
+`dismissed` with `fixed_at` null and would re-fingerprint into fresh open alerts if their lines were
+touched. A specification directory carries no CodeQL alerts and is owned solely by this feature, so
+writing in it cannot breach SC-005. The `docs/reference/TECH_DEBT_REGISTRY.md` exclusion from Q1 is
+unaffected: that file is shared and contended, and stays outside the writable set.
+
+*Evidence*: spec FR-011, FR-008a, SC-006, SC-005; `plan.md:65-74`;
+`specs/001-ingestion-arn-logging/codeql-logging-convention.md` (already written).
+
+---
+
+### Requirements and criteria changed by this session
+
+| Item | Change | Driven by |
+|---|---|---|
+| FR-007 | Added the fixture-isolation constraint covering `SNS_TOPIC_ARN`, `ALERT_TOPIC_ARN` and `AWS_REGION`. The enumeration itself is unchanged. | Q3 |
+| FR-008a | Added the read-only capability probe, and the prohibition on establishing permission by attempting a dismissal. | Q2 |
+| FR-008b | **New requirement.** Terminal state `PENDING-BRANCH-ANALYSIS`. | Q2 |
+| FR-013 | Scope widened to include `specs/001-ingestion-arn-logging/`. All other prohibitions unchanged. | Q4 |
+| Assumption on dismissal permission | Rewritten. The `security-events: write` claim was factually wrong for a public repository. | Q2 |
+
+No success criterion was changed. SC-002 and SC-002a keep their wording; FR-008b names the state
+that exists before they become evaluable rather than altering what they measure.

--- a/specs/001-ingestion-arn-logging/tasks.md
+++ b/specs/001-ingestion-arn-logging/tasks.md
@@ -1,0 +1,1051 @@
+# Tasks: Stop Ingestion Handler Logging Secret ARNs
+
+**Input**: Design documents from `/specs/001-ingestion-arn-logging/`
+**Prerequisites**: `spec.md` (with Adversarial Review #1 and Clarifications Q1 to Q4), `plan.md` (with Adversarial Review #2), `research.md` (D1 to D7), `codeql-logging-convention.md`, `checklists/requirements.md`
+
+**Organization**: Tasks are grouped by user story. US1 (P1) is the defect fix and its regression guard. US2 (P2) is closure evidence, which is only evaluable after the change reaches the default branch. US3 (P3) is the reusable convention.
+
+---
+
+## Standing riders (apply to EVERY task)
+
+1. **`make validate` is NOT a gate for this feature and no task may require it to be green.**
+   `scripts/check-banned-terms.sh` exits 1 on 17 pre-existing matches from other features' files,
+   measured by execution 2026-07-30: `specs/1157-auth-cache-headers/` **9** (research.md 5, plan.md 3,
+   spec.md 1), `.secrets.baseline` **3**, `docs/cleanup/diagram-drift.md` **2**, `CLEANUP-BOARD.html`
+   **2**, `specs/1268-cors-404-headers/plan.md` **1**. (Adversarial Review #3 finding R9 corrected this
+   list: the three-file attribution carried here and in Cross-Artifact Analysis A2 accounts for only
+   7 of the 17, and omits the largest contributor entirely. The count and the conclusion were right;
+   the file list was not.) None of the 17 is under `specs/001-ingestion-arn-logging/`. T004 pins that
+   measurement. Individual
+   checks are invoked directly in T014. This also corrects `plan.md`'s local verification procedure,
+   which names `make validate` as a pre-push step it cannot pass.
+2. **Never key a task or a pass condition on a CodeQL alert NUMBER changing state.** Alert numbers
+   are locating labels only. Every gate is keyed on `most_recent_instance.location.path` plus
+   `rule.id`. The alerts API location object carries only `path`, `start_line`, `end_line`,
+   `start_column`, `end_column` (verified 2026-07-30), so no finer key exists.
+3. **Every `gh`, pipe, or log read needs an explicit exit-code check AND a non-empty proof-of-read
+   assertion.** Empty output means "the read failed" until proven otherwise. Use `${PIPESTATUS[0]}`,
+   never the exit code of the last stage of a pipe.
+4. **Every `gh api` call against the alerts endpoint MUST pass `--paginate`.** Measured 2026-07-30:
+   the repository holds 137 code scanning alerts across all states. One unpaginated page holds 100
+   and covers alert numbers 59 to 180 only. Alerts 1 and 22 through 27, which SC-005 and FR-004 both
+   depend on, are demonstrably off page 1. An unpaginated all-states query returns nothing for them
+   and reads as clean. See Cross-Artifact Analysis finding A1.
+5. **Do NOT pre-reserve a `TD-` identifier.** `docs/reference/TECH_DEBT_REGISTRY.md` holds `TD-001`
+   through `TD-023`; identifiers allocate at merge time in merge order, and `TD-024` is contested by
+   at least three sibling features. Nothing in this feature writes to that file (FR-013).
+6. **Writable set (FR-013, as widened by Clarification Q4)**: `src/lambdas/ingestion/handler.py`,
+   `tests/unit/lambdas/ingestion/test_handler_arn_logging.py`, and any file under
+   `specs/001-ingestion-arn-logging/`. Nothing else. `src/lambdas/shared/secrets.py` is off limits
+   (alerts 22 through 25 sit there with `fixed_at` null, live findings behind a dismissal). Scratch
+   output goes to `/tmp`, never into the repository tree.
+7. **Venv**: `source .venv/bin/activate` before any `python` or `pytest`. The system interpreter at
+   `/usr/bin/python3` is 3.12.3; 3.13 is only inside the venv (or via a pyenv shim). If a subprocess
+   is ever spawned from a test, use `sys.executable`.
+8. **GPG-sign every commit** (`git commit -S`). Never `--no-verify`.
+
+---
+
+## Phase 1: Setup, baselines and probes (ALL before any file is edited)
+
+**Purpose**: establish the "before" half of every before/after criterion, and probe capability
+read-only. Every task here is read-only against the repository. T001 through T005 are mutually
+independent.
+
+- [ ] **T001** [P] **Interpreter precondition.**
+  Command: `source .venv/bin/activate && python -c "import sys; print(sys.version)"`
+  **PASS**: the printed version starts with `3.13.`. **FAIL**: anything starting `3.12.` means the
+  venv is not active and every later `pytest` result is against the wrong interpreter.
+
+- [ ] **T002** [P] **Capture the pre-change code scanning baseline (SC-005 "before" half, and the
+  proof-of-read floor every later query reuses).** Output goes to `/tmp`, never into the repo.
+
+  ```bash
+  gh api --paginate \
+    "repos/traylorre/sentiment-analyzer-gsk/code-scanning/alerts?per_page=100" \
+    > /tmp/codeql-alerts-before.json
+  rc=$?
+  [ "$rc" -eq 0 ] || { echo "READ FAILED: gh exit $rc"; exit 1; }
+  total=$(jq -s 'add | map(select(.rule.id=="py/clear-text-logging-sensitive-data")) | length' \
+    /tmp/codeql-alerts-before.json)
+  [ "$total" -ge 16 ] || { echo "READ FAILED / TRUNCATED: only $total alerts of this rule"; exit 1; }
+  echo "rule alerts in corpus: $total"
+  jq -s 'add' /tmp/codeql-alerts-before.json | jq -r '
+    .[] | select(.rule.id=="py/clear-text-logging-sensitive-data")
+    | "\(.number)\t\(.state)\tfixed_at=\(.fixed_at)\t\(.most_recent_instance.location.path):\(.most_recent_instance.location.start_line)"' \
+    | sort -n
+  ```
+
+  **PASS**, all four conditions together:
+  1. `rc` is 0.
+  2. `total` is at least 16. Measured 2026-07-30: **22**. The floor exists because an unpaginated
+     read returns exactly **9** alerts of this rule, so any value at or below 9 proves truncation
+     rather than cleanliness (rider 4).
+  3. The printed rows include, verbatim: `148 open fixed_at=null src/lambdas/ingestion/handler.py:264`,
+     `149 ... :271`, `150 ... :276`, `144 open fixed_at=null src/lambdas/shared/auth/oauth_state.py:104`.
+  4. Rows `22`, `23`, `24`, `25` all read `dismissed` with `fixed_at=null` at
+     `src/lambdas/shared/secrets.py`. If these four rows are absent, the read was truncated. Do not
+     proceed.
+
+  **FAIL** on any of the four. Note the alert numbers here are locating labels for a human reading
+  the diff later; no pass condition in this feature is keyed on them (rider 2).
+
+  **Conditions 3 and 4 are this task's positive anchor** and must not be reduced to a count. They
+  require named paths to print verbatim **through the same field path** the later gates filter on
+  (`.most_recent_instance.location.path`), which is exactly what a corpus floor cannot do. See T016's
+  R12 note: a mistyped path field returns `null` for every alert, exits `0`, and still satisfies a
+  floor computed from `.rule.id`. If conditions 3 and 4 print, that field path is proven live for the
+  whole run.
+
+- [ ] **T003** [P] **Read-only dismissal capability probe (FR-008a).** Never establish this by
+  attempting a dismissal: a dismissal that succeeds mutates alert state, cannot be cleanly reverted,
+  and SC-005 treats unintended alert-state change as a breach.
+
+  ```bash
+  gh auth status 2>&1 | tee /tmp/gh-auth.txt; rc=${PIPESTATUS[0]}
+  [ "$rc" -eq 0 ] || { echo "PROBE FAILED: gh auth status exit $rc"; exit 1; }
+  grep -q "Token scopes" /tmp/gh-auth.txt || { echo "PROBE FAILED: no scope line read"; exit 1; }
+  gh api repos/traylorre/sentiment-analyzer-gsk --jq '{visibility, permissions}'; rc=$?
+  [ "$rc" -eq 0 ] || { echo "PROBE FAILED: repo read exit $rc"; exit 1; }
+  ```
+
+  **PASS** (verdict `DISMISSAL-AVAILABLE`): both exit codes 0, the scope line is non-empty and
+  contains `repo`, `visibility` is `public`, and `permissions.push` is `true`.
+  **Verdict `DISMISSAL-ABSENT`** only if `visibility` is `public` and the scope list lacks `repo`
+  (and lacks `public_repo`), or `permissions.push` is `false`.
+
+  **A missing `security_events` scope is NOT by itself a block.** That scope is a private-repository
+  requirement. This repository is public and `repo` includes `public_repo`. Measured 2026-07-30:
+  scopes `gist, read:org, repo, workflow`; `visibility: public`; `permissions.admin true, push true`.
+  Verdict on this environment is **`DISMISSAL-AVAILABLE`**, so `BLOCKED-ON-OWNER` is not the expected
+  ending. Record the verdict verbatim; T019 and T022 both read it.
+
+- [ ] **T004** [P] **Pin the pre-existing repository-wide gate failure (rider 1).**
+
+  ```bash
+  bash scripts/check-banned-terms.sh > /tmp/banned.out 2>&1; echo "exit=$?"
+  grep -c '^  \./' /tmp/banned.out
+  grep -c '^  \./specs/001-ingestion-arn-logging' /tmp/banned.out
+  ```
+
+  **PASS**: exit is `1`, the first count is `17`, and the second count is `0`. That is: the gate fails
+  for reasons that pre-date this feature and none of the matches is ours. **FAIL** if the second count
+  is anything but 0, which would mean this feature introduced a banned term. Re-run this exact task
+  after T008 and T009 as part of T013.
+
+- [ ] **T005** [P] **Baseline the ingestion unit suite (SC-004 "before" half).**
+  Command: `source .venv/bin/activate && python -m pytest tests/unit/lambdas/ingestion/ -q; echo "exit=$?"`
+  **PASS**: exit `0` and the summary line reads `43 passed`. Measured 2026-07-30: 43 collected in the
+  directory, of which `test_handler.py` contributes 22. Record both numbers; T011 asserts against
+  them.
+
+**Checkpoint**: baselines captured, capability verdict recorded, no repository file modified.
+
+---
+
+## Phase 2: US1 regression guard, written RED first (Priority: P1)
+
+**Goal**: a test that fails against the current unfixed handler and can only be made to pass by
+removing the value. **This phase MUST complete before Phase 3.** Campaign experience: a test written
+after the fix, or written against `caplog.text`, passes on unfixed code and proves nothing (FR-007,
+spec edge case "A test asserts on rendered log text only", research D4).
+
+**Independent test**: T007's RED gate is itself the proof the guard discriminates.
+
+- [ ] **T006** [US1] **Create `tests/unit/lambdas/ingestion/test_handler_arn_logging.py`.** New file
+  only. `tests/unit/lambdas/ingestion/test_handler.py` is not opened for editing at any point
+  (SC-004 is then satisfied mechanically).
+
+  **Fixture ARNs** (research D5, plan Test design):
+
+  ```
+  arn:aws:secretsmanager:eu-west-2:218795110243:secret:preprod/sentiment-analyzer/tiingo-AbCdEf
+  arn:aws:secretsmanager:eu-west-2:218795110243:secret:preprod/sentiment-analyzer/finnhub-GhIjKl
+  ```
+
+  **Fixture isolation (FR-007 as amended by Clarification Q3, plus plan Adversarial Review #2 M4).**
+  The environment the fixture sets MUST keep every forbidden string unique to the two secret ARNs:
+  - `SNS_TOPIC_ARN` keeps the unrelated account `123456789` and region `us-east-1`, exactly as the
+    existing `env_vars` fixture has it. It must contain none of `218795110243`, `eu-west-2`,
+    `preprod/sentiment-analyzer`.
+  - `ALERT_TOPIC_ARN` is unset by the existing fixture and defaults to `""` in `_get_config()`. If the
+    new fixture sets it, the same three constraints apply.
+  - `AWS_REGION` stays `us-east-1`, **and `CLOUD_REGION` must be explicitly deleted or pinned to
+    `us-east-1`**. `_get_config()` at `src/lambdas/ingestion/handler.py:589-590` reads `CLOUD_REGION`
+    first and only falls back to `AWS_REGION`, so an inherited `CLOUD_REGION` silently defeats the
+    region isolation. `spec.md` FR-007 names three variables; this is the fourth.
+  - Teardown restores or pops every variable the fixture set, including `CLOUD_REGION`.
+
+  **Forbidden strings, six, each asserted on its own** (research D5; `plan.md` calls this "five
+  classes plus a sixth", `research.md` calls it six, FR-007 enumerates five plus the suffix in prose;
+  they reconcile at six and six is what the test asserts):
+  1. the full ARN value, each of the two, separately
+  2. `arn:aws:secretsmanager`
+  3. `218795110243`
+  4. `eu-west-2`
+  5. `preprod/sentiment-analyzer`
+  6. `AbCdEf` and `GhIjKl`
+
+  **Do NOT shorten string 5 to `sentiment-analyzer`.** The haystack includes `record.pathname`, which
+  is an absolute path inside a checkout directory named `sentiment-analyzer-gsk`, so a shortened
+  assertion fails on every record for a reason unrelated to the ARN. Keep the `preprod/` prefix.
+  Equally, never assert on bare `arn:aws:`, which collides with `SNS_TOPIC_ARN`.
+
+  **Assertion surface (FR-007, research D4).** One module-level helper builds the haystack per record:
+  `record.getMessage()` joined with `str(v)` over **every** value in `record.__dict__`. The `str()`
+  coercion is load-bearing: `record.__dict__` holds non-string values (`args`, `exc_info`, `levelno`)
+  and a bare membership test raises `TypeError`. Scanning all of `__dict__` rather than named keys is
+  deliberate; it survives a key rename and catches a leak that migrates to a new `extra` key.
+  **`caplog.text` is not an acceptable surface anywhere in this module.**
+
+  **A second helper is MANDATORY, not optional** (Adversarial Review #3 finding R11). The haystack
+  helper joins values into one string and therefore **discards the key**, so pytest's assertion diff
+  can show that a forbidden string is present but not *where*. T007's pass condition requires
+  observing that the ARN arrives through a `record.__dict__` value rather than through the rendered
+  message, and that observation is not derivable from the haystack alone. Add a `where(record, needle)`
+  helper returning the list of locations (`"message"`, and `f"dict:{key}"` for each matching key) and
+  put its result in every assertion message. Verified 2026-07-30 by running this design against the
+  unfixed handler: the case-2 failure then reads
+  `leak '<tiingo ARN>' at ['dict:tiingo_secret_arn'] on msg='Running in degraded mode: Tiingo adapter unavailable'`,
+  which is exactly the evidence T007 asks for. Without the helper, T007's third condition is
+  unobservable and an implementer will be tempted to wave it through.
+
+  **Restrict the sweep to this module's own logger** (Adversarial Review #3 finding R8). `caplog`
+  captures third-party records too. Measured 2026-07-30, `caplog.records[0]` for the case-1
+  invocation is an INFO record from `botocore.credentials`, and records also arrive from
+  `src.lambdas.ingestion.parallel_fetcher` and `src.lambdas.shared.failure_tracker`. Two consequences:
+  the `record.pathname` collision described below is broader than the checkout directory (a
+  dependency's `pathname` runs through `<checkout>/.venv/lib/python3.13/site-packages/...`, which also
+  contains `sentiment-analyzer`), and an unrestricted sweep makes this suite hostage to whatever any
+  dependency happens to log. Filter case 5 and the per-record loops to
+  `r.name == "src.lambdas.ingestion.handler"`, or to `r.name.startswith("src.lambdas.")` if the wider
+  net is wanted. The sweep still does its job: it catches a leak migrating to a fourth site in this
+  module.
+
+  **Capture**: `caplog.at_level(logging.WARNING, logger="src.lambdas.ingestion.handler")`. Verified:
+  `handler.py:119` uses `logging.getLogger(__name__)`, `configure_lambda_logging()` sets levels only
+  and never touches propagation or attaches handlers or formatters, so records propagate and `caplog`
+  captures cleanly.
+
+  **Mechanics**: `@mock_aws`, `_create_table_with_gsi` plus one active configuration so the handler
+  reaches line 249, and `patch` on `src.lambdas.ingestion.handler.get_api_key`, `.TiingoAdapter`,
+  `.FinnhubAdapter`, `._get_sns_client`, `.emit_metrics_batch`. **The `reset_caches` autouse fixture
+  from `test_handler.py` MUST be duplicated in this module** (it is not shared), otherwise
+  `_active_tickers_cache` leaks across modules.
+
+  **The entrypoint is `lambda_handler`, not `handler`** (Adversarial Review #3 finding R7). No artifact
+  in this feature named it until now; `plan.md` mentions it once in passing and `tasks.md` never did.
+  `from src.lambdas.ingestion.handler import handler` raises
+  `ImportError: cannot import name 'handler'`, observed 2026-07-30. Import
+  `from src.lambdas.ingestion.handler import lambda_handler` and call it as
+  `lambda_handler({"source": "test"}, mock_context)` with a `MagicMock` context carrying
+  `aws_request_id`, matching `test_handler.py`'s existing integration tests. Note that this specific
+  mistake makes **all five** cases fail, including case 4, so T007's shape check catches it: a run
+  where case 4 also fails is an import or wiring error, not a RED gate.
+
+  **Five cases**:
+  1. Both credentials unavailable (`get_api_key` returns `None` for both). Assert an `ERROR` record
+     exists; assert its rendered message contains the **case-sensitive** literals `Tiingo` and
+     `Finnhub` (FR-002); assert it is clean against all six forbidden strings.
+  2. Tiingo only unavailable (`get_api_key` `side_effect` keyed on the ARN argument). Assert the
+     `WARNING` record still names Tiingo and is clean against all six, including structured
+     attributes.
+  3. Finnhub only unavailable. Mirror of case 2.
+  4. Outer exception path (Acceptance Scenario 4, FR-005). With both credentials unavailable the
+     `RuntimeError` reaches the `except` at `handler.py:572`, which logs via `get_safe_error_info(e)`.
+     That helper returns `{"error_type": ...}` only (verified at
+     `src/lambdas/shared/logging_utils.py:106-131`), so this record is clean **by construction even
+     on unfixed code**. The case is a pin, not a discriminator; T007 states so explicitly so nobody
+     reads its green as evidence.
+  5. Sweep: assert **every** record captured across the whole case-1 invocation is clean, not just the
+     targeted one. Catches a leak that migrates to a fourth site.
+
+  **PASS**: the file exists, imports resolve, and `python -m pytest tests/unit/lambdas/ingestion/test_handler_arn_logging.py --collect-only -q`
+  exits 0 and collects at least 5 tests.
+
+- [ ] **T007** [US1] **RED gate. Run the new module against the UNFIXED handler.** This is the single
+  most important gate in the feature and it can only be run before Phase 3.
+  Command: `source .venv/bin/activate && python -m pytest tests/unit/lambdas/ingestion/test_handler_arn_logging.py -v; echo "exit=$?"`
+  **PASS** requires the exact failure shape, not merely a non-zero exit:
+  - exit is non-zero,
+  - cases **1, 2, 3 and 5 FAIL**,
+  - case **4 PASSES** (clean by construction, see T006 case 4),
+  - at least one case-2 or case-3 failure message shows the ARN arriving through a
+    `record.__dict__` value and **not** through the rendered message. That is the proof the assertion
+    surface is the right one; a test that only fails on case 1 is a `caplog.text`-equivalent test in
+    disguise and MUST be rewritten before proceeding.
+
+  **FAIL**: any of cases 1, 2, 3, 5 passing against unfixed code. Do not continue to Phase 3. Record
+  the observed failure list.
+
+**Checkpoint**: the guard demonstrably discriminates fixed from unfixed code.
+
+---
+
+## Phase 3: US1 code change (Priority: P1)
+
+**Goal**: remove every ARN-derived value from message, structured context and exception message at
+the three sites in `src/lambdas/ingestion/handler.py:256-277`.
+
+**Independent test**: T010 plus T011.
+
+- [ ] **T008** [US1] **Site 1, `handler.py:259-265` (the definitely-rendered one).** `error_msg` is
+  built by f-string from `config['tiingo_secret_arn']` and `config['finnhub_secret_arn']`, passed to
+  `logger.error()`, then reused verbatim as the `RuntimeError` message. Both uses are sinks.
+  Replace the f-string with a fixed literal naming both sources, for example
+  `"CONFIGURATION ERROR: Both API keys missing (Tiingo and Finnhub)."` The literal MUST contain
+  case-sensitive `Tiingo` and `Finnhub` (FR-002). The `logger.error(...)` call, the
+  `raise RuntimeError(...)`, the log level, the branch condition and the exception type all stay
+  exactly as they are (FR-006). The exception message is now clean, which is what makes FR-005 hold
+  at the outer `except`. Add the FR-010 inline comment naming `py/clear-text-logging-sensitive-data`
+  and the reason the value was removed.
+  **PASS** (corrected by Adversarial Review #3 finding R1; the earlier "exactly two lines" wording was
+  unsatisfiable). Run:
+
+  ```bash
+  grep -n "tiingo_secret_arn\|finnhub_secret_arn" src/lambdas/ingestion/handler.py > /tmp/arn-refs.txt
+  echo "grep_exit=$?"; wc -l < /tmp/arn-refs.txt; cat /tmp/arn-refs.txt
+  grep -cE "logger\.|f\"|f'|RuntimeError" /tmp/arn-refs.txt
+  ```
+
+  `grep_exit` is `0` and the line count is **exactly 4**. The four surviving references are the two
+  `get_api_key(config[...])` reads inside `lambda_handler` and the two `os.environ[...]` reads inside
+  `_get_config()`. Measured 2026-07-30 on the unfixed file the same grep returns **eight** lines
+  (249, 250, 261, 262, 271, 276, 601, 602); T008 and T009 remove exactly the four in the 259-277
+  region, and lines 601-602 in `_get_config()` are load-bearing configuration construction that MUST
+  NOT be touched. The second grep count MUST be `0`: no surviving reference sits inside a logging
+  call, an f-string or a `RuntimeError` construction. **FAIL** on a line count other than 4, or a
+  second count other than 0.
+
+- [ ] **T009** [US1] **Sites 2 and 3, `handler.py:268-277` (the structured-context ones).** Delete the
+  `extra={...}` argument outright at both warnings. The messages already carry the literal source
+  names, so nothing an on-call engineer uses is lost. **Do not** substitute a sanitized value: that is
+  the `0e7a375` shape, it already failed in this repository, and FR-003 forbids it. Add the FR-010
+  inline comment at each site.
+  **PASS**: `sed -n '256,280p' src/lambdas/ingestion/handler.py` shows no `extra=` in either warning,
+  both warnings retain their literal source name and `logger.warning` level, and both carry the
+  FR-010 comment.
+
+  *Impact note, keep it accurate (do not overstate):* nothing renders `extra` today. The root handler
+  renders `getMessage()` and `configure_lambda_logging()` attaches no formatter; no Terraform in this
+  repository sets a JSON log format for this function (verified: zero matches for `logging_config`,
+  `log_format` or `LogFormat` under `infrastructure/terraform/`). These two sites are a latent leak
+  armed by a future formatter plus an alert the engine raises regardless of rendering, not a live
+  disclosure. Site 1 is the live one.
+
+- [ ] **T010** [US1] **GREEN gate (SC-001, FR-007).**
+  Command: `source .venv/bin/activate && python -m pytest tests/unit/lambdas/ingestion/test_handler_arn_logging.py -v; echo "exit=$?"`
+  **PASS**: exit `0`, all 5 cases pass, zero skips, zero xfails. A skipped case is a failure of this
+  task. Cross-check against T007's recorded failure list: cases 1, 2, 3 and 5 must have flipped from
+  red to green, which is the only evidence that the fix, and not the test, changed.
+
+- [ ] **T011** [US1] **SC-004 regression: nothing existing loosened or removed.**
+  Command: `source .venv/bin/activate && python -m pytest tests/unit/lambdas/ingestion/ -q; echo "exit=$?"`
+  **PASS**: exit `0`, and the summary reads `48 passed` (T005's 43 plus the 5 new cases); the count
+  MUST be `43 + N` where N is the number of new cases, never fewer than 43 pre-existing.
+  Additionally: `git status --porcelain tests/unit/lambdas/ingestion/test_handler.py` prints nothing,
+  proving the existing module was not touched at all.
+
+- [ ] **T012** [US1] **Static negative checks (FR-003, FR-012).**
+
+  ```bash
+  grep -n "_sanitize_secret_id_for_log" src/lambdas/ingestion/handler.py; echo "grep_exit=$?"
+  grep -n "from src.lambdas.shared.secrets import" src/lambdas/ingestion/handler.py
+  grep -nE "logging\.Filter|addFilter|setFormatter|logging\.Formatter|basicConfig" src/lambdas/ingestion/handler.py; echo "grep_exit=$?"
+  ```
+
+  **PASS**: the first grep exits `1` with no output (FR-003: the sanitizer is not called here). The
+  second prints exactly one line, `from src.lambdas.shared.secrets import get_api_key`, unchanged. The
+  third exits `1` with no output (FR-012: no new filter, formatter or logging-framework change).
+  Here an exit of `1` from `grep` is the pass, and it is checked explicitly rather than inferred from
+  silence.
+
+- [ ] **T013** [US1] **Scope lock and comment presence (FR-013, FR-010).**
+
+  ```bash
+  git status --porcelain -- ':!specs/001-bad-tag-filter-dead-suppression' \
+    ':!specs/001-codeql-coverage' ':!specs/001-oauth-provider-taint' > /tmp/scope.txt
+  echo "status_exit=$?"; cat /tmp/scope.txt
+  grep -cvE '(src/lambdas/ingestion/handler\.py|tests/unit/lambdas/ingestion/test_handler_arn_logging\.py|specs/001-ingestion-arn-logging)' /tmp/scope.txt
+  grep -c "py/clear-text-logging-sensitive-data" src/lambdas/ingestion/handler.py
+  bash scripts/check-banned-terms.sh > /tmp/banned-after.out 2>&1; echo "exit=$?"
+  grep -c '^  \./' /tmp/banned-after.out
+  grep -c '^  \./specs/001-ingestion-arn-logging' /tmp/banned-after.out
+  git diff -U0 src/lambdas/ingestion/handler.py | grep -E '^@@'
+  ```
+
+  **PASS**, all five:
+  1. `/tmp/scope.txt` is **non-empty** (an empty file means the read failed or nothing was changed at
+     all, never that scope is clean), and the `grep -cv` count of lines outside the permitted set is
+     **0**. Any other path, and in particular `src/lambdas/shared/secrets.py`, is a breach of FR-013
+     and of SC-005.
+     **The three sibling exclusions are load-bearing** (Adversarial Review #3 finding R2). This
+     campaign runs four features in one shared worktree; measured 2026-07-30, a bare
+     `git status --porcelain` already lists `specs/001-bad-tag-filter-dead-suppression/`,
+     `specs/001-codeql-coverage/` and `specs/001-oauth-provider-taint/` as untracked. Without the
+     pathspec exclusions this condition fails against a perfectly correct implementation. Never
+     "resolve" a sibling directory appearing here by deleting it.
+  2. The rule-id grep count is **3** (FR-010, one comment per site, unconditional).
+  3. `check-banned-terms.sh` exit is still `1` and the feature-directory count (condition 4) is `0`.
+     The total is expected to read **17**, unchanged from T004, but the total is **not** the gate:
+     sibling features write into `specs/` in this same worktree concurrently and can move it. A total
+     that moved while condition 4 stays `0` is attributable elsewhere and is not this feature's
+     defect. Diff `/tmp/banned.out` against `/tmp/banned-after.out` to see which paths moved.
+  4. The feature-directory match count is **`0`**. This is the actual gate.
+  5. The `git diff -U0` hunk headers are all inside the `256-277` region of the pre-change file
+     (`git diff --stat` was named here previously and cannot evaluate this: it emits insertion and
+     deletion counts only, with no line regions. Adversarial Review #3 finding R5).
+
+- [ ] **T014** [US1] **Targeted lint, format and SAST on the touched files only.** Do not invoke
+  `make validate` (rider 1).
+
+  ```bash
+  source .venv/bin/activate
+  ruff check src/lambdas/ingestion/handler.py tests/unit/lambdas/ingestion/test_handler_arn_logging.py; echo "ruff_check=$?"
+  ruff format --check src/lambdas/ingestion/handler.py tests/unit/lambdas/ingestion/test_handler_arn_logging.py; echo "ruff_fmt=$?"
+  bandit -c pyproject.toml -r src/lambdas/ingestion/handler.py -ll; echo "bandit=$?"
+  semgrep scan --config auto --error --severity ERROR --severity WARNING src/lambdas/ingestion/handler.py; echo "semgrep=$?"
+  ```
+
+  **PASS**: all four exit codes are `0`. If `semgrep` is absent from the venv it must be installed
+  (`pip install -r requirements-dev.txt`), never skipped: a skipped scanner reported as a pass is the
+  defect class this campaign keeps finding.
+
+**Checkpoint**: the code change is complete, locally verified, scope-locked, and independently
+mergeable. Every criterion that does not need a default-branch analysis is now satisfied.
+
+---
+
+## Phase 4: US2 closure evidence (Priority: P2)
+
+**Goal**: prove closure from branch state, not from a pull request check.
+
+**These tasks are NOT runnable at the end of implementation.** SC-002 and SC-002a are keyed to a
+default-branch CodeQL analysis on a commit that includes the change, which cannot exist while the
+change sits on a feature branch. If T016 cannot run, the feature terminates at
+`PENDING-BRANCH-ANALYSIS` via T022. That is a recorded outcome, not an abort.
+
+- [ ] **T015** [US2] **Pull request run, as the informative inverse only.** Because this change edits
+  the exact lines flagged today, the diff-informed pull request result is directly informative here.
+  Command: `gh pr checks <PR> ; echo "exit=$?"`, then read the CodeQL result.
+  **Use**: an alert surviving the pull request run is a **genuine survivor**, worth investigating
+  immediately rather than waiting.
+  **PASS/FAIL**: this task has no pass condition that closes anything. **A green pull request CodeQL
+  check is explicitly NOT closure evidence** (SC-002; PR #990 was green with five alerts open). Record
+  the observation and move on. Claiming closure from this task alone is a defect.
+
+- [ ] **T016** [US2] **SC-002 gate: zero open alerts of this rule at this path.** Run only after a
+  default-branch analysis on a commit that includes the change has completed.
+
+  ```bash
+  gh api --paginate \
+    "repos/traylorre/sentiment-analyzer-gsk/code-scanning/alerts?per_page=100" \
+    > /tmp/codeql-alerts-after.json
+  rc=$?
+  [ "$rc" -eq 0 ] || { echo "READ FAILED: gh exit $rc"; exit 1; }
+  total=$(jq -s 'add | map(select(.rule.id=="py/clear-text-logging-sensitive-data")) | length' \
+    /tmp/codeql-alerts-after.json)
+  [ "$total" -ge 16 ] || { echo "READ FAILED / TRUNCATED: only $total"; exit 1; }
+
+  # POSITIVE ANCHOR. The corpus floor above reads .rule.id and therefore says NOTHING about
+  # whether the path field this gate depends on was read at all. Both clauses below must hold.
+  null_paths=$(jq -s 'add | map(select(.most_recent_instance.location.path==null)) | length' \
+    /tmp/codeql-alerts-after.json)
+  [ "$null_paths" -eq 0 ] || { echo "BLIND READ: $null_paths alerts have a null path"; exit 1; }
+  anchor=$(jq -s 'add | map(select(
+      .most_recent_instance.location.path=="src/lambdas/shared/secrets.py")) | length' \
+    /tmp/codeql-alerts-after.json)
+  [ "$anchor" -ge 15 ] || { echo "BLIND READ: known-present path returned $anchor"; exit 1; }
+
+  open_at_path=$(jq -s 'add | map(select(
+      .rule.id=="py/clear-text-logging-sensitive-data"
+      and .state=="open"
+      and .most_recent_instance.location.path=="src/lambdas/ingestion/handler.py")) | length' \
+    /tmp/codeql-alerts-after.json)
+  echo "rule alerts: $total ; null_paths: $null_paths ; anchor: $anchor ; open at path: $open_at_path"
+  ```
+
+  **PASS**: `rc` is 0 **AND** `total` is at least 16 **AND** `null_paths` is exactly `0` **AND**
+  `anchor` is at least 15 **AND** `open_at_path` is exactly `0`.
+
+  **Why the two anchor clauses exist** (Adversarial Review #3 finding R12, added after the corpus-wide
+  wave). **A corpus floor does not protect against a wrong field path.** Reproduced 2026-07-30 on the
+  live corpus: mistyping `.most_recent_instance.location.path` as `.most_recent_instance.locatio.path`
+  makes `jq` return `null` for every alert. It does **not** error and it exits `0`. The `total` floor
+  still passes, because `total` is computed from `.rule.id`, a different field path that the typo does
+  not touch. And `open_at_path` then evaluates to **`0`**, which is this task's PASS value. Measured:
+  correct path gives `null_paths=0` and `anchor=16`; the mistyped path gives `null_paths=137` and
+  `anchor=0`, with `jq_exit=0` in both cases. Every clause of the old pass condition was satisfiable by
+  a completely blind read, and the blind read reported this feature's primary success criterion as met.
+  Exit code plus corpus floor is necessary and **not** sufficient; an absence is only evidence once a
+  known-present value has been shown present through the same field path.
+  **FAIL**: `open_at_path` greater than 0. Any number returned, **including a number that did not
+  exist before**, is a survivor under Acceptance Scenario 2 and goes to T019. It is never dismissed
+  as an unrelated finding.
+  **NOT-YET-EVALUABLE**: the latest completed default-branch analysis does not include the change.
+  Verify with the shape below. **Do not combine `--paginate` with `--jq`** (Adversarial Review #3
+  finding R4): gh applies `--jq` once per page, so `.[0]` prints the newest analysis of *every* page.
+  Measured 2026-07-30, the `--paginate --jq` form printed **10 lines**, one per page, handing the
+  reader ten commit shas and no rule for choosing among them. Only page one is wanted here:
+
+  ```bash
+  gh api "repos/traylorre/sentiment-analyzer-gsk/code-scanning/analyses?ref=refs/heads/main&per_page=1" \
+    > /tmp/latest-analysis.json
+  rc=$?
+  [ "$rc" -eq 0 ] || { echo "READ FAILED: gh exit $rc"; exit 1; }
+  [ "$(jq 'length' /tmp/latest-analysis.json)" -eq 1 ] || { echo "READ FAILED: no analysis row"; exit 1; }
+  jq -r '.[0] | "\(.commit_sha)\t\(.created_at)"' /tmp/latest-analysis.json
+  ```
+
+  Compare that sha against the merge commit. In this case do not record a verdict; go to T022 and
+  terminate at `PENDING-BRANCH-ANALYSIS`.
+
+- [ ] **T017** [US2] **SC-002a: `fixed_at`, never `state`.** For each of alerts 148, 149 and 150 that
+  is reported as repaired rather than dismissed, read `fixed_at` from the same
+  `/tmp/codeql-alerts-after.json` (all states, already paginated):
+
+  ```bash
+  jq -s 'add' /tmp/codeql-alerts-after.json | jq -r '
+    .[] | select(.number==148 or .number==149 or .number==150)
+    | "\(.number)\t\(.state)\tfixed_at=\(.fixed_at)"' | sort -n
+  rc=${PIPESTATUS[0]}
+  [ "$rc" -eq 0 ] || { echo "READ FAILED"; exit 1; }
+  ```
+
+  **PASS**: `rc` is 0, **three rows print** (fewer than three means the read was truncated, not that
+  the alerts vanished), and every row claimed as repaired has `fixed_at` non-null and dated at or
+  after the change. **FAIL**: any row claimed repaired that reads `dismissed` or `closed` with
+  `fixed_at=null`. Alerts 22 through 25 are the standing proof that this combination masks a site
+  that was never repaired. The numbers here are locating labels for an anti-fraud cross-check only;
+  SC-002 (T016) remains the criterion of record.
+
+- [ ] **T018** [US2] **SC-005 blast radius: nothing outside the handler moved.**
+
+  ```bash
+  for f in src/lambdas/shared/secrets.py src/lambdas/shared/auth/oauth_state.py; do
+    for snap in before after; do
+      jq -s 'add' /tmp/codeql-alerts-$snap.json | jq -r --arg p "$f" '
+        .[] | select(.rule.id=="py/clear-text-logging-sensitive-data")
+        | select(.most_recent_instance.location.path==$p)
+        | "\(.number)\t\(.state)\tfixed_at=\(.fixed_at)"' | sort -n > /tmp/sc005-$snap.txt
+      [ "${PIPESTATUS[0]}" -eq 0 ] || { echo "READ FAILED"; exit 1; }
+      [ -s /tmp/sc005-$snap.txt ] || { echo "READ FAILED: empty for $f/$snap"; exit 1; }
+    done
+    diff /tmp/sc005-before.txt /tmp/sc005-after.txt; echo "$f diff_exit=$?"
+  done
+  ```
+
+  **Then the whole-corpus check, which the per-file loop above cannot do** (Adversarial Review #3
+  finding R3). SC-005 says alerts of this rule outside the handler are unchanged **in count**, and a
+  two-file loop is blind to a path it does not name. Measured 2026-07-30 this rule sits on **four**
+  paths: `handler.py` (3), `secrets.py` (16), `oauth_state.py` (2) and
+  **`src/lambdas/shared/errors.py` (1, alert 1)**, which the loop above never reads. A regression that
+  surfaced at a fifth path would be invisible.
+
+  **Compare multiplicity, not membership** (Adversarial Review #3 finding R13). `rule@path` is **not**
+  a unique key in this corpus, and the collapse is severe: measured 2026-07-30,
+  `py/log-injection@src/lambdas/dashboard/auth.py` holds **24** alerts under one key, `ohlc.py` 17,
+  and, inside this feature's own SC-005 scope,
+  `py/clear-text-logging-sensitive-data@src/lambdas/shared/secrets.py` holds **16**. A set-diff keyed
+  on `rule@path` reports membership only, so 15 of those 16 could vanish and it would print nothing.
+  That is the highest-value file in this feature's blast radius. Build `{key: count}` on each side and
+  diff the **counts**, reporting three buckets so a partial loss has somewhere to land.
+
+  ```bash
+  for snap in before after; do
+    jq -s 'add' /tmp/codeql-alerts-$snap.json > /tmp/sc005-corpus-$snap.json
+    [ "${PIPESTATUS[0]}" -eq 0 ] || { echo "READ FAILED"; exit 1; }
+
+    # POSITIVE ANCHOR, same reason as T016: the floor below reads .rule.id and cannot
+    # detect a mistyped path field, which yields null everywhere and exits 0.
+    np=$(jq '[.[] | select(.most_recent_instance.location.path==null)] | length' \
+      /tmp/sc005-corpus-$snap.json)
+    [ "$np" -eq 0 ] || { echo "BLIND READ: $np null paths in $snap"; exit 1; }
+    anch=$(jq '[.[] | select(.most_recent_instance.location.path=="src/lambdas/shared/secrets.py")] | length' \
+      /tmp/sc005-corpus-$snap.json)
+    [ "$anch" -ge 15 ] || { echo "BLIND READ: anchor path returned $anch in $snap"; exit 1; }
+
+    jq '[ .[] | select(.rule.id=="py/clear-text-logging-sensitive-data")
+          | select(.most_recent_instance.location.path!="src/lambdas/ingestion/handler.py")
+          | (.rule.id + "@" + .most_recent_instance.location.path) ]
+        | group_by(.) | map({key:.[0], n:length}) | sort_by(.key)' \
+      /tmp/sc005-corpus-$snap.json > /tmp/sc005-keys-$snap.json
+    rows=$(jq '[.[].n] | add // 0' /tmp/sc005-keys-$snap.json)
+    [ "$rows" -ge 15 ] || { echo "READ FAILED / TRUNCATED: only $rows rows outside the handler"; exit 1; }
+    echo "$snap: keys=$(jq 'length' /tmp/sc005-keys-$snap.json) alerts=$rows null_paths=$np anchor=$anch"
+  done
+
+  jq -n --slurpfile b /tmp/sc005-keys-before.json --slurpfile a /tmp/sc005-keys-after.json '
+    ($b[0] | INDEX(.key) | map_values(.n)) as $B |
+    ($a[0] | INDEX(.key) | map_values(.n)) as $A |
+    { disappeared: [ $B | keys_unsorted[] | select($A[.]==null) ],
+      appeared:    [ $A | keys_unsorted[] | select($B[.]==null) ],
+      changed:     [ $B | keys_unsorted[] | select($A[.]!=null and $A[.]!=$B[.])
+                     | {key:., before:$B[.], after:$A[.]} ] }' > /tmp/sc005-buckets.json
+  echo "buckets_exit=$?"; cat /tmp/sc005-buckets.json
+  ```
+
+  **PASS**, all of:
+  1. Every per-file snapshot is **non-empty** (empty means the read failed, never that the file is
+     clean) and every `diff_exit` is `0`.
+  2. On both sides `null_paths` is `0` and `anchor` is at least 15. These are the positive anchors; a
+     read that cannot see `secrets.py` cannot be trusted to report that nothing changed.
+  3. Both `rows` counts are at least 15 (measured **19**; the floor is proof-of-read, not the
+     criterion).
+  4. **All three buckets are empty**: `disappeared` `[]`, `appeared` `[]`, `changed` `[]`.
+
+  Specifically: alert 144 on `oauth_state.py` unchanged and still owned by sibling
+  `001-oauth-provider-taint`; alerts 22 through 25 still `dismissed` with `fixed_at=null`; alert 1 on
+  `errors.py` unchanged; **no new alert number and no changed count on any path outside
+  `src/lambdas/ingestion/handler.py`**, which would breach both SC-005 and FR-013.
+
+  **`changed` is the bucket that matters and the one a membership set-diff does not have.** Verified in
+  both directions 2026-07-30 against fixtures built from the live corpus:
+  - **Partial loss**, `secrets.py` cut from 16 alerts to 1 plus a fabricated new alert at
+    `src/lambdas/ingestion/parallel_fetcher.py`: three-bucket output was
+    `changed: [{key: ...secrets.py, before: 16, after: 1}]`, `appeared: [...parallel_fetcher.py]`,
+    `disappeared: []`. Caught.
+  - **The same fixture through a membership-only set-diff**: `disappeared: []`,
+    `appeared: [...parallel_fetcher.py]`. The 16-to-1 loss on the single most sensitive file in this
+    feature's scope was **invisible**. That is the defect, reproduced.
+  - **No-change direction**, identical before and after: all three buckets `[]`. No false positive.
+
+- [ ] **T019** [US2] **Survivor branch (FR-008, FR-008a, FR-009, SC-003).** Runs only if T016 returned
+  `open_at_path` greater than 0. Read T003's recorded verdict; **do not re-probe by attempting a
+  dismissal.**
+
+  - **If `DISMISSAL-AVAILABLE`**: dismiss each surviving alert at this path as a false positive with a
+    justification carrying all three FR-009 elements, drafted from the template in
+    `codeql-logging-convention.md` section 2. All three elements are mandatory: what the value
+    actually is (an AWS resource identifier, not a credential value), which convention shape was
+    applied (value stripped from message, structured context and exception), and **why CodeQL still
+    reports the flow**, stated concretely for the surviving site. Do not paste the template verbatim;
+    element three and the re-evaluation trigger must be site-specific.
+    **PASS (SC-003)**: re-read each dismissed alert and confirm `dismissed_comment` is non-empty and
+    contains all three elements. Verify with a read, never by trusting the write's exit code.
+  - **If `DISMISSAL-ABSENT`**: write `specs/001-ingestion-arn-logging/dismissal-handoff.md` carrying
+    (a) the exact alert numbers observed at the path, (b) the exact justification text for each, and
+    (c) the exact `gh api` call or UI steps to apply each. Terminate at `BLOCKED-ON-OWNER` via T022.
+    **PASS**: the file exists and contains all three, and the code change is stated as independently
+    complete and mergeable.
+
+  Under neither branch is the feature reported as done or as failed while a dismissal is outstanding.
+
+---
+
+## Phase 5: US3 reusable convention (Priority: P3)
+
+**Goal**: `001-oauth-provider-taint`, and any later feature working this rule, can cite one artifact
+instead of re-deriving the convention. `codeql-logging-convention.md` already exists; these tasks
+audit it against what this feature actually did. Both are read-only against everything except that
+one file and are mutually independent.
+
+- [ ] **T020** [P] [US3] **FR-011 and SC-006 conformance audit of `codeql-logging-convention.md`.**
+  Confirm by reading that all five required elements are present and correct:
+  1. the decision rule for rewrite versus dismiss (section 1, steps 1 to 4),
+  2. the three-element dismissal wording pattern and its template (section 2),
+  3. the `fixed_at` versus `state` caveat (section 3, trap 1),
+  4. the alert-number-instability caveat and the path-plus-rule keying rule (section 3, trap 2),
+  5. both terminal states, `PENDING-BRANCH-ANALYSIS` and `BLOCKED-ON-OWNER`, with the read-only
+     capability probe and the explicit note that a missing `security_events` scope is not by itself a
+     block (section 5a and 5b).
+
+  **Then apply the one correction this feature discovered**: the query shape in section 3 lacks
+  `--paginate` and has no proof-of-read assertion. Update it to the shape used in T016 (paginate,
+  check the exit code, assert a non-zero corpus count, then count the filtered set). Leave a one-line
+  note that an unpaginated read returns 100 of 137 alerts on this repository and silently omits alert
+  numbers below 59, measured 2026-07-30.
+  **The substantive defect is not the missing flag, it is the sentence under it.** Section 3 of the
+  convention currently ends `Empty output is the pass condition.` with nothing proving the read
+  worked. That is the campaign's canonical vacuous pass, sitting in the one document the sibling
+  feature inherits by citation. Adding `--paginate` while leaving that sentence intact fixes nothing.
+  Replace the block with the ordered shape T016 uses: exit code first, then a corpus-count floor, then
+  read the absence. Say in the file that an absence is only evidence once the read is proven live.
+
+  ```bash
+  grep -c -- "--paginate" specs/001-ingestion-arn-logging/codeql-logging-convention.md
+  grep -n "Empty output is the pass condition" specs/001-ingestion-arn-logging/codeql-logging-convention.md; echo "stale_exit=$?"
+  grep -cE "exit|rc=|floor|proof" specs/001-ingestion-arn-logging/codeql-logging-convention.md
+  ```
+
+  **PASS**: all five elements verified present by reading; the first count is at least `1`;
+  `stale_exit` is **`1`** with no output, meaning the unguarded sentence is gone (an exit of `2`
+  means the file is missing and is a FAIL, not a pass, so the absence here is live-checked); and the
+  third count is at least `1`. Measured 2026-07-30 before the edit: paginate count `0`, the stale
+  sentence present at line 112. **FAIL**: any element missing, the query shape left unpaginated, or
+  the unguarded pass sentence still present. (Adversarial Review #3 finding R6.)
+
+- [ ] **T021** [P] [US3] **Sibling citation readiness (FR-011).**
+  Command:
+  `grep -nE "spec\.md:[0-9]+|plan\.md:[0-9]+|tasks\.md:[0-9]+|research\.md:[0-9]+" specs/001-ingestion-arn-logging/codeql-logging-convention.md; echo "grep_exit=$?"`
+  **PASS**: `grep_exit` is `1` with no output. The convention must be citable by document and section,
+  never by line number: sibling artifacts changed under review and will change again, and a
+  line-number citation rots silently. References to this feature's own files inside the convention
+  must name the file and the section only. **FAIL**: any hit.
+
+**Checkpoint**: a reader who has never seen this feature can get the decision rule, the wording
+pattern, the verification caveats and both terminal states from one file (SC-006).
+
+---
+
+## Phase 6: Terminal state, recorded explicitly
+
+- [ ] **T022** **Determine and RECORD the terminal state.** Reaching a terminal state is an explicit,
+  written outcome. An implementation that stops without filling in the record below has not completed
+  this task, regardless of how much code it wrote.
+
+  Decide in this order and stop at the first match:
+
+  | Condition | State |
+  |---|---|
+  | T016 not runnable: no completed default-branch analysis on a commit containing the change | **`PENDING-BRANCH-ANALYSIS`** (FR-008b) |
+  | T016 `open_at_path` is 0, T017 and T018 pass | **`DONE`** |
+  | T016 `open_at_path` greater than 0, T003 verdict `DISMISSAL-AVAILABLE`, T019 dismissal applied and re-read | **`DONE (dismissed)`** |
+  | T016 `open_at_path` greater than 0, T003 verdict `DISMISSAL-ABSENT`, `dismissal-handoff.md` written | **`BLOCKED-ON-OWNER`** (FR-008a) |
+
+  Then fill in the **Terminal State Record** at the foot of this file. Writing it satisfies FR-008b's
+  requirement that the verification query be on record: the record points at T016, which carries the
+  query in full, and no separate artifact is created (this closes the ambiguity Adversarial Review #2
+  logged as M5).
+
+  **PASS**: the record below is filled in with a date, a state drawn from the four above, the T003
+  verdict, and the T016 result or the reason it was not runnable.
+  **`PENDING-BRANCH-ANALYSIS` and `BLOCKED-ON-OWNER` are reported as neither done nor failed.**
+  `PENDING-BRANCH-ANALYSIS` is the **expected ending of implementation**, because SC-002 and SC-002a
+  are only evaluable after the change reaches the default branch. Reporting either one as a failure,
+  or silently as a success, is a defect.
+
+---
+
+## Terminal State Record
+
+*Filled in by T022. Leave the placeholders until then.*
+
+- **Date**: `<YYYY-MM-DD>`
+- **Terminal state**: `<PENDING-BRANCH-ANALYSIS | DONE | DONE (dismissed) | BLOCKED-ON-OWNER>`
+- **T003 capability verdict**: `<DISMISSAL-AVAILABLE | DISMISSAL-ABSENT>` (probed read-only; measured
+  `DISMISSAL-AVAILABLE` on 2026-07-30)
+- **T016 result**: `<open_at_path value, or "not runnable: reason">`
+- **Verification query of record**: T016 in this file (paginated, exit-checked, floor-asserted)
+- **Outstanding owner action**: `<none | apply dismissal-handoff.md | re-run T016 after the next
+  default-branch analysis | add the next free TECH_DEBT_REGISTRY identifier if the dismissal branch
+  fired>`
+
+---
+
+## Dependencies and execution order
+
+```
+T001..T005  [P, all independent, ALL before any edit]
+     |
+     +-- T002 -> T016, T017, T018   (the "before" snapshot; SC-005 needs both halves)
+     +-- T003 -> T019, T022         (capability verdict; must precede any dismissal)
+     +-- T004 -> T013               (banned-term count before/after)
+     +-- T005 -> T011               (suite count before/after)
+     |
+T006 -> T007  (RED gate)
+     |
+T007 -> T008, T009   (HARD ORDER: the fix must not land before the guard has been seen to fail)
+     |
+T008, T009 -> T010 -> T011 -> T012 -> T013 -> T014
+     |
+     +-- (merge to default branch, outside this task list)
+     |
+T015 (informative only, never closure)
+T016 -> T017, T018
+T016 -> T019 (only when open_at_path > 0; also needs T003)
+     |
+T020, T021 [P with each other, independent of everything after T014]
+     |
+T016, T017, T018, T019 -> T022
+```
+
+**Parallelizable**: T001, T002, T003, T004, T005 (five, Phase 1), and T020, T021 (two, Phase 5).
+Seven of twenty-two. Everything else is strictly ordered.
+
+**Ordering hazards, stated so they are not rediscovered**:
+
+- **T007 before T008/T009 is not a preference.** A test written after the fix cannot demonstrate it
+  discriminates, and the specific failure mode here (`caplog.text` passing against two of three
+  unfixed sites) is silent.
+- **T002 before any edit.** SC-005 is a before/after diff. There is no way to reconstruct the "before"
+  half afterwards.
+- **T003 before T019, always.** The only alternative probe mutates alert state irreversibly.
+- **T016 before T017 and T018**, because all three read the same paginated snapshot and T016 is the
+  task that validates it was not truncated.
+
+---
+
+## Requirement coverage
+
+Every FR and every SC in `spec.md` maps to at least one task. No gaps.
+
+### Functional requirements
+
+| Requirement | Tasks | How it is checked |
+|---|---|---|
+| **FR-001** no ARN or component in any log record, message or structured context | T006, T008, T009, T010 | Six forbidden strings asserted per record over `getMessage()` plus all of `record.__dict__` |
+| **FR-002** each record still names its source in fixed literal text | T006 (case 1), T008, T009 | Case-sensitive `Tiingo` / `Finnhub` assertion on the rendered message |
+| **FR-003** no new helper, existing sanitizer not called from these sites | T009, T012 | `grep -n "_sanitize_secret_id_for_log"` exits 1; import line unchanged |
+| **FR-004** nothing ARN-derived in message, context or exception message | T006, T008, T009, T010 | Site 1 exception message rebuilt from a literal; T008 grep confines the two config reads to lines 249-250 |
+| **FR-005** the raised failure cannot reintroduce the ARN downstream | T006 (case 4), T008 | Outer-except record pinned; `get_safe_error_info` returns type only |
+| **FR-006** runtime behaviour otherwise unchanged (level, branch, exception type, response) | T008, T009, T011 | Level/branch/type preserved by construction; all 43 pre-existing tests still pass |
+| **FR-007** tests assert over rendered message AND structured context, forbidden strings enumerated, fixture isolated | T006, T007, T010 | Haystack definition, six-string enumeration, `SNS_TOPIC_ARN` / `ALERT_TOPIC_ARN` / `AWS_REGION` / `CLOUD_REGION` isolation; T007 proves it fails on unfixed code |
+| **FR-008** any surviving alert at this path is dismissed with a written justification | T016, T019 | Survivor detection keyed on path plus rule; dismissal comment re-read after writing |
+| **FR-008a** `BLOCKED-ON-OWNER` terminal state, read-only capability probe, handoff artifact | T003, T019, T022 | Probe is scopes plus visibility plus permissions; `dismissal-handoff.md` contents specified; state recorded |
+| **FR-008b** `PENDING-BRANCH-ANALYSIS` terminal state, verification query on record | T016, T022 | T016 carries the query; T022 records the state and points at it |
+| **FR-009** three-element dismissal justification | T019, T020 | Element list enforced at write time and re-read; section 2 of the convention audited |
+| **FR-010** inline rule-id comment at all three sites, unconditionally | T008, T009, T013 | `grep -c "py/clear-text-logging-sensitive-data" handler.py` equals 3 |
+| **FR-011** convention recorded for the sibling feature to cite | T020, T021 | Five-element audit; no line-number citations |
+| **FR-012** no new cloud resources, logging mechanism retained | T012 | grep for `logging.Filter`, `addFilter`, `setFormatter`, `Formatter`, `basicConfig` exits 1 |
+| **FR-013** writable set locked | T002, T013 | Scratch to `/tmp`; `git status --porcelain` shows only the three permitted paths |
+
+15 of 15 functional requirements covered.
+
+### Success criteria
+
+| Criterion | Tasks | How it is checked |
+|---|---|---|
+| **SC-001** zero records carry any enumerated forbidden string, message and structured context | T007, T010 | Red-then-green over all five cases |
+| **SC-002** zero open alerts of this rule at this path, from the default-branch analysis | T016 | Paginated, exit-checked, floor-asserted, keyed on path plus rule |
+| **SC-002a** `fixed_at` non-null and dated at or after the change for anything claimed repaired | T017 | Three rows must print; `dismissed`/`closed` with null `fixed_at` fails |
+| **SC-003** every dismissed alert carries a non-empty three-element comment, or the handoff carries the exact text | T019 | Re-read after write, or `dismissal-handoff.md` content check |
+| **SC-004** existing suite passes, additions only | T005, T011 | 43 before, 43 + N after; `test_handler.py` unmodified per `git status` |
+| **SC-005** alerts elsewhere unchanged in count and `fixed_at` | T002, T018 | Non-empty before/after snapshots diffed per file; any new number on `secrets.py` fails |
+| **SC-006** the convention is findable in one artifact under this feature's directory | T020 | Five-element audit of `codeql-logging-convention.md` |
+
+7 of 7 success criteria covered.
+
+---
+
+## Cross-Artifact Analysis
+
+Scope: `spec.md`, `plan.md`, `research.md`, `codeql-logging-convention.md`, `tasks.md` (this file).
+Every claim below was checked against the repository or the live GitHub API on 2026-07-30, not
+against another document. Adversarial Reviews #1 and #2 are treated as settled and are not re-run;
+this pass looks for what survived them.
+
+### Findings
+
+| # | Severity | Finding | Evidence | Disposition |
+|---|---|---|---|---|
+| **A1** | **HIGH** | **The verification procedure is unpaginated and its all-states half is broken today.** `plan.md`'s Closure evidence block and `codeql-logging-convention.md` section 3 both use `gh api "…/code-scanning/alerts?state=open&per_page=100"` with no `--paginate`. `plan.md` then instructs, for SC-002a and SC-005, to "re-query without the `state` filter". Measured: the repository holds **137** alerts across all states; one page holds 100 and spans alert numbers **59 to 180**. Alerts **1 and 22 through 27 are off page 1**, and those are exactly the alerts SC-005 requires checking on `src/lambdas/shared/secrets.py` and FR-004 cites as its evidence base. The unpaginated all-states query returns **zero** rows for them, which reads as clean. This is campaign rule 2's exact failure shape, surviving in the one document the sibling feature inherits. The `state=open` half happens to be safe right now (5 open alerts total) but is silently fragile. | `gh api --paginate …` returns 137; `gh api …?per_page=100` returns 100; page-1 number range 59 to 180; `jq 'map(select(.number>=22 and .number<=27))\|length'` on page 1 is 0, on the paginated corpus is 6 | Closed in this file: rider 4 plus T002, T016, T017, T018 all use `--paginate` with an exit check and a corpus-count floor. T020 propagates the correction into `codeql-logging-convention.md` so the sibling inherits the fixed shape. `plan.md` is left as the reviewers wrote it; the correction lives here and in the convention |
+| **A2** | **MEDIUM** | **`plan.md`'s local verification procedure names `make validate`, which cannot pass on this tree.** `plan.md` Verification procedure lists `make validate` as a pre-push step, and the Constitution Check §10 row asserts "`make validate` runs before push as usual". Measured: `scripts/check-banned-terms.sh` exits 1 on 17 pre-existing matches in `.secrets.baseline`, `docs/cleanup/diagram-drift.md` and `CLEANUP-BOARD.html`, none of them this feature's. Any task keyed on that command is unsatisfiable, and an implementer who treats the failure as their own will hunt a phantom | `bash scripts/check-banned-terms.sh` exits 1, 17 matches, 0 under `specs/001-ingestion-arn-logging/` | Closed in this file: rider 1, T004 pins the pre-existing count, T014 invokes ruff, bandit and semgrep directly, T013 re-checks the count is still 17 |
+| **A3** | **MEDIUM** | **No artifact requires the regression test to be run against unfixed code.** `plan.md`'s Test design specifies the assertion surface correctly (research D4) but never orders test-before-fix. Adversarial Review #1 established that a rendered-text-only test passes against two of the three unfixed sites; nothing downstream forces anyone to observe that. Without a red gate, a test written after the fix that quietly regressed to `caplog.text` is indistinguishable from a correct one | `plan.md` Test design and `research.md` D4 both describe the surface; neither imposes an order. Phase ordering in `plan.md` is silent | Closed in this file: Phase 2 precedes Phase 3, and T007's pass condition is a specific failure shape (cases 1, 2, 3, 5 red; case 4 green by construction), not merely a non-zero exit |
+| **A4** | **MEDIUM** | **Scanning all of `record.__dict__` collides with `record.pathname` if the path-segment forbidden string is shortened.** The haystack includes `pathname`, an absolute path inside a checkout named `sentiment-analyzer-gsk`. The forbidden string `preprod/sentiment-analyzer` is safe, but the near-miss `sentiment-analyzer` matches every record and fails for a reason unrelated to the ARN. No artifact mentions it. Q3 did this analysis for `SNS_TOPIC_ARN`, `ALERT_TOPIC_ARN` and `AWS_REGION` but stopped at environment values and never considered the record's own intrinsic attributes | `record.pathname` for the handler logger is the absolute path to `src/lambdas/ingestion/handler.py` under the checkout root | Closed in this file: T006 states the constraint and pairs it with the existing `arn:aws:` near-miss warning |
+| **A5** | LOW | **Enumeration count stated three ways.** `spec.md` FR-007 enumerates five and mentions the suffix in prose; `plan.md` says "five classes plus a sixth for completeness"; `research.md` D5 says "Six explicit forbidden strings". Adversarial Review #2 logged this as L2 and left it. All three reconcile at six, but three phrasings invite an implementer to assert five | `spec.md` FR-007, `plan.md` Test design, `research.md` D5 | Closed in this file only: T006 pins the assertion count at six and says so. The three source documents are left as written |
+| **A6** | LOW | **`research.md` D3 attributes a quotation to the wrong docstring.** D3 says `configure_lambda_logging()`'s "own docstring says it 'never attaches handlers or formatters'". That sentence is in the **module** docstring of `src/lambdas/shared/logging_config.py`, not the function's. The claim itself is correct and verified | `src/lambdas/shared/logging_config.py:6-7` (module docstring) versus `:30-37` (function docstring) | Recorded, not fixed. No behavioural consequence |
+| **A7** | LOW | **`spec.md` Q1 undercounts the `TD-024` contention.** Q1 says "both features would claim `TD-024`"; Adversarial Review #2 L1 already noted three siblings contain it. The conclusion (do not pre-reserve) is strengthened, not weakened | `spec.md` Q1, `plan.md` Adversarial Review #2 L1 | Recorded, not fixed. Rider 5 in this file forbids pre-reservation outright |
+
+**Requirement coverage gaps**: none. 15 of 15 FRs and 7 of 7 SCs map to at least one task; see the
+coverage tables above.
+
+**Tasks with no requirement behind them**: T001 (interpreter precondition) and T015 (pull request
+run) trace to no FR or SC. Both are deliberate. T001 guards every later `pytest` result against
+`plan.md`'s stated Python 3.13 requirement, which the system interpreter does not satisfy. T015
+exists precisely to be **non-closing**, capturing SC-002's "useful inverse" while stating in its own
+pass condition that it closes nothing. Neither inflates the coverage tables.
+
+**Unfalsifiable pass conditions**: none remaining. Every task that reads from `gh`, a pipe or a log
+carries an explicit exit-code check plus a proof-of-read assertion (T002 and T016 a corpus-count
+floor, T017 a row count, T018 a non-empty file check). The three places where an empty result is the
+pass, T012 and T021, check `grep`'s exit code explicitly rather than inferring cleanliness from
+silence. T015 is deliberately verdict-free and says so.
+
+**Contradictions between artifacts**: A1 and A2 are the two live ones, both between `plan.md` (and,
+for A1, the convention) and the measured repository rather than between two documents. Adversarial
+Review #2 already resolved the post-clarification drift set (C1, H1 to H6, M1 to M3) by edit, and
+spot checks confirm those fixes landed: `codeql-logging-convention.md` section 5b now carries the
+public-repository correction; `plan.md` Terminal States now lists four states with
+`PENDING-BRANCH-ANALYSIS` marked expected; `plan.md` Constraints and Project Structure both carry the
+Q4 directory carve-out; `research.md` D5's second fixture ARN carries the full path segment. Two
+Adversarial Review #2 items were knowingly left open in `spec.md` (M4, `CLOUD_REGION` absent from
+FR-007's variable list; M5, FR-008b not saying where the query is recorded). This file closes both
+operationally: T006 requires `CLOUD_REGION` be cleared or pinned, and T022 makes the Terminal State
+Record the place the query is recorded.
+
+**Live state cross-check**, 2026-07-30: alerts 148 (line 264), 149 (271), 150 (276) open at
+`src/lambdas/ingestion/handler.py` with `fixed_at` null; 144 open at
+`src/lambdas/shared/auth/oauth_state.py:104`; 22 through 25 dismissed with `fixed_at` null; 26 and 27
+dismissed with non-null `fixed_at`; alert 117 `fixed_at` `2026-01-20T22:34:56Z` and alert 144
+`created_at` the identical timestamp. Every factual claim the artifacts make about alert state checks
+out. Token scopes `gist, read:org, repo, workflow`; repository `public`; `push: true`.
+
+### Verdict
+
+**PASS with two actionable findings, neither blocking implementation.**
+
+A1 (HIGH) and A2 (MEDIUM) are both defects in the recorded verification procedure rather than in the
+code design, and both are closed inside this task list before any implementer can trip on them. A1
+additionally requires the one-line propagation into `codeql-logging-convention.md` carried by T020,
+because that document is inherited by citation and would otherwise hand the sibling feature a query
+that reads truncation as cleanliness. The code change design, the assertion surface, the terminal
+states and the scope lock are all internally consistent and match the live repository. No CRITICAL
+finding. Tasks are dependency-ordered, each independently checkable, and no pass condition is
+unfalsifiable.
+
+---
+
+## Adversarial Review #3
+
+Final gate before implementation. The reviewer authored none of these artifacts. Method was
+**execution, not reading**: every read-only command `tasks.md` prescribes was actually run, plus a
+throwaway implementation of T006's test design in `/tmp` executed against the unfixed handler to
+verify T007's required failure shape. Nothing was written outside
+`specs/001-ingestion-arn-logging/`. Adversarial Reviews #1 and #2 and the Cross-Artifact Analysis are
+treated as settled history and are not rewritten.
+
+Findings are numbered R1 onward to avoid collision with A1 to A7 above.
+
+### What was executed, and what it returned
+
+| Ran | Result |
+|---|---|
+| T001 interpreter | `3.13.0 (main, Jan 15 2026)`. PASS |
+| T002 alerts baseline, verbatim | `gh` exit 0; corpus **137**; rule total **22**; all four row conditions verified: `148 open null handler.py:264`, `149 ... :271`, `150 ... :276`, `144 open null oauth_state.py:104`, `22-25 dismissed fixed_at=null secrets.py`. PASS |
+| T002 floor justification | Unpaginated `per_page=100` returns **9** of this rule, number range **59 to 180**. Unpaginated with **no** `per_page` returns 30 alerts and **0** of this rule. Both claims verified |
+| T003 capability probe | `gh auth status` exit 0; scopes `gist, read:org, repo, workflow`; `{"visibility":"public","permissions":{"admin":true,"push":true,...}}`. Verdict **`DISMISSAL-AVAILABLE`**. PASS |
+| T004 banned terms | exit `1`, total `17`, feature-directory `0`. PASS on the numbers, but the file attribution was wrong (R9) |
+| T005 suite baseline | `43 passed in 2.42s`, exit 0. PASS |
+| T008 pass-condition grep | Returns **8** lines today (249, 250, 261, 262, 271, 276, **601, 602**), not the two the task assumes. **R1** |
+| T012 all three greps | grep1 exit `1` (no sanitizer call); grep2 one line, `115:from src.lambdas.shared.secrets import get_api_key`; grep3 exit `1`. All three behave as specified |
+| T013 `git status --porcelain` | Lists four untracked spec directories, three of them siblings'. Condition 1 fails against a correct implementation. **R2** |
+| T014 all four scanners | `ruff check` 0 ("All checks passed"), `ruff format --check` 0 ("1 file already formatted"), `bandit` 0 (0 issues at any severity), `semgrep scan --config auto` 0 (**281 rules actually ran**, 0 findings, no login required). T014 is executable as written and the scanners are not silently skipping |
+| T016 NOT-YET-EVALUABLE probe, verbatim | Printed **10 lines**, one `.[0]` per page. **R4** |
+| T017 jq pipeline | Three rows printed, `PIPESTATUS[0]` 0. Mechanically sound |
+| T018 loop | Ran with a stand-in `after` snapshot: both `diff_exit` 0, `secrets.py` 16 rows, `oauth_state.py` 2 rows, non-empty checks fire correctly. Mechanically sound, but blind outside its two hardcoded paths. **R3** |
+| T020 / T021 checks | T021 `grep_exit=1`, no output: PASS, and live (grep exits 2 on a missing file). T020's paginate count is `0` today, correctly reflecting the not-yet-fixed state, but the check is too weak. **R6** |
+| **T006/T007 design, implemented and run against the unfixed handler** | **5 failed, 2 passed.** Cases 1, 2, 3, 5 **RED**; case 4 **GREEN**. Exactly T007's required shape |
+| Case-2 leak location | `leak '<tiingo ARN>' at ['dict:tiingo_secret_arn'] on msg='Running in degraded mode: Tiingo adapter unavailable'`. T007's third condition is real and satisfiable |
+| **`caplog.text` control** | **PASSED** on the unfixed tiingo-only case. The campaign's central claim, that a rendered-text-only test proves nothing at the two `extra=` sites, is confirmed by execution rather than inherited |
+| `record.pathname` collision control | Failed at `['dict:pathname']` with pathname `<checkout>/.venv/lib/python3.13/site-packages/botocore/credentials.py`. Real, and broader than stated. **R8** |
+| SC-005 path census | This rule sits on **four** paths: `handler.py` 3, `secrets.py` 16, `oauth_state.py` 2, **`errors.py` 1**. **R3** |
+| `rule@path` multiplicity census | Not a unique key. Open set: this rule at `handler.py` count **3** (alerts 150, 149, 148). Whole corpus max group sizes: `py/log-injection@dashboard/auth.py` **24**, `@ohlc.py` **17**, this rule `@secrets.py` **16**. **R13** |
+| Mistyped-field-path reproduction | `.locatio.path`: `null_paths=137`, anchor `0`, **`jq_exit=0`**. Correct path: `null_paths=0`, anchor `16`, `jq_exit=0`. Filtered for this rule at this path under the typo: **`0`**, which is T016's PASS value. **R12** |
+| Three-bucket diff, partial-loss direction | Fixture cutting `secrets.py` 16 to 1 plus a new alert at `parallel_fetcher.py`: `changed:[{secrets.py, before:16, after:1}]`, `appeared:[parallel_fetcher.py]`, `disappeared:[]`. Caught |
+| Membership-only control, same fixture | `disappeared: []`. The 16-to-1 loss was **invisible**. Defect reproduced |
+| Three-bucket diff, no-change direction | Identical before and after: all three buckets `[]`. No false positive |
+
+Read, not run: `plan.md`, `spec.md`, `research.md`, `codeql-logging-convention.md`,
+`checklists/requirements.md`, and the handler and test sources.
+
+### Findings
+
+| # | Severity | Finding | Evidence | Disposition |
+|---|---|---|---|---|
+| **R1** | **HIGH** | **T008's pass condition was unsatisfiable by a correct implementation.** It required the ARN-key grep to return "exactly two lines, both at 249-250". Lines **601-602** are `_get_config()`'s `os.environ["TIINGO_SECRET_ARN"]` / `["FINNHUB_SECRET_ARN"]` dict construction. They are not logging, they are load-bearing, and they survive the fix. A correct implementation returns **four** lines. An implementer taking the condition literally either halts on a phantom failure or, worse, refactors `_get_config()` to satisfy it, breaking the handler. This is the "control check that fails a correct implementation" class the campaign has hit before | `grep -n "tiingo_secret_arn\|finnhub_secret_arn" src/lambdas/ingestion/handler.py` returns 8 lines today; 601-602 are inside `_get_config()` | **Fixed.** T008's pass condition rewritten: line count exactly 4, plus a second grep asserting **0** of the survivors sit in a logging call, an f-string or a `RuntimeError` construction. That second grep is the part that actually encodes the requirement |
+| **R2** | **HIGH** | **T013 condition 1 fails today, before any implementation work, because of sibling features' untracked directories.** This campaign runs four features in one shared worktree. `git status --porcelain` already lists `specs/001-bad-tag-filter-dead-suppression/`, `specs/001-codeql-coverage/` and `specs/001-oauth-provider-taint/`. T013 declares any path outside three permitted patterns "a breach of FR-013 and of SC-005". The dangerous failure mode is not the false alarm, it is an implementer "resolving" the breach by deleting three sibling agents' work | `git status --porcelain` returns 4 untracked directories, measured 2026-07-30 | **Fixed.** T013 now uses `git status --porcelain` with explicit sibling pathspec exclusions, counts lines outside the permitted set with `grep -cv` (must be 0), asserts the status file is non-empty first so an empty read cannot pass as clean, and carries an explicit "never delete a sibling directory" instruction |
+| **R3** | **MEDIUM** | **T018 cannot detect the SC-005 breach it exists to detect, outside two hardcoded paths.** SC-005 requires alerts of this rule outside the handler to be unchanged **in count**. T018 loops over `secrets.py` and `oauth_state.py` only. `src/lambdas/shared/errors.py` (alert 1) is never read, and a regression surfacing at a fifth path is structurally invisible. A per-file loop cannot answer a corpus-level question | Path census: 4 paths carry this rule; T018 reads 2 of the 3 non-handler paths | **Fixed.** A whole-corpus before/after diff added to T018, filtering only `path != handler.py`, with a row-count floor of 15 (measured 19) as its proof-of-read |
+| **R4** | **MEDIUM** | **T016's NOT-YET-EVALUABLE probe combines `--paginate` with `--jq`, the exact per-page defect rider 4 exists to prevent.** Run verbatim it emits ten `{commit_sha, created_at}` objects, one per page of analyses, with no rule for choosing among them. The task then says "compare the sha against the merge commit", singular. Line one happens to be right, which is what makes it dangerous: it works by accident and teaches the wrong shape inside the file that establishes the convention | Executed: `stdout_lines=10`, first row `c01017888484bd5a0fdec9a32ded42378829f6dc` (matches `main` HEAD) | **Fixed.** Replaced with a `per_page=1`, no-`--paginate`, file-plus-standalone-`jq` shape carrying an exit check and a row-count assertion |
+| **R5** | **MEDIUM** | **T013 condition 5 names a command that cannot evaluate its own condition.** `git diff --stat` emits insertion and deletion counts per file. It contains no line numbers, so "shows a net change confined to the `256-277` region" is not checkable from its output. An implementer either reports a pass having verified nothing, or silently substitutes a different command | `git diff --stat` output format | **Fixed.** Condition 5 now reads `git diff -U0 ... \| grep -E '^@@'` and checks the hunk headers |
+| **R6** | **MEDIUM** | **T020's mechanical check does not cover the defect T020 exists to fix.** The substantive defect in `codeql-logging-convention.md` is not the missing `--paginate`; it is the sentence `Empty output is the pass condition.` at line 112, sitting under an unguarded query, in the one document the sibling feature inherits by citation. T020's pass condition is `grep -c -- "--paginate" >= 1`. Add the flag, leave the sentence, and T020 passes while the vacuous pass ships to the sibling | Convention line 106 query has no `--paginate`; line 112 carries the sentence; `grep -c -- "--paginate"` returns `0` | **Fixed.** T020 now additionally requires the stale sentence to be **gone** (`grep` exit 1, and the task states that exit 2 is a FAIL so the absence is itself live-checked) and requires the replacement text to carry exit-code and floor language |
+| **R7** | **MEDIUM** | **No artifact named the entrypoint, and the obvious guess is wrong.** T006 says "so the handler reaches line 249" and specifies patch targets, but never names the function under test. `from src.lambdas.ingestion.handler import handler` raises `ImportError`; the entrypoint is `lambda_handler` at `handler.py:168`, mentioned exactly once across all artifacts, in passing, in `plan.md` | Executed: `ImportError: cannot import name 'handler' from 'src.lambdas.ingestion.handler'` | **Fixed.** T006 now names `lambda_handler`, gives the call shape with a `MagicMock` context carrying `aws_request_id`, and notes that this mistake makes case 4 fail too, so T007's shape check catches it |
+| **R8** | **MEDIUM** | **The `record.pathname` collision is broader than A4 states, and the case-5 sweep is hostage to third-party logging.** `caplog` captures records from `botocore`, `src.lambdas.ingestion.parallel_fetcher` and `src.lambdas.shared.failure_tracker` during the case-1 invocation. `caplog.records[0]` is a botocore record whose `pathname` is `<checkout>/.venv/lib/python3.13/site-packages/botocore/credentials.py`, so the shortened-string collision fires through dependency paths too, not only through the handler's own source path. An unrestricted sweep also makes this suite fail whenever any dependency logs a string that happens to match | Executed: pathname printed above; sweep captured 4 distinct logger names | **Fixed.** T006 now requires the per-record loops and the case-5 sweep to filter on `r.name`, and records the wider collision surface. The six forbidden strings are all ARN-specific enough to be safe today; the filter is what keeps that true |
+| **R9** | **LOW** | **Rider 1, T004's rationale and Cross-Artifact Analysis A2 all misattribute the 17 banned-term matches.** They name `.secrets.baseline`, `docs/cleanup/diagram-drift.md` and `CLEANUP-BOARD.html`, which together account for **7** of 17. The largest contributor, `specs/1157-auth-cache-headers/` with **9**, is not mentioned at all, nor is `specs/1268-cors-404-headers/plan.md`. The count, the exit code and the "none of them is ours" conclusion are all correct; only the provenance is wrong. It matters because an implementer who sees the count move will look in the wrong three files | Executed: `grep '^  \./' /tmp/banned.out \| sed 's/:.*//' \| sort \| uniq -c` | **Fixed in rider 1** with the measured breakdown. A2's own text is left as the reviewer wrote it, per the append-only rule for prior reviews |
+| **R10** | **LOW** | **The count-17 invariant in T013 is fragile under concurrent sibling work.** `check-banned-terms.sh` scans all of `specs/`, and three sibling features are writing there in this same worktree right now. A banned term landing in any sibling directory moves the total and fails T013 for a reason this feature did not cause | Four `001-*` spec directories untracked in one worktree | **Fixed.** T013 condition 3 demoted: the feature-directory count of `0` is the gate, the total is expected-but-not-binding, and the task says to diff the two `/tmp` capture files to attribute any movement |
+| **R11** | **MEDIUM** | **T007's third pass condition was not observable from the test T006 specified.** T007 requires seeing the ARN arrive "through a `record.__dict__` value and **not** through the rendered message". T006's haystack helper joins `getMessage()` and every `str(v)` into one string, which discards the key. Pytest's assertion diff then shows only that the string is present somewhere in a blob. Confirmed by implementing T006 as written: a `where(record, needle)` helper had to be added before the required evidence appeared | Executed: with the helper, case 2 reads `at ['dict:tiingo_secret_arn']`; without it, the failure is an undifferentiated blob | **Fixed.** T006 now makes the location-reporting helper mandatory and requires its output in every assertion message |
+
+| **R12** | **CRITICAL** | **A corpus floor does not protect against a wrong field path, and T016's gate reads `0` from a completely blind read.** Mistyping `.most_recent_instance.location.path` as `.locatio.path` makes `jq` return `null` for every alert. It does not error, it exits `0`. T016's `total` floor still passes because `total` is computed from `.rule.id`, a field the typo does not touch. `open_at_path` then evaluates to **`0`**, which is T016's PASS value. Every clause of the pass condition was satisfiable while reading nothing, and the blind read reports this feature's primary success criterion, SC-002, as met. This is the most dangerous finding in this review: it converts the feature's central gate into a rubber stamp via a one-character typo | Reproduced on the live corpus 2026-07-30: correct path `null_paths=0 anchor=16`; mistyped path `null_paths=137 anchor=0`; `jq_exit=0` **both times**. The filtered read for this rule at this path returned `0` under the typo | **Fixed.** T016 and T018 now carry two positive-anchor clauses each: `null_paths` must be exactly `0`, and a known-present value (`secrets.py`, floor 15) must be seen **through the same field path** the gate filters on. T002's conditions 3 and 4 were already an anchor of this shape and are now labelled as one so they cannot be reduced to a count |
+| **R13** | **HIGH** | **`rule@path` is not a unique key, and R3's own corpus check compared membership where it needed multiplicity.** Measured on the live corpus, `py/log-injection@src/lambdas/dashboard/auth.py` holds **24** alerts under one key, `ohlc.py` 17, and inside this feature's own SC-005 scope `py/clear-text-logging-sensitive-data@src/lambdas/shared/secrets.py` holds **16**. A set-diff keyed on `rule@path` reports only whether a key exists, so 15 of those 16 could vanish silently. `secrets.py` is the single highest-value file in this feature's blast radius, the one FR-013 names explicitly, which is precisely where the blindness is worst | Reproduced: on a fixture cutting `secrets.py` from 16 to 1, membership-only returned `disappeared: []` while three-bucket returned `changed: [{key: ...secrets.py, before: 16, after: 1}]` | **Fixed.** T018's corpus check now builds `{key: count}` on both sides and reports **three** buckets, `disappeared` / `appeared` / `changed`, so a partial loss has somewhere to land. Verified in both directions including the no-change case, which returns all three empty |
+
+Counts: 1 CRITICAL, 3 HIGH, 7 MEDIUM, 2 LOW. All 13 fixed by edit inside
+`specs/001-ingestion-arn-logging/tasks.md`.
+
+### Positive-anchor inventory
+
+Applying the campaign rule that **exit code plus corpus floor is necessary and not sufficient**, every
+absence-based check in this file was re-audited for a positive anchor. An anchor means a known-present
+value is shown present **through the same field path** the pass condition filters on.
+
+| Check | Absence it reads | Positive anchor | Status |
+|---|---|---|---|
+| **T002** | none (baseline capture) | conditions 3 and 4 print named paths verbatim through `.location.path` | **Anchored**, now labelled as such |
+| **T016** | `open_at_path == 0` | `null_paths == 0` plus `secrets.py` count at least 15 | **Anchored** (added) |
+| **T017** | rows claimed repaired | three rows must print; reads `.number`/`.state`/`.fixed_at`, and a mistyped field yields `null`, which is the **FAIL** direction | **Anchored by direction**, no change needed |
+| **T018** per-file loop | per-alert row diff | `[ -s ]` non-empty check per snapshot | **Anchored** already |
+| **T018** corpus block | three buckets empty | `null_paths == 0`, `secrets.py` anchor, `rows` floor | **Anchored** (added) |
+| **T012** | three greps returning nothing | `grep` exit is checked explicitly; exit `2` on a missing file distinguishes "read failed" from "no match", and grep 2 prints a known-present line | **Anchored by exit code** |
+| **T020** | stale sentence gone | `grep` exit `1` is the pass and exit `2` is declared a FAIL, so the file is proven readable | **Anchored by exit code** |
+| **T021** | no line-number citations | same `grep` exit-code discipline | **Anchored by exit code** |
+| **T013** scope lock | no path outside the permitted set | status file asserted **non-empty** before the `grep -cv` count | **Anchored** (added under R2) |
+
+The two that needed real work were T016 and T018, and both were the gates carrying this feature's
+success criteria. The `grep`-based checks were already safe for a reason worth stating: `grep`
+distinguishes "no match" (exit 1) from "could not read" (exit 2), which is the exact distinction `jq`
+does **not** make. That asymmetry is why the `jq` reads were the ones that failed this audit.
+
+### Vacuous pass conditions
+
+The sweep covered the SC block, the FR block, acceptance scenarios, Independent Tests, Edge Cases and
+both decision gates (T019's branch table and T022's terminal-state table), per the campaign rule that
+**an absence is never evidence until the reader proves the read was working**.
+
+Result: the task list was in good shape on the exit-code-and-floor axis, but that axis turned out not
+to be the whole test. R12 showed a floor-satisfying read that saw nothing at all, so the sweep was
+re-run against the stronger standard and its results are tabulated below. T002 and T016 carry corpus floors, T017 a row count, T018 non-empty file checks, T012
+and T021 explicit `grep` exit-code checks, T015 is deliberately verdict-free and says so. The three
+genuine liveness holes found were all outside that hardened set: T013 condition 1 could be satisfied
+by an empty status read (fixed), T018 was structurally blind rather than unproven (fixed), and T020's
+own pass condition permitted the vacuous pass in the inherited convention to survive verbatim (fixed).
+T020's replacement is itself now live-checked, since `grep` returns 2 rather than 1 on a missing file
+and the task states that 2 is a FAIL.
+
+### Ordering hazards
+
+The four hazards already listed under "Ordering hazards, stated so they are not rediscovered" all
+hold and were confirmed. Three more, none of which the list carried:
+
+1. **T007 in isolation versus T011 in sequence.** T007 runs the new module alone; T011 runs the whole
+   `tests/unit/lambdas/ingestion/` directory, where `test_handler.py`'s `env_vars` fixture sets
+   `TIINGO_SECRET_ARN` to an unrelated `us-east-1` / `123456789` ARN. Both fixtures must pop on
+   teardown or the isolation guarantee in T006 holds only in the isolated run. T006 already requires
+   full teardown; this is the reason it matters, stated so it is not optimised away.
+2. **The new test file is untracked when T014 runs.** `semgrep` scans **git-tracked files only** and
+   reports success on a file it never opened. T014 happens to point semgrep at `handler.py` alone, so
+   this is latent rather than live, but anyone widening T014's semgrep target to the test file will
+   get a silent skip reported as a pass. Recorded, not fixed, since T014 as written is correct.
+3. **T018's whole-corpus check must run after T016, not beside it.** It reuses
+   `/tmp/codeql-alerts-after.json`, and T016 is the task that proves that file was not truncated. The
+   dependency graph already orders `T016 -> T018`; the new corpus block does not change that.
+
+### Highest-risk task
+
+**T006.** Named explicitly. It is the only task that produces new code from prose rather than
+executing a prescribed command, and its output is the feature's entire regression guarantee. It
+carries six forbidden strings with two documented near-miss traps, a four-variable environment
+isolation constraint including one variable (`CLOUD_REGION`) that no other artifact lists, a
+non-obvious assertion surface, a mandatory duplicated autouse fixture, five cases of which one must be
+green for a reason unrelated to the fix, an entrypoint name that was absent from every artifact until
+this review, and a helper whose absence makes the next task's gate unobservable. Every one of those is
+a way to write a file that looks right and proves nothing. T007 exists precisely because T006 cannot
+be trusted on inspection, and T007's value is entirely contingent on T006 producing a discriminating
+test rather than a plausible one.
+
+### Most likely source of rework
+
+**The pass conditions of T008 and T013, not the code change they guard.** Named explicitly. The code
+change itself is four lines deleted and three comments added, fully specified, with the shape chosen
+from in-repository precedent and the losing alternative named and forbidden. There is very little to
+get wrong. The rework risk sits in the verification scaffolding around it: R1 and R2 were both control
+checks that failed a correct implementation, and both would have sent an implementer to modify working
+code, `_get_config()` in one case and sibling agents' directories in the other, to satisfy a check
+rather than a requirement. That is rework that damages rather than merely wastes. Both are fixed
+above; the class is worth watching because it produced two of this review's findings and, per the
+briefing, a third of the campaign's.
+
+### Verdict
+
+**READY FOR IMPLEMENTATION**
+
+One CRITICAL, R12, found in the corpus-wide wave after the first pass of this review and fixed by
+edit. It deserves naming plainly: T016's pass condition, the gate carrying SC-002, could be satisfied
+in full by a `jq` read that saw nothing, because a mistyped field path returns `null` rather than
+erroring and the corpus floor was computed from a different field. Three HIGH findings, R1, R2 and
+R13, were all blocking as written and all are fixed by edit in this file. The seven MEDIUM and two LOW findings are fixed. Every read-only command the task
+list prescribes has now been executed against the live repository and the live GitHub API rather than
+read, and each returned what the artifacts claim, with the eleven exceptions itemised above. T014's
+four scanners were confirmed to actually run rather than silently skip. The RED gate was confirmed
+achievable by building T007's target and observing the required failure shape, cases 1, 2, 3 and 5
+red with case 4 green, and the `caplog.text` control was confirmed to pass on unfixed code, which is
+the premise the whole test design rests on.

--- a/specs/001-ingestion-arn-logging/tasks.md
+++ b/specs/001-ingestion-arn-logging/tasks.md
@@ -53,12 +53,12 @@
 read-only. Every task here is read-only against the repository. T001 through T005 are mutually
 independent.
 
-- [ ] **T001** [P] **Interpreter precondition.**
+- [x] **T001** [P] **Interpreter precondition.**
   Command: `source .venv/bin/activate && python -c "import sys; print(sys.version)"`
   **PASS**: the printed version starts with `3.13.`. **FAIL**: anything starting `3.12.` means the
   venv is not active and every later `pytest` result is against the wrong interpreter.
 
-- [ ] **T002** [P] **Capture the pre-change code scanning baseline (SC-005 "before" half, and the
+- [x] **T002** [P] **Capture the pre-change code scanning baseline (SC-005 "before" half, and the
   proof-of-read floor every later query reuses).** Output goes to `/tmp`, never into the repo.
 
   ```bash
@@ -98,7 +98,7 @@ independent.
   floor computed from `.rule.id`. If conditions 3 and 4 print, that field path is proven live for the
   whole run.
 
-- [ ] **T003** [P] **Read-only dismissal capability probe (FR-008a).** Never establish this by
+- [x] **T003** [P] **Read-only dismissal capability probe (FR-008a).** Never establish this by
   attempting a dismissal: a dismissal that succeeds mutates alert state, cannot be cleanly reverted,
   and SC-005 treats unintended alert-state change as a breach.
 
@@ -121,7 +121,7 @@ independent.
   Verdict on this environment is **`DISMISSAL-AVAILABLE`**, so `BLOCKED-ON-OWNER` is not the expected
   ending. Record the verdict verbatim; T019 and T022 both read it.
 
-- [ ] **T004** [P] **Pin the pre-existing repository-wide gate failure (rider 1).**
+- [x] **T004** [P] **Pin the pre-existing repository-wide gate failure (rider 1).**
 
   ```bash
   bash scripts/check-banned-terms.sh > /tmp/banned.out 2>&1; echo "exit=$?"
@@ -134,7 +134,7 @@ independent.
   is anything but 0, which would mean this feature introduced a banned term. Re-run this exact task
   after T008 and T009 as part of T013.
 
-- [ ] **T005** [P] **Baseline the ingestion unit suite (SC-004 "before" half).**
+- [x] **T005** [P] **Baseline the ingestion unit suite (SC-004 "before" half).**
   Command: `source .venv/bin/activate && python -m pytest tests/unit/lambdas/ingestion/ -q; echo "exit=$?"`
   **PASS**: exit `0` and the summary line reads `43 passed`. Measured 2026-07-30: 43 collected in the
   directory, of which `test_handler.py` contributes 22. Record both numbers; T011 asserts against
@@ -153,7 +153,7 @@ spec edge case "A test asserts on rendered log text only", research D4).
 
 **Independent test**: T007's RED gate is itself the proof the guard discriminates.
 
-- [ ] **T006** [US1] **Create `tests/unit/lambdas/ingestion/test_handler_arn_logging.py`.** New file
+- [x] **T006** [US1] **Create `tests/unit/lambdas/ingestion/test_handler_arn_logging.py`.** New file
   only. `tests/unit/lambdas/ingestion/test_handler.py` is not opened for editing at any point
   (SC-004 is then satisfied mechanically).
 
@@ -264,7 +264,7 @@ spec edge case "A test asserts on rendered log text only", research D4).
   **PASS**: the file exists, imports resolve, and `python -m pytest tests/unit/lambdas/ingestion/test_handler_arn_logging.py --collect-only -q`
   exits 0 and collects at least 5 tests.
 
-- [ ] **T007** [US1] **RED gate. Run the new module against the UNFIXED handler.** This is the single
+- [x] **T007** [US1] **RED gate. Run the new module against the UNFIXED handler.** This is the single
   most important gate in the feature and it can only be run before Phase 3.
   Command: `source .venv/bin/activate && python -m pytest tests/unit/lambdas/ingestion/test_handler_arn_logging.py -v; echo "exit=$?"`
   **PASS** requires the exact failure shape, not merely a non-zero exit:
@@ -290,7 +290,7 @@ the three sites in `src/lambdas/ingestion/handler.py:256-277`.
 
 **Independent test**: T010 plus T011.
 
-- [ ] **T008** [US1] **Site 1, `handler.py:259-265` (the definitely-rendered one).** `error_msg` is
+- [x] **T008** [US1] **Site 1, `handler.py:259-265` (the definitely-rendered one).** `error_msg` is
   built by f-string from `config['tiingo_secret_arn']` and `config['finnhub_secret_arn']`, passed to
   `logger.error()`, then reused verbatim as the `RuntimeError` message. Both uses are sinks.
   Replace the f-string with a fixed literal naming both sources, for example
@@ -318,7 +318,7 @@ the three sites in `src/lambdas/ingestion/handler.py:256-277`.
   call, an f-string or a `RuntimeError` construction. **FAIL** on a line count other than 4, or a
   second count other than 0.
 
-- [ ] **T009** [US1] **Sites 2 and 3, `handler.py:268-277` (the structured-context ones).** Delete the
+- [x] **T009** [US1] **Sites 2 and 3, `handler.py:268-277` (the structured-context ones).** Delete the
   `extra={...}` argument outright at both warnings. The messages already carry the literal source
   names, so nothing an on-call engineer uses is lost. **Do not** substitute a sanitized value: that is
   the `0e7a375` shape, it already failed in this repository, and FR-003 forbids it. Add the FR-010
@@ -334,20 +334,20 @@ the three sites in `src/lambdas/ingestion/handler.py:256-277`.
   armed by a future formatter plus an alert the engine raises regardless of rendering, not a live
   disclosure. Site 1 is the live one.
 
-- [ ] **T010** [US1] **GREEN gate (SC-001, FR-007).**
+- [x] **T010** [US1] **GREEN gate (SC-001, FR-007).**
   Command: `source .venv/bin/activate && python -m pytest tests/unit/lambdas/ingestion/test_handler_arn_logging.py -v; echo "exit=$?"`
   **PASS**: exit `0`, all 5 cases pass, zero skips, zero xfails. A skipped case is a failure of this
   task. Cross-check against T007's recorded failure list: cases 1, 2, 3 and 5 must have flipped from
   red to green, which is the only evidence that the fix, and not the test, changed.
 
-- [ ] **T011** [US1] **SC-004 regression: nothing existing loosened or removed.**
+- [x] **T011** [US1] **SC-004 regression: nothing existing loosened or removed.**
   Command: `source .venv/bin/activate && python -m pytest tests/unit/lambdas/ingestion/ -q; echo "exit=$?"`
   **PASS**: exit `0`, and the summary reads `48 passed` (T005's 43 plus the 5 new cases); the count
   MUST be `43 + N` where N is the number of new cases, never fewer than 43 pre-existing.
   Additionally: `git status --porcelain tests/unit/lambdas/ingestion/test_handler.py` prints nothing,
   proving the existing module was not touched at all.
 
-- [ ] **T012** [US1] **Static negative checks (FR-003, FR-012).**
+- [x] **T012** [US1] **Static negative checks (FR-003, FR-012).**
 
   ```bash
   grep -n "_sanitize_secret_id_for_log" src/lambdas/ingestion/handler.py; echo "grep_exit=$?"
@@ -361,7 +361,7 @@ the three sites in `src/lambdas/ingestion/handler.py:256-277`.
   Here an exit of `1` from `grep` is the pass, and it is checked explicitly rather than inferred from
   silence.
 
-- [ ] **T013** [US1] **Scope lock and comment presence (FR-013, FR-010).**
+- [x] **T013** [US1] **Scope lock and comment presence (FR-013, FR-010).**
 
   ```bash
   git status --porcelain -- ':!specs/001-bad-tag-filter-dead-suppression' \
@@ -397,7 +397,7 @@ the three sites in `src/lambdas/ingestion/handler.py:256-277`.
      (`git diff --stat` was named here previously and cannot evaluate this: it emits insertion and
      deletion counts only, with no line regions. Adversarial Review #3 finding R5).
 
-- [ ] **T014** [US1] **Targeted lint, format and SAST on the touched files only.** Do not invoke
+- [x] **T014** [US1] **Targeted lint, format and SAST on the touched files only.** Do not invoke
   `make validate` (rider 1).
 
   ```bash
@@ -641,7 +641,7 @@ instead of re-deriving the convention. `codeql-logging-convention.md` already ex
 audit it against what this feature actually did. Both are read-only against everything except that
 one file and are mutually independent.
 
-- [ ] **T020** [P] [US3] **FR-011 and SC-006 conformance audit of `codeql-logging-convention.md`.**
+- [x] **T020** [P] [US3] **FR-011 and SC-006 conformance audit of `codeql-logging-convention.md`.**
   Confirm by reading that all five required elements are present and correct:
   1. the decision rule for rewrite versus dismiss (section 1, steps 1 to 4),
   2. the three-element dismissal wording pattern and its template (section 2),
@@ -676,7 +676,7 @@ one file and are mutually independent.
   sentence present at line 112. **FAIL**: any element missing, the query shape left unpaginated, or
   the unguarded pass sentence still present. (Adversarial Review #3 finding R6.)
 
-- [ ] **T021** [P] [US3] **Sibling citation readiness (FR-011).**
+- [x] **T021** [P] [US3] **Sibling citation readiness (FR-011).**
   Command:
   `grep -nE "spec\.md:[0-9]+|plan\.md:[0-9]+|tasks\.md:[0-9]+|research\.md:[0-9]+" specs/001-ingestion-arn-logging/codeql-logging-convention.md; echo "grep_exit=$?"`
   **PASS**: `grep_exit` is `1` with no output. The convention must be citable by document and section,
@@ -691,7 +691,7 @@ pattern, the verification caveats and both terminal states from one file (SC-006
 
 ## Phase 6: Terminal state, recorded explicitly
 
-- [ ] **T022** **Determine and RECORD the terminal state.** Reaching a terminal state is an explicit,
+- [x] **T022** **Determine and RECORD the terminal state.** Reaching a terminal state is an explicit,
   written outcome. An implementation that stops without filling in the record below has not completed
   this task, regardless of how much code it wrote.
 
@@ -720,17 +720,37 @@ pattern, the verification caveats and both terminal states from one file (SC-006
 
 ## Terminal State Record
 
-*Filled in by T022. Leave the placeholders until then.*
+*Filled in by T022.*
 
-- **Date**: `<YYYY-MM-DD>`
-- **Terminal state**: `<PENDING-BRANCH-ANALYSIS | DONE | DONE (dismissed) | BLOCKED-ON-OWNER>`
-- **T003 capability verdict**: `<DISMISSAL-AVAILABLE | DISMISSAL-ABSENT>` (probed read-only; measured
-  `DISMISSAL-AVAILABLE` on 2026-07-30)
-- **T016 result**: `<open_at_path value, or "not runnable: reason">`
-- **Verification query of record**: T016 in this file (paginated, exit-checked, floor-asserted)
-- **Outstanding owner action**: `<none | apply dismissal-handoff.md | re-run T016 after the next
-  default-branch analysis | add the next free TECH_DEBT_REGISTRY identifier if the dismissal branch
-  fired>`
+- **Date**: `2026-07-31`
+- **Terminal state**: `PENDING-BRANCH-ANALYSIS` (FR-008b). Reported as **neither done nor failed**.
+  This is the expected ending of implementation, not a failure: SC-002 and SC-002a are keyed to a
+  default-branch CodeQL analysis on a commit that includes the change, and no such analysis can exist
+  while the change sits on a feature branch.
+- **T003 capability verdict**: `DISMISSAL-AVAILABLE` (probed read-only 2026-07-31; `gh auth status`
+  exit 0, scopes `gist, read:org, repo, workflow`; repository `visibility: public`,
+  `permissions.push: true`, `permissions.admin: true`. Unchanged from the 2026-07-30 measurement. A
+  missing `security_events` scope is not a blocker on a public repository, so `BLOCKED-ON-OWNER` was
+  never in play. No dismissal was attempted and no alert state was mutated.)
+- **T016 result**: `not runnable: no completed default-branch analysis includes the change`. Probed
+  2026-07-31 with the `per_page=1`, no-`--paginate` shape T016 specifies: the newest analysis on
+  `refs/heads/main` is commit `c010178` at `2026-07-30T21:06:04Z`, which is the parent of this
+  feature branch and predates the fix commit. The branch is not pushed and no pull request exists,
+  so T015 had nothing to observe either.
+- **Verification query of record**: T016 in this file (paginated, exit-checked, floor-asserted, and
+  positive-anchored on `null_paths == 0` plus the `secrets.py` count read through the same field
+  path the gate filters on).
+- **Pre-change baseline for the re-run** (captured by T002 on 2026-07-31, the "before" half of
+  SC-005, which cannot be reconstructed later): corpus **137** alerts, **22** of this rule; alerts
+  **148 / 149 / 150** `open` with `fixed_at=null` at `src/lambdas/ingestion/handler.py:264 / :271 /
+  :276`; alert **144** `open` at `src/lambdas/shared/auth/oauth_state.py:104`; alerts **22 to 25**
+  `dismissed` with `fixed_at=null` at `src/lambdas/shared/secrets.py`. Outside the handler this rule
+  sits on three paths with counts `secrets.py` **16**, `oauth_state.py` **2**, `errors.py` **1**,
+  total **19**, which is T018's `{key: count}` "before" side.
+- **Outstanding owner action**: re-run T016 after the next default-branch analysis that includes the
+  change, then T017 and T018 against the same snapshot. If T016 returns `open_at_path > 0`, T019's
+  `DISMISSAL-AVAILABLE` branch applies. No `TECH_DEBT_REGISTRY` identifier was pre-reserved (rider 5)
+  and none is needed unless the dismissal branch fires.
 
 ---
 

--- a/src/lambdas/ingestion/handler.py
+++ b/src/lambdas/ingestion/handler.py
@@ -256,25 +256,28 @@ def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
         # CRITICAL: At least one adapter must be available
         # Silent failure here causes "no articles" which looks like no news
         if not tiingo_adapter and not finnhub_adapter:
+            # py/clear-text-logging-sensitive-data: the secret ARNs were
+            # interpolated into this message, which is both logged and reused as
+            # the RuntimeError message. The ARN identifies the secret, so it is
+            # removed rather than sanitized; the fixed literal below names both
+            # sources, which is all an on-call engineer needs.
             error_msg = (
-                "CONFIGURATION ERROR: Both API keys missing. "
-                f"tiingo_secret_arn={config['tiingo_secret_arn']}, "
-                f"finnhub_secret_arn={config['finnhub_secret_arn']}"
+                "CONFIGURATION ERROR: Both API keys missing (Tiingo and Finnhub)."
             )
             logger.error(error_msg)
             raise RuntimeError(error_msg)
 
         # Warn if running in degraded mode (only one source)
         if not tiingo_adapter:
-            logger.warning(
-                "Running in degraded mode: Tiingo adapter unavailable",
-                extra={"tiingo_secret_arn": config["tiingo_secret_arn"]},
-            )
+            # py/clear-text-logging-sensitive-data: the secret ARN was carried
+            # in structured context here. The message already names the source,
+            # so the attribute is dropped outright rather than sanitized.
+            logger.warning("Running in degraded mode: Tiingo adapter unavailable")
         if not finnhub_adapter:
-            logger.warning(
-                "Running in degraded mode: Finnhub adapter unavailable",
-                extra={"finnhub_secret_arn": config["finnhub_secret_arn"]},
-            )
+            # py/clear-text-logging-sensitive-data: the secret ARN was carried
+            # in structured context here. The message already names the source,
+            # so the attribute is dropped outright rather than sanitized.
+            logger.warning("Running in degraded mode: Finnhub adapter unavailable")
 
         # Get SNS client
         sns_client = _get_sns_client(config["aws_region"])

--- a/tests/unit/lambdas/ingestion/test_handler_arn_logging.py
+++ b/tests/unit/lambdas/ingestion/test_handler_arn_logging.py
@@ -1,0 +1,391 @@
+"""Regression guard: the ingestion handler must never log Secrets Manager ARNs.
+
+Feature 001-ingestion-arn-logging. Guards CodeQL rule
+``py/clear-text-logging-sensitive-data`` at ``src/lambdas/ingestion/handler.py``
+lines 264, 271 and 276 (alerts 148, 149, 150).
+
+Assertion surface (FR-007, research D4): every assertion runs over
+``record.getMessage()`` joined with ``str(v)`` for **every** value in
+``record.__dict__``. ``caplog.text`` is deliberately never used anywhere in this
+module: a rendered-text-only assertion passes against the two ``extra={...}``
+sites even on unfixed code, so it proves nothing.
+"""
+
+import logging
+import os
+from unittest.mock import MagicMock, patch
+
+import boto3
+import pytest
+from moto import mock_aws
+
+from src.lambdas.shared.quota_tracker import clear_quota_cache
+
+# ---------------------------------------------------------------------------
+# Fixture ARNs (research D5, plan Test design)
+# ---------------------------------------------------------------------------
+TIINGO_ARN = (
+    "arn:aws:secretsmanager:eu-west-2:218795110243:secret:"
+    "preprod/sentiment-analyzer/tiingo-AbCdEf"
+)
+FINNHUB_ARN = (
+    "arn:aws:secretsmanager:eu-west-2:218795110243:secret:"
+    "preprod/sentiment-analyzer/finnhub-GhIjKl"
+)
+
+# Six forbidden classes (research D5 / FR-007), eight concrete strings.
+# Each is asserted on its own so a failure names exactly which class leaked.
+#
+# Two near-miss traps, both deliberate and both load-bearing:
+#   * NEVER shorten "preprod/sentiment-analyzer" to "sentiment-analyzer".
+#     The haystack includes ``record.pathname``, an absolute path inside a
+#     checkout named ``sentiment-analyzer-gsk`` (and, for dependency records,
+#     inside ``.venv/lib/python3.13/site-packages``). The short form matches
+#     every record for a reason unrelated to the ARN.
+#   * NEVER assert on bare "arn:aws:", which collides with SNS_TOPIC_ARN.
+FORBIDDEN: list[tuple[str, str]] = [
+    ("full ARN (tiingo)", TIINGO_ARN),
+    ("full ARN (finnhub)", FINNHUB_ARN),
+    ("service prefix", "arn:aws:secretsmanager"),
+    ("account id", "218795110243"),
+    ("region", "eu-west-2"),
+    ("secret path segment", "preprod/sentiment-analyzer"),
+    ("secret suffix (tiingo)", "AbCdEf"),
+    ("secret suffix (finnhub)", "GhIjKl"),
+]
+
+HANDLER_LOGGER = "src.lambdas.ingestion.handler"
+
+
+# ---------------------------------------------------------------------------
+# Assertion surface helpers
+# ---------------------------------------------------------------------------
+def haystack(record: logging.LogRecord) -> str:
+    """Rendered message plus every value in ``record.__dict__``.
+
+    The ``str()`` coercion is load-bearing: ``record.__dict__`` holds non-string
+    values (``args``, ``exc_info``, ``levelno``) and a bare membership test
+    against them raises TypeError. Scanning all of ``__dict__`` rather than a
+    named key list is deliberate: it survives a key rename and catches a leak
+    that migrates to a new ``extra`` key.
+    """
+    parts = [record.getMessage()]
+    parts.extend(str(v) for v in record.__dict__.values())
+    return "\n".join(parts)
+
+
+def where(record: logging.LogRecord, needle: str) -> list[str]:
+    """Locations of ``needle`` in a record: "message" and/or "dict:<key>".
+
+    Mandatory, not decorative. ``haystack()`` joins values and therefore
+    discards the key, so a failure diff built from it alone cannot show whether
+    a leak arrived through the rendered message or through a structured
+    attribute. The RED gate (T007) requires exactly that distinction.
+    """
+    found = []
+    if needle in record.getMessage():
+        found.append("message")
+    for key, value in record.__dict__.items():
+        if needle in str(value):
+            found.append(f"dict:{key}")
+    return found
+
+
+def assert_record_clean(record: logging.LogRecord) -> None:
+    """Assert one record carries none of the six forbidden classes."""
+    for label, needle in FORBIDDEN:
+        assert needle not in haystack(record), (
+            f"leak [{label}] {needle!r} at {where(record, needle)} "
+            f"on logger={record.name} msg={record.getMessage()!r}"
+        )
+
+
+def handler_records(caplog: pytest.LogCaptureFixture) -> list[logging.LogRecord]:
+    """Records emitted by this module's own logger only.
+
+    ``caplog`` captures third-party records too (botocore, parallel_fetcher,
+    failure_tracker). An unrestricted sweep would make this suite hostage to
+    whatever any dependency happens to log.
+    """
+    return [r for r in caplog.records if r.name == HANDLER_LOGGER]
+
+
+def project_records(caplog: pytest.LogCaptureFixture) -> list[logging.LogRecord]:
+    """All in-project records. Used by the case-5 sweep."""
+    return [r for r in caplog.records if r.name.startswith("src.lambdas.")]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+@pytest.fixture(autouse=True)
+def reset_caches():
+    """Reset module-level caches before each test.
+
+    Duplicated from ``test_handler.py`` on purpose: autouse fixtures are not
+    shared across modules, and without this ``_active_tickers_cache`` leaks
+    between modules in a full-directory run.
+    """
+    import src.lambdas.ingestion.handler as handler_module
+
+    handler_module._active_tickers_cache = []
+    handler_module._active_tickers_cache_timestamp = 0.0
+    clear_quota_cache()
+    yield
+    handler_module._active_tickers_cache = []
+    handler_module._active_tickers_cache_timestamp = 0.0
+    clear_quota_cache()
+
+
+@pytest.fixture
+def arn_env():
+    """Environment whose only source of the forbidden strings is the two ARNs.
+
+    Isolation constraints (FR-007 as amended by Clarification Q3, plan review
+    M4). Every variable below must contain none of ``218795110243``,
+    ``eu-west-2`` or ``preprod/sentiment-analyzer``:
+      * SNS_TOPIC_ARN keeps the unrelated account/region from ``test_handler``.
+      * ALERT_TOPIC_ARN is left unset (``_get_config()`` defaults it to "").
+      * AWS_REGION stays us-east-1 **and CLOUD_REGION is pinned to us-east-1**.
+        ``_get_config()`` reads CLOUD_REGION first and only falls back to
+        AWS_REGION, so an inherited CLOUD_REGION silently defeats the region
+        isolation. spec.md FR-007 names three variables; this is the fourth.
+
+    Teardown restores the prior value of every variable it set, or pops it.
+    """
+    values = {
+        "DATABASE_TABLE": "test-financial-news",
+        "USERS_TABLE": "test-financial-news",
+        "SNS_TOPIC_ARN": "arn:aws:sns:us-east-1:123456789:test-topic",
+        "TIINGO_SECRET_ARN": TIINGO_ARN,
+        "FINNHUB_SECRET_ARN": FINNHUB_ARN,
+        "MODEL_VERSION": "v1.0.0",
+        "AWS_REGION": "us-east-1",
+        "CLOUD_REGION": "us-east-1",
+        "ENVIRONMENT": "test",
+    }
+    previous = {key: os.environ.get(key) for key in values}
+    previous_alert = os.environ.get("ALERT_TOPIC_ARN")
+    os.environ.pop("ALERT_TOPIC_ARN", None)
+    os.environ.update(values)
+    yield
+    for key, prior in previous.items():
+        if prior is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = prior
+    if previous_alert is not None:
+        os.environ["ALERT_TOPIC_ARN"] = previous_alert
+    else:
+        os.environ.pop("ALERT_TOPIC_ARN", None)
+
+
+def _create_table_with_gsi(dynamodb, table_name: str = "test-financial-news"):
+    """DynamoDB table with the by_entity_status GSI (mirrors test_handler.py)."""
+    return dynamodb.create_table(
+        TableName=table_name,
+        KeySchema=[
+            {"AttributeName": "PK", "KeyType": "HASH"},
+            {"AttributeName": "SK", "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": "PK", "AttributeType": "S"},
+            {"AttributeName": "SK", "AttributeType": "S"},
+            {"AttributeName": "entity_type", "AttributeType": "S"},
+            {"AttributeName": "status", "AttributeType": "S"},
+        ],
+        GlobalSecondaryIndexes=[
+            {
+                "IndexName": "by_entity_status",
+                "KeySchema": [
+                    {"AttributeName": "entity_type", "KeyType": "HASH"},
+                    {"AttributeName": "status", "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            }
+        ],
+        BillingMode="PAY_PER_REQUEST",
+    )
+
+
+def _seed_active_config() -> None:
+    """One active configuration, so lambda_handler reaches the ARN sites."""
+    dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
+    table = _create_table_with_gsi(dynamodb)
+    table.put_item(
+        Item={
+            "PK": "USER#user1",
+            "SK": "CONFIG#config1",
+            "entity_type": "CONFIGURATION",
+            "status": "active",
+            "tickers": [{"symbol": "AAPL"}],
+        }
+    )
+
+
+def _empty_adapter() -> MagicMock:
+    adapter = MagicMock()
+    adapter.get_news.return_value = []
+    adapter.close = MagicMock()
+    return adapter
+
+
+def _invoke(get_api_key_mock) -> dict:
+    """Run lambda_handler with the adapters and side effects stubbed out.
+
+    The entrypoint is ``lambda_handler``; there is no symbol named ``handler``
+    in this module and importing one raises ImportError.
+    """
+    from src.lambdas.ingestion.handler import lambda_handler
+
+    context = MagicMock()
+    context.aws_request_id = "test-request-id"
+
+    with (
+        patch(
+            "src.lambdas.ingestion.handler.get_api_key",
+            get_api_key_mock,
+        ),
+        patch(
+            "src.lambdas.ingestion.handler.TiingoAdapter",
+            return_value=_empty_adapter(),
+        ),
+        patch(
+            "src.lambdas.ingestion.handler.FinnhubAdapter",
+            return_value=_empty_adapter(),
+        ),
+        patch(
+            "src.lambdas.ingestion.handler._get_sns_client",
+            return_value=MagicMock(),
+        ),
+        patch("src.lambdas.ingestion.handler.emit_metrics_batch"),
+    ):
+        return lambda_handler({"source": "test"}, context)
+
+
+def _key_for(tiingo: str | None, finnhub: str | None) -> MagicMock:
+    """get_api_key stub keyed on the ARN it is called with."""
+
+    def side_effect(secret_arn, *args, **kwargs):
+        if secret_arn == TIINGO_ARN:
+            return tiingo
+        if secret_arn == FINNHUB_ARN:
+            return finnhub
+        raise AssertionError(f"unexpected secret arn: {secret_arn!r}")
+
+    return MagicMock(side_effect=side_effect)
+
+
+# ---------------------------------------------------------------------------
+# Cases
+# ---------------------------------------------------------------------------
+class TestIngestionHandlerNeverLogsSecretArns:
+    """Five cases. Case 4 is a pin, not a discriminator (see its docstring)."""
+
+    @mock_aws
+    def test_case1_both_credentials_unavailable(self, arn_env, caplog):
+        """Site 1: the definitely-rendered CONFIGURATION ERROR record."""
+        _seed_active_config()
+        with caplog.at_level(logging.WARNING, logger=HANDLER_LOGGER):
+            _invoke(_key_for(None, None))
+
+        config_errors = [
+            r
+            for r in handler_records(caplog)
+            if r.levelno == logging.ERROR and "CONFIGURATION ERROR" in r.getMessage()
+        ]
+        assert config_errors, (
+            "no CONFIGURATION ERROR record captured from "
+            f"{HANDLER_LOGGER}; saw {[r.getMessage() for r in handler_records(caplog)]}"
+        )
+        record = config_errors[0]
+
+        # FR-002: the record must still name both sources in fixed literal text.
+        message = record.getMessage()
+        assert "Tiingo" in message, f"source name missing (case-sensitive): {message!r}"
+        assert "Finnhub" in message, (
+            f"source name missing (case-sensitive): {message!r}"
+        )
+
+        assert_record_clean(record)
+
+    @mock_aws
+    def test_case2_tiingo_only_unavailable(self, arn_env, caplog):
+        """Site 2: the structured-context WARNING for Tiingo."""
+        _seed_active_config()
+        with caplog.at_level(logging.WARNING, logger=HANDLER_LOGGER):
+            _invoke(_key_for(None, "finnhub-key"))
+
+        warnings = [
+            r
+            for r in handler_records(caplog)
+            if r.levelno == logging.WARNING and "Tiingo" in r.getMessage()
+        ]
+        assert warnings, (
+            "no degraded-mode WARNING naming Tiingo captured; saw "
+            f"{[r.getMessage() for r in handler_records(caplog)]}"
+        )
+        for record in warnings:
+            assert_record_clean(record)
+
+    @mock_aws
+    def test_case3_finnhub_only_unavailable(self, arn_env, caplog):
+        """Site 3: the structured-context WARNING for Finnhub."""
+        _seed_active_config()
+        with caplog.at_level(logging.WARNING, logger=HANDLER_LOGGER):
+            _invoke(_key_for("tiingo-key", None))
+
+        warnings = [
+            r
+            for r in handler_records(caplog)
+            if r.levelno == logging.WARNING and "Finnhub" in r.getMessage()
+        ]
+        assert warnings, (
+            "no degraded-mode WARNING naming Finnhub captured; saw "
+            f"{[r.getMessage() for r in handler_records(caplog)]}"
+        )
+        for record in warnings:
+            assert_record_clean(record)
+
+    @mock_aws
+    def test_case4_outer_exception_path(self, arn_env, caplog):
+        """Acceptance Scenario 4 / FR-005: the outer ``except`` record.
+
+        PIN, NOT A DISCRIMINATOR. ``get_safe_error_info(e)`` returns
+        ``{"error_type": ...}`` only, so this record is clean **by construction
+        even on unfixed code**. Its green must never be read as evidence the
+        fix landed. It exists to prove the raised RuntimeError message cannot
+        reintroduce the ARN downstream.
+        """
+        _seed_active_config()
+        with caplog.at_level(logging.WARNING, logger=HANDLER_LOGGER):
+            response = _invoke(_key_for(None, None))
+
+        assert response["statusCode"] == 500
+
+        outer = [
+            r
+            for r in handler_records(caplog)
+            if r.getMessage() == "Financial ingestion failed"
+        ]
+        assert outer, (
+            "outer except record not captured; saw "
+            f"{[r.getMessage() for r in handler_records(caplog)]}"
+        )
+        for record in outer:
+            assert_record_clean(record)
+
+    @mock_aws
+    def test_case5_sweep_every_record(self, arn_env, caplog):
+        """Sweep: every in-project record from the case-1 invocation is clean.
+
+        Catches a leak that migrates to a fourth site in this module.
+        """
+        _seed_active_config()
+        with caplog.at_level(logging.WARNING, logger=HANDLER_LOGGER):
+            _invoke(_key_for(None, None))
+
+        records = project_records(caplog)
+        assert records, "sweep captured no in-project records at all (read failed)"
+        for record in records:
+            assert_record_clean(record)


### PR DESCRIPTION
Feature A of a four-part CodeQL burndown. Closes the `py/clear-text-logging-sensitive-data`
findings on `src/lambdas/ingestion/handler.py` (alerts 148, 149, 150).

Also adds `codeql-logging-convention.md`, written to be cited by the sibling features so
the same rule is not re-derived three more times.

## Terminal state: PENDING-BRANCH-ANALYSIS

This is the expected ending, not a failure. Closure for this rule is only admissible from
a default-branch CodeQL analysis, and none can exist until this lands on `main`. 17 of 22
tasks done; T015-T019 need a merged analysis and are recorded as not runnable with the
reason, rather than simulated.

The guard test was proven red before the fix: 4 failed / 1 passed, with the leak at
`['dict:tiingo_secret_arn']`, i.e. in a `__dict__` value rather than the rendered message.

No alert was mutated. Nothing was dismissed.

Draft on purpose.