### PR TITLE
fix(001): remove the provider-derived value from the OAuth state log context

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1787,6 +1787,17 @@
         "is_removed": false
       }
     ],
+    "specs/001-oauth-provider-taint/evidence.md": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "specs/001-oauth-provider-taint/evidence.md",
+        "hashed_secret": "74890017c0596ebdaee58792b91ea2fc26fbb3a0",
+        "is_verified": false,
+        "line_number": 117,
+        "is_added": false,
+        "is_removed": false
+      }
+    ],
     "specs/072-market-data-ingestion/contracts/news-item.schema.json": [
       {
         "type": "Hex High Entropy String",
@@ -2517,5 +2528,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-31T19:03:09Z"
+  "generated_at": "2026-08-01T05:39:28Z"
 }

--- a/specs/001-oauth-provider-taint/evidence.md
+++ b/specs/001-oauth-provider-taint/evidence.md
@@ -1,0 +1,290 @@
+# Evidence: Close CodeQL alert 144 (OAuth provider taint)
+
+**Feature**: `001-oauth-provider-taint` | **Executed**: 2026-07-31
+**Executed document**: [tasks.md](tasks.md) | **Runbook**: [quickstart.md](quickstart.md)
+
+This file is the record required by T017, T023 and T033. It carries the baseline set, the change SHA,
+the filled-in gate query, and exactly one terminal state.
+
+---
+
+## Terminal state
+
+**`PENDING-BRANCH-ANALYSIS`**
+
+That is the whole of the recorded state. Six other states exist in tasks.md's table and none of them
+is recorded here; where they are named below it is to record that they were considered and rejected,
+never as a second classification.
+
+Inherited from `specs/001-ingestion-arn-logging/codeql-logging-convention.md` **§5a** via FR-008,
+which calls it "the normal ending, not an edge case". Reported as **neither done nor failed**.
+
+**The observation it rests on.** Closure is read from a default-branch CodeQL analysis (FR-009,
+convention §3 Trap 3). The change is committed on the feature branch and has not been pushed, so no
+qualifying analysis can exist:
+
+```
+$ git ls-remote --heads origin 001-oauth-provider-taint
+(no output)
+ls-remote exit=0
+```
+
+An exit of 0 with no matching ref is the read succeeding and finding nothing, which is the whole
+distinction: the branch is absent from the remote, not unreadable. Pushing is gated on the repository
+owner and was not attempted.
+
+**Why not `BLOCKED-NO-ANALYSIS`.** That state's 7-day clock starts when `$CHANGE_SHA` lands on
+`main`. Nothing has landed, so the clock has not started (tasks.md T017; quickstart Step 1d).
+
+**Why not `BLOCKED-ON-OWNER`.** That state requires a survivor to have been observed at the gate and
+the dismissal permission to be absent. No survivor has been observed, because the gate was not
+evaluated, and the T006 probe resolved to **available** in any case.
+
+**Why not `CONFIRMED`.** FR-009 and SC-002 admit only default-branch evidence. The local unit suite
+being green is not closure evidence and is not treated as any.
+
+---
+
+## `$CHANGE_SHA`
+
+Recorded here rather than left in a shell, per T017 as amended by Adversarial Review #3 finding
+**G-06**: T019's freshness proof is its only consumer and the wait it bounds outlives any shell.
+
+| Field | Value |
+|---|---|
+| Feature-branch commit | **`f264c1d`** (`fix(001): remove the provider-derived value from the OAuth state log context`) |
+| GPG signature | `G` (good), per `git log --format='%h %G? %s'` |
+| Branch | `001-oauth-provider-taint`, parent `1d68832` |
+| `$CHANGE_SHA` (merge commit on `main`) | **ABSENT.** Not yet pushed, no PR, no merge commit exists. |
+
+`$CHANGE_SHA` must be filled in with the **merge commit SHA on `main`**, not with `f264c1d`, at the
+moment the change lands. T019 compares `$CHANGE_SHA...$ANALYZED_SHA` and a feature-branch SHA that
+never reached `main` makes that call 404 rather than answer wrongly.
+
+---
+
+## Phase execution record
+
+| Phase | Status |
+|---|---|
+| 1. Preconditions and baseline (T001-T006) | Executed, all pass |
+| 2. Regression guard written first (T007, T008) | Executed, guard proven failing on unfixed code |
+| 3. Production change (T009-T011) | Executed |
+| 4. Local gates (T012-T016) | Executed, all pass |
+| 5. Land the change (T017) | Commit executed; push, PR and merge **not** attempted (owner-gated) |
+| 6. Decision gate (T018-T023) | **Not executed.** No default-branch analysis can exist. |
+| 7. Terminal branches (T024-T030) | **Not executed.** No classification was made, so no branch is reachable. |
+| 8. Durability and close-out (T031-T033) | Executed. Phase 8 runs on this branch per Adversarial Review #3 finding **G-03**. |
+
+Phases 6 and 7 are skipped and Phase 8 still runs. T031 reads only `research.md` and has no
+dependency on a merge; T032 and T033 are declared unconditional across every terminal state, and this
+is the state quickstart Step 1d calls the likeliest ending, so skipping Phase 8 here would leave
+FR-012, FR-013, SC-005 and SC-007 unverified on the most probable execution path.
+
+### T032 substitution, recorded explicitly
+
+SC-007 is stated against the **merged file**. No merged file exists. T032 was therefore run against
+**the committed file on the feature branch**, read with `git show HEAD:...` rather than from the
+working tree, so the check is against committed bytes and not against an unstaged edit. tasks.md T017
+prescribes exactly this substitution for this state and requires it be recorded here. It is recorded
+here.
+
+---
+
+## T004 baseline set, verbatim
+
+Recorded as a **set**, never as a count (SC-003 is an attribution test). Read 2026-07-31 with the
+mandatory paginated shape from invariant 7.
+
+```
+gh exit=0 jq exit=0 corpus=137
+baseline=[{"number":150,"rule":"py/clear-text-logging-sensitive-data","path":"src/lambdas/ingestion/handler.py","line":276},{"number":149,"rule":"py/clear-text-logging-sensitive-data","path":"src/lambdas/ingestion/handler.py","line":271},{"number":148,"rule":"py/clear-text-logging-sensitive-data","path":"src/lambdas/ingestion/handler.py","line":264},{"number":147,"rule":"py/bad-tag-filter","path":"scripts/regenerate-mermaid-url.py","line":82},{"number":144,"rule":"py/clear-text-logging-sensitive-data","path":"src/lambdas/shared/auth/oauth_state.py","line":104}]
+```
+
+Corpus floor of 137 met exactly. The set is `{144, 147, 148, 149, 150}`, matching the value recorded
+at authoring time, with 144 at `oauth_state.py:104`. The premise is present: the complete read
+contains an entry whose `path` is `$FILE` and whose `rule` is `$RULE`, so T004's "premise already
+gone" routing to `CONFIRMED` does **not** apply.
+
+Siblings legitimately move this set. `001-ingestion-arn-logging` owns 148-150,
+`001-bad-tag-filter-dead-suppression` owns 147, and `001-codeql-coverage` is expected to raise the
+total on purpose. The count is not the test.
+
+### T005 locating snapshot of alert 144
+
+```
+gh exit=0
+{"code_flows":0,"commit_sha":"c01017888484bd5a0fdec9a32ded42378829f6dc","dismissed_reason":null,"fixed_at":null,"number":144,"path":"src/lambdas/shared/auth/oauth_state.py","start_line":104,"state":"open"}
+```
+
+`code_flows` is `0`, which is why no artifact here claims to know the taint path. Nothing downstream
+keys on this alert's state; 144 is a locating label.
+
+### T006 dismissal-permission probe, read-only
+
+```
+  - Token scopes: 'gist', 'read:org', 'repo', 'workflow'
+gh exit=0
+perm={"permissions":{"admin":true,"maintain":true,"pull":true,"push":true,"triage":true},"visibility":"public"}
+```
+
+Resolved **available**: `visibility` is `public`, `permissions.push` is `true`, and the scope list
+contains `repo`, which subsumes `public_repo`. The absent `security_events` scope is **not** a
+blocker; GitHub requires it only on **private** repositories (convention §5b). Established by a
+read-only probe, never by attempting a `PATCH`, which mutates alert state and cannot be cleanly
+reverted.
+
+---
+
+## The gate query, filled in and ready to run
+
+Required by T017 so the check is mechanical the moment the change lands. `$RULE` and `$FILE` are
+already substituted. Run the control first, then the gate, against the **same** file. Do not re-fetch
+between them.
+
+```bash
+export REPO=traylorre/sentiment-analyzer-gsk
+export RULE=py/clear-text-logging-sensitive-data
+export FILE=src/lambdas/shared/auth/oauth_state.py
+export ALERTS_JSON=/tmp/oauth-alerts-gate.json
+
+# T018 first: locate the newest default-branch python analysis.
+# Deliberately unpaginated. The endpoint is newest-first, this wants exactly the
+# newest, and emptiness here is a FAILURE condition, so truncation cannot render
+# as clean. Do not "fix" this into a paginated query.
+AN=$(gh api "repos/$REPO/code-scanning/analyses?ref=refs/heads/main&per_page=5" \
+  --jq '[.[] | {id, commit_sha, created_at, analysis_key, category}]')
+RC=$?; printf 'gh exit=%s\n%s\n' "$RC" "$AN"
+export ANALYZED_SHA=<commit_sha of the newest /language:python analysis>
+
+# T019 freshness proof. A result predating the change decides nothing.
+# CHANGE_SHA is the MERGE COMMIT ON main, not f264c1d.
+export CHANGE_SHA=<merge commit sha on main>
+ST=$(gh api "repos/$REPO/compare/$CHANGE_SHA...$ANALYZED_SHA" --jq '.status')
+RC=$?; printf 'gh exit=%s status=%s\n' "$RC" "$ST"
+# Accept only "ahead" or "identical". Bound: 7 days from CHANGE_SHA landing on
+# main, then BLOCKED-NO-ANALYSIS via T029.
+
+# T020 positive control, FIRST. The gate's pass condition is emptiness, so it is
+# worthless without proof the query can return anything at all.
+gh api --paginate --slurp \
+  "repos/$REPO/code-scanning/alerts?ref=refs/heads/main&per_page=100" > "$ALERTS_JSON"
+GH_RC=$?
+CORPUS=$(jq '[.[][]] | length' "$ALERTS_JSON"); JQ_RC=$?
+RULETOT=$(jq --arg r "$RULE" '[.[][] | select(.rule.id == $r)] | length' "$ALERTS_JSON")
+CTRL=$(jq -c --arg r "$RULE" --arg f "$FILE" \
+  '[.[][] | select(.rule.id == $r)
+          | select(.most_recent_instance.location.path == $f)
+          | {number, state}]' "$ALERTS_JSON")
+printf 'gh exit=%s jq exit=%s corpus=%s rule_total=%s\ncontrol=%s\n' \
+  "$GH_RC" "$JQ_RC" "$CORPUS" "$RULETOT" "$CTRL"
+
+# T021 gate, over the SAME file the control just validated.
+GATE=$(jq -c --arg r "$RULE" --arg f "$FILE" \
+  '[.[][] | select(.state == "open")
+          | select(.rule.id == $r)
+          | select(.most_recent_instance.location.path == $f)
+          | {number, start_line: .most_recent_instance.location.start_line,
+             commit_sha: .most_recent_instance.commit_sha}]' "$ALERTS_JSON")
+JQ_RC=$?; printf 'jq exit=%s\ngate=%s\n' "$JQ_RC" "$GATE"
+```
+
+**T020 pass, all four**: `gh exit=0` and `jq exit=0`; `corpus` at least **137**; `rule_total` at
+least **22**; and `$CTRL` containing **alert 117**, which is `state: fixed` at this path and is
+therefore an immovable anchor that stays satisfied whatever the outcome. `state=open` is deliberately
+**not** in this query, because that filter would remove alert 117 and destroy the control.
+
+**T021 pass for `CONFIRMED`**: T020 passed on all four floors, `jq exit=0`, and `$GATE` is exactly
+`[]`. A **blank** `$GATE` is a failed filter, not a closed alert, and is discarded rather than
+classified. Emptiness is a pass only because the control proved, on the same bytes, that a finding of
+this rule at this path is visible to this query when one exists.
+
+**Never** run the alerts query unpaginated. Measured on this repository: unpaginated it reports zero
+open alerts and exits 0 while five are open, because the default page is 30 alerts ordered by
+descending number and all thirty are `fixed`. `per_page=100` alone is not a fix either: page one at
+that size drops alert 117, which is the control's anchor.
+
+If `$GATE` is non-empty, attribute every survivor at `$ANALYZED_SHA` per T022 before acting on it. A
+survivor inside `store_oauth_state()` is this feature's, and routes to T026 plus a
+`docs/reference/TECH_DEBT_REGISTRY.md` entry whose `TD-` id is read from the registry's then-highest
+entry at that moment. A survivor outside it, most likely the FR-004-frozen `validate_oauth_state()`
+sink at lines 253-258, is **reported and never dismissed**.
+
+---
+
+## Local gate results
+
+Every one of these was run, not read. Output is verbatim.
+
+| Task | Command | Result |
+|---|---|---|
+| T001 | `python --version` in `.venv` | `Python 3.13.0` |
+| T002 | `git status --short -- src tests` | `0` lines. Clean. |
+| T003 | `pytest tests/unit/auth/ -q` | `30 passed`, `pytest exit=0` |
+| T008 | `pytest tests/unit/auth/test_oauth_state.py -q`, **before** the production edit | `1 failed, 15 passed`, `pytest exit=1`, sole failure `test_log_context_excludes_provider` on `assert not hasattr(records[0], "provider")` |
+| T011 | `git diff -U0 ... \| grep -E '^@@'` | `@@ -99,3 +99,4 @@` and `@@ -105 +105,0 @@`, `grep exit=0`. Both below 122. |
+| T012 | `pytest tests/unit/auth/ -q` | `31 passed`, `pytest exit=0` |
+| T013 | `ruff format` then `ruff check` | `2 files left unchanged`, `All checks passed!`, `ruff exit=0`. No `F841`. |
+| T014 | SC-007 grep, `-B6` window | Rule id present at line 99, `grep exit=0`. Pragma grep `exit=1`. |
+| T015 | `git diff` byte count and changed-line count | `diff bytes=946`, 10 lines matching `^[-+]` (8 real, 2 diff headers) |
+| T016 | `git status --short -- .github/ .semgrep* pyproject.toml` | Prints nothing. No analysis config, query pack, severity or path exclusion touched. |
+| T016 | `make sast` | `Findings: 0 (0 blocking)`, 478 rules, 164 targets, `make sast exit=0` |
+| T031 | `grep -c '8424cbd\|0e7a375\|ebcc2f4' research.md` | `16`, `grep exit=0`. Floor of 3 cleared. |
+| T032 | SC-007 grep against `git show HEAD:` output | Rule id present, `research.md` pointer present, pragma grep `exit=1` |
+
+**T008 is the load-bearing one.** The guard was written and proven failing before the production edit
+existed, on precisely the assertion T008 predicts. It asserts on the `LogRecord` attribute rather
+than on `caplog.text`, because the production formatter renders no `extra` keys and a text assertion
+would have passed on unfixed code. Red first, then green: that is the only thing that shows the guard
+is not decoration.
+
+**`make validate` was not run as a gate**, per invariant 3. It chains `check-banned-terms`, which
+exits 1 on pre-existing matches in other features' spec directories. `make sast` is the substitute
+and it passed. Repairing other features' directories is a different feature's scope.
+
+---
+
+## Diff, confined
+
+Two files, plus this one.
+
+- `src/lambdas/shared/auth/oauth_state.py`: the `safe_provider` assignment **deleted** (not orphaned,
+  which would fail `ruff check` with `F841` and block the required `Lint` context), the
+  `"provider": safe_provider` entry deleted from the `extra` dict, and the four-line FR-013 comment
+  added above `logger.info(`. Nothing substituted for the removed value: not a literal, not an
+  allowlist-selected constant, not a boolean (FR-001, FR-002).
+- `tests/unit/auth/test_oauth_state.py`: `import logging` added, one method
+  `test_log_context_excludes_provider` added to `TestStoreOAuthState`. No existing assertion edited
+  (FR-011, SC-004).
+
+**FR-003**: the `put_item` item dict, including the deliberately persisted `"provider": provider` at
+line 87, the returned `OAuthState`, and the `code_verifier` generation appear in no `+`/`-` line.
+Behavior outside the log call is unchanged.
+
+**FR-004**: `validate_oauth_state()` is untouched. Its `safe_provider_validated` and its
+`extra={"provider": safe_provider_validated}` carry the identical sanitize-in-place shape that left
+alerts 22-25 with `fixed_at` null to this day, and this feature does **not** fix it. Both diff hunks
+start below line 122, which is the next top-level `def` after the sink.
+
+**FR-010**: nothing suppressed. No `# nosec`, `# noqa`, `# lgtm`, no CodeQL pragma, no severity
+change, no path exclusion, no analysis configuration touched.
+
+---
+
+## What is outstanding
+
+1. Push the branch, open a PR, merge. Both are gated on the repository owner and were not attempted.
+2. Record the **merge commit SHA on `main`** into the `$CHANGE_SHA` row above.
+3. Wait for a default-branch `/language:python` analysis and prove freshness with T019's `compare`.
+4. Run the control and the gate above, in that order, and classify **once** per T023.
+5. Run the T030 SC-003 attribution recount, which carries its own two controls: `null_paths` must be
+   exactly `0` and the alert-117 path anchor must return
+   `src/lambdas/shared/auth/oauth_state.py`. A corpus floor proves the fetch worked and proves
+   nothing about the path selector; mistyping `.location` as `.locatio` returns `null` for every
+   alert, exits 0, satisfies the floor and produces a clean result.
+6. Record the resulting terminal state, replacing `PENDING-BRANCH-ANALYSIS` with exactly one of
+   `CONFIRMED`, `REPORTED-FOREIGN-SINK`, `REFUTED-DISMISSED`, `BLOCKED-ON-OWNER`,
+   `BLOCKED-NO-ANALYSIS` or `BLOCKED-REGRESSION`.
+
+The T030 set difference is not recorded here because T030 was not run; it belongs to Phase 7, which
+is unreachable in this state.

--- a/specs/001-oauth-provider-taint/plan.md
+++ b/specs/001-oauth-provider-taint/plan.md
@@ -1,0 +1,409 @@
+# Implementation Plan: Close CodeQL alert 144 (OAuth provider taint)
+
+**Branch**: `001-oauth-provider-taint` | **Date**: 2026-07-30 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/001-oauth-provider-taint/spec.md`
+
+## Summary
+
+Delete every `provider`-derived value from the `logger.info()` `extra` context in
+`store_oauth_state()` (`src/lambdas/shared/auth/oauth_state.py`), which is the exact shape that
+carries a non-null `fixed_at` on alerts 26, 27, 106, 107, 110 and 111 after `ebcc2f4`. That means
+removing the `"provider": safe_provider` entry and the now-unused `safe_provider` sanitizer
+assignment above it. Nothing is substituted in its place: the `extra` dict is never rendered by any
+handler in this repository, so there is no operational capability to preserve, and `provider`
+remains persisted in the DynamoDB item written eight lines earlier.
+
+One caveat on how far that precedent transfers, carried here from spec.md and research.md so the
+implementer does not have to go looking for it: `ebcc2f4` did not delete its value outright, it
+relocated the sanitized identifier into a raised exception message, a sink the analyzer tolerates.
+`store_oauth_state()` is `put_item`, log, return, with no raise anywhere on its path, so no
+equivalent relocation target exists and this deletion is strictly more aggressive than the shape it
+cites. That is a reason to expect the fix to hold, not a reason to doubt it, but the precedent is
+being stretched and the artifacts say so rather than claiming an exact match.
+
+Verification is a single evaluation of the spec's decision gate against one completed default-branch
+CodeQL analysis whose commit contains the change, read from the code scanning alerts API and scoped
+to the path `src/lambdas/shared/auth/oauth_state.py` plus the rule id
+`py/clear-text-logging-sensitive-data`. Never to an alert number, never to a line number, and not to
+a function: this file already produced a respawn from line 95 to line 104 in a single analysis run,
+this change itself shifts every line below the sink, and the alerts API exposes no function field at
+all, so function attribution is derived from a line number and cannot be the criterion. Attribution
+happens, per FR-006a, but only to decide who owns a survivor.
+
+## Technical Context
+
+**Language/Version**: Python 3.13 (Lambda runtime and local `.venv`; `requires-python = ">=3.13"`).
+**Primary Dependencies**: None added, removed, or upgraded. The edit touches one stdlib `logging.Logger.info()` call already present in the file. Verification tooling is already installed: the GitHub CLI (`gh`) for the code scanning alerts and analyses APIs, plus `pytest` and `ruff` from `requirements-dev.txt`.
+**Storage**: DynamoDB, unchanged. `provider` continues to be persisted in the item written by `table.put_item()` at `oauth_state.py:87`. No table, key, index, or item-shape change.
+**Testing**: `pytest tests/unit/auth/` (30 tests, green at baseline; `store_oauth_state` covered by `TestStoreOAuthState` with a `MagicMock` table fixture, no moto needed). One new caplog-based regression assertion is added. Closure evidence comes from `gh api .../code-scanning/alerts` against `refs/heads/main`, not from any test.
+**Target Platform**: AWS Lambda (`python3.13`), dashboard Lambda OAuth authorize path.
+**Project Type**: Single project. One backend source file edited, one unit test file extended.
+**Performance Goals**: N/A. The change strictly removes work (three `str.replace()` calls and a slice per authorize).
+**Constraints**: FR-003 (runtime behavior outside the log call unchanged: stored item, returned `OAuthState`, PKCE verifier); FR-004 (`validate_oauth_state()` not modified); FR-010 (no rule suppression, no severity change, no file exclusion, no inline suppression comment); FR-013 (the sink carries a mandatory documentation comment naming the rule id, on every gate branch); inherited via FR-008 from `specs/001-ingestion-arn-logging/codeql-logging-convention.md` §4 (`src/lambdas/shared/secrets.py` MUST NOT be edited, its alerts 22-25 sit behind sticky dismissals with null `fixed_at` and re-fingerprint on touch); GPG-signed commits; no new AWS resources.
+**Scale/Scope**: One function. Three lines deleted (`safe_provider` assignment), one dict entry deleted, one documentation comment added, one test method added. Under 20 lines changed in total.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Evaluated against `.specify/memory/constitution.md` v1.6 (last amended 2025-12-09).
+
+| Gate | Status | Justification |
+|------|--------|---------------|
+| §7 Implementation Accompaniment Rule (all implementation code accompanied by unit tests; happy path plus one error path; 80% coverage on new code) | PASS | No new function or module is introduced, so the "new code" coverage clause is vacuous. The gate is nevertheless satisfied actively rather than by exemption: a caplog assertion is added to `TestStoreOAuthState` proving no `provider` attribute reaches the emitted `LogRecord`. That is the only durable guard against a later refactor silently reintroducing the sink, which is the failure mode this file has already suffered once. |
+| §7 Environment matrix (LOCAL/DEV run unit tests only, all AWS mocked) | PASS | The touched suite is `tests/unit/auth/`, which uses a `MagicMock` DynamoDB table. No AWS call, no preprod dependency. |
+| §7 External dependency mocking (mandatory in all environments) | PASS | No external API is involved. `gh api` is a verification-time operator action against GitHub, not a test dependency. |
+| §7 Deterministic time handling (no `date.today()` / `datetime.now()` / `time.time()` in tests) | PASS | The added assertion is time-independent. The production `datetime.now(UTC)` at `oauth_state.py:78` is untouched and is source code, not a test. |
+| §8 Pre-push requirements (ruff check, ruff format, GPG-signed commit, feature branch, never push to main) | PASS | Standard flow. Note the `safe_provider` assignment MUST be deleted, not merely orphaned: `[tool.ruff.lint] select` includes `F`, so a retained unused local fails `ruff check` with F841 and blocks the required `Lint` context. |
+| §10 Local SAST (Bandit pre-commit, Semgrep via `make sast`, required pattern "Clear-text logging of sensitive data (CWE-312, CWE-532)") | PASS | This feature removes an instance of exactly that pattern class rather than suppressing it. Neither tool's configuration is touched, and FR-010 forbids the suppression route the constitution's "DO NOT suppress without documented justification" clause is aimed at. |
+| §6 Observability (structured logs for requests carrying request id, model_version, latency, outcome) | PASS | The constitution's named fields are request id, model_version, latency and outcome. `provider` is none of them, and this is not a request log. The field is also unrendered in production today (evidence: `specs/001-lambda-log-visibility/evidence/post-deploy/logshape-dashboard.json`), so no telemetry, metric filter, alarm, dashboard or runbook loses an input. The repository's only log metric filter is `dashboard_import_errors`. |
+| §9 Tech debt tracking (registry entry required for workarounds and "security shortcuts with documented acceptance criteria") | PASS on the Confirmed branch; **conditional on the Refuted branch** | A code fix that closes the finding creates no debt. A dismissal is a documented security shortcut and requires a registry entry (TD-XXX, location, status, root cause, proposed fix, effort, risk). The registry lives at **`docs/reference/TECH_DEBT_REGISTRY.md`**, not at the `docs/TECH_DEBT_REGISTRY.md` path §9 names: it was relocated by `f8db8d2` (PR #668) and §9 was never updated. **The identifier is allocated at merge time** against the registry's then-highest entry and is NOT pre-reserved here: `001-ruff-bump-forward` T016 and `001-codeql-coverage` Phase F both write registry entries in this same window, so any number written into a spec is a collision waiting to happen. Clarification Q2 promoted this obligation into spec.md itself (FR-007, SC-006), so it is no longer carried only here. |
+| Standing owner constraint: no new AWS resources | PASS | Nothing infrastructural. No Terraform file is touched. |
+
+**Post-design re-check (after Phase 1)**: unchanged. All gates PASS, with the §9 obligation still
+conditional on which gate branch the analysis selects. No Complexity Tracking entries needed.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/001-oauth-provider-taint/
+├── spec.md              # Stage 1 + Adversarial Review #1 appendix
+├── plan.md              # This file
+├── research.md          # Phase 0: decision record and prior-art ledger (satisfies US3 / FR-012)
+├── quickstart.md        # Phase 1: verification and dismissal runbook
+└── tasks.md             # Phase 2 output (/speckit.tasks, not created here)
+```
+
+**Artifacts deliberately not produced.** The plan template's Phase 1 asks for `data-model.md` and
+`contracts/`. Neither has content here and both are omitted rather than padded:
+
+- **`data-model.md`**: this feature introduces, removes and alters zero entities. The only data
+  structure in scope is a `dict` literal passed as `logging`'s `extra` keyword, and it is losing one
+  key. The persisted item and the returned `OAuthState` model are frozen by FR-003.
+- **`contracts/`**: no interface is exposed or changed. `store_oauth_state()` keeps its exact
+  signature, its return type and its DynamoDB write. The two production call sites are not touched.
+  There is no API surface, no CLI surface and no schema to contract against.
+
+### Source Code (repository root)
+
+```text
+src/lambdas/shared/auth/oauth_state.py   # store_oauth_state(): delete lines 99-101 (safe_provider
+                                         #   assignment) and the "provider" entry at line 105;
+                                         #   add a documentation comment naming the rule id.
+                                         #   validate_oauth_state() (lines 253-258) NOT touched.
+tests/unit/auth/test_oauth_state.py      # TestStoreOAuthState: add one caplog regression assertion.
+```
+
+**Structure Decision**: No structural change. Two existing files are edited in place. Nothing is
+created or deleted outside `specs/001-oauth-provider-taint/`. In particular
+`src/lambdas/shared/secrets.py` and `src/lambdas/ingestion/handler.py` are not opened; the latter
+belongs to sibling feature `001-ingestion-arn-logging`, and file disjointness between the two
+features is confirmed.
+
+## Implementation Design
+
+### The edit
+
+`store_oauth_state()` currently reads, at lines 99 to 109:
+
+```python
+    safe_provider = (
+        str(provider).replace("\r\n", " ").replace("\n", " ").replace("\r", " ")[:200]
+    )
+    logger.info(
+        "OAuth state stored",
+        extra={
+            "provider": safe_provider,
+            "has_user_id": user_id is not None,
+            "ttl_seconds": OAUTH_STATE_TTL_SECONDS,
+        },
+    )
+```
+
+It becomes:
+
+```python
+    # py/clear-text-logging-sensitive-data: no value derived from `provider` may
+    # appear in this extra context. Removing the derived value, rather than
+    # sanitizing it in place, is the shape that closed this rule in ebcc2f4.
+    # See specs/001-oauth-provider-taint/research.md before adding a key here.
+    logger.info(
+        "OAuth state stored",
+        extra={
+            "has_user_id": user_id is not None,
+            "ttl_seconds": OAUTH_STATE_TTL_SECONDS,
+        },
+    )
+```
+
+Four properties of that diff carry weight:
+
+1. **The `safe_provider` assignment is deleted, not orphaned.** `provider` is its only input and the
+   `extra` entry was its only consumer, so retaining it would be dead code and would fail
+   `ruff check` under F841, blocking the required `Lint` context. It also has to go on the merits:
+   FR-001 forbids any value derived from `provider` by replacement or slicing from reaching the
+   context, and leaving the derivation alive next to the sink is precisely the shape `8424cbd` left
+   behind.
+2. **Nothing is substituted.** Not a literal, not an allowlist-selected constant, not a boolean.
+   Adversarial Review #1 deleted the allowlist "Form A" for cause and it must not return: `extra` is
+   not rendered, so a substitute preserves nothing, and it would require editing this sink a second
+   time on a sink with a documented respawn.
+3. **The comment is required, and it is documentation rather than suppression.** Clarification Q1
+   promoted it from a plan-level choice to **FR-013**: it is mandatory on every gate branch,
+   including the confirmed one. It carries no `# nosec`, no `# noqa`, no `# lgtm`, and no CodeQL
+   alert-suppression pragma. FR-010 forbids an inline suppression comment as a substitute for the
+   dismissal path; so constrained, this comment is not that, and FR-013 states the disjointness
+   explicitly so the two requirements cannot be read as contradictory. It is also the mechanism by
+   which US3's second acceptance scenario survives in the code rather than only in these artifacts,
+   which matters because whoever writes the refactor that would reintroduce the key is looking at
+   the file, not at `specs/`. The obligation is inherited via FR-008 from
+   `specs/001-ingestion-arn-logging/codeql-logging-convention.md` §1, whose closing paragraph makes
+   the site comment unconditional.
+4. **`validate_oauth_state()` is not touched.** Its `safe_provider_validated` at line 253 and its
+   `extra={"provider": safe_provider_validated}` at line 258 are a materially different case,
+   request-derived provenance, and FR-004 freezes them. They carry no open alert.
+
+### The regression assertion
+
+Added to `TestStoreOAuthState` in `tests/unit/auth/test_oauth_state.py`. It calls
+`store_oauth_state()` under `caplog` and asserts the emitted `LogRecord` has no `provider`
+attribute, while `has_user_id` and `ttl_seconds` remain. `logging` promotes every `extra` key to a
+record attribute, so this is a direct assertion on the sink's contents and not on rendered text,
+which matters because the rendered text is bare in production and would pass either way. It uses no
+date or time function, satisfying the constitution's deterministic-time clause.
+
+No existing assertion changes, satisfying FR-011 and SC-004.
+
+## Verification Design
+
+The gate is evaluated **once**, against **one** completed default-branch analysis whose commit
+contains the change. Copy-pasteable commands, the analyzed-ref requirement, the freshness proof and
+every terminal state are in [quickstart.md](quickstart.md). The design in summary:
+
+1. **Establish the closure query.** Closure is read from the alerts API filtered to
+   `ref=refs/heads/main`, rule `py/clear-text-logging-sensitive-data`, path
+   `src/lambdas/shared/auth/oauth_state.py`. That triple is the criterion, and an empty result on a
+   successful, **paginated** call is the pass condition. Per FR-009 no pull request check result is
+   admissible; the `Analyze` job on a PR reports into the PR's own ref, not the default branch's.
+
+   Pagination is load-bearing rather than hygienic, because emptiness is the pass condition here.
+   Measured on this repository 2026-07-30: an unpaginated alerts query returns **zero** open alerts
+   and exits **0** on a repository carrying five, since the default page size is 30 against a corpus
+   of 137 and the open alerts sit at numbers 144 to 150. `per_page=100` is not a fix; page one at that
+   size spans numbers 180 down to 59 and drops alerts 22 to 27, the `secrets.py` sanitize-in-place
+   sites this feature's evidence rests on. The query therefore uses `--paginate --slurp` into a file,
+   filtered by standalone `jq`, and asserts a corpus floor plus a positive control before an empty
+   result is read as `CONFIRMED`. `--slurp` cannot be combined with `--jq`, and `--paginate` without
+   `--slurp` applies `--jq` per page, so the file-plus-`jq` shape is the only one that yields a single
+   answer with an uncorrupted exit code. quickstart.md Step 3a and tasks.md T020 and T021 carry it.
+2. **Prove the analysis is not stale.** The gate's fourth row exists because a result predating the
+   change decides nothing. Freshness is proved by comparing the analysis `commit_sha` against the
+   merge commit that landed the change:
+   `gh api repos/OWNER/REPO/compare/<CHANGE_SHA>...<ANALYZED_SHA>` must report status `ahead` or
+   `identical`. Anything else means the change is not in the analyzed tree and the observation is
+   discarded.
+3. **Attribute a survivor, at the analyzed commit.** This step runs only when step 1 returns a
+   non-empty result, and it never licenses a pass. A survivor's `start_line` is mapped to a function
+   by fetching `oauth_state.py` **at the analyzed commit** and locating the `store_oauth_state`
+   definition bounds there, computed fresh per analysis and never carried from authoring time. The
+   mapping is derived and best-effort by necessity: the alerts API carries no function field, only
+   `path` and line and column bounds. Its sole output is ownership, whether the survivor is this
+   feature's (dismiss, FR-007) or belongs to the FR-004-frozen `validate_oauth_state()` sink and must
+   be reported instead (FR-006a).
+4. **Classify, once.** Five observations map to five actions, per the spec's Decision Gate table. A
+   new alert number for this rule on this path is **Refuted**, not success, regardless of what
+   happened to 144.
+5. **Terminal states.** Exactly seven, and the feature must end in one of them. `PENDING-BRANCH-ANALYSIS`
+   was added after the Stage 7 cross-artifact analysis found that FR-008 binds this feature to the
+   convention **in full** while this table carried only one of the two terminal states
+   `codeql-logging-convention.md` §5 defines. It is the likeliest ending of the three that are neither
+   done nor failed, and without it an implementing agent whose change has not landed has no state to
+   record:
+
+| Terminal state | Reached when | What is recorded |
+|---|---|---|
+| `PENDING-BRANCH-ANALYSIS` | The code change and its regression guard are complete and green, but the change has not landed on `main`, so no qualifying default-branch analysis can exist | The gate is not evaluated. Record the code change as complete and write the closure query, filled in with this feature's path and rule id, so the check is mechanical the moment it lands. Inherited from `specs/001-ingestion-arn-logging/codeql-logging-convention.md` §5a, which calls it "the normal ending, not an edge case". Neither done nor failed. Distinct from `BLOCKED-NO-ANALYSIS`, whose 7-day clock starts only once the change is on `main`. |
+| `CONFIRMED` | No open finding for this rule on `oauth_state.py` in a fresh analysis | The analysis id and its `commit_sha`. `fixed_at` on alert 144 is recorded as **corroboration only**, never as the criterion: the criterion is the path being free of open findings, and 144 is a locating label. Stop. No dismissal. |
+| `REPORTED-FOREIGN-SINK` | A finding for this rule survives on the path but attributes outside `store_oauth_state()` | Reported to the owner per FR-006a. Not Confirmed, and not dismissed here: `validate_oauth_state()` is frozen by FR-004 and carries the same sanitize-in-place shape at lines 253 to 258. The code change is independently complete. |
+| `REFUTED-DISMISSED` | A finding survives; the maintainer dismisses it as `false positive` with the three-element justification | The alert number, the exact justification text, the API response, and a `docs/reference/TECH_DEBT_REGISTRY.md` entry (identifier allocated at merge time, never pre-reserved) per FR-007 and the §9 conditional gate. |
+| `BLOCKED-ON-OWNER` | A finding survives and the **read-only probe** of convention §5b (token scopes read together with repository visibility and the actor's repository permissions) resolves to *absent*. Never established by attempting a dismissal. **A missing `security_events` scope is not by itself the trigger**: GitHub requires that scope only on private repositories, and on this public one `repo` subsumes `public_repo`, which is what the endpoint needs. Probed 2026-07-30 the local environment resolves to *available*, so this is not the expected ending | A handoff artifact in this directory carrying the observed alert numbers, the exact justification text for each, and the exact API call. The code change is independently complete and mergeable. Inherited via FR-008 from `specs/001-ingestion-arn-logging/codeql-logging-convention.md` §5, not newly defined here. |
+| `BLOCKED-NO-ANALYSIS` | No completed default-branch analysis covering the change within **7 days** of the change landing on `main` | Reported to the repository owner naming the missing analysis. Not classified. Not dismissed. Terminal, not a further attempt. |
+| `BLOCKED-REGRESSION` | The unit suite fails, or a new open alert is attributable to this feature's diff (SC-003) | Reported before any gate evaluation. The gate is not evaluated on a broken tree. A repo-wide open-alert count is NOT the trigger: sibling `001-codeql-coverage` is expected to raise that number, and the owner's directive is that coverage is the goal, not a low count. |
+
+The 7-day bound is generous against observed behavior: the `codeql` job lives in
+`.github/workflows/pr-checks.yml`, which triggers on `push` to `main`, and the three most recent
+default-branch analyses landed within roughly 25 minutes of their commits. The bound covers a
+workflow outage, not normal turnaround.
+
+**On what a green build is worth here.** CodeQL is not a required status check. The required
+contexts are exactly `Secrets Scan`, `Lint`, `Run Tests` and `Playwright E2E Tests`, and the
+rulesets API returns `[]`. The `Analyze` job passing tells you the analysis ran, never that the
+alert closed. Only the alerts API tells you that.
+
+## Phase Notes
+
+**Phase 0 (research)**: complete. `research.md` holds the decision record, the prior-art ledger keyed
+on `commit_sha` and `fixed_at` rather than on dates or `state`, and the two questions that are
+deliberately left unresolved. There were no NEEDS CLARIFICATION markers to resolve: spec.md, after
+Adversarial Review #1, fixes the approach to a single form and leaves no technical choice open.
+
+**Phase 1 (design)**: complete, minus the two artifacts documented as skipped above.
+
+**Agent context update not run.** The workflow's Phase 1 step 3 calls
+`.specify/scripts/bash/update-agent-context.sh claude`, which writes the repository-root `CLAUDE.md`.
+Three sibling agents share this worktree and this feature's write scope is
+`specs/001-oauth-provider-taint/` only, so the script was deliberately not executed. It would have
+had nothing to add regardless: this feature introduces no language, dependency or storage technology
+that is not already listed there.
+
+## Gaps found in spec.md
+
+Both were raised in Stage 4 clarification and are now **closed in spec.md itself**. Retained as a
+record of what was found and how it was resolved.
+
+1. **No terminal state for absent dismissal permission.** spec.md Assumption 2 asserts the maintainer
+   can dismiss, and the gate's Refuted row routed straight to FR-007, with nothing covering the case
+   where the implementing agent lacks `security-events: write`. CLOSED by clarification Q3. The old
+   FR-008 bound only the dismissal justification's wording and recording location, so it did not in
+   fact reach the sibling's terminal state and the plan's "inherited via FR-008" citation was
+   unsupported. FR-008 is now widened to consume
+   `specs/001-ingestion-arn-logging/codeql-logging-convention.md` in full, which carries
+   `BLOCKED-ON-OWNER` at §5, so the inheritance is real rather than asserted.
+2. **The tech debt registry is never mentioned.** Constitution §9 requires a registry entry for
+   security shortcuts with documented acceptance criteria, and a CodeQL dismissal is one. CLOSED by
+   clarification Q2: the obligation now lives in FR-007 and SC-006. The investigation also found
+   that the registry exists at `docs/reference/TECH_DEBT_REGISTRY.md` rather than the
+   `docs/TECH_DEBT_REGISTRY.md` path this plan and §9 both named, having been relocated by `f8db8d2`
+   (PR #668) without a constitution update. That constitution defect is carded, not fixed here.
+
+## Complexity Tracking
+
+No constitution violations. Table intentionally empty.
+
+---
+
+## Adversarial Review #2
+
+Reviewer did not author these artifacts. Focus is drift introduced by the Stage 4 clarification
+answers, which are written into spec.md only and never propagated to plan.md, research.md or
+quickstart.md, plus cross-artifact consistency. Adversarial Review #1's findings are not re-litigated.
+Every API-shaped and tool-shaped claim below was re-derived by running the thing, not by reading
+about it.
+
+### A. Drift from the clarification session
+
+| # | Sev | Clarification | Artifact left stale | Finding and correction |
+|---|---|---|---|---|
+| D1 | HIGH | Q1 (new FR-013) | `research.md:35` | The Alternatives table rejected "Inline suppression comment ... Forbidden by FR-010" with no carve-out. After Q1 the feature **mandates** an inline comment at that exact site. A reader of research.md alone would conclude the FR-013 comment is forbidden, which is precisely the reading Q1's answer went to the trouble of pre-empting inside spec.md and then failed to carry across. **FIXED**: row narrowed to name the four suppression pragmas explicitly and to point at the new Decision 5. |
+| D2 | HIGH | Q1 (US3 gained a second acceptance scenario) | `research.md:5` | research.md opens "Its test is the US3 acceptance scenario", singular, and describes only the first. US3 now has two, and the second (a reader with only the source file is warned at the sink) is **unsatisfiable by this file by construction**. The artifact claimed a passing grade against a requirement it cannot meet. **FIXED**: reworded to claim the first scenario only, and to state that the second is discharged in code by FR-013. |
+| D3 | HIGH | Q1 (new FR-013) | `research.md`, whole file | FR-013 had no representation in research.md at all, yet the comment text mandated by plan.md and quickstart.md **points the reader at research.md** ("See specs/001-oauth-provider-taint/research.md before adding a key here"). The pointer resolved to a document that never mentioned the comment or its FR-010 disjointness. **FIXED**: added **Decision 5**, covering the obligation, why the sink is marked unconditionally, and why FR-010 and FR-013 partition rather than conflict. |
+| D4 | HIGH | Q3 (FR-008 widened to require citing the convention document's sections, never a sibling requirement number) | `research.md:141` | research.md cited the blast-radius prohibition as "sibling feature `001-ingestion-arn-logging` FR-013". That is exactly the fragile form widened FR-008 now forbids, so the artifact violated its own feature's requirement. The number happens to be correct today (`specs/001-ingestion-arn-logging/spec.md:96`), which makes it worse, not better: it will rot silently. **FIXED**: re-anchored on `codeql-logging-convention.md` §4, with the reason stated inline. |
+| D5 | HIGH | Q1 (new SC-007) | `quickstart.md`, `plan.md` terminal-state table | SC-007 requires the FR-013 comment to be present on the merged file with no suppression pragma, "verifiable by inspecting the merged file". **No artifact contained a verification step for it.** Step 1c ran format, lint, tests and `make validate`; Step 4a recorded analysis id, `commit_sha`, `fixed_at` and an SC-003 recount; Step 4b recorded the dismissal and the registry entry. SC-007 appeared in none of them. A success criterion nobody checks is decoration. **FIXED**: added an SC-007 check to quickstart Step 1c (grep for the rule id in the preceding comment block, assert absence of the four pragmas) and a re-run instruction in Step 4a. |
+| D6 | MEDIUM | Q3 (FR-008 widened to consume the convention in full, which carries `BLOCKED-ON-OWNER` at §5) | `spec.md` Assumptions | Assumption 2 still read, flatly, "The maintainer can dismiss a code scanning alert ... permission and precedent are both established". That is the exact assumption Q3 spent a terminal state removing. plan.md's "Gaps found" section claims this was "CLOSED in spec.md itself"; the requirement was closed, the assumption that motivated it was not. **FIXED** (single edit): rewritten to separate "some actor holds the permission" from "the implementing agent holds it", and to route the second case to `BLOCKED-ON-OWNER` via §5. |
+
+### B. Cross-artifact inconsistencies
+
+| # | Sev | Finding |
+|---|---|---|
+| X1 | HIGH | **The gate's primary query does not execute.** `quickstart.md:169` (pre-fix) read `gh api ... --jq --arg rule "$RULE" --arg file "$FILE" '[...]'`. `gh api` has **no `--arg` flag**; its only jq flag is `--jq`/`-q`, taking one expression. Verified against `gh api --help` on this machine. The single most load-bearing command in the runbook, the one that reads the decision gate, fails on invocation. Worse than that, the natural repair (piping into standalone `jq`) sets the trap the campaign's own rule warns about: a failed `gh api` piped into `jq` prints nothing, and empty output **is the documented pass condition**, so a read failure renders as `CONFIRMED`. **FIXED**: variables interpolated into a single `--jq` expression, with an explicit `gh exit=$?` echo and a sentence stating that `[]` is only a pass when the exit code is 0. |
+| X2 | HIGH | **SC-003 makes this feature's success depend on a sibling doing its job.** `spec.md:291` (pre-fix) required the repo-wide open-alert count to be "no higher after this feature than the baseline of 5". Sibling `001-codeql-coverage` enables an additional analysis leg and states at `specs/001-codeql-coverage/spec.md:15` that this "will very likely RAISE the open alert number"; its own SC-004 (`:427`) explicitly refuses to fail on a rise, and its acceptance scenario at `:91` records the rise as expected outcome. The owner's directive governing the campaign is that coverage is the goal, not a low alert count. As written, SC-003 fails this feature for a sibling doing exactly what it was asked to do, and it is the mirror image of fact-checking on alert numbers that AR#1 spent three findings removing. Propagated into `plan.md:201` as a **blocking** terminal state (`BLOCKED-REGRESSION`) and into `quickstart.md:41` as a hard stop before the work even starts. **FIXED in all three**: SC-003 restated as an attribution test with three conditions wholly inside this feature's control (no new alert in `store_oauth_state()`, none new on `oauth_state.py`, none new on `secrets.py`); the terminal state retriggered on attribution; quickstart Step 0 now records the baseline set rather than gating on its count, and names which sibling owns each expected movement. |
+| X3 | HIGH | **SC-001 and the decision gate could return opposite answers on the same evidence.** `spec.md:287` scoped SC-001 to the whole **path** `src/lambdas/shared/auth/oauth_state.py`. FR-006, the Decision Gate's scoping paragraph, plan.md's verification design and `quickstart.md:196` all scoped to the **function** `store_oauth_state()`, and quickstart 3c scored "every finding maps outside `store_oauth_state()`" as **Confirmed**. So an open finding at the path could return Confirmed from the gate and FAIL from SC-001 at the same time. Not hypothetical: `validate_oauth_state()` carries `extra={"provider": safe_provider_validated}` at `oauth_state.py:258`, the identical sanitize-in-place shape whose `fixed_at` is null to this day on alerts 22 through 25, and FR-004 freezes it. **FIXED, and the fix direction was reversed mid-review** (see the note below): the gate is now keyed on **path plus rule id**, matching SC-001 as originally written and matching the inherited convention §3 Trap 2. FR-006 rewritten, gate scoping paragraph rewritten, plan verification step 3 and quickstart 3b demoted to survivor attribution, research.md Decision 4 retitled. New **FR-006a** and a sixth terminal state `REPORTED-FOREIGN-SINK` handle the real case the function scoping was reaching for: a survivor attributing to the FR-004-frozen sink is reported to the owner, never dismissed here and never scored Confirmed. |
+| X4 | HIGH | **`make validate` cannot pass on this tree, and the runbook prescribes it with no caveat.** `quickstart.md:118` instructed `make validate`. `Makefile:42` chains `check-banned-terms`, and `scripts/check-banned-terms.sh` exits **1** today on 17 pre-existing matches in other features' spec directories, one of which is the unfilled plan-template placeholder at `specs/1268-cors-404-headers/plan.md:21`. Verified by running it. An implementer following the runbook hits a red gate caused by files this feature is forbidden to touch, and the two available reactions are both bad: edit a sibling's directory, or start disregarding the gate. **FIXED**: Step 1c now runs `make sast` directly, states the pre-existing failure and its cause, confirms this feature's own directory is clean, and instructs that other features' directories are not to be repaired here. |
+| X5 | MEDIUM | **plan.md asserted the `ebcc2f4` precedent without the caveat that limits it.** spec.md and research.md both carry it: `ebcc2f4` did not delete its value, it relocated the sanitized identifier into a raised exception message, and `store_oauth_state()` has no raise on its path, so this deletion is strictly more aggressive than the shape it cites. plan.md's Summary asserted the shape match with no qualifier, and plan.md is the artifact the implementer reads first. **FIXED** (one paragraph added to Summary). |
+| X6 | LOW | `plan.md` Source Code block describes `validate_oauth_state()` as "(lines 253-258)". Those are the sink lines inside it; the function's `def` is at line 154 and it runs to end of file (260). Verified. Not corrected: the intent is unambiguous and the numbers are the ones the reader needs. |
+| X7 | LOW | `plan.md` Scale/Scope enumerates the diff as "three lines deleted, one dict entry deleted, one documentation comment added, one test method added" and omits the `import logging` addition that `quickstart.md:85` requires. Recorded, not corrected. |
+| X8 | LOW | `research.md` Decision 4 says the change "deletes four lines from the middle of the function, which shifts every line below 99". True of the deletion alone; the mandated four-line FR-013 comment lands in the same place, so the net shift is approximately zero. Harmless, because the gate is function-scoped precisely so that no line arithmetic matters. Recorded, not corrected. |
+| X10 | HIGH | **The spec's own US2 Independent Test keyed on alert 144 reaching a state.** `spec.md:157` read "query the alert-state API and confirm alert **144** reports `dismissed`". That is the exact hazard this feature exists as the proof of: `8424cbd` closed 117 and opened 144 at the identical timestamp, so a correctly handled respawn dismisses a *different* number and this test fails, while an unhandled disappearance of 144 passes it. Found only by re-reading the source spec **after** the derived artifacts had been checked: plan.md and quickstart.md both already forbade alert-number keying (quickstart's anti-checklist calls it out by name), so the derived artifacts looked clean and were weak evidence about the source. Drift in this pipeline runs source to derived, so a clean derived artifact proves little about the spec. **FIXED**: re-keyed on the path plus rule id being free of open findings, with 144 demoted to a locating label and the failure mode stated. Two derived-artifact echoes demoted alongside it: the `CONFIRMED` terminal-state row in plan.md and quickstart Step 4a now record alert 144's `fixed_at` as corroboration only, never as the criterion. |
+| X9 | LOW | `quickstart.md` Step 3b pipes `gh api ... \| base64 -d \| grep -n '^def '` and reads the result without checking `PIPESTATUS[0]`. A failed fetch yields no matches, which reads as "no functions found" rather than as an error. Lower severity than X1 only because the failure mode is visibly absurd rather than silently green. Recorded, not corrected. |
+
+### C. The TD-024 pre-reservation, all four sites
+
+Confirmed cross-feature conflict, and this feature was the last holdout still asserting the claim.
+Three features reason from the same `TD-023` high-water mark: `001-ruff-bump-forward` task T016
+(`tasks.md:36`) claims "the next sequential TD entry"; `001-codeql-coverage` Phase F writes registry
+entries; and this feature named the number outright. Both siblings had already independently settled
+on merge-time allocation and said so on the record (`specs/001-ingestion-arn-logging/spec.md:249`,
+`specs/001-codeql-coverage/plan.md:282`, the latter naming this feature as the claimant). Severity
+**HIGH**: two features writing `TD-024` into a shared registry file is a merge conflict at best and a
+duplicated identifier in a compliance artifact at worst.
+
+All four sites corrected to merge-time allocation. The registry **path** correction
+(`docs/reference/TECH_DEBT_REGISTRY.md`, not the constitution's stale flat path) is left intact
+everywhere, since that part of Q2's answer was right.
+
+### D. Checks run that produced no finding
+
+Recorded so a later reader knows these were tested rather than assumed.
+
+- **No surviving live reference to the deleted "Form A".** All three mentions (`spec.md` "Why
+  deletion, and not a substituted literal", `research.md` alternatives table, `quickstart.md` Step 5
+  anti-checklist) frame it as deleted for cause and forbidden. None resurrects it.
+- **The regression test fails on unfixed code**, which is the whole point of fact 7. It asserts
+  `not hasattr(records[0], "provider")` on the `LogRecord`, and `logging` promotes every `extra` key
+  to a record attribute, so today's code sets `.provider` and the assertion fails. No `caplog.text`
+  assertion exists anywhere in the artifacts.
+- **Test preconditions hold.** `tests/unit/auth/test_oauth_state.py` does **not** currently import
+  `logging` (so quickstart 1b is right to add it) and **does** already import
+  `OAUTH_STATE_TTL_SECONDS`. Verified by reading the file.
+- **Every line citation into `oauth_state.py` is correct.** `safe_provider` assignment at 99 to 101;
+  `extra={` at 104; `"provider": safe_provider` at 105; `"provider": provider` persisted in the item
+  at 87; `safe_provider_validated` at 253; `extra={"provider": ...}` at 258. All verified against the
+  260-line file.
+- **`plan.md` line 21 carries no template seed.** The banned term in
+  `.specify/templates/plan-template.md` placeholder text is absent from this plan, and the whole
+  feature directory greps clean for all seven banned terms.
+- **No success criterion keys on an alert number.** SC-001 through SC-007 all key on path plus rule
+  id, on the merged file, or on the test suite. The gate table's rows are written so that a respawned
+  number classifies Refuted. This check initially passed on the SC list alone and **missed X10**,
+  which was in an Independent Test line rather than in an SC; the sweep was redone across acceptance
+  scenarios and independent tests as well, which is where it was caught.
+- **`plan.md` line 21 carries no template placeholder.** Separately confirmed that
+  `scripts/check-banned-terms.sh` excludes `./.specify/` (line 42), so the seeded term in
+  `plan-template.md` is never scanned at source. The only real exposure is a placeholder copied into
+  a feature's own plan, which is what happened at `specs/1268-cors-404-headers/plan.md:21` and did
+  not happen here.
+
+### D-bis. Mid-review correction applied
+
+The coordinator corrected one premise this review had been given, verified against the live API by a
+sibling reviewer: **the code scanning alerts API exposes no function field.**
+`most_recent_instance.location` carries `path`, `start_line`, `end_line`, `start_column` and
+`end_column`. Function-level keying is therefore not mechanically achievable, and deriving a function
+from a `start_line` smuggles the line instability back into the criterion. The correct standard is
+**path plus rule id**.
+
+This review had initially "fixed" X3 in the wrong direction, re-scoping SC-001 from path to
+path-plus-function to match the gate. That edit was reverted and the gate was moved to path plus rule
+id instead, which is what SC-001 said all along and what the inherited convention §3 Trap 2 already
+required. Recorded rather than quietly amended, because the wrong fix was live in the artifacts for
+part of this session and the reversal is the substantive event.
+
+Worth stating plainly: the contradiction X3 identified was real and the finding stands. Only the
+resolution moved. The function boundary keeps a genuine but smaller job, deciding who owns a
+survivor, which is now FR-006a.
+- **The convention document exists and every cited section is real.**
+  `specs/001-ingestion-arn-logging/codeql-logging-convention.md` is present, and §1's closing
+  paragraph (lines 43 to 45), §2, §3, §4 and §5 all carry the content cited against them.
+- **`BLOCKED-ON-OWNER` triggering on a failed `PATCH` is not the anti-pattern the sibling forbids.**
+  Sibling FR-008a bans determining permission by *attempting a dismissal*, because a successful one
+  cannot be undone. Step 4b is the intended dismissal, not a probe, so a permission failure there is
+  an observation rather than a mutation. No finding.
+
+### E. Counts and gate
+
+**5 HIGH and 1 MEDIUM of drift (section A), 5 HIGH plus 1 MEDIUM plus 4 LOW of cross-artifact
+inconsistency (section B), 1 HIGH cross-feature conflict (section C).**
+
+Totals: **0 CRITICAL, 11 HIGH, 2 MEDIUM, 4 LOW.** All CRITICAL and HIGH findings are fixed in place,
+plus the two MEDIUMs that were single-edit repairs (D6, X5). The four LOWs are recorded and left.
+
+Two of the eleven HIGHs (X3 and X10) arrived through coordinator propagation from sibling reviewers
+rather than from this review's own sweep, and one of those (X3) had already been "fixed" here in the
+wrong direction before the correction landed. Both are recorded at full severity with the correction
+history intact rather than folded in silently, because the review-technique lesson is the more
+transferable finding: **check the source spec last and independently, not by reading outward from it.
+A derived artifact that obeys a rule is weak evidence that the source does.**
+
+**GATE: 0 CRITICAL, 0 HIGH remaining.**

--- a/specs/001-oauth-provider-taint/quickstart.md
+++ b/specs/001-oauth-provider-taint/quickstart.md
@@ -1,0 +1,562 @@
+# Verification Runbook: Close CodeQL alert 144 (OAuth provider taint)
+
+**Feature**: `001-oauth-provider-taint` | **Date**: 2026-07-30 | **Plan**: [plan.md](plan.md)
+
+Everything needed to apply the change, evaluate the decision gate exactly once, and land in one of
+the **seven** terminal states. Commands are copy-pasteable. `REPO` is set once and reused.
+
+```bash
+export REPO=traylorre/sentiment-analyzer-gsk
+export RULE=py/clear-text-logging-sensitive-data
+export FILE=src/lambdas/shared/auth/oauth_state.py
+source .venv/bin/activate   # required before any python or pytest
+```
+
+The seven states are `CONFIRMED`, `REPORTED-FOREIGN-SINK`, `REFUTED-DISMISSED`, `BLOCKED-ON-OWNER`,
+`BLOCKED-NO-ANALYSIS`, `BLOCKED-REGRESSION` and `PENDING-BRANCH-ANALYSIS`. The last is inherited
+from `specs/001-ingestion-arn-logging/codeql-logging-convention.md` §5a via FR-008 and is, in that
+document's words, "the normal ending, not an edge case": it is where this runbook stops if the change
+has not landed on `main`. See Step 1d. plan.md's terminal-state table and tasks.md carry the same
+seven.
+
+### Read this before running any alerts query
+
+**An unpaginated code-scanning alerts query silently truncates, and the truncation renders as
+CLEAN.** Measured on this repository 2026-07-30: `gh api repos/$REPO/code-scanning/alerts` filtered
+to open alerts returns **zero** results and exits **0**, because the default page size is 30 and the
+corpus is **137**, with the open alerts at numbers 144 to 150 sitting past the end of page one.
+`per_page=100` is not a fix either: page one at that size spans alert numbers 180 down to 59, which
+drops alerts 1 and 22 to 27, and 22 to 27 are the `secrets.py` sanitize-in-place sites this feature
+reasons about throughout.
+
+Every alerts query below therefore uses `--paginate --slurp` into a file, filtered by standalone
+`jq` with its own exit code, and asserts a **corpus floor** before anything derived from it is
+believed. Two mechanical notes, both verified by running them: `--slurp` is rejected in combination
+with `--jq`, which is why the response goes to a file; and `--paginate` without `--slurp` applies
+`--jq` once per page, so a per-page `[...]` collector prints one array per page and a two-page
+response would print `[]` twice, satisfying an "output is `[]`" pass condition twice over while
+telling you nothing.
+
+---
+
+## Step 0a. Record the baseline, before touching anything
+
+```bash
+# SC-003 baseline. Record the SET, never the count: three sibling features are
+# landing in this window and each legitimately moves it.
+export ALERTS_JSON=/tmp/oauth-alerts-baseline.json
+gh api --paginate --slurp \
+  "repos/$REPO/code-scanning/alerts?ref=refs/heads/main&per_page=100" > "$ALERTS_JSON"
+GH_RC=$?
+CORPUS=$(jq '[.[][]] | length' "$ALERTS_JSON"); JQ_RC=$?
+BASE=$(jq -c '[.[][] | select(.state == "open")
+                     | {number, rule: .rule.id,
+                        path: .most_recent_instance.location.path,
+                        line: .most_recent_instance.location.start_line}]' "$ALERTS_JSON")
+printf 'gh exit=%s jq exit=%s corpus=%s\nbaseline=%s\n' "$GH_RC" "$JQ_RC" "$CORPUS" "$BASE"
+```
+
+Accept the baseline only if `gh exit=0`, `jq exit=0` and `corpus` is at least **137** (measured
+2026-07-30; the figure only rises, because code scanning alerts are never deleted). Below the floor
+the read was truncated or failed and the baseline is discarded. The set observed 2026-07-30 was
+`{144, 147, 148, 149, 150}`, with 144 at `oauth_state.py:104`. If the set contains no entry for
+`$FILE` on a complete read, this feature's premise is gone: stop and record that, rather than
+"fixing" a finding that is not there.
+
+```bash
+# Alert 144's pre-change record, for the eventual before/after comparison.
+# Single-alert endpoint, so no pagination applies.
+gh api "repos/$REPO/code-scanning/alerts/144" \
+  --jq '{number, state, fixed_at, dismissed_reason,
+         path: .most_recent_instance.location.path,
+         start_line: .most_recent_instance.location.start_line,
+         commit_sha: .most_recent_instance.commit_sha,
+         code_flows: (.most_recent_instance.code_flows | length)}'
+```
+
+`code_flows` is expected to be `0`. That is why no claim is made anywhere about the taint path.
+
+```bash
+# Unit suite baseline: expect 30 passed.
+pytest tests/unit/auth/ -q
+```
+
+**How to read a baseline that is not 5.** Record the set, do not stop on the count. Three sibling
+features are landing in this same window and each of them legitimately moves this number:
+`001-ingestion-arn-logging` closes 148 through 150, `001-bad-tag-filter-dead-suppression` closes
+147, and `001-codeql-coverage` enables an additional analysis leg that is *expected to raise* the
+count (its own spec says so, and its SC-004 refuses to fail on a rise). Per the owner's directive,
+coverage is the goal, not a low alert count.
+
+What actually triggers `BLOCKED-REGRESSION` is narrow and attributable, per SC-003:
+
+- the unit suite is not green, **or**
+- a new open alert of any rule appears on `src/lambdas/shared/auth/oauth_state.py` or on
+  `src/lambdas/shared/secrets.py`.
+
+A repo-wide count moving for a sibling's reasons is recorded in the artifacts and is not a
+regression. The gate is still not evaluated on a tree whose unit suite was already broken.
+
+---
+
+## Step 0b. Probe the dismissal permission, read-only, before anything can mutate an alert
+
+Required by `specs/001-ingestion-arn-logging/codeql-logging-convention.md` **§5b**, consumed via
+FR-008: "Check the permission with a read-only probe. **Never establish it by attempting a
+dismissal**", because a successful dismissal cannot be cleanly reverted. This step exists so that
+Step 4b is never used as a probe. It runs here, before the change is even applied, so the outcome is
+known long before it is needed.
+
+```bash
+gh auth status 2>&1 | grep -i 'Token scopes'
+PERM=$(gh api "repos/$REPO" --jq '{visibility, permissions}')
+RC=$?; printf 'gh exit=%s\nperm=%s\n' "$RC" "$PERM"
+```
+
+Require `gh exit=0` and a non-empty `$PERM`, then record one of two outcomes:
+
+- **available**: `visibility` is `public`, `permissions.push` is `true`, and the scope list contains
+  `repo`. The update-code-scanning-alert endpoint needs `security_events` only on **private**
+  repositories; on a public one `public_repo` suffices and `repo` subsumes it.
+- **absent**: anything else. Step 4b is then not attempted at all, and the dismissal branch, if it is
+  ever reached, terminates directly in `BLOCKED-ON-OWNER` (Step 4c).
+
+**A missing `security_events` scope is not by itself a blocker.** Reading `gh auth status` alone and
+concluding "no `security_events`, therefore blocked" is the specific mistake §5b exists to prevent,
+and the sibling made it once before correcting it. Probed 2026-07-30 on this machine: scopes
+`gist, read:org, repo, workflow`, `visibility: public`, `permissions.admin: true`, so the outcome is
+**available** and `BLOCKED-ON-OWNER` is not the expected ending here.
+
+---
+
+## Step 1. Apply the change
+
+Two files. Nothing else is opened. In particular `src/lambdas/shared/secrets.py` and
+`src/lambdas/ingestion/handler.py` stay closed.
+
+### 1a. `src/lambdas/shared/auth/oauth_state.py`
+
+In `store_oauth_state()` only, delete the `safe_provider` assignment (lines 99-101) and the
+`"provider"` entry from the `extra` dict, and add the documentation comment. The comment is
+**required by FR-013**, on every branch of the gate including the confirmed one, and is not
+optional polish:
+
+```python
+    # py/clear-text-logging-sensitive-data: no value derived from `provider` may
+    # appear in this extra context. Removing the derived value, rather than
+    # sanitizing it in place, is the shape that closed this rule in ebcc2f4.
+    # See specs/001-oauth-provider-taint/research.md before adding a key here.
+    logger.info(
+        "OAuth state stored",
+        extra={
+            "has_user_id": user_id is not None,
+            "ttl_seconds": OAUTH_STATE_TTL_SECONDS,
+        },
+    )
+```
+
+The `safe_provider` assignment must be **deleted**, not left orphaned: `ruff` selects `F` in
+`pyproject.toml`, so an unused local fails `ruff check` with `F841 Local variable safe_provider is
+assigned to but never used` at line 99, and the `Lint` job runs `ruff check src/ tests/`
+(`.github/workflows/pr-checks.yml:62`), which is one of the four required contexts. Verified by
+running it during Stage 4 clarification, not merely asserted. Leaving the derivation alive beside
+the sink is also the exact shape `8424cbd` left behind, and FR-001 forbids it independently of what
+the linter does.
+
+`validate_oauth_state()` (its `safe_provider_validated` at line 253 and `extra` at line 258) is
+**not** modified. FR-004.
+
+### 1b. `tests/unit/auth/test_oauth_state.py`
+
+Add `import logging` to the imports, and one method to `TestStoreOAuthState`:
+
+```python
+    def test_log_context_excludes_provider(self, mock_table, caplog):
+        """Regression guard for py/clear-text-logging-sensitive-data (alert 144).
+
+        No value derived from `provider` may reach the logger's extra context.
+        `logging` promotes every extra key to a LogRecord attribute, so this
+        asserts on the sink itself rather than on rendered output, which is bare
+        in production and would pass either way.
+        """
+        with caplog.at_level(
+            logging.INFO, logger="src.lambdas.shared.auth.oauth_state"
+        ):
+            store_oauth_state(
+                mock_table, "state-1", "google", "https://example.com/callback"
+            )
+
+        records = [r for r in caplog.records if r.getMessage() == "OAuth state stored"]
+        assert len(records) == 1
+        assert not hasattr(records[0], "provider")
+        assert records[0].has_user_id is False
+        assert records[0].ttl_seconds == OAUTH_STATE_TTL_SECONDS
+```
+
+No existing assertion is edited. FR-011, SC-004.
+
+### 1c. Local gates
+
+```bash
+ruff format src/lambdas/shared/auth/oauth_state.py tests/unit/auth/test_oauth_state.py
+ruff check src/lambdas/shared/auth/oauth_state.py tests/unit/auth/test_oauth_state.py
+pytest tests/unit/auth/ -q          # expect 31 passed
+make sast                            # bandit + semgrep
+```
+
+**`make validate` does not pass on this tree, and not because of this change.** It chains
+`check-banned-terms`, which exits 1 today on 17 pre-existing matches of two legacy framework names in
+other features' spec directories, including the raw plan-template placeholder left unfilled at
+`specs/1268-cors-404-headers/plan.md:21`. The names are not repeated here, because writing them into
+this directory is what the scanner exists to prevent; run the script to see them. Verified by
+running it. Run the targeted gates above
+instead, and if `make validate` is run anyway, confirm the only failures are those pre-existing
+banned-term matches and that none of them is in `specs/001-oauth-provider-taint/` (verified clean).
+Do not "fix" other features' directories to make the gate green; that is a separate feature's scope
+and three sibling agents share this worktree. Carded, not folded in.
+
+### SC-007 check, before the commit
+
+The FR-013 comment is a spec requirement with its own success criterion, so verify it mechanically
+rather than trusting the diff:
+
+```bash
+grep -n -B6 'OAuth state stored' src/lambdas/shared/auth/oauth_state.py
+```
+
+The window must be at least `-B5` and is set to `-B6` for one line of slack. `grep` matches the
+string literal `"OAuth state stored",`, which sits below `logger.info(`, which sits below the four
+comment lines, so the rule id is exactly five lines above the match. `-B4` prints a window that
+excludes it and the check can never pass on correct code (Adversarial Review #3, finding **G-01**;
+measured, `-B4` yields zero occurrences of the rule id and `-B5` yields one).
+
+Expect the rule id `py/clear-text-logging-sensitive-data` present in the preceding comment block, and
+expect **no** `# nosec`, `# noqa`, `# lgtm` or CodeQL pragma on any of those lines. Re-run this same
+check against the merged file at the end of Step 4a or 4b: SC-007 is stated against the merged file,
+and it is the one criterion that is true on the `CONFIRMED` branch as well as the refuted one.
+
+FR-003 sanity check, by inspection of the diff: the `put_item` item dict, the returned `OAuthState`,
+and the `code_verifier` generation are untouched. The diff touches only the two lines described
+above plus the comment.
+
+### 1d. If the change cannot land: terminal state `PENDING-BRANCH-ANALYSIS`
+
+Read this before Step 2, because for this feature it is the likeliest ending rather than an edge
+case, and the convention says so in those words.
+
+Closure is read from a default-branch analysis (FR-009, and convention §3 Trap 3), so **no
+qualifying analysis can exist while the change sits on a feature branch**. If the push or the merge
+is gated on the repository owner, or the PR is open and unmerged, stop here and record terminal state
+**`PENDING-BRANCH-ANALYSIS`**, inherited from
+`specs/001-ingestion-arn-logging/codeql-logging-convention.md` **§5a** via FR-008. Record that the
+code change and its regression guard are complete and green, and write the Step 3a gate query,
+filled in with this feature's `$RULE` and `$FILE`, into this directory so the check is mechanical the
+moment the change lands. Report it as **neither done nor failed**, and do not evaluate the gate.
+
+This is **not** `BLOCKED-NO-ANALYSIS`. That state's 7-day clock starts only once the change is on
+`main` (Step 2). This one is entered before the change gets there, and the clock has not started.
+
+Commit GPG-signed on the feature branch, open a PR, merge through the normal pipeline. Record the
+resulting **merge commit SHA on `main`**:
+
+```bash
+export CHANGE_SHA=<merge commit sha on main>
+```
+
+---
+
+## Step 2. Wait for a default-branch analysis that contains the change
+
+The `codeql` job (name `Analyze`, category `/language:python`) lives in
+`.github/workflows/pr-checks.yml` and triggers on `push` to `main`. Recent default-branch analyses
+have landed within roughly 25 minutes of their commit.
+
+```bash
+gh api "repos/$REPO/code-scanning/analyses?ref=refs/heads/main&per_page=5" \
+  --jq '.[] | {id, commit_sha, created_at, analysis_key, category}'
+export ANALYZED_SHA=<commit_sha of the newest analysis>
+```
+
+### Freshness proof (mandatory, do not skip)
+
+A result predating the change decides nothing. Prove the change is in the analyzed tree:
+
+```bash
+gh api "repos/$REPO/compare/$CHANGE_SHA...$ANALYZED_SHA" --jq '.status'
+```
+
+Accept only `ahead` or `identical`. `behind` or `diverged` means the analysis does not cover the
+change; discard the observation and keep waiting.
+
+**Bound**: if no analysis satisfying this check exists **7 days** after `CHANGE_SHA` landed on
+`main`, stop. Terminal state `BLOCKED-NO-ANALYSIS`: report to the repository owner naming the missing
+analysis. Do not classify. Do not dismiss. This is a terminal reportable state, not a third attempt.
+
+---
+
+## Step 3. Read the gate
+
+### 3a. Open findings for this rule at this path, on the default branch
+
+Two rules govern this query, and the second is why the first is not enough.
+
+`gh api` has **no `--arg` flag** (its only jq flag is `--jq`/`-q`, which takes one expression). Do
+not pipe `gh api` into a standalone `jq` to get one either: a failed `gh api` piped into `jq` yields
+empty output, which is indistinguishable from the pass condition and would be misread as
+`Confirmed`. If you ever do pipe, check `PIPESTATUS[0]`. The shape below avoids the whole question by
+writing the response to a file and running `jq` over the file, where `jq --arg` is available and
+where nothing sits downstream of a pipe.
+
+And the read **must be paginated**, per "Read this before running any alerts query" at the top of this
+runbook: unpaginated, this exact query
+reports zero open alerts on a repository that has five, and exits 0 while doing it.
+
+#### The control, first. It is not optional.
+
+The gate's pass condition is empty output, so it is worthless without proof that the query can return
+anything at all. A typo in `$RULE`, `$FILE` or the ref returns `[]` forever and reads as success.
+The control is the same corpus, same filters, with the `state == "open"` predicate dropped.
+
+```bash
+export ALERTS_JSON=/tmp/oauth-alerts-gate.json
+gh api --paginate --slurp \
+  "repos/$REPO/code-scanning/alerts?ref=refs/heads/main&per_page=100" > "$ALERTS_JSON"
+GH_RC=$?
+CORPUS=$(jq '[.[][]] | length' "$ALERTS_JSON"); JQ_RC=$?
+RULETOT=$(jq --arg r "$RULE" '[.[][] | select(.rule.id == $r)] | length' "$ALERTS_JSON")
+CTRL=$(jq -c --arg r "$RULE" --arg f "$FILE" \
+  '[.[][] | select(.rule.id == $r)
+          | select(.most_recent_instance.location.path == $f)
+          | {number, state}]' "$ALERTS_JSON")
+printf 'gh exit=%s jq exit=%s corpus=%s rule_total=%s\ncontrol=%s\n' \
+  "$GH_RC" "$JQ_RC" "$CORPUS" "$RULETOT" "$CTRL"
+```
+
+Require all four, each a figure measured 2026-07-30 rather than a vague "non-empty": `gh exit=0` and
+`jq exit=0`; `corpus` at least **137**; `rule_total` at least **22**; and `$CTRL` containing **alert
+117**, which is `state: fixed` at this path for this rule and is therefore an immovable anchor, so
+the control stays satisfied after the change lands whatever the outcome. Measured `$CTRL`:
+`[{"number":144,"state":"open"},{"number":117,"state":"fixed"}]`. Alert 117 is a fixture for the
+control here, never a criterion for the gate.
+
+If any of the four fails, the read or the query shape is broken and **the gate result below is not an
+observation**. Discard it and re-run.
+
+#### The gate itself
+
+Filters the same file the control just validated. Do not re-fetch in between.
+
+```bash
+GATE=$(jq -c --arg r "$RULE" --arg f "$FILE" \
+  '[.[][] | select(.state == "open")
+          | select(.rule.id == $r)
+          | select(.most_recent_instance.location.path == $f)
+          | {number, start_line: .most_recent_instance.location.start_line,
+             commit_sha: .most_recent_instance.commit_sha}]' "$ALERTS_JSON")
+JQ_RC=$?; printf 'jq exit=%s\ngate=%s\n' "$JQ_RC" "$GATE"
+```
+
+An empty array `[]` is the pass condition **only if** the control passed on all four floors and
+`jq exit=0`. A blank `$GATE` is a failed filter, not a closed alert, and the observation is discarded
+rather than classified.
+
+Per FR-009, this is the only admissible evidence. A green `Analyze` check on a pull request is not:
+CodeQL is not a required status check here, and a PR run reports into the PR's own ref.
+
+An empty array under those conditions is **Confirmed**, full stop. The criterion is path plus rule
+id, and that is the strongest identity the API supports: `most_recent_instance.location` carries
+`path`, `start_line`, `end_line`, `start_column` and `end_column`, and no function field.
+
+### 3b. Only if the result is non-empty: attribute each survivor at the analyzed commit
+
+This step never turns a non-empty result into a pass. It decides **who owns the survivor**, nothing
+else. The mapping is derived from a `start_line`, so it inherits the line instability the gate is
+built to avoid, which is exactly why it is not the criterion. Never map against the working tree, and
+never against a line window frozen at authoring time.
+
+```bash
+gh api "repos/$REPO/contents/$FILE?ref=$ANALYZED_SHA" --jq '.content' \
+  | base64 -d | grep -n '^def '
+```
+
+`store_oauth_state()` spans from its `def` line to the line before the next top-level `def`. A
+finding whose `start_line` falls in that span is this feature's to dismiss. One outside it is a
+different function, most likely the FR-004-frozen `validate_oauth_state()` sink at lines 253 to 258,
+which carries the same sanitize-in-place shape and is not this feature's to touch. That case is
+**reported, never dismissed here, and never scored as Confirmed**.
+
+Check `PIPESTATUS[0]` on the fetch above. A failed `gh api` piped into `base64 -d` produces no
+matches, which reads as "no functions found" rather than as an error.
+
+### 3c. Classify, once
+
+| Observation | Classification | Action |
+|---|---|---|
+| Step 3a returns empty **and** `gh exit=0` | **Confirmed** | Go to Step 4a. Stop. No dismissal. |
+| Alert 144 still open on the path, attributed to `store_oauth_state()` | **Refuted** | Go to Step 4b, dismissing 144. |
+| 144 closed but a different alert number for this rule is open on the path, attributed to `store_oauth_state()` | **Refuted** (a respawn, exactly what `8424cbd` produced) | Go to Step 4b, dismissing the new number, and record that a respawn occurred. |
+| A finding for this rule is open on the path but attributes outside `store_oauth_state()` | **Not Confirmed**, and not this feature's | Terminal state `REPORTED-FOREIGN-SINK`. Report to the owner per FR-006a with the alert number, `start_line` and `ANALYZED_SHA`. Do not dismiss. Do not edit `validate_oauth_state()` (FR-004). |
+| Step 3a errored (`gh exit` non-zero) | Not an observation | Discard and re-run. Empty output from a failed call is not a pass. |
+| No fresh analysis (Step 2's freshness proof never satisfied) | Not yet decidable | Wait, bounded at 7 days, then `BLOCKED-NO-ANALYSIS`. |
+
+The change is retained on the refuted branch as well. It is a defensible improvement on its own
+terms, and reverting it would restore a derived-string log for no benefit.
+
+---
+
+## Step 4a. Terminal state `CONFIRMED`
+
+```bash
+gh api "repos/$REPO/code-scanning/alerts/144" \
+  --jq '{number, state, fixed_at, dismissed_reason}'
+```
+
+Record in this feature's artifacts: the analysis `id` and `commit_sha`, the `compare` status that
+proved freshness, alert 144's `fixed_at` as **corroboration only** (expected non-null and dated at or
+after `CHANGE_SHA`; the pass was already decided by Step 3a's empty result, and 144 is a locating
+label, not the criterion), and
+the SC-003 recount below. Then stop. No dismissal, no tech debt entry.
+
+```bash
+# SC-003 is an attribution check, not a count. List the open set with paths and
+# compare it to the Step 0a baseline set, then confirm the binding condition:
+# no new alert of any rule on oauth_state.py or on secrets.py.
+export AFTER_JSON=/tmp/oauth-alerts-after.json
+gh api --paginate --slurp \
+  "repos/$REPO/code-scanning/alerts?ref=refs/heads/main&per_page=100" > "$AFTER_JSON"
+GH_RC=$?
+CORPUS=$(jq '[.[][]] | length' "$AFTER_JSON"); JQ_RC=$?
+AFTER=$(jq -c '[.[][] | select(.state == "open")
+                      | {number, rule: .rule.id,
+                         path: .most_recent_instance.location.path}]' "$AFTER_JSON")
+printf 'gh exit=%s jq exit=%s corpus=%s\nafter=%s\n' "$GH_RC" "$JQ_RC" "$CORPUS" "$AFTER"
+```
+
+Require `gh exit=0`, `jq exit=0` and `corpus` at least **137** before believing the comparison.
+Unpaginated, this query reads zero open alerts and would certify SC-003 while blind.
+
+Record the diff against the Step 0a set and name which sibling feature each change belongs to. A
+higher total that is wholly attributable to `001-codeql-coverage`'s new analysis leg satisfies
+SC-003; it does not breach it. Also re-run the SC-007 comment check from Step 1c against the merged
+file.
+
+Note on reading the result: `state` alone is not proof of repair. Dismissal is sticky and survives a
+later genuine fix, which is why alerts 26 and 27 read `dismissed` while carrying `fixed_at`, and why
+alerts 22 through 25 read `dismissed` with `fixed_at` still null eight months on. `fixed_at` is the
+load-bearing field.
+
+---
+
+## Step 4b. Terminal state `REFUTED-DISMISSED`
+
+Only reachable after the Step 1 change has landed and been refuted at the gate (FR-007), **and** only
+if Step 0b's read-only probe recorded the outcome **available**. If it recorded **absent**, do not
+run the `PATCH` below at all: go straight to Step 4c. The `PATCH` here is the intended dismissal, not
+a permission probe, and it is only ever reached with the permission question already answered.
+
+The justification carries the three elements settled at
+`specs/001-ingestion-arn-logging/codeql-logging-convention.md` **§2**, consumed here rather than
+redefined (FR-008). Cite the convention's section, not a sibling requirement number: FR-008 requires
+restatements to anchor on that document so a renumbering in the sibling cannot silently break this
+feature. Adjust `<N>` and the alert-number references to what was actually observed.
+
+```bash
+export ALERT=<observed alert number>
+export JUSTIFICATION="Not a credential. The only non-constant input to this expression was the \
+OAuth provider name, a two-value identifier ('google' or 'github') passed as a string literal by \
+both production call sites, and it has now been removed from the log context entirely, so no value \
+derived from it reaches this sink at all. Convention applied: the no-derived-value-in-log-context \
+shape established by ebcc2f4 (PR #322) and recorded in specs/001-ingestion-arn-logging; see \
+specs/001-oauth-provider-taint/research.md. Why CodeQL still reports the flow: unknown. The alert \
+returns zero code_flows, so the taint path cannot be inspected, and the finding survives the exact \
+rewrite that carries a non-null fixed_at on alerts 26, 27, 106, 107, 110 and 111. The value is \
+persisted deliberately in the DynamoDB item written at oauth_state.py:87 and is unaffected."
+
+gh api -X PATCH "repos/$REPO/code-scanning/alerts/$ALERT" \
+  -f state=dismissed \
+  -f dismissed_reason='false positive' \
+  -f dismissed_comment="$JUSTIFICATION"
+
+# Verify it took.
+gh api "repos/$REPO/code-scanning/alerts/$ALERT" \
+  --jq '{number, state, dismissed_reason, dismissed_comment, dismissed_at, dismissed_by: .dismissed_by.login}'
+```
+
+Then add a registry entry, per **FR-007** and constitution §9 (security shortcuts with documented
+acceptance criteria). The file is **`docs/reference/TECH_DEBT_REGISTRY.md`**. Constitution §9 names
+`docs/TECH_DEBT_REGISTRY.md`, which has not existed since `f8db8d2` (PR #668) moved the file into
+`docs/reference/`; §9 was never updated and the stale path is carded separately. Do not create a new
+file at the §9 path.
+
+**Allocate the identifier at merge time, never from this document.** Read the registry's
+then-highest `TD-` entry at the moment the entry is written and take the next one. It ran TD-001
+through TD-023 at authoring time, but `001-ruff-bump-forward` task T016 and `001-codeql-coverage`
+Phase F both write registry entries in this same window, so any number written here is a collision
+rather than a convenience. Sibling `001-ingestion-arn-logging` (`spec.md:249`) settled the same rule
+independently. Required fields:
+`ID`, `Location` (`src/lambdas/shared/auth/oauth_state.py`, `store_oauth_state()`), `Status:
+Acceptable`, `Root Cause`, `Proposed Fix`, `Effort`, `Risk`. Link it back to this feature's
+directory.
+
+Finally, recount for SC-003 as in Step 4a.
+
+---
+
+## Step 4c. Terminal state `BLOCKED-ON-OWNER`
+
+Reached when **Step 0b's read-only probe recorded `absent`**, which is how the permission question is
+answered here. Inherited via FR-008 from
+`specs/001-ingestion-arn-logging/codeql-logging-convention.md` **§5b**, not newly defined here. The
+three bullets below are a restatement for convenience; §5b governs if they ever drift.
+
+A Step 4b `PATCH` that fails on permissions despite a probe reading `available` also lands here, but
+that is a contradiction to record and investigate, not the normal route in. The route in is the
+probe. §5b is unconditional that permission is never established by attempting a dismissal, because a
+successful one cannot be cleanly reverted, and this runbook previously had no probe at all, which
+left the failed `PATCH` doing that job by default.
+
+Write a handoff artifact into `specs/001-oauth-provider-taint/` carrying:
+
+- the exact alert numbers observed on the path and attributed to `store_oauth_state()`, with their
+  `start_line` and the
+  `ANALYZED_SHA` they were read from;
+- the exact `JUSTIFICATION` text above, verbatim, per alert;
+- the exact `gh api -X PATCH` invocation, ready to run.
+
+State plainly that the code change is independently complete and mergeable and only the dismissal is
+outstanding. A feature blocked this way is reported as neither done nor failed.
+
+---
+
+## Step 5. Anti-checklist
+
+None of these may be done at any point, on any branch:
+
+- Suppressing the rule repo-wide, lowering its severity, excluding the file from analysis, or adding
+  an inline suppression comment as a substitute for the dismissal (FR-010). The comment added in
+  Step 1a is documentation, is required by FR-013, and carries no `# nosec`, `# noqa`, `# lgtm` or
+  CodeQL pragma. FR-010 and FR-013 do not conflict: one forbids suppressing the finding, the other
+  requires explaining it.
+- Skipping the Step 1a comment because the gate came back `CONFIRMED`. FR-013 is unconditional. The
+  refactor that would reintroduce the key is written against the source file, not against `specs/`.
+- Substituting a literal, an allowlist-selected constant, or any other stand-in for the removed
+  `provider` value (FR-002). Deleted for cause by Adversarial Review #1.
+- Editing `validate_oauth_state()` (FR-004).
+- Editing `src/lambdas/shared/secrets.py`. Its alerts 22 through 25 are live findings behind sticky
+  dismissals with `fixed_at` null; touching those lines re-fingerprints them into fresh open alerts,
+  which is what happened to that file on 2025-12-09.
+- Editing `src/lambdas/ingestion/handler.py` or its alerts 148 through 150. Sibling feature
+  `001-ingestion-arn-logging` owns them.
+- Citing a pull request check result as evidence of closure (FR-009).
+- Reporting `CONFIRMED` because alert 144 disappeared, without checking whether a replacement number
+  for this rule appeared anywhere on the path. That is precisely what `8424cbd` produced: it closed
+  alert 117 at line 95 and opened alert 144 at line 104 in the same run. The criterion is path plus
+  rule id, never the function and never one alert number.
+- Reading a code-scanning alerts query without `--paginate`, or believing one whose corpus floor was
+  not checked. Unpaginated, the open set reads as empty on a repository with five open alerts, and
+  the call exits 0. Emptiness is the pass condition here, so a truncated read certifies the gate while
+  blind. `per_page=100` alone does not fix it.
+- Establishing the dismissal permission by attempting a dismissal (convention §5b). Step 0b probes it
+  read-only, before the change is even applied. A successful dismissal cannot be cleanly reverted.
+- Revisiting the seven existing dismissals of this rule, or changing analysis configuration, query
+  packs, or scan scheduling.

--- a/specs/001-oauth-provider-taint/research.md
+++ b/specs/001-oauth-provider-taint/research.md
@@ -1,0 +1,236 @@
+# Phase 0 Research: Close CodeQL alert 144 (OAuth provider taint)
+
+**Feature**: `001-oauth-provider-taint` | **Date**: 2026-07-30 | **Plan**: [plan.md](plan.md)
+
+This file exists to satisfy User Story 3 and FR-012. Its test is US3's **first** acceptance
+scenario: a reader who has never opened this repository's commit history should be able to state,
+from this file alone, which approaches were tried against this rule, which one worked, and how that
+was verified.
+
+US3 gained a **second** acceptance scenario at Stage 4 clarification (Q1), and this file cannot
+satisfy it: a reader who has only the source file in front of them must be warned at the sink
+itself. That obligation lives in the code, as **FR-013**, and is discharged by the mandatory inline
+comment described in Decision 5 below, not by anything in `specs/`. The comment points back here,
+so this file is the destination of that warning rather than a substitute for it.
+
+There were no NEEDS CLARIFICATION markers in the technical context to resolve. spec.md, after
+Adversarial Review #1, fixes the approach to a single form and leaves no technology choice open. What
+follows is therefore a decision record and an evidence ledger rather than an options study.
+
+---
+
+## Decision 1: Remove every `provider`-derived value from the log `extra` context
+
+**Decision**: Delete the `"provider": safe_provider` entry from the `extra` dict in
+`store_oauth_state()`, and delete the `safe_provider` sanitizer assignment that fed it. Substitute
+nothing.
+
+**Rationale**: This is the only shape with in-repo evidence of closing
+`py/clear-text-logging-sensitive-data`. Commit `ebcc2f4` (PR #322, merged 2025-12-09 22:18:14Z)
+states the finding in its own message: the analyzer "traces taint through function calls, so
+intermediate variables still trigger alerts. The only solution is to avoid using ANY value derived
+from `secret_id` in the `logger.info()` extra context." Alerts 110 and 111 both carry
+`fixed_at = 2025-12-09T22:19:20Z`, one minute after that merge.
+
+**Alternatives considered and rejected**:
+
+| Alternative | Why rejected |
+|---|---|
+| Sanitize in place (`str(x).replace(...)[:200]`) | Already applied to this exact line by `8424cbd` and it relocated the finding rather than clearing it (see Ledger B). It cannot work in principle: in the analyzer's Python dataflow model, `replace()` and slicing propagate taint rather than removing it, as this repo's own `sanitize_for_log()` docstring states. It also addresses a different rule, `py/log-injection`. |
+| Route through an intermediate variable | Tried by `0e7a375` (PR #321) and refuted the same day; see Ledger A. |
+| Substitute a literal chosen by an allowlist membership check | Deleted for cause by Adversarial Review #1 (CRITICAL 2). Its sole rationale was preserving a Google-versus-GitHub distinction in the logs, and that distinction does not exist (Decision 2). Unproven at a cost: `ebcc2f4` proved that *removing* a derived value closes the rule, never that *a literal selected by branching on the tainted value* counts as removal. If the analyzer models implicit or control-flow taint here, that form still flags, and trying it first means editing this sink twice. |
+| Inline **suppression** comment (`# nosec`, `# noqa`, `# lgtm`, a CodeQL pragma), rule-level suppression, severity downgrade, file exclusion | Forbidden by FR-010. Note this is not the same artefact as the mandatory **documentation** comment required by FR-013; see Decision 5, which states the disjointness. |
+| Do nothing and dismiss immediately | Forbidden by FR-007 and by the sibling convention. A proven in-repo remedy must be exhausted before a dismissal is recorded. |
+
+**One honest caveat about the precedent.** `ebcc2f4` did not delete its value outright. It relocated
+the sanitized identifier into a raised exception message, a sink the analyzer tolerates.
+`store_oauth_state()` has no raise anywhere on its path (it is `put_item`, log, return), so there is
+no equivalent relocation target and the deletion here is strictly more aggressive than the precedent
+it cites. Given Decision 2 and Decision 3, that costs nothing.
+
+---
+
+## Decision 2: The removed value has no operational consumer, so nothing is substituted
+
+**Decision**: Treat the deletion as lossless. Do not add a replacement key, a boolean, or a counter.
+
+**Rationale**: `oauth_state.py` logs through the standard library logger
+(`logging.getLogger(__name__)`). No handler or formatter in this repository renders `extra` keys.
+`src/lambdas/shared/logging_config.py` is documented and implemented as a level-setter and by its own
+docstring "never attaches handlers or formatters". The root handler is the Lambda runtime's default,
+which formats `record.getMessage()` and nothing else.
+
+Captured production output confirms it rather than merely predicting it. The post-deploy evidence at
+`specs/001-lambda-log-visibility/evidence/post-deploy/logshape-dashboard.json` records three real
+emissions of this exact call on 2026-07-27, and every one is bare:
+
+```text
+[INFO]	2026-07-27T16:54:55.291Z	ccc0f079-351f-464c-85ec-7082529fbe36	OAuth state stored
+```
+
+No `provider`, no `has_user_id`, no `ttl_seconds`. **The logs do not today distinguish a Google
+authorize from a GitHub authorize on this line, and never have.** Any requirement to preserve that
+distinction would be protecting a capability that does not exist.
+
+Independently: no metric filter, alarm, dashboard or runbook consumes this line. The repository's
+only log metric filter is `dashboard_import_errors`
+(`infrastructure/terraform/modules/monitoring/main.tf:30`).
+
+**Standing assumption this rests on**: no consumer of the `extra` dict is introduced concurrently. If
+a structured-JSON formatter were ever attached to the root handler, the provider distinction would
+still be absent from this line, and restoring it would be a new feature with its own analysis of
+this rule.
+
+---
+
+## Decision 3: The information is not lost from the system
+
+**Decision**: Accept the value's absence from the log without compensating storage.
+
+**Rationale**: `provider` is written into the DynamoDB item at `oauth_state.py:87`, inside the
+`put_item` call eight lines above the log site, and FR-003 freezes that write. It is also carried on
+the returned `OAuthState`. Anyone who needs to know which provider a state belongs to reads the item,
+which is where they would have had to look anyway given Decision 2.
+
+---
+
+## Decision 4: Anchor success on the path and the rule id, never on numbers
+
+**Decision**: Key success on **zero open findings for rule
+`py/clear-text-logging-sensitive-data` at path `src/lambdas/shared/auth/oauth_state.py`**. Never on
+alert 144 disappearing, never on a line window, and not on a function either. Function attribution is
+performed on a survivor only, to decide ownership, with the function's line bounds resolved fresh at
+the analyzed commit.
+
+**Why not function-scoped, which an earlier draft of the gate assumed.** The code scanning alerts API
+exposes no function field: `most_recent_instance.location` carries `path`, `start_line`, `end_line`,
+`start_column` and `end_column`. Any function attribution is therefore derived from a `start_line`,
+which drags the line instability of the next two bullets back into the criterion through the side
+door. Path plus rule id is the strongest identity the API mechanically supports, and it is what the
+inherited convention independently settled on
+(`specs/001-ingestion-arn-logging/codeql-logging-convention.md` §3, Trap 2: "Zero open alerts of this
+rule at this path"). Attribution still earns its keep, just not as the gate: `validate_oauth_state()`
+carries the same sanitize-in-place shape at lines 253 to 258 and is frozen by FR-004, so a survivor
+there is reported rather than dismissed (FR-006a).
+
+**Rationale for rejecting the two number-based alternatives**: both are provably wrong on this file's
+own history.
+
+- **Alert numbers**: `8424cbd` closed alert 117 and opened alert 144 in the same analysis run. A
+  disappearing alert number is compatible with the disclosure surviving.
+- **Line numbers**: the respawn moved the finding from line 95 to line 104, a gap of nine lines. An
+  adjacency window of 99 to 109 drawn around the current sink would have missed the very precedent it
+  was written to catch. This feature also deletes four lines from the middle of the function, which
+  shifts every line below 99.
+
+**Consequence for the gate**: a new alert number appearing on this path for this rule classifies as
+**Refuted**, not as success. If it attributes to `store_oauth_state()` it routes to the dismissal
+branch with a note that a respawn occurred; if it attributes elsewhere in the file it is reported,
+not dismissed.
+
+---
+
+## Decision 5: Mark the sink in the source, unconditionally
+
+**Decision**: The `logger.info()` call keeps a documentation comment naming the rule id
+`py/clear-text-logging-sensitive-data` and stating why no `provider`-derived value may be added back.
+It is written on every branch of the decision gate, including the branch where the fix worked
+cleanly. This is **FR-013**, promoted from a plan-level choice at Stage 4 clarification (Q1).
+
+**Rationale**: it is the only part of this feature that survives in the place the next author will
+actually be reading. The failure mode US3 exists to prevent is a later refactor reintroducing the
+key, and whoever writes that refactor is looking at `oauth_state.py`, not at `specs/`. This file has
+already been through one such cycle: `8424cbd` re-touched this exact sink in January, apparently
+unaware of the December `0e7a375` and `ebcc2f4` results recorded in Ledger A, and relocated the
+finding rather than closing it. An unmarked sink is what made that possible. The obligation is not
+this feature's invention either: it is the unconditional closing clause of
+`specs/001-ingestion-arn-logging/codeql-logging-convention.md` §1, consumed via FR-008.
+
+**Why it is not the thing FR-010 forbids**, which is a real question and not a rhetorical one. FR-010
+forbids "an inline suppression comment as a substitute for FR-007", meaning a pragma that hides the
+finding instead of dismissing it through the reviewable path. The FR-013 comment carries no
+`# nosec`, no `# noqa`, no `# lgtm` and no CodeQL pragma. It changes no analyzer behaviour, hides
+nothing, and substitutes for no part of the dismissal path. The two requirements partition cleanly:
+FR-010 forbids suppressing the finding, FR-013 requires explaining it.
+
+---
+
+## Ledger A: what the repository has already tried against this rule
+
+Every row is anchored on `most_recent_instance.commit_sha` and on `fixed_at`, not on calendar dates
+and not on `state`. Both of those weaker fields have already produced a wrong conclusion in this
+feature's own drafting history.
+
+| Commit | Shape attempted | Outcome | Evidence |
+|---|---|---|---|
+| `0e7a375` (PR #321, merged 2025-12-09 21:40:15Z) | Route the sensitive value through an intermediate sanitized variable before logging it | **Failed**, instructively | Alerts 110 and 111 created 2025-12-09T21:38:16Z, both pinned by the API to `0e7a3752aaba49c502d0403a11544965911b8262`, at the lines that commit had just rewritten (`secrets.py:230` and `:243`) |
+| `ebcc2f4` (PR #322, merged 2025-12-09 22:18:14Z) | Remove every derived value from the `extra` context; relocate the sanitized identifier into a raised exception message | **Worked** | Alerts 110 and 111 both carry `fixed_at = 2025-12-09T22:19:20Z` |
+| `8424cbd` (2026-01-20) | Inline CRLF sanitization on this exact line in `oauth_state.py` | **Relocated the finding**, which is worse than no progress | See Ledger B |
+
+**Correction on the record**: an earlier draft attributed alert 107 to `0e7a375`. It is pinned to
+commit `a245d1d9` and was created 2025-12-09T08:47:23Z, roughly 13 hours before `0e7a375` was
+committed. Only 110 and 111 carry `0e7a375`'s SHA. The error came from reasoning on calendar dates,
+which is why this ledger cites `commit_sha`.
+
+### Why `fixed_at` and not `state`
+
+Dismissal is sticky and survives a later genuine repair, so `state` conflates "a human dismissed
+this" with "the code was repaired". The split is causal, not circumstantial:
+
+| Site shape | Alerts | `fixed_at` |
+|---|---|---|
+| Derived value removed from `extra` (`ebcc2f4`) | 26, 27, 106, 107, 110, 111 | all set |
+| Sanitizer call left inside `extra` (`secrets.py:171, 186, 198, 210`) | 22, 23, 24, 25 | **null to this day**, 8 months on |
+
+Alerts 26 and 27 read `dismissed` only because the dismissal (2025-11-24) predates the fix by two
+weeks. They carry `fixed_at` regardless. The four sites that kept a sanitizer call inside `extra`
+were never fixed, only annotated. That is also why the blast radius rule at
+`specs/001-ingestion-arn-logging/codeql-logging-convention.md` **§4** forbids editing
+`src/lambdas/shared/secrets.py`, a prohibition this feature inherits via FR-008: those four findings
+are still live behind a dismissal and re-fingerprint into fresh open alerts on touch. The citation
+anchors on the convention document's section rather than on a sibling requirement number, as FR-008
+requires, because the sibling can renumber and this feature would not notice.
+
+---
+
+## Ledger B: this file has already produced a respawn
+
+| Alert | Path:line | Created | Fixed |
+|---|---|---|---|
+| 117 | `oauth_state.py:95` | 2026-01-10T19:25:14Z | **2026-01-20T22:34:56Z** |
+| 144 | `oauth_state.py:104` | **2026-01-20T22:34:56Z** | null |
+
+The same analysis run closed 117 and opened 144, nine lines further down, for the same rule in the
+same function. `8424cbd` did not fix this finding; it moved it, producing the appearance of progress
+while the reported disclosure survived. This is the decisive precedent behind Decision 4, and it is
+exact rather than merely same-day: the two timestamps are identical to the second.
+
+---
+
+## What remains genuinely unknown
+
+Recorded so no later reader mistakes confidence in the remedy for confidence in the diagnosis.
+
+1. **Why the engine classifies this value as "password".** The alert message reads "This expression
+   logs sensitive data (password) as clear text." The only non-constant input is `provider`, whose
+   two production call sites pass the string literals `"google"` and `"github"`. No secret, token,
+   credential or user input reaches the expression. The REST API returns `code_flows` of length **0**
+   for alert 144, so the taint path cannot be inspected. This feature makes no claim about the cause
+   and no requirement depends on discovering it. The prior art raises confidence in the remedy; it
+   does not explain the diagnosis.
+2. **Whether the analyzer models implicit or control-flow taint on this sink.** Unresolved, and
+   deliberately left that way: the chosen form removes the value entirely, so the question does not
+   need an answer. It would have needed one under the rejected allowlist form, which is part of why
+   that form was rejected.
+
+## What a CodeQL result is worth on this repository
+
+CodeQL is not a required status check. The required contexts are exactly `Secrets Scan`, `Lint`,
+`Run Tests` and `Playwright E2E Tests`, and the rulesets API returns `[]`. No CodeQL result blocks a
+merge today. The `codeql` job lives inside `.github/workflows/pr-checks.yml` (job id `codeql`, name
+`Analyze`, category `/language:python`) and runs on `push` to `main` as well as on pull requests, so
+default-branch analyses are produced automatically on merge.
+
+The alert is worth closing because it is a standing open high-severity finding on the default branch,
+not because it gates anything. Correspondingly, a green `Analyze` job is not evidence of closure;
+only the alerts API is (FR-009).

--- a/specs/001-oauth-provider-taint/spec.md
+++ b/specs/001-oauth-provider-taint/spec.md
@@ -1,0 +1,679 @@
+# Feature Specification: Close CodeQL alert 144 (OAuth provider taint)
+
+**Feature Branch**: `001-oauth-provider-taint`
+**Created**: 2026-07-30
+**Status**: Draft (revised after Adversarial Review #1, Adversarial Review #2, and the Stage 7
+cross-artifact analysis in [tasks.md](tasks.md))
+**Input**: User description: "Resolve CodeQL alert 144 (`py/clear-text-logging-sensitive-data`) at `src/lambdas/shared/auth/oauth_state.py:104`."
+
+## Context
+
+CodeQL alert 144 is open on `refs/heads/main` with severity `high`. The reported sink is the
+`extra={...}` dict literal in `store_oauth_state()`, spanning lines 104 to 108 of
+`src/lambdas/shared/auth/oauth_state.py`. The alert message is "This expression logs sensitive
+data (password) as clear text."
+
+The only non-constant value entering that dict is `safe_provider`, derived from the function's
+`provider` parameter. In production `provider` is never request-derived: the two production call
+sites pass string literals (`"google"` and `"github"`). No secret, token, credential, or user
+input reaches this expression.
+
+### The `extra` dict is never rendered
+
+`oauth_state.py` uses the standard library logger (`logging.getLogger(__name__)`). No handler or
+formatter in this repository renders `extra` keys: `src/lambdas/shared/logging_config.py` is
+documented and implemented as a level-setter only, and it "never attaches handlers or formatters".
+The root handler is the runtime's default, which formats `record.getMessage()` and nothing else.
+
+Captured production log output confirms this. The post-deploy evidence in
+`specs/001-lambda-log-visibility/evidence/post-deploy/logshape-dashboard.json` records three real
+emissions of this exact call on 2026-07-27, and every one is bare:
+
+```text
+[INFO]	2026-07-27T16:54:55.291Z	ccc0f079-351f-464c-85ec-7082529fbe36	OAuth state stored
+```
+
+No `provider`, no `has_user_id`, no `ttl_seconds`. **The logs do not today distinguish a Google
+authorize from a GitHub authorize, and never have on this line.** Any requirement to preserve that
+distinction would be protecting a capability that does not exist. This is why the remedy below is
+a straight deletion rather than a substitution, and why the deletion costs nothing operationally.
+
+Independently: no metric filter, alarm, dashboard, or runbook consumes this line. The repository's
+only log metric filter is `dashboard_import_errors`
+(`infrastructure/terraform/modules/monitoring/main.tf:30`). And `provider` is persisted regardless,
+at `oauth_state.py:87`, inside the item written by `put_item`.
+
+### Prior art: transformation fails, removal works
+
+Two things are established and must not be re-litigated. Inline CRLF sanitization was already tried
+on this exact line by `8424cbd` (2026-01-20). It did not merely fail: it **relocated** the finding,
+closing alert 117 at line 95 and opening alert 144 at line 104 in the same analysis run (see "This
+file has already produced a respawn" below). That is worse than no progress, because it produced
+the appearance of a fix while the reported disclosure survived nine lines away. CRLF stripping
+addresses `py/log-injection`, a different rule. And sanitization cannot work here in principle: in
+the analyzer's Python dataflow model `str(x).replace(...)` and slicing propagate taint rather than
+removing it, as the repo's own `sanitize_for_log()` docstring states.
+
+The remediation that does work is on record, with alert-state evidence anchored on commit SHAs
+rather than dates.
+
+- **`0e7a375` (PR #321, merged 2025-12-09 21:40:15Z)** routed the sensitive value through an
+  intermediate variable before logging it. It failed instructively: alerts **110 and 111** were
+  created at 2025-12-09T21:38:16Z and are both pinned by the API to commit
+  `0e7a3752aaba49c502d0403a11544965911b8262`, at the lines that commit had just rewritten
+  (`secrets.py:230` and `:243`).
+- **`ebcc2f4` (PR #322, merged 2025-12-09 22:18:14Z)** superseded it and worked. Its commit message
+  states the finding directly: the analyzer "traces taint through function calls, so intermediate
+  variables still trigger alerts. The only solution is to avoid using ANY value derived from
+  `secret_id` in the `logger.info()` extra context." Alerts 110 and 111 both carry
+  `fixed_at = 2025-12-09T22:19:20Z`.
+
+The `fixed_at` field makes the split causal rather than circumstantial:
+
+| Site shape | Alerts | `fixed_at` |
+|---|---|---|
+| Derived value removed from `extra` (`ebcc2f4`) | 26, 27, 106, 107, 110, 111 | all set |
+| Sanitizer call left inside `extra` (`secrets.py:171, 186, 198, 210`) | 22, 23, 24, 25 | **null to this day**, 8 months on |
+
+Alerts 26 and 27 still read `dismissed` only because dismissal is sticky and predates the fix by
+two weeks; they carry `fixed_at` values as well. The four sites that kept a sanitizer call inside
+`extra` were never fixed, only annotated.
+
+### This file has already produced a respawn
+
+The decisive precedent is in this very file, and it is exact rather than same-day:
+
+| Alert | Path:line | Created | Fixed |
+|---|---|---|---|
+| 117 | `oauth_state.py:95` | 2026-01-10T19:25:14Z | **2026-01-20T22:34:56Z** |
+| 144 | `oauth_state.py:104` | **2026-01-20T22:34:56Z** | null |
+
+The same analysis run closed 117 and opened 144, nine lines further down, for the same rule in the
+same function. `8424cbd` did not fix this finding; it moved it. A disappearing alert number is not
+evidence of a fixed sink, and the replacement can land well outside any narrow line window drawn
+around the old sink.
+
+**What is still genuinely unknown:** why the engine classifies this value as "password". The REST
+API returns no `code_flows` for alert 144, so the taint path cannot be inspected. This
+specification makes no claim about the cause and no requirement depends on discovering it. The
+prior art raises confidence in the remedy; it does not explain the diagnosis.
+
+### What a CodeQL result is worth here
+
+CodeQL is not a required status check on this repository. The required contexts are exactly
+`Secrets Scan`, `Lint`, `Run Tests`, and `Playwright E2E Tests`, and the rulesets API returns `[]`.
+No CodeQL result blocks a merge today. The alert is worth closing because it is a standing open
+high-severity finding on the default branch, not because it gates anything.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Apply the proven remediation shape (Priority: P1)
+
+A maintainer removes the `provider` key from the log `extra` context of `store_oauth_state()`
+entirely, which is the exact shape that closed this rule in `ebcc2f4`. The maintainer then reads
+the alert state from the default-branch analysis to confirm the outcome.
+
+**Why this priority**: A real code fix is strictly better than a dismissal: it removes the finding
+rather than annotating it, and leaves no standing exception. The repo has already demonstrated that
+this precise shape works for this rule, so it must be attempted before any dismissal.
+
+**Independent Test**: Apply the change, let the default-branch analysis run, then query the alert
+state. This alone resolves the feature if the alert closes, and produces the decisive evidence for
+the fallback branch if it does not.
+
+**Acceptance Scenarios**:
+
+1. **Given** no value derived from `provider` appears in the `extra` context, **When** the
+   default-branch analysis completes, **Then** the maintainer can classify the outcome against the
+   decision gate without ambiguity.
+2. **Given** the change is applied, **When** the existing OAuth unit tests run, **Then** they pass
+   without modification to their assertions about stored state or returned values.
+
+#### Why deletion, and not a substituted literal
+
+An earlier draft proposed logging a genuine literal selected by an allowlist membership check, to
+keep a provider distinction while no derived string reached the sink. It is dropped because it
+preserves nothing (`extra` is not rendered, so there is no distinction to keep) and because it is
+unproven at a cost. `ebcc2f4` proved that *removing* a derived value closes the rule; it did not
+prove that *a literal selected by branching on the tainted value* counts as removal, and if the
+analyzer models implicit or control-flow taint here, that form still flags. Trying it first means
+editing this sink twice, and the 117-to-144 record above shows what a second edit costs.
+
+One honest caveat about the precedent: `ebcc2f4` did not delete information outright, it relocated
+the sanitized identifier into a raised exception message, a sink the analyzer tolerates.
+`store_oauth_state()` has no raise on its path at all (it is `put_item`, log, return), so there is
+no equivalent relocation target here, making this deletion strictly more aggressive than the
+precedent. Given that the value is not rendered anyway and remains persisted at line 87, that
+difference costs nothing.
+
+---
+
+### User Story 2 - Fall back to a justified dismissal (Priority: P2)
+
+If removing the value does not close the alert, the maintainer dismisses it as a false positive
+with a written justification, following the convention settled by `001-ingestion-arn-logging`. This
+is the contingency branch, reached only after the proven code shape is refuted. Given the `ebcc2f4`
+precedent it is unlikely, but it is what guarantees the alert count reaches zero either way.
+
+**Independent Test**: With the dismissal applied, query the alert-state API and confirm that
+`src/lambdas/shared/auth/oauth_state.py` carries **zero open findings** for
+`py/clear-text-logging-sensitive-data`, and that whichever alert number was actually observed at the
+sink reports `dismissed` with a non-empty justification matching the convention. The test is keyed on
+the path plus the rule id, never on alert 144 reaching a state: 144 is a locating label for the
+finding as it stood at authoring time, and `8424cbd` already demonstrated on this exact file that the
+number carrying a finding can change between analyses while the finding survives. A test written as
+"144 is dismissed" would fail on a correctly handled respawn and pass on an unhandled one.
+
+**Acceptance Scenarios**:
+
+1. **Given** the code fix left an open finding at the sink, **When** the maintainer dismisses it,
+   **Then** the dismissal reason is "false positive" and the recorded comment names the value
+   logged, the convention applied, and why the analyzer still reports the flow.
+2. **Given** the code fix has not been applied and evaluated, **When** the maintainer reaches the
+   dismissal step, **Then** the step is blocked. A proven remedy must be exhausted first.
+
+---
+
+### User Story 3 - Prevent the failed approach from being retried (Priority: P3)
+
+Pure durability value. The alert closes without it, but without it the same dead end costs someone
+else a cycle, as it already has twice: `0e7a375` in December and `8424cbd` in January, the second
+apparently unaware of the first.
+
+**Acceptance Scenarios**:
+
+1. A reader of the feature's artifacts can state, without reading commit history, which approaches
+   were tried, which one worked, and how that was verified.
+2. A reader who has only the source file in front of them, and none of these artifacts, is warned at
+   the sink itself that the key was removed for this rule, and is pointed at where the reasoning
+   lives. Artifacts alone do not satisfy this story: the failure mode is a later refactor
+   reintroducing the key, and whoever writes that refactor is looking at the file, not at
+   `specs/`. See FR-013.
+
+---
+
+### Edge Cases
+
+- **The analysis does not re-run, or reports a stale result.** A result predating the change decides
+  nothing. See the decision gate for the bound on that wait.
+- **Alert 144 closes but a new finding of the same rule appears on the path.** Refuted, not success,
+  and exactly what `8424cbd` produced. Success is
+  `src/lambdas/shared/auth/oauth_state.py` being free of open findings for
+  `py/clear-text-logging-sensitive-data`, not one alert number disappearing. The criterion is **path
+  plus rule id**, matching FR-006 and SC-001: the alerts API exposes no function field, so a
+  function-scoped reading of this bullet would key on a value derived from a `start_line` and would
+  smuggle back the line instability the gate exists to avoid. Attribution to a function still happens
+  on a survivor, per FR-006a, but only to decide who owns it.
+- **A survivor attributes outside `store_oauth_state()`.** Not Confirmed, and not this feature's to
+  dismiss. It is reported per FR-006a, and the feature terminates in that reported state.
+  `validate_oauth_state()` is frozen by FR-004.
+- **The change is complete and green but has not landed on the default branch.** No qualifying
+  analysis can exist yet, so the gate is not evaluated at all. This is `PENDING-BRANCH-ANALYSIS`,
+  inherited whole from `specs/001-ingestion-arn-logging/codeql-logging-convention.md` §5a, which
+  calls it "the normal ending, not an edge case". It is distinct from the 7-day
+  `BLOCKED-NO-ANALYSIS` bound below, which starts only once the change is on `main`.
+- **Both branches fail.** The feature reports the blockage rather than suppressing the rule or
+  lowering its severity.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: No value derived from the `provider` parameter by transformation, slicing,
+  formatting, replacement, or an intervening helper call MAY appear in the log `extra` context of
+  `store_oauth_state()`. This is the property `ebcc2f4` established as the remedy for this rule.
+- **FR-002**: FR-001 MUST be satisfied by removing the `provider` key from the `extra` context
+  entirely, which is the exact `ebcc2f4` shape. A substituted or allowlist-selected value MUST NOT
+  be used, because `extra` is not rendered and such a substitution would preserve nothing while
+  requiring an unproven second rewrite of the sink.
+- **FR-003**: The runtime behavior of `store_oauth_state()` outside the log call MUST be unchanged.
+  The stored item (including the persisted `provider` at line 87), the returned object, and the
+  generated PKCE verifier are untouched.
+- **FR-004**: `validate_oauth_state()` MUST NOT be modified by this feature. Its `provider` value
+  is request-derived, which makes it a materially different case, and it is not this alert's sink.
+- **FR-005**: The outcome MUST be classified against the decision gate below, defined before the
+  change is applied, with each observation mapping to exactly one follow-on action.
+- **FR-006**: Confirmed MUST require that `src/lambdas/shared/auth/oauth_state.py` carries no open
+  finding for `py/clear-text-logging-sensitive-data` in a completed default-branch analysis of a
+  commit containing the change. The criterion is path plus rule id, matching SC-001 and the inherited
+  convention §3. An open finding anywhere in that file blocks Confirmed, including one outside
+  `store_oauth_state()`: the API exposes no function field, so any function attribution is derived
+  and MUST NOT be what licenses a Confirmed result. Attribution is still performed, but only to
+  decide how a survivor is handled (FR-006a), never to declare success while one is open.
+- **FR-006a**: A survivor MUST be attributed before it is acted on. If it maps inside
+  `store_oauth_state()`, it is this feature's, and FR-007's dismissal path applies. If it maps
+  elsewhere in the file, in particular to the `validate_oauth_state()` sink at lines 253 to 258 that
+  FR-004 freezes, it is NOT this feature's to dismiss: it MUST be reported to the repository owner
+  as a finding needing its own owner, and the feature terminates in that reported state rather than
+  in Confirmed. Attribution is a derived, best-effort mapping and is recorded as such.
+- **FR-007**: Only after the FR-002 change is applied and refuted at the gate MAY the alert be
+  dismissed as a false positive, with a written justification naming the value logged, the
+  convention applied, and why the analyzer still reports the flow despite no derived value reaching
+  the sink. A dismissal is a security shortcut under constitution §9, so recording one MUST also
+  add an entry to the tech debt registry at `docs/reference/TECH_DEBT_REGISTRY.md` carrying the
+  fields §9 requires (ID, Location, Status, Root Cause, Proposed Fix, Effort, Risk). No registry
+  entry is created on the confirmed branch, where a closed finding creates no debt.
+- **FR-008**: This feature MUST consume the convention recorded at
+  `specs/001-ingestion-arn-logging/codeql-logging-convention.md` in full, not only its dismissal
+  wording. That document was written under the sibling's FR-011 to be cited by this feature, and
+  consuming it whole is what keeps the following from being independently redefined here: the
+  dismissal wording pattern and its three required elements (§2), the `fixed_at` versus `state` and
+  alert-number-instability caveats (§3), the blast radius prohibition on editing
+  `src/lambdas/shared/secrets.py` (§4), and **both** terminal states §5 defines:
+  `PENDING-BRANCH-ANALYSIS` for the case where the change is complete but no default-branch analysis
+  of it can exist yet (§5a), and `BLOCKED-ON-OWNER`, with its handoff artifact contents, for the case
+  where the implementing agent lacks permission to dismiss (§5b). Consuming §5 whole means consuming
+  both: §5a is the state the convention itself calls "the normal ending, not an edge case", and
+  omitting it leaves an implementing agent whose change has not yet landed with no terminal state to
+  record, which is an implicit abort. §5b also fixes **how** the dismissal permission is
+  established: by a read-only probe of the token's scopes together with the repository's visibility
+  and the actor's repository permissions, **never** by attempting a dismissal, because a successful
+  one cannot be cleanly reverted. A missing `security_events` scope is not by itself a blocker; that
+  scope is a private-repository requirement, and on a public repository `repo` subsumes what the
+  endpoint needs.
+  This feature MUST NOT define a second convention for any of them, and where its own artifacts
+  restate one they MUST cite that document's section rather than a sibling requirement number.
+- **FR-009**: Alert closure MUST be evidenced from default-branch analysis state or the alert-state
+  API. A green pull request check MUST NOT be accepted as evidence of closure.
+- **FR-010**: The feature MUST NOT suppress the rule repo-wide, lower its severity, exclude the
+  file from analysis, or add an inline suppression comment as a substitute for FR-007.
+- **FR-011**: The existing OAuth unit tests MUST pass without modification to their assertions
+  about stored state or returned values.
+- **FR-012**: The record of prior art MUST state that `8424cbd` *relocated* this finding rather
+  than failing to clear it, naming alert 117 (line 95, `fixed_at` 2026-01-20T22:34:56Z) and alert
+  144 (line 104, `created_at` the same timestamp); state that the rule it addressed was log
+  injection rather than clear-text logging; and cite `0e7a375` (failed, intermediate variable,
+  spawned alerts 110 and 111) and `ebcc2f4` (succeeded, value removed from log context) as the
+  in-repo precedent for what does and does not close this rule.
+- **FR-013**: The log call in `store_oauth_state()` MUST carry an inline comment naming the rule id
+  `py/clear-text-logging-sensitive-data` and stating why no `provider`-derived value may be added to
+  the `extra` context, on every branch of the decision gate including the confirmed one. This is the
+  unconditional site-comment clause of the inherited convention (§1, closing paragraph), consumed
+  via FR-008, and it is what carries US3's durability into the code rather than leaving it only in
+  this directory. The comment is documentation and MUST NOT carry `# nosec`, `# noqa`, `# lgtm`, or
+  any CodeQL suppression pragma; so constrained it is not the inline suppression comment FR-010
+  forbids, because it suppresses nothing and substitutes for no part of FR-007.
+
+### Decision Gate
+
+The gate is evaluated once, against one completed default-branch analysis of a commit that contains
+the FR-002 change.
+
+**Scope of the gate.** The gate is anchored on **path plus rule id**: any open
+`py/clear-text-logging-sensitive-data` finding on `src/lambdas/shared/auth/oauth_state.py`. Never on
+an alert number, and never on a line number or a window around one. Alert numbers are not identity,
+because `8424cbd` closed alert 117 at line 95 and opened alert 144 at line 104 at the identical
+timestamp. Line numbers are not identity either, because this feature edits the file and shifts every
+line below the sink. Function is not used as the criterion because the alerts API exposes no function
+field: `most_recent_instance.location` carries only `path` and line and column bounds, so any
+function attribution is derived from a `start_line` and inherits precisely the line instability the
+gate exists to avoid. Attribution to a function is still performed on a survivor, per FR-006a, but it
+decides *who owns the survivor*, never whether the gate passed.
+
+| Observation | Classification | Required follow-on |
+|---|---|---|
+| No open `py/clear-text-logging-sensitive-data` finding on `oauth_state.py` | Confirmed | Stop. Record the result. No dismissal. |
+| Alert 144 still open on the path, attributed to `store_oauth_state()` | Refuted | Proceed to dismissal per FR-007 and FR-008. |
+| Alert 144 closed but a new finding of the same rule is open on the path, attributed to `store_oauth_state()` | Refuted | Proceed to dismissal per FR-007 and FR-008, dismissing the new alert number and recording that a respawn occurred. |
+| A finding of this rule is open on the path but attributes outside `store_oauth_state()` | Not Confirmed, and not this feature's to dismiss | Report to the repository owner per FR-006a. Terminal and reported. Do not dismiss it here; `validate_oauth_state()` is frozen by FR-004. |
+| The change is complete and green but has not landed on the default branch | Not evaluable yet, and not blocked | Terminal state `PENDING-BRANCH-ANALYSIS` (below). Neither done nor failed. |
+| The change has landed, but no completed default-branch analysis covers it yet | Not yet decidable | Wait, bounded (below). |
+
+**The change has not landed yet.** Closure is read from a default-branch analysis (FR-009), and no
+such analysis can exist while the change sits on a feature branch, so the gate is not evaluated at
+all rather than evaluated and failed. The feature MUST terminate in `PENDING-BRANCH-ANALYSIS`,
+recording the code change as complete and green and writing the gate query, filled in with this
+feature's own path and rule id, so the check is mechanical the moment the change lands. This state is
+inherited whole from `specs/001-ingestion-arn-logging/codeql-logging-convention.md` §5a via FR-008,
+which calls it "the normal ending, not an edge case", and it MUST NOT be reported as done or as
+failed. It is not the same state as the bound below: this one is entered before the change reaches
+`main`, and the 7-day clock has not started.
+
+**Bounding the wait.** The "not yet decidable" state MUST NOT persist unbounded. If no completed
+default-branch analysis covering the change is available within 7 days of the change landing on the
+default branch, the feature MUST be reported as blocked to the repository owner, naming the missing
+analysis, rather than left open. It MUST NOT be classified, and it MUST NOT be dismissed. Blocked
+is a terminal reportable state; it is not a third attempt.
+
+The change is retained on the refuted branch as well. It is a defensible improvement on its own
+terms, and reverting it would restore a derived-string log for no benefit.
+
+## Success Criteria *(mandatory)*
+
+- **SC-001**: Querying the alert-state API shows zero open `py/clear-text-logging-sensitive-data`
+  findings against `src/lambdas/shared/auth/oauth_state.py`, in either the fixed or dismissed state.
+  The scope is **path plus rule id**, which is the strongest identity the API mechanically supports:
+  `most_recent_instance.location` carries `path`, `start_line`, `end_line`, `start_column` and
+  `end_column`, and no function field. It is also the formulation the inherited convention settled on
+  (`specs/001-ingestion-arn-logging/codeql-logging-convention.md` §3, Trap 2: "Zero open alerts of
+  this rule at this path"). Function-level scoping is deliberately NOT used as the criterion, because
+  deriving a function from a `start_line` reintroduces exactly the line-number instability the
+  criterion exists to dodge.
+- **SC-002**: The evidence cited for SC-001 comes from default-branch analysis state or the
+  alert-state API. No pull request check result is cited as closure evidence.
+- **SC-003**: This feature's diff introduces no new open code scanning alert anywhere in the
+  repository. The test is attribution, not a repo-wide count: every open alert present after the
+  change is either one of the five observed at authoring time (144, 147, 148, 149, 150) or is
+  attributable, by path, to a change this feature did not make. A repo-wide count MUST NOT be used
+  as the criterion, for two reasons. Sibling `001-codeql-coverage` enables an additional analysis
+  leg and states plainly that the open count "will very likely RAISE" (`specs/001-codeql-coverage/spec.md:15`,
+  and its own SC-004 refuses to fail on a rise); and the owner's directive governing this campaign is
+  that coverage is the goal, not a low alert count. Keying this feature's success on a global counter
+  would fail it for a sibling doing exactly what it was asked to do. The condition that remains
+  binding, and is wholly within this feature's control, is keyed on paths rather than on a count: no
+  alert of any rule newly appears on `src/lambdas/shared/auth/oauth_state.py` or on
+  `src/lambdas/shared/secrets.py`.
+- **SC-004**: The existing OAuth state unit test suites pass with no assertion changes.
+- **SC-005**: The decision gate resolves to exactly one classification, and the artifacts state
+  which branch was taken and on what observed evidence.
+- **SC-006**: If the dismissal branch is taken, the recorded justification is non-empty, matches the
+  convention adopted from `001-ingestion-arn-logging`, and the artifacts show the FR-002 change was
+  applied and refuted before the dismissal was recorded. A corresponding entry exists in
+  `docs/reference/TECH_DEBT_REGISTRY.md` carrying every field constitution §9 requires.
+- **SC-007**: The log call in `store_oauth_state()` carries the FR-013 comment, on whichever branch
+  the gate selected, and that comment contains no suppression pragma. Verifiable by inspecting the
+  merged file.
+
+## Dependencies
+
+- **`001-ingestion-arn-logging` (convention settled)**: Owns the dismissal convention, which this
+  feature consumes rather than redefining: attempt the real fix first using the
+  no-derived-value-in-log-context shape, and treat dismissal as a fallback carrying a written
+  justification. FR-001, FR-007 and FR-008 are this feature's expression of it.
+- **File disjointness**: confirmed. The sibling covers `src/lambdas/ingestion/handler.py` (alerts
+  148, 149, 150); this one covers `src/lambdas/shared/auth/oauth_state.py` (alert 144). No shared
+  files, so the two may complete in either order.
+
+## Assumptions
+
+- The default-branch analysis runs on merge and produces a fresh alert state within a normal
+  turnaround. The 7-day bound in the decision gate covers the case where it does not.
+- Dismissing a code scanning alert requires write access to code scanning alerts. On a **private**
+  repository that means the `security_events` scope; on a **public** one, which this is,
+  `public_repo` suffices and the `repo` scope subsumes it (convention §5b). A missing
+  `security_events` scope is therefore **not** by itself a blocker, and reading `gh auth status`
+  alone and concluding otherwise is the specific mistake §5b exists to prevent. Seven prior
+  dismissals of this rule exist here (alerts 1 and 22 through 27), so the precedent is established
+  and some actor holds the permission. It is **not** assumed that the implementing agent does; that
+  is settled by the read-only probe, never by attempting a dismissal. If the probe resolves to
+  *absent*, the
+  dismissal branch terminates in `BLOCKED-ON-OWNER` with a handoff artifact, inherited via FR-008
+  from `specs/001-ingestion-arn-logging/codeql-logging-convention.md` §5. That is a reported terminal
+  state, neither done nor failed.
+- The production call sites remain the only production callers passing `provider`. If a future
+  change makes it request-derived here, that is a new assessment, not a regression of this one.
+  Removing the value from the log context is safe under either provenance, which is a further
+  argument for FR-002 over a substituted literal.
+- No consumer of the `extra` dict is introduced concurrently. If a structured-JSON formatter were
+  attached to the root handler later, the provider distinction would still be absent from this
+  line, and restoring it would be a new feature with its own analysis of this rule.
+
+## Out of Scope
+
+- The request-derived `provider` in `validate_oauth_state()`. Different function, different data
+  provenance, not this alert's sink.
+- The other four open alerts (148, 149, 150 in `src/lambdas/ingestion/handler.py`; 147
+  `py/bad-tag-filter` in `scripts/regenerate-mermaid-url.py`). Each is owned by its own feature.
+- Changing `sanitize_for_log()`, `logging_config.py`, or any other shared logging helper. Making
+  `extra` render is a separate concern with its own blast radius.
+- The inline CRLF sanitization applied elsewhere in `oauth_state.py`. It is still doing its job for
+  the log injection rule.
+- Revisiting the seven existing dismissals of this rule, or any change to analysis configuration,
+  rule severity, query packs, or scan scheduling.
+- New infrastructure of any kind.
+
+---
+
+## Adversarial Review #1
+
+Reviewer did not author this spec. All API claims below were re-derived independently against the
+GitHub code scanning API, not taken from the prior draft.
+
+### Findings
+
+| Severity | Finding | Resolution |
+|---|---|---|
+| CRITICAL | **FR-002 (old) protected a capability that does not exist.** `oauth_state.py` uses `logging.getLogger(__name__)`; `logging_config.py` is a level-setter that by its own docstring "never attaches handlers or formatters"; the root handler is the runtime default, which renders `record.getMessage()` only. Captured production output in `specs/001-lambda-log-visibility/evidence/post-deploy/logshape-dashboard.json` shows three real emissions of this call on 2026-07-27, all bare: `OAuth state stored`, with no `provider`, `has_user_id`, or `ttl_seconds`. The logs have never distinguished Google from GitHub on this line. | FIXED. Old FR-002 and FR-003 deleted, along with SC-004 (the allowlist unit test) and the "unknown provider fallback" edge case. New Context section documents the non-rendering with the evidence path. |
+| CRITICAL | **Form A's sole rationale was the void FR-002.** With nothing to preserve, the allowlist-literal form is an unproven speculative attempt whose only effect is to edit this sink twice, on a sink with a documented respawn history. | FIXED. Form A, FR-001a, FR-001b, the two-form table and the per-form gate re-evaluation are all removed. The proven `ebcc2f4` shape is now the first and only code attempt (new FR-002). The owner's principle, that a proven in-repo fix must be exhausted before dismissal, is preserved and strengthened: the proven fix is now attempt one, not attempt two. |
+| HIGH | **False precedent claim.** The draft stated `0e7a375` raised alerts 107, 110 and 111. Alert 107 is pinned by the API to commit `a245d1d9` and was created 2025-12-09T08:47:23Z, roughly 13 hours *before* `0e7a375` was committed (21:40:15Z). Only 110 and 111 carry `0e7a375`'s SHA. | FIXED. Corrected to 110 and 111, and re-anchored on the `most_recent_instance.commit_sha` field rather than on the calendar date, which was the source of the error. |
+| HIGH | **The strongest available evidence was absent.** Alert 117 (`oauth_state.py:95`) has `fixed_at = 2026-01-20T22:34:56Z`; alert 144 (`oauth_state.py:104`) has `created_at =` the identical timestamp. One analysis run closed one finding in this function and opened this one nine lines down. Decision Gate row 3 is not a hypothetical borrowed from another file; it already happened here. | FIXED. Promoted to its own subsection, "This file has already produced a respawn", and cited directly in the gate's scoping paragraph. |
+| CRITICAL | **Line-number adjacency was self-invalidating and already provably wrong.** Escalated from HIGH once the 117-to-144 respawn was confirmed. The draft's "adjacent = lines 99 to 109 at authoring time" would have *missed the very precedent it was written to catch*: the historical respawn moved a finding from line 95 to line 104, and 95 falls outside 99-109. The feature also edits this file, shifting every line number in it. | FIXED. The gate is scoped to the body of the function `store_oauth_state()` plus the rule id, with an explicit note that line numbers are deliberately not used and why. The assumption defining "adjacent" as 99-109 is deleted. |
+| HIGH | **`8424cbd`'s history was mischaracterized as "the alert did not clear."** It did clear one: the run closed alert 117 and opened alert 144. Saying it "failed" invites the reader to conclude sanitization does nothing, when it did something worse, producing the appearance of progress while the disclosure survived nine lines down. | FIXED in both the prior-art paragraph and FR-012, which now requires the record to say "relocated", with both alert numbers and the shared timestamp. |
+| HIGH | **The gate did not terminate.** "Not yet decidable, wait" had no owner, no bound, and no alternative action, so the feature could sit indefinitely in a state that was neither done nor advancing. | FIXED. Added a 7-day bound from the change landing on the default branch, after which the feature is reported blocked to the repository owner. Blocked is stated as terminal and reportable, explicitly not a further attempt. |
+| MEDIUM | **CodeQL-based success criteria are weaker than they read.** CodeQL is not a required status check; required contexts are exactly `Secrets Scan`, `Lint`, `Run Tests`, `Playwright E2E Tests`, and the rulesets API returns `[]`. No CodeQL result blocks a merge. | RECORDED, with a short "What a CodeQL result is worth here" subsection added so the criteria are not read as gating. Not treated as a defect: the finding is a real open high-severity alert on the default branch regardless of what gates on it. |
+| MEDIUM | **No consolation sink, understated.** `ebcc2f4` relocated its sanitized identifier into a raised exception message. `store_oauth_state()` is `put_item`, log, return, with no raise anywhere on its path, so the deletion here is strictly more aggressive than the precedent it cites. | FIXED. Stated plainly in "Why deletion, and not a substituted literal", together with why it costs nothing given the non-rendering finding and the persistence at line 87. |
+| MEDIUM | **Over-specified.** 316 lines of spec for a one-line deletion, much of it structure serving a form that has now been removed. | FIXED by cutting. Removed: the form-comparison table, FR-001a/FR-001b, old FR-002/FR-003, the per-form gate language, SC-004, one edge case, two assumptions, and the "sequencing constraint discharged" bullet. Thirteen FRs became twelve; seven SCs became six. Net line count is flat (316 body lines to 315) because roughly 45 lines of removed speculative structure were traded for the same volume of hard evidence that was previously missing. Density is up; length is not. |
+| LOW | **US3 spent 20 lines on one sentence of content.** | FIXED. Compressed to a single acceptance scenario. |
+| LOW | **Two secrets.py line citations were wrong.** The draft listed the alert 22-25 sites as `171, 187, 199, 211`; the API reports `171, 186, 198, 210`. | FIXED in the prior-art table. |
+
+Counts: **3 CRITICAL, 4 HIGH, 3 MEDIUM, 2 LOW.**
+
+Note on the mid-review input from the coordinator: the 117-to-144 respawn had already been found
+and folded in by this reviewer before that message arrived, via the same API queries. It is
+confirmed, with one correction of detail: the gap is **nine** lines (95 to 104), not four. The
+coordinator's third instruction, "make sure a literal-selecting allowlist that closes 144 and opens
+151 is not scored as success", is satisfied by construction rather than by tightening the gate: the
+allowlist form is removed entirely (CRITICAL 2), and the gate is anchored on the function plus the
+rule id, so any replacement alert number in `store_oauth_state()` classifies as refuted.
+
+### Independent API verification
+
+Every claim below was re-derived by the reviewer via `gh api`, not inherited.
+
+- Alert 144: `state=open`, `start_line=104`, `end_line=108`, severity `high`, ref `refs/heads/main`, `code_flows` length **0**. Confirmed; the spec correctly makes no claim about the taint path.
+- `fixed_at` non-null for exactly 26, 27, 106, 107, 110, 111. Confirmed.
+- `fixed_at` null for 22, 23, 24, 25, all `state=dismissed`, all in `secrets.py`. Confirmed.
+- 26 and 27 are `dismissed` (2025-11-24) yet carry `fixed_at` (2025-12-03 and 2025-12-09). Confirmed; dismissal is sticky and predates the fix.
+- Alerts 110 and 111 created 2025-12-09T21:38:16Z, both `commit_sha = 0e7a3752aaba49c502d0403a11544965911b8262`. Confirmed as `0e7a375`'s respawn.
+- Alert 107 created 2025-12-09T08:47:23Z, `commit_sha = a245d1d9…`, 13 hours before `0e7a375`. **Refutes** the draft's attribution.
+- Alert 117 `fixed_at` equals alert 144 `created_at` exactly (2026-01-20T22:34:56Z), same file, lines 95 and 104. New, and load-bearing.
+- Seven dismissed alerts for `py/clear-text-logging-sensitive-data` (22-27 plus one other). Confirmed.
+- Five open alerts repo-wide: 144, 147, 148, 149, 150. Baseline confirmed.
+
+### Gate
+
+**0 CRITICAL, 0 HIGH remaining.**
+
+---
+
+## Clarifications
+
+### Session 2026-07-30
+
+Four questions were raised. All four were self-answered from the repository, the GitHub API, or git
+history; **none were deferred to the owner**. No fifth question was raised: after Adversarial Review
+#1 and the planning pass, the remaining artifacts left no further genuine ambiguity, and manufacturing
+one to fill a quota would have been noise. Two of the four changed requirements; the other two closed
+as verifications.
+
+Every answer below cites evidence that was re-derived at clarification time rather than inherited
+from the prior artifacts.
+
+---
+
+#### Q1. Does the inline comment at the sink belong in the spec as a requirement, or does it stay a plan-level implementation choice?
+
+**Answer: it belongs in the spec, and it is now FR-013.** Two independent reasons, and the first is
+decisive.
+
+The inherited convention already mandates it, unconditionally. The closing paragraph of §1 of
+`specs/001-ingestion-arn-logging/codeql-logging-convention.md` (lines 43 to 46) reads:
+
+> **Always**, whichever branch you land on: leave an inline comment at the site naming the rule id
+> and the reason the value was removed. Unconditionally, including on sites where the fix worked
+> cleanly. Without it, a later refactor reintroduces the interpolation and nothing objects.
+
+That is not incidental wording. The sibling's own adversarial review raised it as a MEDIUM finding
+and escalated the requirement for exactly this failure mode (`specs/001-ingestion-arn-logging/spec.md:149`:
+"No regression guard on the success path. FR-010 required the inline comment only on sites behind a
+dismissed alert, so if the fix worked cleanly all three sites would end unmarked and a later refactor
+could reintroduce the interpolation silently. Fixed. FR-010 made unconditional across all three
+sites."). Sibling FR-010 (`spec.md:92`) is the resulting unconditional requirement.
+
+**Why the obligation was not already flowing through, which is the real defect this question
+found.** FR-008 as written before this session bound only "the dismissal justification's wording and
+recording location" to the sibling. The comment clause is in neither the wording nor the recording
+location of a dismissal, so it fell outside the inheritance and survived only as a plan choice. An
+implementer reading spec.md alone had no requirement to write the comment, and one reading plan.md
+could reasonably drop it as stylistic. Q3 found the identical break on a different clause, and both
+are fixed by the same widening of FR-008.
+
+**On the FR-010 tension, which is real and now explicit.** This feature's FR-010 forbids "an inline
+suppression comment as a substitute for FR-007". Left unaddressed, FR-013 and FR-010 read as
+contradictory to anyone who does not already know the distinction. FR-013 therefore states the
+disjointness in its own text rather than relying on the reader: the comment is documentation, it
+carries no `# nosec`, `# noqa`, `# lgtm` or CodeQL pragma, it suppresses nothing, and it substitutes
+for no part of the dismissal path. The plan had already reasoned its way to this position
+(`plan.md`, Implementation Design, property 3); the difference is that it is now binding and
+verifiable rather than a choice recorded in a design note.
+
+**Requirements changed**: new **FR-013**; **FR-008** widened (see Q3); **US3** gained a second
+acceptance scenario, because the original one was satisfiable by the `specs/` directory alone while
+the failure mode it exists to prevent is a refactor of the source file; new **SC-007** making the
+comment verifiable on the merged file.
+
+---
+
+#### Q2. Constitution §9 requires a `docs/TECH_DEBT_REGISTRY.md` entry on the dismissal branch, but that file does not exist. Resolve or escalate.
+
+**Answer: resolve. The registry exists; the path in the constitution is stale, and plan.md and
+quickstart.md inherited the stale path from it.** No escalation is needed, and the §9 obligation is
+live and satisfiable exactly as written apart from the path.
+
+Evidence:
+
+- `docs/TECH_DEBT_REGISTRY.md` does not exist. Confirmed.
+- `docs/reference/TECH_DEBT_REGISTRY.md` does exist, carries 23 numbered entries (`TD-001` through
+  `TD-023`), and is actively maintained. Its most recent commit is `cfa3202` (2026-07-30,
+  "fix(toolchain): ruff 0.15.14 everywhere", PR #977).
+- The file was originally created at `docs/TECH_DEBT_REGISTRY.md` on 2025-11-19 (`2a8746a`, "docs:
+  Add tech debt registry and expand lessons learned") and was relocated by `f8db8d2`, "feat(docs):
+  Reorganize documentation into categorical subdirectories" (PR #668).
+- Constitution Amendment 1.4 is dated 2025-11-28, which is after the file was created and before it
+  was moved. §9 was never updated to follow the move, which is why it names a path that has not
+  existed since #668.
+- §9's required fields and its allowed `Status` values (`Open | Resolved | Deferred | Blocked |
+  Acceptable`) are unchanged and are met by the existing entries, so the `Status: Acceptable` value
+  the plan intends for a dismissal is valid.
+
+**Consequences applied.** FR-007 now carries the registry obligation explicitly, so it is a spec
+requirement rather than something recorded only in plan.md's Constitution Check table. SC-006 now
+requires the entry to exist on the dismissal branch. The path is corrected to
+`docs/reference/TECH_DEBT_REGISTRY.md` in plan.md and quickstart.md.
+
+**Superseded by Adversarial Review #2 on the identifier question.** This answer originally had
+quickstart.md pre-reserve the next free id (**TD-024**, which is NOT reserved to this feature and
+MUST NOT be taken from this document) "so the implementer does not have to derive it".
+That was wrong: the registry is a shared file and three concurrent features were all reasoning from
+the same `TD-023` high-water mark, so pre-reserving the id guaranteed a collision rather than saving
+work. Sibling `001-ingestion-arn-logging` (`spec.md:249`) and sibling `001-codeql-coverage`
+(`plan.md:282`) both already settled on merge-time allocation for exactly this reason. The rule is
+now: **the identifier is read from the registry's then-highest entry at the moment the entry is
+written, and is never pre-reserved in a spec.** The registry path stays corrected as above; only the
+number is deferred.
+
+**Carried forward, not fixed here.** Constitution §9's stale path is a defect in
+`.specify/memory/constitution.md`, which is outside this feature's write scope and is shared with
+three sibling agents. It is recorded for carding rather than folded into this feature. Note the
+knock-on: §9's Acceptance Criteria clause "`docs/TECH_DEBT_REGISTRY.md` exists and follows the
+documented format" is literally false today and has been since #668, so any future compliance check
+reading §9 literally will fail on a path error rather than on a real gap.
+
+**Requirements changed**: **FR-007** extended with the registry obligation and the correct path;
+**SC-006** extended to require the entry.
+
+---
+
+#### Q3. Does the sibling actually define `BLOCKED-ON-OWNER` in a form this feature can cite, and does anything here silently duplicate it?
+
+**Answer: yes, it is defined twice over and is citable. But the citation chain the plan used was
+broken, and it is now repaired. Nothing duplicates it.**
+
+The definition exists in two places, both usable:
+
+- `specs/001-ingestion-arn-logging/spec.md:90`, FR-008a, which names the terminal state and requires
+  a handoff artifact carrying "the exact alert numbers observed at the path, the exact dismissal
+  justification text for each, and the exact API call or UI steps needed to apply them", and states
+  that the code change is independently mergeable and that such a feature "MUST NOT be reported as
+  done, and MUST NOT be reported as failed".
+- `specs/001-ingestion-arn-logging/codeql-logging-convention.md` §5, lines 130 to 136, which carries
+  the same content in a document whose header states it was "Written to be cited by
+  `001-oauth-provider-taint`".
+
+**The break.** plan.md and quickstart.md both cited it as "Inherited from sibling FR-008a via
+FR-008". FR-008's scope was the dismissal justification's *wording and recording location*.
+`BLOCKED-ON-OWNER` is a terminal state, not a wording and not a recording location, so FR-008 did
+not reach FR-008a and the word "via" was doing work the requirement did not support. The same break
+hid the §1 comment clause found in Q1. Quickstart also cited the three-element wording as sibling
+"FR-009"; that number is correct (`spec.md:91`), but citing a sibling's requirement *number* is the
+fragile form, since the sibling may renumber and this feature would not notice.
+
+**The repair.** FR-008 is widened to consume the convention document in full and to require that
+restatements cite that document's section rather than a sibling requirement number. The document is
+the right anchor precisely because sibling FR-011 (`spec.md:93`) mandated its existence so that
+"`001-oauth-provider-taint`, which works the same CodeQL rule, can cite it instead of inventing its
+own". Citing the artifact the sibling was required to produce is stable; citing the numbering that
+produced it is not.
+
+**Duplication check: clean.** quickstart.md Step 4c restates the three handoff contents, but declares
+them inherited rather than defined, and now cites §5. That is a restatement for operator
+convenience, not a second convention. Nothing in this feature defines its own dismissal wording,
+its own handoff contents, its own `fixed_at` caveat, or its own blast-radius rule. The one place
+this feature does go beyond the sibling is the `BLOCKED-NO-ANALYSIS` and `BLOCKED-REGRESSION`
+terminal states, which are genuinely this feature's own (the sibling has no decision gate and no
+7-day analysis bound) and so are not duplications of anything.
+
+**Requirements changed**: **FR-008** rewritten and widened.
+
+---
+
+#### Q4. Do the artifacts state clearly enough that the `safe_provider` assignment must be deleted rather than unwired, so an implementer cannot miss it?
+
+**Answer: yes. Verified empirically and no change was needed.** This item closes as a confirmation.
+
+The claim is true, and stronger than the artifacts asserted. Reproduced at clarification time by
+copying `oauth_state.py`, deleting only the `"provider": safe_provider` entry, and running the
+linter:
+
+```text
+F841 Local variable `safe_provider` is assigned to but never used
+   --> probe.py:99:5
+```
+
+The line number matches the artifacts exactly: the assignment occupies lines 99 to 101 of
+`src/lambdas/shared/auth/oauth_state.py`, as plan.md and quickstart.md both state. The rule is
+active because `[tool.ruff.lint] select` in `pyproject.toml` includes `"F"` (pyflakes), and it
+reaches CI because the `Lint` job runs `ruff check src/ tests/` at
+`.github/workflows/pr-checks.yml:62`. `Lint` is one of the four required contexts, so an orphaned
+assignment blocks the merge rather than merely producing a warning.
+
+The artifacts state this in three places, at increasing specificity: plan.md's Constitution Check §8
+row, plan.md's Implementation Design property 1 ("deleted, not orphaned"), and quickstart.md step 1a
+("must be **deleted**, not left orphaned"). Two of the three name F841 and the required `Lint`
+context by name. That is sufficient; no wording change was made, because adding a fourth statement of
+the same point would dilute rather than clarify.
+
+Worth recording alongside it: the deletion is also required on the merits independent of the linter.
+FR-001 forbids any value derived from `provider` by replacement or slicing from reaching the context,
+and leaving the derivation alive next to the sink is the exact shape `8424cbd` left behind. If F841
+did not exist, the assignment would still have to go.
+
+---
+
+#### Verifications performed but not raised as questions
+
+Recorded so a later reader knows these were checked rather than assumed.
+
+- **SC-003's baseline still holds.** The open-alert set re-read at clarification time is exactly
+  `{144, 147, 148, 149, 150}`, five alerts, and alert 144 is still `open` at
+  `src/lambdas/shared/auth/oauth_state.py:104`. The baseline written at authoring time has not
+  drifted.
+- **The quickstart's regression test is implementable as written.** `store_oauth_state(table,
+  state_id, provider, redirect_uri, user_id=None)` matches the snippet's four positional arguments;
+  the module logger resolves to `src.lambdas.shared.auth.oauth_state`, which is the exact string the
+  snippet passes to `caplog.at_level`; `logger.propagate` is `True`, without which `caplog` would
+  capture nothing and the assertion would pass vacuously; and `OAUTH_STATE_TTL_SECONDS` is already
+  imported at the top of `tests/unit/auth/test_oauth_state.py`, so no new production import is
+  needed.
+- **The test baseline is 30 passed**, as quickstart.md Step 0 states, so its "expect 31 passed"
+  after the added method is right.

--- a/specs/001-oauth-provider-taint/tasks.md
+++ b/specs/001-oauth-provider-taint/tasks.md
@@ -1,0 +1,984 @@
+# Tasks: Close CodeQL alert 144 (OAuth provider taint)
+
+**Input**: Design documents from `/specs/001-oauth-provider-taint/`
+**Prerequisites**: spec.md (FR-001..FR-013 including FR-006a, SC-001..SC-007, Decision Gate),
+plan.md (Implementation Design, Verification Design, Adversarial Review #2), research.md
+(Decisions 1-5, Ledgers A and B), quickstart.md (Steps 0 through 5).
+**Inherited convention**: `specs/001-ingestion-arn-logging/codeql-logging-convention.md`, consumed in
+full per FR-008. Cited by document and section, never by a sibling requirement number and never by a
+sibling line number.
+
+**Organization**: tasks follow quickstart.md's step order. The code change is one atomic GPG-signed
+commit; the phases after it are observation and classification, not further edits. Story labels map
+to spec.md: US1 = apply the proven remediation, US2 = justified dismissal fallback, US3 = stop the
+failed approach being retried.
+
+**Tests**: FR-011 and SC-004 freeze the existing assertions. One new regression method is added under
+constitution §7, and it is written and proven failing *before* the production edit (T007, T008), which
+is the only way to show it is not vacuous.
+
+---
+
+## Execution invariants
+
+These bind every task below. A task that breaks one of them has failed even if its own pass condition
+was met.
+
+1. **Never key anything on an alert number changing state.** The criterion is always
+   **path + rule id**. `8424cbd` closed alert 117 at `oauth_state.py:95` and opened alert 144 at
+   `oauth_state.py:104` at the identical timestamp (research.md Ledger B). Alert numbers appear below
+   only as locating labels and as corroboration, never as a pass condition. The alerts API exposes no
+   function field (`most_recent_instance.location` carries `path` plus line and column bounds only),
+   so nothing keys finer than path + rule either.
+2. **Empty output is only a pass when the read succeeded.** Every task reading from `gh`, a pipe, or a
+   log captures the exit code explicitly and asserts a non-empty channel where emptiness would
+   otherwise be indistinguishable from success. Pipelines are avoided entirely, or `PIPESTATUS[0]` is
+   read. A failed read is discarded, never classified.
+3. **`make validate` is NOT a gate for this feature.** `Makefile:42` chains `check-banned-terms`, and
+   `scripts/check-banned-terms.sh` exits 1 on **17 pre-existing matches** in other features' spec
+   directories (re-verified 2026-07-30: 15 of one legacy framework name, 2 of another; the names are
+   not written here because writing them into this directory is what that scanner exists to prevent).
+   `make sast` is the substitute, per quickstart Step 1c.
+4. **No `TD-` identifier is pre-reserved.** `docs/reference/TECH_DEBT_REGISTRY.md` runs TD-001 to
+   TD-023 today. The number is read from the registry's then-highest entry at the moment the entry is
+   written, at merge time. `001-ruff-bump-forward` T016 and `001-codeql-coverage` Phase F write
+   registry entries in this same window.
+5. **Repo-wide alert counts are never a criterion.** SC-003 is an attribution test. Sibling
+   `001-codeql-coverage` is expected to raise the repo-wide open count on purpose, and per the owner's
+   directive that is success, not regression.
+6. **Permission is established by reading scopes, never by attempting a mutation** (convention §5b).
+   T006 is that read-only probe and it runs before anything in Phase 7 can execute.
+7. **Every code-scanning alerts query MUST be paginated, and truncation MUST be proved absent.**
+   An unpaginated query silently truncates and the truncation renders as **clean**. Measured on this
+   repository 2026-07-30: `gh api repos/OWNER/REPO/code-scanning/alerts` filtered to `state == "open"`
+   returns **zero** open alerts and exits **0**, because the default page size is 30 and the corpus is
+   **137** with the open alerts sitting at numbers 144 to 150, past the end of page one.
+   `per_page=100` is **not** a fix: page one at that size spans alert numbers 180 down to 59, which
+   silently drops alerts 1 and 22 to 27, and 22 to 27 are precisely the `secrets.py` sanitize-in-place
+   sites this feature reasons about. The mandatory shape is below, and it is used verbatim by T004,
+   T020, T021 and T030.
+
+   ```bash
+   export ALERTS_JSON=/tmp/oauth-alerts.json
+   gh api --paginate --slurp \
+     "repos/$REPO/code-scanning/alerts?ref=refs/heads/main&per_page=100" > "$ALERTS_JSON"
+   GH_RC=$?
+   CORPUS=$(jq '[.[][]] | length' "$ALERTS_JSON"); JQ_RC=$?
+   printf 'gh exit=%s jq exit=%s corpus=%s\n' "$GH_RC" "$JQ_RC" "$CORPUS"
+   ```
+
+   **Corpus floor**: `GH_RC=0`, `JQ_RC=0`, and `CORPUS` at least **137** (measured 2026-07-30). The
+   floor is safe to assert as a minimum because code scanning alerts are never deleted; a fixed or
+   dismissed alert stays in the all-states corpus forever, so this number only rises. A corpus below
+   the floor is a truncated or failed read and **every** result derived from it is discarded, not
+   classified.
+   Two mechanical notes, both verified by running them: `--slurp` is rejected in combination with
+   `--jq` ("the `--slurp` option is not supported with `--jq` or `--template`"), which is why the
+   response is written to a file and filtered by standalone `jq` with its own exit code; and
+   `--paginate` **without** `--slurp` applies `--jq` once per page, so a per-page `[...]` collector
+   emits one array per page and the pass condition "output is exactly `[]`" would be met by a
+   two-page response printing `[]` twice. Filtering the slurped file avoids both traps and involves
+   no pipe, so no exit code is lost downstream of one.
+
+---
+
+## Terminal states
+
+The feature MUST end in exactly one recorded state. There are no implicit aborts.
+
+| State | Trigger | Recorded by |
+|---|---|---|
+| `CONFIRMED` | Fresh default-branch analysis shows zero open findings of this rule at this path | T024 |
+| `REPORTED-FOREIGN-SINK` | A survivor of this rule on the path attributes outside `store_oauth_state()` | T025 |
+| `REFUTED-DISMISSED` | A survivor attributes inside `store_oauth_state()` and is dismissed with the §2 justification | T026, T027 |
+| `BLOCKED-ON-OWNER` | A survivor is observed and the T006 probe shows the dismissal permission absent | T028 |
+| `BLOCKED-NO-ANALYSIS` | No analysis satisfying the T019 freshness proof within 7 days of the change landing on `main` | T029 |
+| `BLOCKED-REGRESSION` | Unit suite not green, or a new open alert of any rule attributable to this diff on `oauth_state.py` or `secrets.py` | T029 |
+| `PENDING-BRANCH-ANALYSIS` | Code change complete and green, but it has not landed on `main`, so no qualifying analysis can exist yet | T017 |
+
+`PENDING-BRANCH-ANALYSIS` is inherited from `codeql-logging-convention.md` **§5a**, which calls it
+"the normal ending, not an edge case", and is consumed here under FR-008 rather than newly defined.
+It is absent from plan.md's six-row terminal-state table and from quickstart.md, which is recorded as
+finding **F-01** in the Cross-Artifact Analysis below. Without it, an implementing agent that cannot
+merge has no state to end in, which is precisely the implicit abort the gate exists to prevent.
+
+### Routing for failures that are not gate outcomes
+
+Added by Adversarial Review #3, finding **G-04**. Seven states cover every *gate* outcome, but six
+task-level failure paths told the implementer to "stop" without naming a state, which is the same
+implicit abort in a different place. **No new state is introduced.** Each is routed to an existing
+one, and the routing is exhaustive: any task-level failure not listed here is `BLOCKED-REGRESSION`.
+
+| Failure | State | Note |
+|---|---|---|
+| T001 wrong Python major/minor | `BLOCKED-REGRESSION` | The tree cannot be validated, so no gate may be evaluated on it. Report the interpreter version. No edit is made. |
+| T002 dirty `src/` or `tests/` | `BLOCKED-REGRESSION` | **The likeliest of these.** Three sibling agents share this worktree and at least one of them edits `src/`. Report the foreign paths verbatim; do not revert them, and do not proceed, because T011, T015 and T016 all read a diff that would then be another feature's. |
+| T004 complete read (corpus at or above floor) contains no entry for `$FILE` | `CONFIRMED` | The premise is gone before the work starts, and the definition of `CONFIRMED` is satisfied verbatim: no open finding of this rule at this path on the default branch. Record it as `CONFIRMED` **with the classification dated before the edit**, note that no change was needed, and still run T031 and T032 if the FR-013 comment is absent from the file. Do not "fix" a finding that is not there. |
+| T016 `make sast` non-zero | `BLOCKED-REGRESSION` | Includes the offline case: `make sast` runs `semgrep scan --config auto`, which fetches registry rules over the network. A network failure is a blocked gate, not a clean one. |
+| T023 read repeatedly not an observation | `BLOCKED-NO-ANALYSIS` | The discard-and-re-run row has no bound of its own. It inherits T019's: **7 days from `$CHANGE_SHA` landing on `main`**. A persistently failing `gh` read (token expiry, rate limit, outage) otherwise loops forever with no exit. |
+| T026 `PATCH` fails for any reason other than permissions | `BLOCKED-ON-OWNER` | T028 is scoped to the permission case only. A 422, a 5xx or a network failure is still "the code change is complete and only the dismissal is outstanding", which is what T028 records. State the actual HTTP status in the handoff. |
+
+One further routing correction: **T023's mixed-survivor precedence also triggers T027.** T026 running
+in the mixed case is a real dismissal, and FR-007 and SC-006 require a registry entry for *any*
+dismissal regardless of which state is finally recorded. The recorded state stays
+`REPORTED-FOREIGN-SINK`; the registry entry is still mandatory.
+
+---
+
+## Phase 1: Preconditions and baseline (blocking, no edits)
+
+- [ ] **T001** Environment precondition. Run `source .venv/bin/activate && python --version`.
+  **Pass**: prints `Python 3.13.x`. Any other major/minor stops the feature before an edit is made.
+- [ ] **T002** [P] Working-tree precondition. Run
+  `git status --short -- src tests | tee /tmp/oauth-pre.txt; wc -l < /tmp/oauth-pre.txt`.
+  **Pass**: prints `0`. A dirty `src/` or `tests/` means another agent is mid-edit in this shared
+  worktree and the FR-003 diff inspection at T015 would be unreadable.
+- [ ] **T003** [P] Unit baseline. Run `pytest tests/unit/auth/ -q; echo "pytest exit=$?"`.
+  **Pass**: `pytest exit=0` **and** the summary line reads `30 passed` (re-verified 2026-07-30). Any
+  other count means the baseline drifted and quickstart Step 1c's "expect 31 passed" is no longer the
+  right target; record the new baseline and add one.
+- [ ] **T004** [P] SC-003 baseline set, by path, never by count. Uses the paginated shape from
+  invariant 7:
+  ```bash
+  export REPO=traylorre/sentiment-analyzer-gsk
+  export RULE=py/clear-text-logging-sensitive-data
+  export FILE=src/lambdas/shared/auth/oauth_state.py
+  export ALERTS_JSON=/tmp/oauth-alerts-baseline.json
+  gh api --paginate --slurp \
+    "repos/$REPO/code-scanning/alerts?ref=refs/heads/main&per_page=100" > "$ALERTS_JSON"
+  GH_RC=$?
+  CORPUS=$(jq '[.[][]] | length' "$ALERTS_JSON"); JQ_RC=$?
+  BASE=$(jq -c '[.[][] | select(.state == "open")
+                       | {number, rule: .rule.id,
+                          path: .most_recent_instance.location.path,
+                          line: .most_recent_instance.location.start_line}]' "$ALERTS_JSON")
+  printf 'gh exit=%s jq exit=%s corpus=%s\nbaseline=%s\n' "$GH_RC" "$JQ_RC" "$CORPUS" "$BASE"
+  ```
+  **Pass**: `gh exit=0`, `jq exit=0`, `corpus` at least **137**, **and** `$BASE` contains an entry
+  whose `path` is `$FILE` and whose `rule` is `$RULE`. A corpus under the floor is a truncated read
+  and the baseline is discarded, not recorded: an unpaginated version of this exact query returns an
+  empty open set with exit 0 (invariant 7). A complete read that contains **no** entry for `$FILE`
+  means this feature's premise is already gone: stop, record it, do not "fix" a finding that is not
+  there.
+  **Record**: the full set verbatim into `specs/001-oauth-provider-taint/evidence.md`. Observed
+  2026-07-30: `{144, 147, 148, 149, 150}`, with 144 at `oauth_state.py:104`. Siblings legitimately
+  move this set (`001-ingestion-arn-logging` closes 148-150, `001-bad-tag-filter-dead-suppression`
+  closes 147, `001-codeql-coverage` raises it). Record the set, do not gate on its size.
+- [ ] **T005** [P] Locating snapshot of alert 144, explicitly not a criterion. Run:
+  ```bash
+  A144=$(gh api "repos/$REPO/code-scanning/alerts/144" \
+    --jq '{number, state, fixed_at, dismissed_reason,
+           path: .most_recent_instance.location.path,
+           start_line: .most_recent_instance.location.start_line,
+           commit_sha: .most_recent_instance.commit_sha,
+           code_flows: (.most_recent_instance.code_flows | length)}')
+  RC=$?; printf 'gh exit=%s\n%s\n' "$RC" "$A144"
+  ```
+  **Pass**: `gh exit=0` and `$A144` non-empty. `code_flows` is expected to be `0`, which is why no
+  artifact claims to know the taint path. Nothing downstream keys on this alert's state.
+- [ ] **T006** [P] Read-only dismissal-permission probe (convention **§5b**; never probe by attempting
+  a `PATCH`, which mutates alert state and cannot be cleanly reverted). Run:
+  ```bash
+  gh auth status 2>&1 | grep -i 'Token scopes'
+  PERM=$(gh api "repos/$REPO" --jq '{visibility, permissions}')
+  RC=$?; printf 'gh exit=%s\nperm=%s\n' "$RC" "$PERM"
+  ```
+  **Pass**: `gh exit=0`, `$PERM` non-empty, and the probe resolves to one of two recorded outcomes:
+  *available* when `visibility` is `public` and `permissions.push` is `true` and the scope list
+  contains `repo` (which subsumes `public_repo`); *absent* otherwise. **A missing `security_events`
+  scope is NOT by itself a blocker**: GitHub requires it only on private repositories, and §5b exists
+  to stop exactly that misreading. Observed 2026-07-30: scopes `gist, read:org, repo, workflow`,
+  `visibility: public`, `permissions.admin: true`, so the outcome is **available** and
+  `BLOCKED-ON-OWNER` is not the expected ending.
+
+**Checkpoint**: baseline recorded, premise confirmed present, dismissal permission known in advance of
+needing it. No file has been edited.
+
+---
+
+## Phase 2: US1 regression guard, written first
+
+**Goal**: prove the guard fails on unfixed code before the fix exists. A guard that would pass either
+way is decoration, and `caplog.text` assertions are the known instance of that failure mode.
+
+- [ ] **T007** [US1] In `tests/unit/auth/test_oauth_state.py`, add `import logging` to the imports
+  (the module does not currently import it; `OAUTH_STATE_TTL_SECONDS` is already imported) and add one
+  method to `TestStoreOAuthState` (class at line 37), exactly as quickstart Step 1b specifies:
+  ```python
+      def test_log_context_excludes_provider(self, mock_table, caplog):
+          """Regression guard for py/clear-text-logging-sensitive-data (alert 144).
+
+          No value derived from `provider` may reach the logger's extra context.
+          `logging` promotes every extra key to a LogRecord attribute, so this
+          asserts on the sink itself rather than on rendered output, which is bare
+          in production and would pass either way.
+          """
+          with caplog.at_level(
+              logging.INFO, logger="src.lambdas.shared.auth.oauth_state"
+          ):
+              store_oauth_state(
+                  mock_table, "state-1", "google", "https://example.com/callback"
+              )
+
+          records = [r for r in caplog.records if r.getMessage() == "OAuth state stored"]
+          assert len(records) == 1
+          assert not hasattr(records[0], "provider")
+          assert records[0].has_user_id is False
+          assert records[0].ttl_seconds == OAUTH_STATE_TTL_SECONDS
+  ```
+  The assertion is on the `LogRecord` attribute, never on `caplog.text`: rendered output is bare in
+  production (research.md Decision 2) and a text assertion would pass on unfixed code. No existing
+  assertion is edited (FR-011, SC-004).
+- [ ] **T008** [US1] Prove the guard is not vacuous, before the production edit exists. Run
+  `pytest tests/unit/auth/test_oauth_state.py -q; echo "pytest exit=$?"`.
+  **Pass**: `pytest exit=1` **and** exactly one failure, `test_log_context_excludes_provider`, failing
+  on `assert not hasattr(records[0], "provider")`. If it passes here, the guard is not testing the
+  sink and T007 must be rewritten before proceeding.
+
+**Checkpoint**: a failing, non-vacuous guard exists. It is red on purpose.
+
+---
+
+## Phase 3: US1 production change
+
+- [ ] **T009** [US1] In `src/lambdas/shared/auth/oauth_state.py`, inside `store_oauth_state()` **only**
+  (`def` at line 59): delete the `safe_provider` assignment (lines 99-101) and delete the
+  `"provider": safe_provider` entry from the `extra` dict (line 105). Substitute nothing: not a
+  literal, not an allowlist-selected constant, not a boolean (FR-001, FR-002; the allowlist form was
+  deleted for cause by Adversarial Review #1 and must not return). Anchor by content, not by line
+  number. The assignment must be **deleted, not orphaned**: `[tool.ruff.lint] select` includes `F`, so
+  a retained unused local fails `ruff check` with `F841` and blocks the required `Lint` context
+  (`.github/workflows/pr-checks.yml:62`).
+- [ ] **T010** [US1] [US3] In the same edit, add the FR-013 documentation comment immediately above the
+  `logger.info(` call:
+  ```python
+      # py/clear-text-logging-sensitive-data: no value derived from `provider` may
+      # appear in this extra context. Removing the derived value, rather than
+      # sanitizing it in place, is the shape that closed this rule in ebcc2f4.
+      # See specs/001-oauth-provider-taint/research.md before adding a key here.
+  ```
+  Mandatory on **every** branch of the decision gate including `CONFIRMED` (FR-013). It carries no
+  `# nosec`, `# noqa`, `# lgtm` and no CodeQL pragma, which is what keeps it disjoint from the inline
+  suppression FR-010 forbids. Obligation inherited from `codeql-logging-convention.md` **§1**, closing
+  paragraph, via FR-008.
+- [ ] **T011** [US1] Confirm `validate_oauth_state()` is untouched (FR-004). Its
+  `safe_provider_validated` at line 253 and `extra={"provider": safe_provider_validated}` at line 258
+  carry the identical sanitize-in-place shape that left alerts 22-25 with `fixed_at` null to this day,
+  and this feature does **not** fix it. Run:
+  ```bash
+  git diff -U0 -- src/lambdas/shared/auth/oauth_state.py | grep -E '^@@' ; echo "grep exit=$?"
+  ```
+  **Pass**: `grep exit=0` (hunk headers were printed, so the diff was read) **and** every hunk header's
+  start line is below 122 (`def get_oauth_state` at 122 is the next top-level definition after the
+  sink). Any hunk at or beyond line 154 means `validate_oauth_state()` was edited: revert it.
+
+**Checkpoint**: the sink carries no `provider`-derived value and does carry the FR-013 comment.
+
+---
+
+## Phase 4: Local gates
+
+- [ ] **T012** Run the guard against the fixed code:
+  `pytest tests/unit/auth/ -q; echo "pytest exit=$?"`.
+  **Pass**: `pytest exit=0` and the summary reads `31 passed` (30 baseline from T003 plus the T007
+  method). FR-011, SC-004: no pre-existing assertion changed.
+- [ ] **T013** [P] Lint and format the two touched files:
+  ```bash
+  ruff format src/lambdas/shared/auth/oauth_state.py tests/unit/auth/test_oauth_state.py
+  ruff check src/lambdas/shared/auth/oauth_state.py tests/unit/auth/test_oauth_state.py
+  echo "ruff exit=$?"
+  ```
+  **Pass**: `ruff exit=0`. Specifically no `F841`, which is the signal that T009's deletion left the
+  `safe_provider` assignment orphaned.
+- [ ] **T014** [P] **SC-007 check** on the working tree, before the commit:
+  ```bash
+  grep -n -B6 'OAuth state stored' src/lambdas/shared/auth/oauth_state.py; echo "grep exit=$?"
+  grep -nEi '#\s*(nosec|noqa|lgtm)|codeql\[|lgtm\[' src/lambdas/shared/auth/oauth_state.py
+  echo "pragma grep exit=$?"
+  ```
+  **Pass**: the first `grep exit=0` and its output contains the literal
+  `py/clear-text-logging-sensitive-data` in the comment block preceding the log call; the second grep
+  exits **exactly 1** (no match). Exit 2 is a grep error, not a clean file, and must be re-run. This
+  same check is re-run against the merged file at T024 or T026, because SC-007 is stated against the
+  merged file.
+  **The window is `-B6`, and the arithmetic is load-bearing** (Adversarial Review #3, finding
+  **G-01**). `grep` matches the string literal `"OAuth state stored",`, which after the T010 edit sits
+  on the line *below* `logger.info(`, which sits below the four comment lines. The rule id is on the
+  **first** comment line, exactly **five** lines above the match. `-B4` therefore prints lines 100 to
+  104 and the rule id is not in the output, so the pass condition could never be met on correct code.
+  Measured against the T009+T010 result 2026-07-30: `-B4` yields `0` occurrences of the rule id,
+  `-B5` yields `1`. `-B6` is `-B5` plus one line of slack against a one-line drift in the comment.
+- [ ] **T015** [P] **FR-003 check** by diff inspection:
+  ```bash
+  git diff -- src/lambdas/shared/auth/oauth_state.py > /tmp/oauth-fr003.diff
+  echo "diff bytes=$(wc -c < /tmp/oauth-fr003.diff)"
+  grep -cE '^[-+]' /tmp/oauth-fr003.diff
+  ```
+  **Pass**: `diff bytes` greater than 0 (an empty diff means nothing was applied, not that nothing
+  changed), and the changed lines are confined to the deleted assignment, the deleted dict entry, and
+  the added comment. The `put_item` item dict (including the persisted `"provider": provider` at line
+  87), the returned `OAuthState`, and the `code_verifier` generation appear in no `+`/`-` line.
+- [ ] **T016** [P] **FR-010 check**, that nothing was suppressed rather than fixed:
+  ```bash
+  git diff --name-only; echo "---"
+  git status --short -- .github/ .semgrep* pyproject.toml
+  make sast; echo "make sast exit=$?"
+  ```
+  **Pass**: `git diff --name-only` lists exactly `src/lambdas/shared/auth/oauth_state.py` and
+  `tests/unit/auth/test_oauth_state.py` (plus files under `specs/001-oauth-provider-taint/`); the
+  second command prints nothing, proving no analysis configuration, query pack, severity or path
+  exclusion was touched; and `make sast exit=0`.
+  **Do NOT run `make validate` as a gate** (invariant 3). If it is run anyway, confirm the only
+  failures are the 17 pre-existing banned-term matches and that none of them is in this feature's
+  directory: `bash scripts/check-banned-terms.sh 2>&1 | grep -c '001-oauth-provider-taint'` prints
+  `0`. Do not repair other features' directories; three sibling agents share this worktree.
+
+**Checkpoint**: the change is complete, green, and provably confined. This is the last point at which
+any file is edited outside `specs/001-oauth-provider-taint/`.
+
+---
+
+## Phase 5: Land the change, or stop in a recorded state
+
+- [ ] **T017** Commit GPG-signed on the feature branch (`git commit -S`; never `--no-gpg-sign`, never
+  `--no-verify`), push, open a PR, and record the **merge commit SHA on `main`**:
+  `export CHANGE_SHA=<merge commit sha on main>`.
+  **If pushing or merging is gated on the repository owner and the change cannot land**, stop here and
+  record terminal state **`PENDING-BRANCH-ANALYSIS`** per `codeql-logging-convention.md` §5a: the code
+  change and its regression guard are complete and green, no default-branch analysis can exist yet,
+  and the feature is neither done nor failed. Write the T020 gate query, filled in, into
+  `specs/001-oauth-provider-taint/evidence.md` so the check is mechanical the moment the change lands.
+  **Phases 6 and 7 are then not executed. Phase 8 still is** (Adversarial Review #3, finding
+  **G-03**): T031 reads only `research.md` and has no dependency on a merge at all; T032 and T033 are
+  declared **unconditional across every terminal state**, and this is the state quickstart Step 1d
+  calls "the likeliest ending", so skipping the whole of Phase 8 here would leave FR-012, FR-013,
+  SC-005 and SC-007 unverified on the most probable execution path. T032's "merged file" clause reads
+  against the committed file on the feature branch in this state, and evidence.md records that
+  substitution explicitly.
+  **Also record `$CHANGE_SHA`, or its absence, into `evidence.md` rather than leaving it in the
+  shell.** T019's freshness proof needs it and the wait it bounds is up to 7 days, which outlives any
+  shell. A lost `$CHANGE_SHA` makes T019 unrunnable and strands the feature between
+  `PENDING-BRANCH-ANALYSIS` and `BLOCKED-NO-ANALYSIS` with no way back. This applies on the normal
+  path too, not only here.
+- [ ] **T018** Locate a default-branch analysis. The `codeql` job (name `Analyze`, category
+  `/language:python`) lives in `.github/workflows/pr-checks.yml` and triggers on `push` to `main`.
+  ```bash
+  AN=$(gh api "repos/$REPO/code-scanning/analyses?ref=refs/heads/main&per_page=5" \
+    --jq '[.[] | {id, commit_sha, created_at, analysis_key, category}]')
+  RC=$?; printf 'gh exit=%s\n%s\n' "$RC" "$AN"
+  export ANALYZED_SHA=<commit_sha of the newest python analysis>
+  ```
+  **Pass**: `gh exit=0` and `$AN` is a non-empty array whose first element has category
+  `/language:python`. An empty array with exit 0 means no default-branch analysis exists at all,
+  which is a wait condition, not a pass.
+  **Why this one is not paginated, unlike every alerts query** (invariant 7): the analyses endpoint
+  returns results newest first (verified 2026-07-30: five consecutive `/language:python` analyses with
+  strictly descending `created_at`), this task wants exactly the newest, and page one therefore
+  contains it by construction. More importantly the truncation hazard does not apply here, because
+  emptiness is a **failure** condition for this task rather than a pass: a truncated or failed read
+  cannot render as clean. Paginating this endpoint would instead walk the repository's entire analysis
+  history for a value already on line one.
+- [ ] **T019** **Freshness proof (mandatory, FR-005 prerequisite).** A result predating the change
+  decides nothing.
+  ```bash
+  ST=$(gh api "repos/$REPO/compare/$CHANGE_SHA...$ANALYZED_SHA" --jq '.status')
+  RC=$?; printf 'gh exit=%s status=%s\n' "$RC" "$ST"
+  ```
+  **Pass**: `gh exit=0` and `$ST` is exactly `ahead` or `identical`. `behind` or `diverged` means the
+  analysis does not cover the change: discard the observation and wait. An empty `$ST` is a failed
+  read, not a pass.
+  **Bound**: if no analysis satisfies this within **7 days** of `$CHANGE_SHA` landing on `main`, stop
+  and record **`BLOCKED-NO-ANALYSIS`** via T029. Do not classify. Do not dismiss.
+
+---
+
+## Phase 6: Evaluate the decision gate, exactly once
+
+- [ ] **T020** **Positive control for the gate query, run first.** A check whose pass condition is
+  empty output is worthless without proof that the query can return anything at all: a typo in
+  `$RULE`, `$FILE` or the ref returns `[]` forever and reads as success.
+  ```bash
+  export ALERTS_JSON=/tmp/oauth-alerts-gate.json
+  gh api --paginate --slurp \
+    "repos/$REPO/code-scanning/alerts?ref=refs/heads/main&per_page=100" > "$ALERTS_JSON"
+  GH_RC=$?
+  CORPUS=$(jq '[.[][]] | length' "$ALERTS_JSON"); JQ_RC=$?
+  RULETOT=$(jq --arg r "$RULE" '[.[][] | select(.rule.id == $r)] | length' "$ALERTS_JSON")
+  CTRL=$(jq -c --arg r "$RULE" --arg f "$FILE" \
+    '[.[][] | select(.rule.id == $r)
+            | select(.most_recent_instance.location.path == $f)
+            | {number, state}]' "$ALERTS_JSON")
+  printf 'gh exit=%s jq exit=%s corpus=%s rule_total=%s\ncontrol=%s\n' \
+    "$GH_RC" "$JQ_RC" "$CORPUS" "$RULETOT" "$CTRL"
+  ```
+  This reads the same slurped corpus T021 filters, without the `state == "open"` predicate, so it
+  returns findings of this rule at this path in **every** state. Note `jq --arg` is used here, which
+  is a real `jq` flag; `gh api` has no `--arg` flag, which is the defect Adversarial Review #2 X1
+  removed from quickstart Step 3a.
+  **Pass**, all four, each a number measured 2026-07-30 rather than a vague "non-empty":
+  `gh exit=0` and `jq exit=0`; `corpus` at least **137**; `rule_total` at least **22**; and `$CTRL`
+  containing **alert 117**, which is `state: fixed` on this path for this rule and therefore an
+  immovable anchor, so the control stays satisfied after the change lands whatever the outcome.
+  Measured value of `$CTRL`: `[{"number":144,"state":"open"},{"number":117,"state":"fixed"}]`.
+  If any of the four fails, the query shape or the read is broken and **T021's result is not an
+  observation**. Alert 117 appears here as a fixture for the control, never as a criterion for the
+  gate.
+- [ ] **T021** [US1] **Primary gate query**, path + rule id, default branch only:
+  Filters the **same slurped corpus T020 just validated**, so the anti-truncation floor has already
+  been proved on the exact bytes this classification rests on. Do not re-fetch between T020 and T021.
+  ```bash
+  GATE=$(jq -c --arg r "$RULE" --arg f "$FILE" \
+    '[.[][] | select(.state == "open")
+            | select(.rule.id == $r)
+            | select(.most_recent_instance.location.path == $f)
+            | {number, start_line: .most_recent_instance.location.start_line,
+               commit_sha: .most_recent_instance.commit_sha}]' "$ALERTS_JSON")
+  JQ_RC=$?; printf 'jq exit=%s\ngate=%s\n' "$JQ_RC" "$GATE"
+  ```
+  **Pass condition for `CONFIRMED`**: T020 passed on all four of its floors, **and** `jq exit=0`,
+  **and** `$GATE` is exactly `[]`. Because the expression always collects into an array, a **blank**
+  `$GATE` means the filter itself failed and is discarded, never classified. Emptiness here is a pass
+  only because T020 proved, on the same file, that a finding of this rule at this path is visible to
+  this query when one exists.
+  Per FR-009 and SC-002 this is the only admissible evidence: a green `Analyze` check on a pull
+  request is not, because CodeQL is not a required status check here and a PR run reports into the
+  PR's own ref.
+- [ ] **T022** Attribute **every** survivor, only if `$GATE` is non-empty. This step can never turn a
+  non-empty result into a pass; it decides **who owns** the survivor (FR-006a). Map at the analyzed
+  commit, never against the working tree and never against a line window frozen at authoring time. No
+  pipeline, so no exit code is lost downstream of one:
+  ```bash
+  gh api "repos/$REPO/contents/$FILE?ref=$ANALYZED_SHA" --jq '.content' > /tmp/oauth.b64
+  RC=$?; printf 'gh exit=%s bytes=%s\n' "$RC" "$(wc -c < /tmp/oauth.b64)"
+  base64 -d < /tmp/oauth.b64 > /tmp/oauth_at_analyzed.py; echo "base64 exit=$?"
+  grep -n '^def ' /tmp/oauth_at_analyzed.py; echo "grep exit=$?"
+  ```
+  **Pass**: `gh exit=0`, `bytes` greater than 0, `base64 exit=0`, `grep exit=0`, and the output
+  contains a `def store_oauth_state(` line. `store_oauth_state()` spans from its `def` line to the
+  line before the next top-level `def`. A survivor whose `start_line` falls inside that span is this
+  feature's; one outside it is not. If any of those four checks fails, the attribution is unknown, and
+  an unknown attribution is handled as **foreign** (T025), never as this feature's to dismiss.
+- [ ] **T023** [US1] **Classify, once** (FR-005, SC-005). Record the classification, the evidence it
+  rests on, the analysis `id`, `$ANALYZED_SHA` and the T019 `compare` status into
+  `specs/001-oauth-provider-taint/evidence.md`.
+
+  | Observation | Classification | Next |
+  |---|---|---|
+  | T021 `gh exit=0` and `$GATE == []`, with T020 control non-empty | **Confirmed** | T024 |
+  | `$GATE` non-empty, every survivor attributes inside `store_oauth_state()` | **Refuted** | T026 |
+  | `$GATE` non-empty, any survivor attributes outside `store_oauth_state()` or is unattributable | **Not Confirmed, not this feature's** | T025 |
+  | T021 `gh exit` non-zero, or `$GATE` blank, or T020 control empty | **Not an observation** | Discard, re-run T020 and T021 |
+  | T019 never satisfied within 7 days | **Not decidable** | T029, `BLOCKED-NO-ANALYSIS` |
+
+  **Mixed result precedence, stated here because neither spec.md's Decision Gate nor quickstart Step
+  3c covers it** (finding **F-05**): if survivors exist both inside and outside the function, both
+  obligations run. The inside survivor is dismissed under T026, the outside one is reported under
+  T025, and the feature's recorded terminal state is **`REPORTED-FOREIGN-SINK`**, because FR-006
+  forbids `CONFIRMED` while any finding is open at the path and FR-006a makes the reported state
+  terminal.
+  A survivor bearing an alert number other than 144 is **Refuted with a respawn recorded**, not
+  success. The disappearance of alert 144 on its own decides nothing.
+
+---
+
+## Phase 7: Terminal branches (exactly one is executed, except as noted in T023)
+
+- [ ] **T024** **`CONFIRMED`.** Record into `specs/001-oauth-provider-taint/evidence.md`: the analysis
+  `id` and `commit_sha`, the T019 `compare` status, and the T021 result. Then:
+  ```bash
+  gh api "repos/$REPO/code-scanning/alerts/144" --jq '{number, state, fixed_at, dismissed_reason}'
+  echo "gh exit=$?"
+  ```
+  `fixed_at` is recorded as **corroboration only** (expected non-null and dated at or after
+  `$CHANGE_SHA`). It is not the criterion; the pass was already decided by T021, and 144 is a locating
+  label. Note that `state` alone is not proof of repair: dismissal is sticky, which is why alerts 26
+  and 27 read `dismissed` while carrying `fixed_at`, and alerts 22-25 read `dismissed` with `fixed_at`
+  still null eight months on (convention §3, Trap 1).
+  Then re-run the **T014 SC-007 check against the merged file**, and run the **SC-003 attribution
+  recount** below. No dismissal. No tech debt entry (a closed finding creates no debt, FR-007).
+- [ ] **T025** **`REPORTED-FOREIGN-SINK`** (FR-006a). Report to the repository owner, in
+  `specs/001-oauth-provider-taint/evidence.md` and in the PR thread: the alert number, its
+  `start_line`, `$ANALYZED_SHA`, the attributed function, and the statement that this feature does not
+  own it. **Do not dismiss it. Do not edit `validate_oauth_state()`** (FR-004): its sink at lines 253
+  to 258 carries the same sanitize-in-place shape that has left alerts 22-25 unrepaired since
+  2025-12-09, and fixing it is a different feature's job. The code change from Phase 3 is
+  independently complete and stays. **Pass**: the report exists and names all five items.
+- [ ] **T026** [US2] **`REFUTED-DISMISSED`**, reachable only after Phase 3 landed and T023 classified
+  Refuted (FR-007; a dismissal before the proven remedy is exhausted is blocked by US2 acceptance
+  scenario 2), and only if T006 resolved to *available*. If T006 resolved to *absent*, go to T028
+  instead without attempting the `PATCH`.
+  The justification carries the three elements of `codeql-logging-convention.md` **§2** (what the value
+  actually is; which convention shape was applied; why CodeQL still reports the flow), cited by
+  section rather than by any sibling requirement number, per FR-008. Use the text drafted in quickstart
+  Step 4b, adjusted to what was actually observed.
+  ```bash
+  export ALERT=<observed alert number, whatever it is>
+  gh api -X PATCH "repos/$REPO/code-scanning/alerts/$ALERT" \
+    -f state=dismissed -f dismissed_reason='false positive' \
+    -f dismissed_comment="$JUSTIFICATION"
+  echo "patch exit=$?"
+  VER=$(gh api "repos/$REPO/code-scanning/alerts/$ALERT" \
+    --jq '{number, state, dismissed_reason, dismissed_comment, dismissed_at,
+           dismissed_by: .dismissed_by.login}')
+  RC=$?; printf 'gh exit=%s\n%s\n' "$RC" "$VER"
+  ```
+  **Pass**: `patch exit=0`, `gh exit=0`, `$VER` non-empty, `state` is `dismissed`, `dismissed_reason`
+  is `false positive`, and `dismissed_comment` is non-empty and contains all three §2 elements. A
+  `PATCH` failing on permissions is an observation that routes to T028, not a retry loop.
+- [ ] **T027** [US2] Tech debt registry entry, required on this branch only (FR-007, SC-006,
+  constitution §9: a dismissal is a documented security shortcut). File is
+  **`docs/reference/TECH_DEBT_REGISTRY.md`**. Constitution §9 names `docs/TECH_DEBT_REGISTRY.md`,
+  which has not existed since `f8db8d2` (PR #668) relocated it; the stale constitution path is carded,
+  not repaired here, and no new file is created at it.
+  **Allocate the identifier at merge time** by reading the registry's then-highest `TD-` entry and
+  taking the next one. Never take a number from any spec artifact (invariant 4). Fields: `ID`,
+  `Location` (`src/lambdas/shared/auth/oauth_state.py`, `store_oauth_state()`), `Status: Acceptable`,
+  `Root Cause`, `Proposed Fix`, `Effort`, `Risk`, plus a link back to this directory.
+  **Pass**: `grep -n 'oauth_state' docs/reference/TECH_DEBT_REGISTRY.md` exits 0, and the entry's `ID`
+  is greater than every other `TD-` id in the file at the time of writing.
+- [ ] **T028** **`BLOCKED-ON-OWNER`**, reached only when the T006 read-only probe resolved to *absent*
+  or a T026 `PATCH` failed on permissions. Inherited from `codeql-logging-convention.md` **§5b**, not
+  newly defined. Write a handoff artifact into `specs/001-oauth-provider-taint/` carrying: the exact
+  alert numbers observed at the path with their `start_line` and `$ANALYZED_SHA`; the exact
+  justification text verbatim per alert; and the exact `gh api -X PATCH` invocation, ready to run.
+  State plainly that the code change is independently complete and mergeable and only the dismissal is
+  outstanding. Reported as neither done nor failed.
+  **Pass**: the artifact exists and carries all three items.
+- [ ] **T029** **`BLOCKED-NO-ANALYSIS`** or **`BLOCKED-REGRESSION`**. Report to the repository owner,
+  naming the missing analysis (for the former) or the exact failing check (for the latter). Neither is
+  classified against the gate and neither is dismissed; both are terminal and reportable, not a further
+  attempt. `BLOCKED-REGRESSION` triggers on a non-green unit suite **or** on a new open alert of any
+  rule appearing on `src/lambdas/shared/auth/oauth_state.py` or on `src/lambdas/shared/secrets.py`
+  (SC-003). It does **not** trigger on the repo-wide count moving: `001-codeql-coverage` is expected to
+  raise it and that is success, not regression.
+- [ ] **T030** **SC-003 attribution recount**, run on whichever of T024, T025 or T026 was reached:
+  ```bash
+  export AFTER_JSON=/tmp/oauth-alerts-after.json
+  gh api --paginate --slurp \
+    "repos/$REPO/code-scanning/alerts?ref=refs/heads/main&per_page=100" > "$AFTER_JSON"
+  GH_RC=$?
+  CORPUS=$(jq '[.[][]] | length' "$AFTER_JSON"); JQ_RC=$?
+  AFTER=$(jq -c '[.[][] | select(.state == "open")
+                        | {number, rule: .rule.id,
+                           path: .most_recent_instance.location.path}]' "$AFTER_JSON")
+  AFTER_RC=$?
+  # Positive control for the path selector itself. This is an ABSENCE assertion, and an absence
+  # is not evidence until the read is proved working (Adversarial Review #3, finding G-02).
+  PATHCTRL=$(jq '[.[][] | select(.most_recent_instance.location.path == null)] | length' "$AFTER_JSON")
+  PATHCTRL_RC=$?
+  ANCHOR=$(jq -c '[.[][] | select(.number == 117)
+                         | {number, state, path: .most_recent_instance.location.path}]' "$AFTER_JSON")
+  ANCHOR_RC=$?
+  printf 'gh exit=%s jq exit=%s after_rc=%s corpus=%s null_paths=%s (rc=%s) anchor_rc=%s\nanchor=%s\nafter=%s\n' \
+    "$GH_RC" "$JQ_RC" "$AFTER_RC" "$CORPUS" "$PATHCTRL" "$PATHCTRL_RC" "$ANCHOR_RC" "$ANCHOR" "$AFTER"
+  ```
+  **Pass**, and every clause is required:
+  `gh exit=0`; `jq exit=0`, `after_rc=0`, `rc=0` and `anchor_rc=0`; `corpus` at least **137**
+  (invariant 7: without `--paginate` this comparison silently reads zero open alerts and would certify
+  SC-003 while blind); `null_paths` exactly **0**; `$ANCHOR` exactly
+  `[{"number":117,"state":"fixed","path":"src/lambdas/shared/auth/oauth_state.py"}]`; **and** no alert
+  of any rule newly appears on `src/lambdas/shared/auth/oauth_state.py` or on
+  `src/lambdas/shared/secrets.py` relative to the T004 baseline.
+  **Why the two extra controls exist.** T030 is the feature's only *other* pass-on-absence condition
+  besides T021, and unlike T021 it had no control. The corpus floor proves the **fetch** worked; it
+  proves nothing about the **path selector**. Demonstrated 2026-07-30 by running it: mistyping
+  `.location` as `.locatio` does not make `jq` fail. It returns `path: null` for all 137 entries,
+  exits **0**, leaves the corpus floor satisfied, and the resulting set contains no entry on
+  `oauth_state.py` or `secrets.py`, so the pass condition is met while the read is blind. That is
+  exactly the shape T020 exists to prevent on the gate query. `null_paths = 0` catches a broken
+  selector; the alert-117 anchor catches a selector that is well-formed but reading the wrong field,
+  because 117 is permanently `fixed` at this exact path and its path string is therefore an immovable
+  fixture (same anchor as T020, same reason).
+  A higher total attributable to `001-codeql-coverage`'s additional analysis leg satisfies
+  SC-003; it does not breach it. Record the set difference against T004 and name the sibling feature
+  that owns each movement. **The count is not the test.**
+
+---
+
+## Phase 8: US3 durability and close-out
+
+- [ ] **T031** [P] [US3] Verify the prior-art record satisfies FR-012 without reading commit history.
+  ```bash
+  grep -c '8424cbd\|0e7a375\|ebcc2f4' specs/001-oauth-provider-taint/research.md
+  echo "grep exit=$?"
+  ```
+  **Pass**: `grep exit=0` and the count is at least 3, **and** by inspection research.md states: that
+  `8424cbd` *relocated* the finding rather than failing to clear it, naming alert 117 (line 95,
+  `fixed_at` 2026-01-20T22:34:56Z) and alert 144 (line 104, `created_at` the same timestamp); that the
+  rule `8424cbd` addressed was log injection, a different rule; that `0e7a375` failed via an
+  intermediate variable and spawned alerts 110 and 111; and that `ebcc2f4` succeeded by removing the
+  value from the log context. All four are present in research.md Ledgers A and B as written.
+- [ ] **T032** [P] [US3] Verify US3's second acceptance scenario is discharged **in the code**, not only in
+  `specs/`. Re-run the T014 check against the merged file: a reader with only
+  `src/lambdas/shared/auth/oauth_state.py` in front of them is warned at the sink and pointed at
+  `specs/001-oauth-provider-taint/research.md`. **Pass**: the rule id and the pointer are both present
+  and no suppression pragma is. This is unconditional across every terminal state including
+  `CONFIRMED` (FR-013, SC-007).
+- [ ] **T033** Close-out. `specs/001-oauth-provider-taint/evidence.md` names exactly one terminal
+  state, the observation it rests on, the analysis id and `commit_sha` where applicable, and the T030
+  set difference. **Pass**: exactly one terminal state is named (SC-005); a document naming two, or
+  none, is not a close-out.
+
+---
+
+## Dependencies and parallelism
+
+```
+T001 ──> T002,T003,T004,T005,T006  [P, all five independent reads]
+     └─> T007 ──> T008 ──> T009 ──> T010 ──> T011
+                                       └─> T012 ──> T013,T014,T015,T016  [P]
+                                                       └─> T017 ──> T018 ──> T019
+                                                                        └─> T020 ──> T021 ──> T022 ──> T023
+                                                                                                  └─> one of T024 / T025 / T026+T027 / T028 / T029
+                                                                                                          └─> T030 ──> T031,T032  [P] ──> T033
+```
+
+- **Parallelizable**: T002, T003, T004, T005, T006 (Phase 1 reads, no shared state); T013, T014, T015,
+  T016 (all read-only over an already-applied diff); T031 and T032. **Eleven tasks marked [P].**
+- **Hard ordering that must not be relaxed**: T007 before T009 (a guard proven failing first is the
+  only proof it is not vacuous); T020 before T021 (a control before a check whose pass is emptiness);
+  T019 before T021 (a stale analysis decides nothing); T006 before T026 (permission is read, never
+  probed by mutation); T009-T012 before T026 (FR-007: the proven remedy is exhausted before any
+  dismissal).
+
+---
+
+## Requirement coverage
+
+Every functional requirement and every success criterion maps to at least one task. No gaps.
+
+| Requirement | Tasks |
+|---|---|
+| FR-001 no `provider`-derived value in the `extra` context | T009, T007 (guard), T012 |
+| FR-002 satisfied by removal, nothing substituted | T009, T015 |
+| FR-003 runtime behavior outside the log call unchanged | T015, T012 |
+| FR-004 `validate_oauth_state()` not modified | T011, T025 |
+| FR-005 outcome classified against the decision gate | T023, T033 |
+| FR-006 Confirmed requires zero open findings of this rule at this path | T020, T021, T023 |
+| **FR-006a** survivor attributed before it is acted on; foreign survivor reported, not dismissed | **T022, T023 (precedence), T025** |
+| FR-007 dismissal only after the change is applied and refuted; registry entry required | T026, T027 |
+| FR-008 consume `codeql-logging-convention.md` in full, cite by section | T006 (§5b), T010 (§1), T017 (§5a), T024 (§3), T026 (§2), T028 (§5b) |
+| FR-009 closure evidenced from default-branch state, never a PR check | T018, T019, T021 |
+| FR-010 no suppression, severity change, exclusion or pragma | T016, T014 |
+| FR-011 existing OAuth unit tests pass unmodified | T012, T007 |
+| FR-012 prior-art record names what was tried and what worked | T031 |
+| FR-013 unconditional site comment naming the rule id, no pragma | T010, T014, T032 |
+| SC-001 zero open findings of this rule at this path | T021, T023 |
+| SC-002 evidence from default-branch analysis or the alerts API | T018, T019, T021 |
+| SC-003 no new alert attributable to this diff on `oauth_state.py` or `secrets.py` | T004 (baseline), T030 (recount), T029 (trigger) |
+| SC-004 existing suites pass with no assertion changes | T003, T012 |
+| SC-005 exactly one classification, on stated evidence | T023, T033 |
+| SC-006 dismissal justification non-empty and per convention; registry entry exists | T026, T027 |
+| SC-007 site comment present on the merged file, no pragma | T014, T024, T032 |
+
+**Coverage: 14 of 14 functional requirements (FR-001 to FR-013 including FR-006a), 7 of 7 success
+criteria. No requirement is unmapped, and no task exists without a requirement behind it.**
+
+**Terminal-state coverage: 7 of 7** (`CONFIRMED` T024, `REPORTED-FOREIGN-SINK` T025,
+`REFUTED-DISMISSED` T026 and T027, `BLOCKED-ON-OWNER` T028, `BLOCKED-NO-ANALYSIS` T029,
+`BLOCKED-REGRESSION` T029, `PENDING-BRANCH-ANALYSIS` T017).
+
+---
+
+## Cross-Artifact Analysis
+
+Scope: `spec.md`, `plan.md`, `research.md`, `quickstart.md`, `tasks.md`, plus the inherited
+`specs/001-ingestion-arn-logging/codeql-logging-convention.md`. Adversarial Reviews #1 and #2 are not
+re-litigated; findings below are either new, or are cases where a review's stated fix did not reach
+every site. Every claim was re-derived by running the thing.
+
+### Findings
+
+| # | Severity | Finding | Evidence | Disposition |
+|---|---|---|---|---|
+| **F-01** | **HIGH** | **The inherited convention defines a terminal state this feature never adopted.** `codeql-logging-convention.md` §5a defines `PENDING-BRANCH-ANALYSIS` and calls it "the normal ending, not an edge case": closure is read from a default-branch analysis, and none can exist while the change sits on a branch. FR-008 requires consuming that document **in full**, yet plan.md's terminal-state table lists six states and omits it, and quickstart.md never mentions it. `BLOCKED-NO-ANALYSIS` is not the same state: it triggers 7 days **after** the change lands on `main`, so an implementing agent whose push is owner-gated has no state to end in and aborts implicitly. | plan.md:207-216 ("Exactly six"); convention §5a lines 132-142; quickstart.md greps clean for the string. | **FIXED in all four artifacts** on coordinator instruction. tasks.md T017 and the terminal-state table; spec.md FR-008 now names both §5 states explicitly and the Decision Gate carries a `PENDING-BRANCH-ANALYSIS` row plus a paragraph distinguishing it from the 7-day bound; plan.md's table gained the row and reads "Exactly seven"; quickstart.md gained Step 1d and lists all seven in its header. Adopted as inheritance under FR-008, never as a new definition. |
+| **F-02** | **HIGH** | **spec.md's Edge Cases still key success on the *function*, contradicting FR-006 and SC-001.** The second edge case reads "Success is the function being free of open findings for this rule". Adversarial Review #2's X3 moved the criterion to **path + rule id** and rewrote FR-006, the gate's scoping paragraph, plan.md's verification design and quickstart 3b, but this sentence survived. On the exact evidence X3 cited (a survivor in the FR-004-frozen `validate_oauth_state()`), the Edge Case returns success while FR-006 and SC-001 return failure. That is the same contradiction X3 was raised to remove, at a site the sweep did not reach. AR#2's own note says the sweep was redone "across acceptance scenarios and independent tests"; Edge Cases was not in that list. | spec.md:198-200 versus spec.md:222-228 (FR-006) and spec.md:308-316 (SC-001). | **FIXED in spec.md** on coordinator instruction. The bullet is re-keyed to path plus rule id with the reason stated inline (a function-scoped reading derives from a `start_line` and reimports the line instability the gate exists to avoid), and two bullets were added covering the foreign-sink case and `PENDING-BRANCH-ANALYSIS`. **Edge Cases were then swept exhaustively for the same error: this was the only instance.** The remaining `store_oauth_state()` mentions in that section are attribution language under FR-006a, which is correct, not gate criteria. |
+| **F-03** | **HIGH** | **Five sibling citations are already stale, three of them by exactly one line.** Campaign rule 5 said two had gone stale; it is now at least five. Re-derived 2026-07-30: spec.md Q1 cites sibling FR-010 as `spec.md:92`, but line 92 is now **FR-009**; Q3 cites the three-element wording as sibling "FR-009 (`spec.md:91`)", but line 91 is now **FR-008b**; Q3 cites sibling FR-011 as `spec.md:93`, but line 93 is now **FR-010**. The sibling inserted an FR-008b and shifted everything below it. Also stale: AR#2 X2 cites `specs/001-codeql-coverage/spec.md:427` as "its own SC-004", but line 427 is prose about tolerance widths; and spec.md Q2 cites `specs/001-codeql-coverage/plan.md:282` as settling merge-time TD allocation, but line 282 is about a §10 local-SAST gap. | `sed -n '90,96p' specs/001-ingestion-arn-logging/spec.md`; `sed -n '427p' specs/001-codeql-coverage/spec.md`; `sed -n '282p' specs/001-codeql-coverage/plan.md`. | **Not fixed here.** tasks.md cites the convention document by **section only** and cites no sibling line number anywhere. The stale citations are all in Clarifications and Adversarial Review appendices, so they are provenance rather than normative, but the rot is real and confirms the rule. |
+| **F-04** | **MEDIUM** | **quickstart.md Step 3a's primary gate command sits inside a broken code fence.** Line 205 opens a bash code fence, lines 206-209 are English prose about the missing `--arg` flag, and line 211 opens a second bash fence. Per CommonMark a closing fence may not carry an info string, so line 211 closes nothing: the prose, the second fence marker and the command all render inside one bash block. AR#2's X1 fix repaired the command's content and left the fence malformed, so the single most load-bearing command in the runbook is not cleanly copy-pasteable. | quickstart.md:203-218 raw. | **FIXED in quickstart.md** on coordinator instruction. Step 3a is restructured into prose, a `#### The control, first` block and a `#### The gate itself` block, each in its own well-formed fence. The command is now copy-pasteable, and is also the paginated shape required by F-11. |
+| **F-05** | **MEDIUM** | **No artifact classifies a mixed survivor set.** spec.md's Decision Gate and quickstart Step 3c each have one row for "attributed to `store_oauth_state()`" and one for "attributes outside", with no rule for both being present at once. FR-006a is written per-survivor ("A survivor MUST be attributed before it is acted on"), so both obligations apply, but nothing says which terminal state is recorded. | spec.md:289-295; quickstart.md:253-260. | **Resolved in tasks.md** T023 by a stated precedence derived from the existing requirements, not a new one: both obligations run, and the recorded state is `REPORTED-FOREIGN-SINK` because FR-006 forbids `CONFIRMED` while any finding is open at the path and FR-006a makes the reported state terminal. |
+| **F-06** | **MEDIUM** | **quickstart.md contradicts campaign rule 6 and convention §5b on how permission is established.** Step 4c says `BLOCKED-ON-OWNER` is "Reached if Step 4b's `PATCH` fails on permissions", and no read-only probe appears anywhere in the runbook. §5b is explicit: "Check the permission with a read-only probe. **Never establish it by attempting a dismissal**, which mutates alert state and cannot be cleanly reverted." AR#2 section D dismissed this as "not the anti-pattern the sibling forbids" because Step 4b is the intended dismissal rather than a probe; that reasoning holds only if the probe happened earlier, and it never does. | quickstart.md:353-358; convention §5b lines 146-164. | **FIXED in quickstart.md and spec.md** on coordinator instruction, who has struck the earlier clearance. quickstart gained **Step 0b**, a read-only probe placed before the change is even applied and therefore before any step that could mutate an alert; Step 4b is now explicitly gated on its outcome and Step 4c is entered from the probe rather than from a failed `PATCH`; the anti-checklist gained a bullet. spec.md FR-008 now carries §5b's probe rule and the "`security_events` is a private-repository requirement" carve-out. tasks.md T006 already covered it. Probe run 2026-07-30: scopes `gist, read:org, repo, workflow`, `visibility: public`, `permissions.admin: true`, so dismissal is **available**. |
+| **F-07** | **LOW** | **quickstart.md's header says five terminal states; there are six in plan.md and seven counting the inherited §5a state.** Stale since FR-006a and `REPORTED-FOREIGN-SINK` were added. | quickstart.md:5-6 versus plan.md:207. | **FIXED.** quickstart's header now says seven and enumerates them; plan.md says seven; tasks.md says seven. |
+| **F-08** | **LOW** | **quickstart Step 0's inline comment reads "expect exactly 5 open alerts", four lines above a paragraph explaining that the count is not the test.** Harmless as prose, but it is exactly the shape SC-003 was rewritten to remove, sitting in the copy-pasteable part where an operator will read it as the pass condition. | quickstart.md:20 versus quickstart.md:41-46. | **FIXED.** The comment now reads "Record the SET, never the count", and the acceptance text asserts the corpus floor plus the presence of this path's entry. |
+| **F-09** | **LOW** | **quickstart Step 5's anti-checklist still uses function scoping.** "Reporting `CONFIRMED` because alert 144 disappeared, without checking whether a replacement number appeared **inside the same function**." Post-X3 the criterion is the path. The bullet is right in spirit and stale in wording. | quickstart.md:393-394. | **FIXED.** Re-keyed to "a replacement number for this rule anywhere on the path", with the 117-to-144 evidence stated in the bullet. |
+| **F-10** | **LOW** | **spec.md's status line still reads "Draft (revised after Adversarial Review #1)"** after Adversarial Review #2 landed in plan.md and rewrote FR-006, SC-003 and the gate. | spec.md:5. | **FIXED.** Now names both adversarial reviews and this cross-artifact analysis. |
+| **F-11** | **HIGH** | **Every code-scanning alerts query in this feature was unpaginated, and truncation renders as CLEAN.** Raised by a sibling after Stage 7 and re-derived here against the live API. Measured 2026-07-30: `gh api repos/OWNER/REPO/code-scanning/alerts` filtered to open alerts returns **zero** and exits **0**, on a repository with five open; default page size is 30 against an all-states corpus of **137**, and the open alerts sit at 144 to 150, past the end of page one. `per_page=100` is not a fix: page one at that size spans numbers 180 down to 59 (`{"max":180,"min":59,"n":100}`), silently dropping alerts 1 and 22 to 27, and 22 to 27 are the `secrets.py` sanitize-in-place sites this feature's whole `fixed_at` argument rests on. Worst placement was tasks.md's T020 **positive control**, whose entire job is to prove the gate query can see anything: a truncated control certifies the gate while blind. | `gh api ".../alerts" --jq '[.[]\|select(.state=="open")]\|length'` returns 0, exit 0; `gh api --paginate --slurp` yields 2 pages, `[.[][]]\|length` = 137, open set `[150,149,148,147,144]`; alerts 22-27 present only via page 2. | **FIXED in tasks.md, quickstart.md and plan.md.** New invariant 7 in tasks.md fixes the mandatory shape: `--paginate --slurp` into a file, standalone `jq` with its own exit code, no pipe, and an asserted corpus floor. T004, T020, T021 and T030 rewritten; quickstart Step 0a, Step 3a and Step 4a rewritten; plan.md verification step 1 states why pagination is load-bearing rather than hygienic. The T020 control is kept, as instructed, and its floor is now three measured numbers (corpus 137, rule total 22, and the presence of alert 117, which is permanently `fixed` at this path) rather than "non-empty". Two mechanical constraints verified by running them: `--slurp` is rejected with `--jq`, and `--paginate` without `--slurp` applies `--jq` per page, so a two-page response would print `[]` twice and satisfy an "output is `[]`" condition twice over. The analyses endpoint is deliberately left unpaginated, with the reason stated at T018: it is newest-first, this feature wants exactly the newest, and emptiness is a **failure** condition there rather than a pass, so truncation cannot render as clean. |
+
+**No finding of any severity was raised against**: requirement coverage (14/14 FRs, 7/7 SCs mapped,
+no orphan tasks); the ordering graph (no task depends on a later one); the regression guard's
+falsifiability (it asserts `not hasattr(record, "provider")` over the `LogRecord`, so it fails on
+today's code, and no `caplog.text` assertion exists in any artifact); the banned-term surface (this
+directory greps clean, re-verified); or the `TD-` identifier (no artifact of this feature names a
+number, re-verified across all five files).
+
+### Unfalsifiable pass conditions
+
+Swept deliberately, because a check that cannot fail is the campaign's recurring defect.
+
+- **T021 is the one task whose pass condition is emptiness.** It is made falsifiable by four things:
+  the **corpus floor** of 137, without which an unpaginated read of an empty page reads as a clean
+  repository (F-11); the T020 positive control, which proves the query can return results at this path
+  for this rule and which stays satisfied permanently because alert 117 is `fixed` there; the explicit
+  `gh` and `jq` exit assertions; and the distinction between the string `[]` (a real empty result) and
+  a blank string (a failed filter), which the array collector makes observable. The floor and the
+  control are independent: the floor catches a truncated or failed read, the control catches a
+  well-formed read filtered by a typo'd path or rule.
+- **T014's second grep passes on exit 1**, which is a match-absent result and not an error. Exit 2 is
+  called out explicitly as a re-run condition, because a grep error would otherwise read as clean.
+- **T016 asserts a non-empty diff before asserting what is in it**, so "nothing was applied" cannot
+  masquerade as "nothing forbidden was applied".
+- **T022 avoids pipelines entirely** rather than relying on `PIPESTATUS[0]`, and routes an
+  unattributable survivor to the foreign branch rather than to the dismissal branch. quickstart Step 3b
+  keeps the pipeline and mentions `PIPESTATUS[0]` only in prose after the command (AR#2 X9, recorded
+  and left); tasks.md does not.
+- **No task's pass condition is "CI is green"**, and none cites a pull request check as closure
+  evidence (FR-009, SC-002).
+
+### Quickstart versus tasks disagreements
+
+Five were recorded at first authoring. Four have since been closed by repairing quickstart.md on
+coordinator instruction, so they are kept here as a record of what was found rather than as live
+disagreements.
+
+1. **Permission probe** (F-06): **closed.** quickstart gained Step 0b, a read-only probe placed before
+   any step that can mutate an alert, and Steps 4b and 4c now key on its outcome. Convention §5b
+   governs and both documents now follow it.
+2. **Test-first ordering**: **open, and deliberately.** quickstart Step 1 applies the source edit (1a)
+   before adding the test (1b); tasks.md inverts this (T007, T008 before T009) so the guard is proven
+   failing on unfixed code. Nothing in quickstart forbids it and the constitution §7 accompaniment gate
+   is satisfied either way, so quickstart is left alone. The inverted order is what makes the guard's
+   non-vacuity checkable rather than asserted, and tasks.md is the document the implementer executes.
+3. **Terminal-state count** (F-01, F-07): **closed.** All three documents now say seven and name the
+   same seven.
+4. **Gate query hygiene** (F-04, F-11, T020): **closed.** quickstart Step 3a now carries the control,
+   the corpus floor and the paginated shape, in well-formed fences.
+5. **Baseline framing** (F-08): **closed.** quickstart Step 0a records the set and asserts the corpus
+   floor; neither document states an expected count as a pass condition.
+
+### Verdict
+
+**PASS.** Revised after the repair pass: ten of the eleven findings are fixed in the artifacts, and
+the one that is not (**F-03**, five stale sibling citations) is deliberately left alone at the
+coordinator's instruction, because cross-feature citations are being swept campaign-wide in one pass
+after the final stage and repairing them now guarantees they drift again. The evidence for all five
+is recorded in the F-03 row.
+
+The artifact set is internally consistent on everything load-bearing. The criterion is path plus rule
+id in FR-006, FR-006a, SC-001, the Decision Gate, the Edge Cases, plan.md's verification design,
+research.md Decision 4, quickstart Step 3a and every task here. No success criterion, acceptance
+scenario, Independent Test, Edge Case or task keys on an alert number reaching a state; alert 117
+appears once as a control fixture and alert 144 only as a locating label and as corroboration.
+Requirement coverage is complete with no orphan tasks. All seven terminal states are named identically
+in spec.md, plan.md, quickstart.md and tasks.md, and each is reachable and recorded.
+
+The most consequential repair was **F-11**, which was not a documentation defect but a live verification
+defect: every alerts query in the feature read one page of a 137-alert corpus, and on this repository
+that reads as zero open alerts with exit 0. It sat in the T020 positive control, whose sole purpose is
+to prove the gate is not blind. A control that can itself truncate certifies the gate while blind, so
+the feature's single pass-on-emptiness condition rested on a query that could not fail. It now rests on
+a corpus floor of 137, a rule total of 22, and the presence of a permanently `fixed` alert at the target
+path, each a number measured against the live API rather than asserted.
+
+---
+
+## Adversarial Review #3
+
+Final gate before implementation. Reviewer authored none of these artifacts. The question answered
+here is narrow: **can an implementer execute tasks.md start to finish without getting stuck, misled,
+or silently passing?**
+
+The runbook was **executed, not read**. Every read-only command in tasks.md and quickstart.md was run
+against the live repository and the live tree on 2026-07-30, and the regression guard of T007 was
+built in a scratch copy and run against both unfixed and fixed source. What follows separates what
+was RUN from what was READ, because Adversarial Reviews #1 and #2 both found defects that were
+invisible on the page.
+
+### Findings
+
+| # | Severity | Finding | Evidence (executed) | Disposition |
+|---|---|---|---|---|
+| **G-01** | **HIGH** | **T014's SC-007 check cannot pass on correct code. Its `-B4` window is off by one and excludes the only line that carries the rule id.** `grep` matches the string literal `"OAuth state stored",`, which after the T010 edit sits below `logger.info(`, which sits below the four mandated comment lines. The rule id is on the first comment line, **five** lines above the match. `-B4` prints the four lines below it. The task's pass condition, "its output contains the literal `py/clear-text-logging-sensitive-data`", is therefore unsatisfiable by construction. This is the worst class of defect for this gate: an implementer who applies T009 and T010 exactly as written then fails their own verification, and there is no terminal state for "my instruction contradicts my check", so the path ends in an implicit abort. It is also re-run twice more, at T024 and at T032, so it fails three times. The same `-B4` sat in quickstart.md at the SC-007 check. | Applied T009+T010 to a scratch copy of `oauth_state.py` and ran the check verbatim. `-B4` prints lines 100-104 and `grep -c` for the rule id returns **0**. `-B5` prints lines 99-104 and returns **1**. | **FIXED** in tasks.md T014 and quickstart.md. Window widened to `-B6` (`-B5` plus one line of slack against a one-line drift in the comment), with the arithmetic stated inline in both files so it cannot be re-narrowed by a later reflow. |
+| **G-02** | **HIGH** | **T030 is a pass-on-absence condition with no control, and it passes while blind.** T021 got a positive control (T020), a corpus floor, and an exit-code assertion. T030 asserts an equally load-bearing absence, "no alert of any rule newly appears on `oauth_state.py` or `secrets.py`", and got only the corpus floor. The floor proves the **fetch** worked. It proves nothing about the **path selector**, and the selector is what the absence is read from. The `AFTER` filter's own `jq` exit code was not captured either; the captured `JQ_RC` belongs to the preceding `CORPUS` call. | Ran T030 verbatim against the live 137-alert corpus with `.most_recent_instance.location.path` mistyped as `.locatio.path`. `jq` does **not** error: it returns `path: null` for all 137 entries and exits **0**. `gh exit=0`, `jq exit=0`, `corpus=137`, and the resulting open set contains **no** entry on `oauth_state.py` or `secrets.py`. **Every clause of T030's pass condition is satisfied by a read that sees nothing.** This is the governing rule of this review violated exactly: an absence taken as evidence without proving the read was working. | **FIXED** in tasks.md T030. Added `AFTER_RC` capture, a `null_paths` control that must be **0**, and an alert-117 path anchor that must return the literal string `src/lambdas/shared/auth/oauth_state.py`, the same immovable fixture T020 uses, for the same reason. Verified by running both: correct filter gives `null_paths=0` and a populated anchor path; the `.locatio` filter gives `null_paths=137` and `path: null`, so the broken read now fails loudly. |
+| **G-03** | **HIGH** | **The likeliest terminal state skips the close-out and two checks the artifacts call unconditional.** T017 reads "Phases 6 to 8 are then not executed" on the `PENDING-BRANCH-ANALYSIS` branch. Phase 8 is T031 (FR-012 prior art), T032 (FR-013/SC-007 site comment, stated "unconditional across every terminal state") and T033 (SC-005 close-out, "exactly one terminal state is named"). Quickstart Step 1d calls `PENDING-BRANCH-ANALYSIS` "the likeliest ending rather than an edge case" for this feature, so on the most probable path the feature ends with FR-012, SC-005 and SC-007 unverified and no close-out written. T031 in particular reads only `research.md` and has no dependency on a merge whatsoever. | Read of T017 against the Phase 8 task bodies and against quickstart.md:238. No execution needed; the contradiction is between two sentences in the same file. | **FIXED** in tasks.md T017. Phases 6 and 7 are skipped; **Phase 8 still runs**, with T032's "merged file" clause reading against the committed file on the feature branch and that substitution recorded in evidence.md. |
+| **G-04** | **HIGH** | **Six task-level failure paths say "stop" and name no terminal state.** The seven states cover every *gate* outcome and were verified reachable and distinct (below), but the abort risk had simply moved upstream of the gate. Specifically: T001 wrong Python ("stops the feature"); **T002 dirty `src/`/`tests/`**, with no stated action at all; T004's "premise is already gone: stop, record it"; T016's `make sast` non-zero; T023's "Discard, re-run T020 and T021", which unlike T019 carries **no bound** and loops forever on a persistently failing `gh` read; and a T026 `PATCH` failing for any reason other than permissions, which T028 is not scoped to accept. T002 is not hypothetical: the briefing states three sibling agents share this worktree and at least one of them (`001-ingestion-arn-logging`) edits `src/lambdas/ingestion/handler.py`, so a dirty `src/` is a *likely* observation, and T011, T015 and T016 all read a diff that would then be partly another feature's. | Read of the six task bodies against the terminal-state table. Corroborated by the live baseline showing alerts 148-150 on `src/lambdas/ingestion/handler.py`, the file a co-resident sibling is chartered to edit. | **FIXED** in tasks.md by a new "Routing for failures that are not gate outcomes" subsection under the terminal-state table. **No new state is introduced**; all six route to an existing one, with a catch-all making the routing exhaustive. T004's "premise already gone" routes to `CONFIRMED`, which its definition satisfies verbatim. Also corrected: T023's mixed-survivor precedence now explicitly triggers **T027**, because T026 running in the mixed case is a real dismissal and FR-007/SC-006 require a registry entry for any dismissal regardless of the state finally recorded. |
+| **G-05** | **HIGH** | **The `security_events` misreading that convention §5b exists to prevent survives in two normative places.** F-06 sanitised quickstart.md and spec.md's FR-008, but plan.md's terminal-state table still defined the `BLOCKED-ON-OWNER` trigger as "the implementing agent lacks `security-events: write`", and spec.md's Assumptions still opened "Dismissing a code scanning alert requires `security-events: write`" as a flat premise with no carve-out. plan.md is, by its own AR#2 X5, "the artifact the implementer reads first". An implementer applying that trigger reads `gh auth status`, finds scopes `gist, read:org, repo, workflow`, sees no `security_events`, and lands in `BLOCKED-ON-OWNER`, which is the wrong terminal state, on a repository where the dismissal is available. §5b records that the sibling made this exact mistake once already. | Ran the T006 probe: scopes `gist, read:org, repo, workflow`; `visibility: public`; `permissions.admin: true`, `push: true`. Convention §5b (lines 144-164) read directly: `security_events` is required "only on **private** repositories". So the plan.md trigger and the observed environment together produce a false `BLOCKED-ON-OWNER`. | **FIXED** in plan.md (trigger restated as the §5b read-only probe with the public-repository carve-out) and in spec.md Assumptions (premise corrected, permission settled by probe rather than by attempted dismissal). |
+| **G-06** | **MEDIUM** | **`$CHANGE_SHA` lives only in a shell across a wait bounded at 7 days.** T017 exports it; T019's freshness proof is the only consumer and may run days later; nothing instructs persisting it except on the `PENDING-BRANCH-ANALYSIS` branch, where what gets written is the gate query rather than the SHA. A lost `$CHANGE_SHA` makes T019 unrunnable and strands the feature between `PENDING-BRANCH-ANALYSIS` and `BLOCKED-NO-ANALYSIS`. `$RULE`, `$FILE` and `$REPO` have the same lifetime problem but are self-catching: an empty `$RULE` makes T020's `rule_total` **0** and its control empty, which fails loudly. `$CHANGE_SHA` is not self-catching, because an empty one makes the `compare` call 404 rather than silently mis-answer. | Read, plus the observation that T020's floors do catch the environment-variable case: an unset `$REPO` yields `repos//code-scanning/alerts` and a non-zero `gh` exit. | **FIXED** in tasks.md T017: `$CHANGE_SHA` is recorded into `evidence.md`, on every path and not only the pending one. |
+| **G-07** | **LOW** | **The verdict of the Stage 7 Cross-Artifact Analysis overclaims.** It states "All seven terminal states are named identically in spec.md, plan.md, quickstart.md and tasks.md." They are not. `CONFIRMED`, `REFUTED-DISMISSED` and `REPORTED-FOREIGN-SINK` do not appear as literal strings in spec.md at all; spec.md's Decision Gate uses the classification vocabulary "Confirmed" / "Refuted" / "Not Confirmed, and not this feature's" and names only the four `BLOCKED-*`/`PENDING-*` states literally. | `grep -o` for the seven names across all four files: plan.md, quickstart.md and tasks.md return all seven; spec.md returns four. | **Not fixed.** T023's classification table bridges the two vocabularies explicitly and tasks.md is the executed document, so nothing is ambiguous at execution time. Recorded because a verdict line that overstates its own sweep is the thing a fourth reviewer would trust. |
+| **G-08** | **LOW** | **T011's two thresholds disagree.** Its pass condition is "every hunk header's start line is **below 122**"; its remediation sentence is "any hunk at or beyond line **154** means `validate_oauth_state()` was edited: revert it". A hunk starting at line 130 (inside `get_oauth_state()`) fails the pass and matches no remediation. | Read. Confirmed against the live file: `def get_oauth_state` at 122, `def validate_oauth_state` at 154. | **Not fixed.** The stricter threshold governs and an edit at 130 is out of scope for this feature anyway, so both readings reject it. Recorded only. |
+| **G-09** | **LOW** | **T016 greps a configuration path that does not exist.** `git status --short -- .github/ .semgrep* pyproject.toml` includes `.semgrep*`; no such file or directory exists in the repository. The FR-010 surface is still fully covered (CodeQL's config is `.github/codeql/codeql-config.yml`, inside `.github/`; bandit's and ruff's are in `pyproject.toml`; and `make sast` invokes `semgrep scan --config auto` with no local config at all), so the dangling glob costs nothing. | `ls -d .semgrep*` → "No such file or directory". `make sast` output confirms `--config auto`, Community registry, 1032 rules. | **Not fixed.** No-op, and removing it would weaken the check if a `.semgrep.yml` is ever added. |
+
+### What was RUN, and what it returned
+
+Executed against the live repository and the live tree, 2026-07-30. Everything in this table is real
+output, not a restatement of the artifact.
+
+| Command | Result | Verdict |
+|---|---|---|
+| T001 `python --version` in `.venv` | `Python 3.13.0` | PASS |
+| T003 `pytest tests/unit/auth/ -q` | `30 passed`, `pytest exit=0` | PASS, baseline confirmed at the documented figure |
+| T004 paginated baseline | `gh exit=0 jq exit=0 corpus=137`; open set `{150,149,148,147,144}`; 144 at `oauth_state.py:104` | PASS, matches the recorded observation exactly |
+| T005 alert 144 snapshot | `state: open`, `fixed_at: null`, `start_line: 104`, `code_flows: 0`, `commit_sha c010178` | PASS, `code_flows: 0` confirmed, so the "no claim about the taint path" position holds |
+| T006 permission probe | scopes `gist, read:org, repo, workflow`; `visibility: public`; `permissions.admin/push: true` | PASS, resolves **available** |
+| **T007 + T008 guard, built and run against UNFIXED source** | `1 failed, 15 passed`, `pytest exit=1`, sole failure `test_log_context_excludes_provider` on `assert not hasattr(records[0], "provider")`, with `where True = hasattr(<LogRecord ...>, 'provider')` | **PASS. The guard is genuinely non-vacuous, and it fails on precisely the assertion T008 predicts.** This is the single most important thing this review verified, and it holds. |
+| T009 + T010 applied to a scratch copy, then `ruff check` with the repo's rule selection | `All checks passed!`, `ruff exit=0`, no `F841` | PASS, the deletion-not-orphaning requirement is satisfiable |
+| The same guard re-run against the FIXED source | `1 passed` | PASS, so the guard is red-then-green, not red-forever |
+| T013 `ruff format --check` + `ruff check` on the two real files | `2 files already formatted`, `All checks passed!`; `ruff 0.15.14` matches `required-version = "==0.15.14"` | PASS, no version-skew trap |
+| **T014 SC-007 check on the fixed scratch copy** | `-B4` window is lines 100-104; rule id occurrences: **0**. `-B5`: **1**. Pragma grep: `exit 1` | **FAIL → G-01, fixed** |
+| T016 `make sast` | `Findings: 0 (0 blocking)`, 478 rules, 164 targets, `make sast exit=0` | PASS, the substitute gate is achievable |
+| Invariant 3, `bash scripts/check-banned-terms.sh` | `exit=1`; `FAIL: 17 total banned-term matches`, 15 + 2 across two legacy framework names; matches inside `001-oauth-provider-taint`: **0** | PASS, the figure and the split are both exactly as documented, and this directory is clean |
+| T018 analyses lookup | `gh exit=0`, five `/language:python` analyses, `created_at` strictly descending, newest `id 1551613089` at `c010178` | PASS, and the newest-first property the unpaginated design rests on is confirmed |
+| **T020 positive control** | `gh exit=0 jq exit=0 corpus=137 rule_total=22`; `control=[{"number":144,"state":"open"},{"number":117,"state":"fixed"}]` | **PASS on all four floors, byte-identical to the recorded value.** Confirmed as the strongest control in the artifact set. Not weakened. |
+| T021 gate query (pre-change, so expected non-empty) | `jq exit=0`; `gate=[{"number":144,"start_line":104,"commit_sha":"c010178..."}]` | PASS, the query returns the finding it is supposed to see |
+| T022 attribution at the analyzed commit | `gh exit=0 bytes=10550`, `base64 exit=0`, `grep exit=0`; defs at 50, 59, 122, 154, so `store_oauth_state()` spans **59-121** and alert 144 at line 104 attributes **inside** | PASS |
+| quickstart 3b pipeline variant of the same | `PIPESTATUS=0 0 0` | PASS today; the X9 exposure stands but is not triggered |
+| **T030 with a mistyped path selector** | `jq exit=0`, `corpus=137`, all 137 entries `path: null`, resulting set clean of both target files | **FAIL → G-02, fixed** |
+| Invariant 7, unpaginated open read | `0`, `exit=0` on a repository with five open alerts | Trap confirmed exactly as stated |
+| Invariant 7, default page composition | `n=30`, numbers **180 down to 151**, all `state: fixed`; alert 144 present: **0** | The "past the end of page one" claim is precisely right |
+| Invariant 7, `per_page=100` page one | `{"max":180,"min":59,"n":100,"open":[150,149,148,147,144]}` | Confirmed, with a nuance recorded below |
+| `--slurp` with `--jq` | `the --slurp option is not supported with --jq or --template` | Confirmed |
+| `--paginate` without `--slurp`, per-page collector | prints `[]` **twice** | Confirmed |
+| `gh api --arg` | `unknown flag: --arg`; `gh version 2.89.0` | Confirmed, AR#2 X1 was a real defect |
+| T031 prior-art grep | `16` matching lines, `grep exit=0` | PASS, floor of 3 cleared |
+| T027 registry target | `docs/reference/TECH_DEBT_REGISTRY.md` exists, highest id `TD-023` | PASS, merge-time allocation remains correct |
+| `.github/workflows/pr-checks.yml:62` | `run: ruff check src/ tests/` | Citation is accurate to the line |
+| Convention §5a / §5b | lines 132 and 144 | Citations accurate |
+
+### The seven terminal states
+
+Each was checked for reachability, distinctness, and gaps between them.
+
+| State | Reachable? | Distinct? | Notes |
+|---|---|---|---|
+| `CONFIRMED` | Yes, T024, and now also from T004's "premise already gone" via G-04 routing | Yes | The only pass-on-emptiness state. Guarded by T020's control and the corpus floor, both re-verified by execution. |
+| `REPORTED-FOREIGN-SINK` | Yes, T025 | Yes | Also the recorded state for the mixed case per T023. `validate_oauth_state()` at 154-260 is a live, verified candidate for producing it. |
+| `REFUTED-DISMISSED` | Yes, T026+T027; T006 probed *available*, so the `PATCH` is not blocked | Yes | Registry obligation now also attaches when T026 runs inside the mixed case (G-04). |
+| `BLOCKED-ON-OWNER` | Yes, T028 | Yes | Was reachable **for the wrong reason** from plan.md and spec.md until G-05. Now entered only from the §5b probe or a failed `PATCH`, the latter widened past permission-only failures. |
+| `BLOCKED-NO-ANALYSIS` | Yes, T029 | Yes, the 7-day clock starts at `main` | Now also the exit for T023's previously unbounded discard loop (G-04). |
+| `BLOCKED-REGRESSION` | Yes, T029 | Yes | Now also absorbs T001, T002 and T016 failures (G-04). Correctly does **not** trigger on repo-wide count movement. |
+| `PENDING-BRANCH-ANALYSIS` | Yes, T017 | Yes, the clock has not started | Quickstart calls it the likeliest ending, and it was skipping the entire close-out until G-03. |
+
+**Verdict on the set: seven states, all reachable, all distinct, and after G-03 and G-04 there are no
+remaining paths that fall between them.** The gaps found were not gaps *between* the states; they
+were failures *upstream* of the gate that named no state, which is the same implicit abort at a
+different altitude. That failure mode has now occurred twice in this feature (once as F-01, once as
+G-04), which argues the routing subsection should be inherited by siblings rather than re-derived.
+
+### Highest-risk task
+
+**T009 and T010, taken as one edit.** Not because the edit is hard, since it is four deleted lines and a
+four-line comment, but because it is the only irreversible-in-practice step whose verification
+was broken. The T014 check that proves T010 landed correctly could not pass (G-01), and it is
+re-run at T024 and T032, so the same false negative fires three times across the feature. A second
+factor: T009's "anchor by content, not by line number" instruction is correct and necessary, because
+the mandated comment lands in the same place as the deleted lines and the net line shift is near
+zero, which makes line-number anchoring look like it works right up until it does not.
+
+Nothing else in the feature edits code. Everything downstream is observation.
+
+### Most likely source of rework
+
+**T002 failing, or its check being skipped and the failure surfacing later at T015 and T016.** Three
+sibling agents share this worktree; `001-ingestion-arn-logging` is chartered on
+`src/lambdas/ingestion/handler.py`, which the live baseline confirms carries alerts 148-150. A dirty
+`src/` makes T011's hunk-header check, T015's confined-diff check and T016's `git diff --name-only`
+"exactly two files" check all read a diff that is partly another feature's, and the natural but wrong
+reaction is to relax the pass condition rather than to stop. Second most likely: a merge that does
+not happen, landing the feature in `PENDING-BRANCH-ANALYSIS` and, before G-03, skipping the close-out
+that records it.
+
+### Ordering hazards
+
+- **T007 before T009 is the load-bearing order and must not be relaxed.** Verified by execution: the
+  guard fails on unfixed source with the exact predicted assertion. Run in the other order, the guard
+  is green from birth and proves nothing. Note that quickstart Step 1 still applies the source edit
+  (1a) before the test (1b); that disagreement was recorded as deliberate at Stage 7 and tasks.md is
+  the executed document, so it stands.
+- **T020 strictly before T021, and no re-fetch between them.** Enforced in the text, and correct.
+- **T019 before T021.** A stale analysis decides nothing.
+- **T006 before anything in Phase 7.** Correct, and now also correct in plan.md and spec.md (G-05).
+- **T017's phase skip is itself an ordering hazard**, resolved by G-03: Phase 8 is not downstream of
+  a merge.
+- **The gap between T017 and T019 spans up to 7 days and one or more shell sessions.** Resolved by
+  G-06 for `$CHANGE_SHA`. `$REPO`, `$RULE` and `$FILE` are self-catching via T020's floors.
+
+### Corrections to the campaign facts and to the artifacts
+
+Recorded because a briefing that is never wrong is a briefing nobody checked.
+
+1. **The briefing's canonical query differs from the one tasks.md mandates, and both work.** The
+   briefing's form is `...&state=open&per_page=100` with `jq 'add | length'`; tasks.md drops
+   `state=open` and uses `jq '[.[][]] | length'`. Both return **137** here, which is initially
+   surprising: `add` on the slurped array of pages and `[.[][]]` are equivalent, and `state=open`
+   turns out **not** to filter the corpus count in this call. tasks.md's form is the right one to
+   keep, because the T020 control needs `fixed` alerts in the corpus and `state=open` would remove
+   alert 117, the control's anchor. Worth stating explicitly so a future reader does not "harmonise"
+   them toward the briefing.
+2. **"`per_page=100` still drops alerts 22-27" is true, but the sharper statement is that it does
+   not drop any *open* alert.** Measured: page one at `per_page=100` returns
+   `open:[150,149,148,147,144]`, the complete open set. So the gate query T021 would be *accidentally*
+   correct at `per_page=100` today; it is the **T020 control** that genuinely requires pagination,
+   because alert 117 sits at number 117 < 59 and falls off page one. This makes F-11's judgement that
+   the control was the worst placement exactly right, and it means the pagination requirement must
+   never be justified to a future reader on the grounds that the gate needs it. It does not, today,
+   and that argument would collapse the moment someone tested it.
+3. **The briefing says "Unpaginated reads return ZERO open alerts while FIVE are open."** Confirmed,
+   and the mechanism is worth recording because it is not "the API hides open alerts": the default
+   page is 30 alerts ordered by descending number, 180 down to 151, and **all thirty are `fixed`**.
+   The open alerts are simply lower-numbered. This is stable only while no new alert is created; a
+   sibling opening a new high-numbered alert would move open alerts onto page one and make the
+   unpaginated read look correct again. The corpus floor is what keeps that from mattering.
+4. **The briefing's line-number citation for the T007 insertion point is accurate**
+   (`TestStoreOAuthState` at line 37), as are T009's `def` at 59, deletions at 99-101 and 105,
+   `get_oauth_state` at 122, `validate_oauth_state` at 154, `safe_provider_validated` at 253 and the
+   `extra` at 258, and the persisted `"provider": provider` at 87. All ten verified against the live
+   file. This is unusual for this campaign and is worth saying.
+5. **`pytest -q` does not produce quiet output in this repository.** `addopts` in `pyproject.toml`
+   carries `-v`, and `log_cli = true`, so T003, T008 and T012 print per-test lines and live log
+   output. The summary line is still `N passed`, so no pass condition breaks, but an implementer
+   expecting a one-line result will not get one.
+6. **The briefing's claim that "`make validate` cannot pass on this tree" is correct**, and the
+   figure is exact: 17 matches, 15 + 2, none in this directory. `make sast` as the substitute is
+   achievable: it returned 0 findings and exit 0 in 4 minutes.
+
+### Adjacent defects, outside this feature's scope. Carded, not fixed.
+
+1. **`validate_oauth_state()` at `oauth_state.py:253-258` carries the identical sanitize-in-place
+   shape that this feature is deleting from `store_oauth_state()`, and it is not currently reported
+   by any open alert.** FR-004 correctly freezes it and `REPORTED-FOREIGN-SINK` correctly exists for
+   it. But it is worth carding on its own: the same shape at lines 202-217 and 222-238 logs
+   `expected`/`received` pairs for both provider and `redirect_uri`. A future CodeQL query update
+   that starts reporting it will spawn alerts on a file this campaign has just churned.
+2. **Constitution §9 still names `docs/TECH_DEBT_REGISTRY.md`**, relocated by `f8db8d2` (PR #668).
+   Already noted in T027 and quickstart 4b as carded. Confirmed still stale.
+3. **Five stale sibling citations (F-03)** remain, deliberately, pending the campaign-wide sweep.
+   Not re-derived here.
+4. **`make sast` only scans files tracked by git** ("Scan was limited to files tracked by git", from
+   the live run). Both files this feature touches are tracked, so nothing is missed here, but a
+   feature that adds a brand-new untracked source file would get a clean SAST result on a file that
+   was never scanned. That is a repository-wide gate weakness, not this feature's.
+5. **`.github/workflows/pr-checks.yml` runs CodeQL as job `codeql` / name `Analyze`, and it is not a
+   required status check.** The artifacts already rely on this being true (FR-009 refuses PR-check
+   evidence because of it). Carded as a repository observation, not a defect to fix here.
+
+### Verdict
+
+Five HIGH findings, one MEDIUM and three LOW. Two of the HIGH findings were live verification
+defects rather than documentation drift, and both were found by running the runbook rather than
+reading it:
+
+- **G-01** made the SC-007 check unsatisfiable on correct code, at three separate call sites.
+- **G-02** left the feature's second pass-on-absence condition certifying SC-003 while blind, on a
+  broken read that `jq` reports as successful. A mistyped field name in that filter returns
+  `path: null` for all 137 alerts, exits 0, satisfies the corpus floor, and produces a clean result.
+
+Both are fixed and both fixes were verified by execution, not by inspection. G-03, G-04 and G-05 are
+fixed in the artifacts. G-06 is fixed. G-07, G-08 and G-09 are recorded and deliberately not fixed.
+
+What holds up: the T007 regression guard is genuinely non-vacuous and was proved so by building and
+running it against both unfixed and fixed source; the T020 positive control is exactly as strong as
+claimed and its three floors reproduce byte-for-byte against the live API; every line-number citation
+into `oauth_state.py` is accurate; the pagination invariant is correct in every particular including
+the ones that are counter-intuitive; and requirement coverage remains 14/14 and 7/7 with no orphan
+tasks. The T018 decision to leave the analyses endpoint unpaginated is correct and was re-verified:
+five consecutive `/language:python` analyses, strictly descending `created_at`.
+
+**READY FOR IMPLEMENTATION**

--- a/src/lambdas/shared/auth/oauth_state.py
+++ b/src/lambdas/shared/auth/oauth_state.py
@@ -96,13 +96,13 @@ def store_oauth_state(
 
     table.put_item(Item=item)
 
-    safe_provider = (
-        str(provider).replace("\r\n", " ").replace("\n", " ").replace("\r", " ")[:200]
-    )
+    # py/clear-text-logging-sensitive-data: no value derived from `provider` may
+    # appear in this extra context. Removing the derived value, rather than
+    # sanitizing it in place, is the shape that closed this rule in ebcc2f4.
+    # See specs/001-oauth-provider-taint/research.md before adding a key here.
     logger.info(
         "OAuth state stored",
         extra={
-            "provider": safe_provider,
             "has_user_id": user_id is not None,
             "ttl_seconds": OAUTH_STATE_TTL_SECONDS,
         },

--- a/tests/unit/auth/test_oauth_state.py
+++ b/tests/unit/auth/test_oauth_state.py
@@ -1,5 +1,6 @@
 """Unit tests for OAuth state management."""
 
+import logging
 from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock
 
@@ -51,6 +52,27 @@ class TestStoreOAuthState:
         assert state.user_id == "u-1"
         item = mock_table.put_item.call_args.kwargs["Item"]
         assert item["user_id"] == "u-1"
+
+    def test_log_context_excludes_provider(self, mock_table, caplog):
+        """Regression guard for py/clear-text-logging-sensitive-data (alert 144).
+
+        No value derived from `provider` may reach the logger's extra context.
+        `logging` promotes every extra key to a LogRecord attribute, so this
+        asserts on the sink itself rather than on rendered output, which is bare
+        in production and would pass either way.
+        """
+        with caplog.at_level(
+            logging.INFO, logger="src.lambdas.shared.auth.oauth_state"
+        ):
+            store_oauth_state(
+                mock_table, "state-1", "google", "https://example.com/callback"
+            )
+
+        records = [r for r in caplog.records if r.getMessage() == "OAuth state stored"]
+        assert len(records) == 1
+        assert not hasattr(records[0], "provider")
+        assert records[0].has_user_id is False
+        assert records[0].ttl_seconds == OAUTH_STATE_TTL_SECONDS
 
 
 class TestGetOAuthState:


### PR DESCRIPTION
Feature B of a four-part CodeQL burndown. Closes `py/clear-text-logging-sensitive-data`
alert 144 on `src/lambdas/shared/auth/oauth_state.py`.

The fix removes the provider-derived value from the log `extra` dict rather than
sanitizing it in place. Sanitizing in place is the shape that left alerts 22-25 open
since 2025-12-09; removal is the shape that actually closed this rule before.

## Terminal state: PENDING-BRANCH-ANALYSIS

Expected ending. Closure is only admissible from a default-branch analysis, and none
could exist while the branch was local-only (`git ls-remote` returned empty, exit 0).
Phases 6 and 7 are recorded not runnable; Phase 8 still ran.

Guard test written first and proven red on unfixed code:
`assert not True ... hasattr(LogRecord, 'provider')`, 1 failed / 15 passed. Green after.

`validate_oauth_state()` is deliberately untouched (FR-004 freezes it). It carries the
same shape and is reported, not fixed, so the cleanup cannot silently widen.

No alert was mutated. Nothing was dismissed.

Draft on purpose.