### PR TITLE
feat(001): close py/bad-tag-filter and gate dead scanning suppressions

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -86,6 +86,29 @@ jobs:
         if: always()
         run: python3 scripts/scan-waitforresponse-race.py
 
+      # Dead scanning-suppression guard (001-bad-tag-filter-dead-suppression,
+      # FR-018, FR-019).
+      #
+      # Why it lives in `Lint` and not in `Pre-commit Hooks`: `Lint` is one of
+      # main's required status checks and `Pre-commit Hooks` is not, so this is
+      # the only place the guard can block a merge. Moving it silently downgrades
+      # the guard to advisory, with no symptom until a violation merges green.
+      # Required contexts verified 2026-07-31:
+      #   gh api repos/traylorre/sentiment-analyzer-gsk/branches/main/protection \
+      #     --jq .required_status_checks.contexts
+      #
+      # Invoked directly rather than through pre-commit so the `Pre-commit Hooks`
+      # job's SKIP env cannot reach it, and directly rather than through
+      # `make audit-pragma` because that target also runs bandit, which this job
+      # does not install. No pip install here: the checker is stdlib-only and
+      # setup-python above already provides 3.13.
+      #
+      # `if: always()` because steps are fail-fast and this one is last. Without
+      # it any earlier failure means the guard never runs and reports nothing.
+      - name: Check for dead scanning suppressions
+        if: always()
+        run: python3 scripts/check_dead_suppressions.py
+
   # ========================================================================
   # JOB 2: Test (pytest + coverage)
   # ========================================================================

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -136,7 +136,7 @@
         "filename": ".github/workflows/pr-checks.yml",
         "hashed_secret": "03949ed2d94d19eba0e056d0445af62debbd851a",
         "is_verified": false,
-        "line_number": 234,
+        "line_number": 257,
         "is_added": false,
         "is_removed": false
       }
@@ -2528,5 +2528,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-01T05:39:28Z"
+  "generated_at": "2026-08-01T05:54:02Z"
 }

--- a/Makefile
+++ b/Makefile
@@ -82,12 +82,16 @@ sast: ## Run SAST (Static Application Security Testing) - Bandit + Semgrep
 	semgrep scan --config auto --error --severity ERROR --severity WARNING src/
 	@echo "$(GREEN)✓ SAST scan complete$(NC)"
 
-audit-pragma: ## Audit pragma comments (# noqa, # nosec) for validity
-	@echo "$(YELLOW)=== Checking for unused # noqa comments (RUF100) ===$(NC)"
-	ruff check --extend-select RUF100 src/ tests/
+audit-pragma: ## Audit pragma comments (# noqa, # nosec) and dead scanning suppressions
+	@echo "$(YELLOW)=== [BLOCKING] Unused # noqa comments (RUF100) ===$(NC)"
+	ruff check --extend-select RUF100 src/ tests/ scripts/
 	@echo ""
-	@echo "$(YELLOW)=== Auditing # nosec usage (Bandit with suppressions disabled) ===$(NC)"
-	bandit -r src/ --ignore-nosec 2>/dev/null | grep -E "^(>>|Issue)" || echo "No issues found"
+	@echo "$(YELLOW)=== [BLOCKING] Dead inline scanning suppressions ===$(NC)"
+	@python3 scripts/check_dead_suppressions.py
+	@echo ""
+	@echo "$(YELLOW)=== [ADVISORY - never fails this target] # nosec usage (Bandit, suppressions disabled) ===$(NC)"
+	@bandit -r src/ scripts/ --ignore-nosec 2>/dev/null | grep -E "^(>>|Issue)" || true
+	@echo "$(YELLOW)(the line above is advisory by design; see FR-012)$(NC)"
 	@echo ""
 	@echo "$(GREEN)✓ Pragma audit complete$(NC)"
 

--- a/scripts/check_dead_suppressions.py
+++ b/scripts/check_dead_suppressions.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+"""Detect inline scanning-suppression markers that suppress nothing.
+
+This repository's code scanning setup does not honour inline suppression
+comments. A marker written in a comment therefore has no effect at all: it
+reads as a decision that was made and enforced, while the finding stays open.
+One high-severity alert sat open on the default branch for six months behind
+exactly such a comment, on the exact line the comment was on.
+
+This checker walks a fixed set of roots and fails when it finds a marker in a
+comment, naming the file, the line, the marker, why the form is inert, and
+what to do instead.
+
+Exit codes:
+    0   at least one file was scanned and no marker was found
+    1   one or more markers were found
+    2   zero files were scanned, for any reason
+
+Code 2 is deliberately distinct from 0. A scan that examined nothing must not
+report the same result as a scan that found nothing, or a moved root reads as
+a clean tree.
+
+Standard library only, and no floor above CPython 3.9. The Makefile consumer
+runs under whatever `python3` a contributor's shell resolves, and the CI
+consumer installs no packages beyond ruff, so a single third-party import
+would put a required check permanently red.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from collections.abc import Iterable, Iterator
+from pathlib import Path
+from typing import NamedTuple
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+DEFAULT_ROOTS = ("src", "tests", "scripts")
+
+ROOTS_ENV = "DEAD_SUPPRESSION_ROOTS"
+
+# Prose has to write a marker in order to describe one, so documentation
+# extensions are deliberately absent from this set.
+ALLOWED_EXTENSIONS = frozenset(
+    {".py", ".sh", ".js", ".ts", ".tsx", ".jsx", ".html", ".yml", ".yaml", ".tf"}
+)
+
+SKIP_DIRECTORIES = frozenset(
+    {"__pycache__", "node_modules", ".venv", ".git", ".pytest_cache", ".hypothesis"}
+)
+
+MARKERS = ("lgtm[", "codeql[")
+
+COMMENT_INTRODUCERS = ("#", "//", "<!--", "/*", "--")
+
+# Exact repository-relative paths, never basenames or globs. A basename glob
+# would exempt any identically named file anywhere in the tree. Exactly two
+# members: every addition is a place a real suppression could hide, and the
+# point of exact-path exclusion is that the hole stays enumerable.
+SELF_EXCLUSIONS = frozenset(
+    {
+        Path("scripts/check_dead_suppressions.py"),
+        Path("tests/unit/scripts/test_check_dead_suppressions.py"),
+    }
+)
+
+
+class Finding(NamedTuple):
+    """One marker occurrence."""
+
+    path: str
+    lineno: int
+    marker: str
+    source: str
+
+
+def repo_relative(path: Path) -> Path | None:
+    """Repository-relative form of *path*, or None when it is outside.
+
+    Never raises. Under a roots override the scan walks files outside the
+    repository, and a bare ``relative_to`` would raise on every one of them.
+    """
+    resolved = path.resolve()
+    try:
+        return resolved.relative_to(REPO_ROOT)
+    except ValueError:
+        return None
+
+
+def display_path(path: Path) -> str:
+    """Repository-relative when inside the repository, absolute when not."""
+    relative = repo_relative(path)
+    return str(relative) if relative is not None else str(path.resolve())
+
+
+def is_self_excluded(path: Path) -> bool:
+    """True only for the two exact repository-relative paths above."""
+    relative = repo_relative(path)
+    return relative is not None and relative in SELF_EXCLUSIONS
+
+
+def resolve_roots() -> list[Path]:
+    """Default roots, or the override set when the environment names one.
+
+    The override replaces the default set rather than extending it. It is a
+    testing seam: neither consumer sets it.
+    """
+    override = os.environ.get(ROOTS_ENV)
+    if override:
+        roots = []
+        for entry in override.split(os.pathsep):
+            if not entry:
+                continue
+            candidate = Path(entry)
+            roots.append(
+                candidate if candidate.is_absolute() else REPO_ROOT / candidate
+            )
+        return roots
+    return [REPO_ROOT / name for name in DEFAULT_ROOTS]
+
+
+def iter_files(roots: Iterable[Path]) -> Iterator[Path]:
+    """Yield every allowlisted file under *roots*, skip list applied."""
+    for root in roots:
+        if not root.is_dir():
+            continue
+        for dirpath, dirnames, filenames in os.walk(root):
+            dirnames[:] = sorted(d for d in dirnames if d not in SKIP_DIRECTORIES)
+            for name in sorted(filenames):
+                candidate = Path(dirpath) / name
+                if candidate.suffix.lower() in ALLOWED_EXTENSIONS:
+                    yield candidate
+
+
+def find_case_insensitive(haystack: str, needle: str) -> int:
+    """Index of *needle* in *haystack*, ignoring case, or -1.
+
+    Written as a scan rather than as ``haystack.lower().find(needle)`` because
+    lowercasing can change a string's length (U+0130 is the common example),
+    which would shift every index computed from it.
+    """
+    span = len(needle)
+    for index in range(len(haystack) - span + 1):
+        if haystack[index : index + span].lower() == needle:
+            return index
+    return -1
+
+
+def first_introducer_index(line: str) -> int:
+    """Index of the earliest comment introducer, or -1 when there is none.
+
+    The introducers are caseless, so this searches the line as written.
+    """
+    positions = [line.find(token) for token in COMMENT_INTRODUCERS]
+    found = [position for position in positions if position >= 0]
+    return min(found) if found else -1
+
+
+def marker_in_comment(line: str) -> str | None:
+    """The marker text when this line carries one in a comment, else None.
+
+    Purely textual: it does not know what a string literal is. A marker with
+    no introducer earlier on the same line does not match, which is what keeps
+    URLs, docstrings and this checker's own constants out of the results.
+    """
+    introducer = first_introducer_index(line)
+    if introducer < 0:
+        return None
+    hits = [find_case_insensitive(line, marker) for marker in MARKERS]
+    positions = [position for position in hits if position > introducer]
+    if not positions:
+        return None
+    start = min(positions)
+    end = line.find("]", start)
+    return line[start : end + 1] if end >= 0 else line[start:].rstrip()
+
+
+def scan_file(path: Path) -> list[Finding]:
+    """Every marker occurrence in *path*, at most one per line."""
+    text = path.read_text(encoding="utf-8", errors="replace")
+    findings = []
+    for lineno, line in enumerate(text.split("\n"), start=1):
+        marker = marker_in_comment(line)
+        if marker is not None:
+            findings.append(Finding(display_path(path), lineno, marker, line.strip()))
+    return findings
+
+
+WHY_BLOCK = (
+    "Why this is a problem:",
+    "  Inline lgtm[...] and codeql[...] comments are NOT honoured by this",
+    "  repository's code scanning setup. They suppress nothing. A high-severity",
+    "  alert sat open on the default branch for six months behind exactly this",
+    "  comment, on the exact line the comment was on.",
+)
+
+WHAT_BLOCK = (
+    "What to do instead:",
+    "  - Preferred: change the code so the finding does not arise.",
+    "  - If the finding is genuinely a false report, dismiss it through the code",
+    "    scanning product's own dismissal workflow, with a recorded reason. That",
+    "    is the only suppression route that has any effect here.",
+    "  - Do not swap lgtm[...] for codeql[...]. Neither of them works.",
+)
+
+
+def report(roots: list[Path], scanned: int, findings: list[Finding]) -> None:
+    """Print the run, clean or failing, to stdout."""
+    print("=== Dead Suppression Scanner ===")
+    print("Roots: " + ", ".join(display_path(root) + "/" for root in roots))
+    print(f"Scanned {scanned} files.")
+
+    if not findings:
+        print("PASS: no inline scanning-suppression markers found.")
+        return
+
+    noun = "marker" if len(findings) == 1 else "markers"
+    print()
+    print(f"FAIL: {len(findings)} inline scanning-suppression {noun} found.")
+    print()
+    for finding in findings:
+        print(f"  {finding.path}:{finding.lineno}")
+        print(f"    marker: {finding.marker}")
+        print(f"    line:   {finding.source}")
+    print()
+    for line in WHY_BLOCK:
+        print(line)
+    print()
+    for line in WHAT_BLOCK:
+        print(line)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Scan and return the exit code."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Detect inline scanning-suppression markers, which this "
+            "repository's code scanning setup does not honour."
+        )
+    )
+    parser.add_argument(
+        "files",
+        nargs="*",
+        help=(
+            "Accepted and ignored. A pre-commit hook handing over a file list "
+            "must not be able to narrow the scan."
+        ),
+    )
+    parser.parse_known_args(argv)
+
+    roots = resolve_roots()
+    scanned = 0
+    findings: list[Finding] = []
+    for path in iter_files(roots):
+        if is_self_excluded(path):
+            continue
+        scanned += 1
+        findings.extend(scan_file(path))
+
+    if scanned == 0:
+        print("=== Dead Suppression Scanner ===")
+        print("Roots: " + ", ".join(display_path(root) + "/" for root in roots))
+        print("Scanned 0 files.")
+        print(
+            "ERROR: the scan examined nothing. A scan that examined nothing is "
+            "not a clean tree. Check that the roots above still exist."
+        )
+        return 2
+
+    report(roots, scanned, findings)
+    return 1 if findings else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/regenerate-mermaid-url.py
+++ b/scripts/regenerate-mermaid-url.py
@@ -78,8 +78,18 @@ def validate_mermaid_syntax(code: str) -> list[str]:
         )
 
     # Check for common Mermaid syntax errors (not HTML filtering)
-    # CodeQL py/bad-tag-filter: False positive - validates Mermaid arrow syntax, not HTML
-    if re.search(r"-->\s*$", code, re.MULTILINE):  # lgtm[py/bad-tag-filter]
+    # This check is deliberately not written as a pattern match. The CodeQL rule
+    # py/bad-tag-filter fires on the pattern form, and no inline suppression
+    # comment is honoured by this repository's scanning setup, so the only fix
+    # that holds is to stop using a pattern here.
+    # Two details below are load-bearing and must not be "simplified":
+    #   - split("\n"), not splitlines(): splitlines() also breaks on \v, \f, \r,
+    #     \x85, U+2028 and U+2029, none of which regex $ treats as a line
+    #     boundary under MULTILINE. On "A -->\rB" that difference flips the
+    #     verdict from False to True.
+    #   - bare rstrip(), not rstrip(" \t"): the narrowed form disagrees with the
+    #     \s class the original expression trimmed with.
+    if any(line.rstrip().endswith("-->") for line in code.split("\n")):
         errors.append("Arrow without target node (line ends with -->)")
 
     if re.search(r"==>\s*$", code, re.MULTILINE):

--- a/specs/001-bad-tag-filter-dead-suppression/checklists/requirements.md
+++ b/specs/001-bad-tag-filter-dead-suppression/checklists/requirements.md
@@ -1,0 +1,73 @@
+# Specification Quality Checklist: Close py/bad-tag-filter and Kill the Dead Suppression
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-30
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- This is a tooling and security-hygiene feature, so "non-technical stakeholder" is
+  read as "a reviewer who does not know this codebase". Rule identifiers, file roles,
+  and check names are described by function rather than by symbol where possible.
+- Success criteria are stated as observable states and counts (alert state, match
+  counts, exit codes, mismatch counts) rather than as commands to run, keeping them
+  verifiable without prescribing implementation.
+- The highest-risk requirement is FR-003. The obvious rewrite is subtly non-equivalent
+  on exotic line separators; this was confirmed empirically during specification, not
+  assumed. FR-001 and SC-003 exist to force that equivalence to be proven at
+  implementation time rather than trusted.
+- The key design call is FR-012 with FR-015: pre-existing findings surfaced by the
+  widened path set land in an advisory check that cannot fail the build, so no
+  baseline or grandfathering mechanism is required.
+
+## Adversarial Review #1 (2026-07-30)
+
+An independent reviewer falsified three of the items ticked above against the initial
+draft. All three now pass against the revised spec; the ticks are retained but the
+history is recorded here rather than erased.
+
+- **"Success criteria are measurable"** failed on two counts. SC-004 required a
+  tree-wide marker scan to return matches only inside the auditor, but the spec file
+  itself contained fifteen marker occurrences at the moment it was written, so the
+  criterion could never reach its stated state (F2). SC-009 required an existing test
+  suite for the diagram script to pass unchanged; no such suite exists anywhere in the
+  repository (F3). Both criteria rewritten.
+- **"Requirements are testable and unambiguous"** failed on FR-008 through FR-015,
+  which specified behaviour for a target that no automated process invokes: not a
+  prerequisite of the aggregate validation target, absent from every workflow, absent
+  from the commit hooks, and with its security-linter half structurally unable to fail
+  (F1, CRITICAL). Every requirement in that block was satisfiable without the check
+  ever running against a change under review. Resolved by FR-018, FR-019, SC-011,
+  SC-012, and a new US3 acceptance scenario measuring an observed check result.
+- **"Edge cases are identified"** failed on the trailing-whitespace character class
+  (F5). The draft's most-emphasised edge case was the line-separator divergence, and
+  the identical trap one level down, where a narrowed trim set disagrees with the
+  original expression's whitespace class, was not covered. FR-003 now constrains both.
+
+Full findings table, severity counts, and the reproduction method for every claim are
+in the spec's own Adversarial Review #1 section. Gate: 0 CRITICAL, 0 HIGH remaining.

--- a/specs/001-bad-tag-filter-dead-suppression/contracts/dead-suppression-cli.md
+++ b/specs/001-bad-tag-filter-dead-suppression/contracts/dead-suppression-cli.md
@@ -1,0 +1,264 @@
+# Contract: dead-suppression checker CLI
+
+**Feature**: `001-bad-tag-filter-dead-suppression` | **Satisfies**: FR-008, FR-009, FR-009a, FR-014, FR-018, FR-019
+**Subject**: `scripts/check_dead_suppressions.py`
+**Consumers**: the `audit-pragma` recipe in `Makefile`, and the `Lint` job in `.github/workflows/pr-checks.yml`
+**Status**: proposed, pinned before implementation
+
+## Why this contract exists
+
+The checker has two independent consumers that will be written at different times, and one of them
+lives in a required status check. If the CI step and the Makefile recipe drift apart, the failure
+is silent: CI passes, the local target passes, and the gate covers less than either author thinks.
+
+This repository has already paid for that once. The waitForResponse detector needed
+`specs/002-waitforresponse-lint-guard/contracts/detector-cli.md` written for exactly this reason,
+and pinning the interface surfaced four requirements that contradicted the owning specification.
+This document is the same object, one page, and it is a CLI contract rather than an API contract.
+There is no API in this feature.
+
+---
+
+## C1. Invocation
+
+```bash
+python3 scripts/check_dead_suppressions.py
+```
+
+| Property | Requirement |
+|---|---|
+| Interpreter | Any CPython 3.9 or newer reachable as `python3`. MUST NOT require `.venv`, and MUST NOT use syntax that raises the floor above 3.9. |
+| Arguments | None required. The bare invocation scans the full default root set. |
+| Positional arguments | Accepted and **ignored**. Parsed with `parse_known_args`, so a pre-commit hook handing over a file list cannot narrow the scan. |
+| Working directory | Any. The script resolves the repository root from `Path(__file__).resolve().parent.parent` rather than from the cwd. |
+| Imports | **Standard library only.** No import of anything in `requirements.txt`, `requirements-dev.txt`, or `requirements-ci.txt`. |
+| Executable bit | Not required. Always invoked through the interpreter. |
+| Network, filesystem writes | None. The checker reads and prints. |
+
+The 3.9 floor is deliberately lower than the project's 3.13. The `Lint` job gets 3.13 from
+`setup-python`, but the Makefile consumer runs under whatever `python3` the contributor's shell
+resolves, and that is not the project interpreter: `/usr/bin/python3` on the reference machine is
+3.12.3 while `python3` resolves through a pyenv shim to 3.13.0. Nothing in this design needs a
+version-gated feature, so requiring one would fail contributors for no benefit.
+`scripts/scan-waitforresponse-race.py:75-81` does carry a hard 3.13 guard. If that pattern is ever
+copied here, it MUST NOT exit `2`: C2 assigns `2` to "zero files scanned", and the precedent
+already collides on that code, so a wrong-interpreter run there is indistinguishable from a scan
+whose roots have vanished.
+
+The stdlib-only rule is not stylistic. `.github/workflows/pr-checks.yml:52-56` installs
+`ruff==0.15.14` and nothing else in the `Lint` job. A single third-party import puts a required
+check permanently red, and adding an install step to fix it is the tooling addition FR-019 forbids.
+
+Working-directory independence matters because the optional pre-commit hook runs from wherever the
+committing shell happens to be, which is not guaranteed to be the repository root.
+
+---
+
+## C2. Exit codes
+
+| Code | Meaning | Consumer behaviour |
+|---|---|---|
+| `0` | At least one file scanned, no marker found | Makefile continues, CI step passes |
+| `1` | One or more markers found | Makefile recipe fails, CI step fails, merge blocked |
+| `2` | Zero files scanned, for any reason | Both consumers fail |
+
+Code `2` is separate from `0` deliberately. A scan that examines nothing must not report the same
+result as a scan that found nothing, or a moved root reads as a clean tree. The default roots are
+three hard-coded directory names, so this is a live risk rather than a theoretical one.
+
+---
+
+## C3. Default root set
+
+```text
+src/
+tests/
+scripts/
+```
+
+Resolved relative to the repository root, not the cwd. A root that does not exist contributes zero
+files, and if that leaves the total at zero the run exits `2`.
+
+Extension allowlist, case-insensitive:
+
+```text
+.py .sh .js .ts .tsx .jsx .html .yml .yaml .tf
+```
+
+Skipped unconditionally, at any depth: `__pycache__`, `node_modules`, `.venv`, `.git`,
+`.pytest_cache`, `.hypothesis`.
+
+Files are read as UTF-8 with `errors="replace"`, so an undecodable file is scanned harmlessly
+rather than raising and taking the gate down.
+
+`.md` and `.txt` are absent from the allowlist on purpose. Prose that describes a marker has to
+write it, which is the defect that made the specification's original tree-wide criterion false at
+the moment it was written.
+
+---
+
+## C4. Root override
+
+| Property | Requirement |
+|---|---|
+| Variable | `DEAD_SUPPRESSION_ROOTS` |
+| Format | `os.pathsep`-separated paths. Relative paths resolve against the repository root. |
+| Effect | Replaces the default root set entirely. Does not extend it. |
+| Purpose | Testing only. Neither consumer sets it. |
+
+This exists so the negative test required by SC-006 can point the checker at a `tmp_path`
+containing a real marker, without that marker ever existing inside the audited set. It mirrors
+`SCAN_ROOT_ENV` in `scripts/scan-waitforresponse-race.py`, which was added for the same reason.
+
+The extension allowlist and the skip list still apply under an override. A test fixture must
+therefore be given an allowlisted extension, `.py` being the obvious choice.
+
+---
+
+## C5. Detection rule
+
+A line matches when **both** hold:
+
+1. It contains `lgtm[` or `codeql[`, compared case-insensitively.
+2. The marker's position on the line is **after** the first occurrence of a comment introducer:
+   `#`, `//`, `<!--`, `/*`, or `--`.
+
+Consequences that consumers and test authors depend on:
+
+- A marker inside a string literal, a docstring, or a URL does not match, because no introducer
+  precedes it on that line.
+- A marker after `#` matches regardless of what else is on the line, so a real suppression appended
+  to a line of code is caught.
+- Matching is per line. Markers spanning a line break are not detected, which is accepted: the
+  target is the contributor who typed a suppression they believed would work, not an adversary.
+
+---
+
+## C6. Self-exclusion
+
+Exclusion is by **exact repository-relative path**, never by basename or glob:
+
+```python
+SELF_EXCLUSIONS = frozenset({
+    Path("scripts/check_dead_suppressions.py"),
+    Path("tests/unit/scripts/test_check_dead_suppressions.py"),
+})
+```
+
+A candidate is skipped if and only if it resolves inside the repository root **and** its
+repository-relative path is a member of that set. A candidate that resolves outside the repository
+root is never excluded, and computing its relative path MUST NOT raise.
+
+That second sentence is load-bearing, not pedantry. Under a `DEAD_SUPPRESSION_ROOTS` override the
+scan walks files outside the repository, and
+`Path("/tmp/x/bad.py").resolve().relative_to(repo_root)` raises
+`ValueError: '/tmp/x/bad.py' is not in the subpath of ...`. A naive `relative_to` in the exclusion
+test therefore crashes the checker on every file the SC-006 negative test creates. Use a
+containment test (`Path.is_relative_to`, or `relative_to` inside `try/except ValueError`) and treat
+the outside case as "not excluded".
+
+This is explicitly **not** the mechanism `scripts/check-banned-terms.sh:32` uses.
+`--exclude=check-banned-terms.sh` is a grep basename glob and exempts any identically named file
+anywhere in the tree. FR-009 forbids that form after Adversarial Review finding F6.
+
+The set MUST have exactly the two members above. Adding a third is a requirements change: every
+addition is a place a real suppression can hide, and the whole point of exact-path exclusion is
+that the hole is enumerable.
+
+Fails safe. A renamed or relocated checker stops being excluded and immediately flags itself,
+which is loud rather than silent.
+
+---
+
+## C7. Output
+
+### Clean run
+
+Goes to stdout. Must state the number of files scanned, so a root that quietly shrank is visible
+in a passing log rather than only in a `2`.
+
+```text
+=== Dead Suppression Scanner ===
+Roots: src/, tests/, scripts/
+Scanned 583 files.
+PASS: no inline scanning-suppression markers found.
+```
+
+### Failing run
+
+Paths are printed repository-relative when the file is inside the repository, and absolute when it
+is not. The fallback is required for the same reason as C6's containment test, and it is what
+`scripts/scan-waitforresponse-race.py:418-423` already does.
+
+Goes to stdout. Per FR-014 every finding names the **file**, the **line number**, and the
+**marker**, and the run states both **why the form is inert** and **what the supported alternative
+is**. A failure that only says "found a bad comment" gets worked around instead of fixed, which is
+how the repository ended up here.
+
+```text
+=== Dead Suppression Scanner ===
+Roots: src/, tests/, scripts/
+Scanned 583 files.
+
+FAIL: 1 inline scanning-suppression marker found.
+
+  scripts/regenerate-mermaid-url.py:82
+    marker: lgtm[py/bad-tag-filter]
+    line:   if re.search(r"-->\s*$", code, re.MULTILINE):  # lgtm[...]
+
+Why this is a problem:
+  Inline lgtm[...] and codeql[...] comments are NOT honoured by this repository's
+  code scanning setup. They suppress nothing. A high-severity alert sat open on main
+  for six months behind exactly this comment, on the exact line the comment was on.
+
+What to do instead:
+  - Preferred: change the code so the finding does not arise.
+  - If the finding is genuinely a false positive, dismiss it through the code
+    scanning product's own dismissal workflow, with a recorded reason. That is the
+    only suppression route that has any effect here.
+  - Do not swap lgtm[...] for codeql[...]. Neither works.
+```
+
+Assertions in tests SHOULD target substrings such as the path, the line number, the marker text,
+and a distinctive phrase from each explanatory block. They MUST NOT target exact whitespace or the
+full block verbatim, or every wording improvement becomes a test failure.
+
+---
+
+## C8. What consumers MUST NOT do
+
+- MUST NOT wrap the invocation in anything that swallows the exit status. That includes
+  `|| true`, piping into `grep`, and piping into `echo`. The bandit half of `audit-pragma` is
+  advisory precisely because of a pipe, and FR-013 exists because that was an accident rather than
+  a decision. Repeating the accident here would recreate the whole defect.
+- MUST NOT reach the checker through `pre-commit run` **from the merge-blocking context**. The
+  `Pre-commit Hooks` CI job sets `SKIP` and is not a required context, so the `Lint` step invokes
+  the script directly for both reasons. This does not forbid a local pre-commit hook: an additive
+  one is permitted and recommended, and the precedent carries all three wirings at once, a hook at
+  `.pre-commit-config.yaml:206-212`, a direct `Lint` step at `.github/workflows/pr-checks.yml:85-87`,
+  and a `make validate` prerequisite at `Makefile:42`. What is forbidden is the required check
+  depending on the hook runner.
+- MUST NOT pass positional file lists expecting the scan to narrow. They are ignored by design.
+- MUST NOT set `DEAD_SUPPRESSION_ROOTS`. It is a testing seam.
+
+---
+
+## C9. Consumer wiring, verbatim
+
+**`Makefile`**, inside `audit-pragma`:
+
+```make
+	@echo "$(YELLOW)=== [BLOCKING] Dead inline scanning suppressions ===$(NC)"
+	@python3 scripts/check_dead_suppressions.py
+```
+
+**`.github/workflows/pr-checks.yml`**, final step of the `lint` job:
+
+```yaml
+      - name: Check for dead scanning suppressions
+        if: always()
+        run: python3 scripts/check_dead_suppressions.py
+```
+
+Both are the bare invocation. Neither passes arguments, neither sets the override, neither
+swallows the status.

--- a/specs/001-bad-tag-filter-dead-suppression/plan.md
+++ b/specs/001-bad-tag-filter-dead-suppression/plan.md
@@ -1,0 +1,675 @@
+# Implementation Plan: Close py/bad-tag-filter and Kill the Dead Suppression
+
+**Branch**: `001-bad-tag-filter-dead-suppression` | **Date**: 2026-07-30 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/001-bad-tag-filter-dead-suppression/spec.md`
+
+## Summary
+
+Three changes, one of which carries all the design risk.
+
+1. Rewrite the arrow-without-target check at `scripts/regenerate-mermaid-url.py:82` from a
+   regular expression into string operations, so the analyzer has no pattern to flag. One line,
+   plus a note telling the next author why it is written that way.
+2. Delete the `# lgtm[py/bad-tag-filter]` comment and the false-positive note above it. Nothing
+   inline replaces them, because no inline form is honoured here.
+3. Add a dedicated marker checker, wire it into `make audit-pragma`, and wire it independently
+   into the required `Lint` job so it can actually fail a merge. Widen the audit's path set to
+   include `scripts/`, and make each half's blocking or advisory status explicit rather than an
+   accident of shell pipeline semantics.
+
+The third item is where the plan spends its effort. Parts 1 and 2 are a four-line diff whose only
+difficulty is proving behaviour did not shift, which a differential test does.
+
+## Technical Context
+
+**Language/Version**: Python 3.13 for the repository (`requires-python = ">=3.13"`; CI `setup-python` pins 3.13 in the `Lint` job). **The new checker is the exception and targets a 3.9 floor**, per `contracts/dead-suppression-cli.md` C1: its Makefile consumer runs under whatever `python3` the contributor's shell resolves, which is 3.12.3 at `/usr/bin/python3` on the reference machine. See "Reconciling the 3.9 floor with ruff" under Constraints; this is not free and getting it wrong reddens a blocking line.
+**Primary Dependencies**: Python standard library only for the new checker (`argparse`, `os`, `pathlib`, `sys`). Existing tooling reused unchanged: ruff 0.15.14 (RUF100 rule), bandit (advisory half of the audit), pytest 7+ with the repository's configured `testpaths = ["tests"]`. No dependency is added to any requirements file.
+**Storage**: N/A. The checker reads files and writes nothing.
+**Testing**: pytest, collected under `tests/unit/scripts/`. No AWS, no moto, no network. Compliant with the constitution's LOCAL/unit row.
+**Target Platform**: Developer shell (`make audit-pragma`) and GitHub Actions `ubuntu-latest` (the `Lint` job).
+**Project Type**: Single project. Repository tooling under `scripts/`, tests under `tests/`.
+**Performance Goals**: The checker walks roughly 583 source files. It must not measurably lengthen the `Lint` job. A single pass reading each file once is comfortably inside a second.
+**Constraints**: The checker MUST import nothing outside the standard library, because the `Lint` job installs only `ruff==0.15.14` (verified at `.github/workflows/pr-checks.yml:52-56`). It MUST NOT require `.venv`. It MUST NOT flag its own source or its own tests, and that exclusion MUST be by exact repository-relative path rather than by filename pattern.
+
+**Reconciling the 3.9 floor with ruff.** These two pull against each other and the collision is
+reproducible, not theoretical. `pyproject.toml` sets `target-version = "py313"` and selects `UP`,
+so pyupgrade rewrites 3.9-compatible source into 3.10+ source. Run against the pinned ruff
+0.15.14, a 3.9-shaped file trips UP035 and UP006 (`typing.List`), UP045 (`Optional[X]` becomes
+`X | None`, which is 3.10+ at runtime), and UP036 (any `sys.version_info` guard below 3.13 reads as
+dead). This matters because §2 widens `ruff check --extend-select RUF100` to `scripts/`, and
+`--extend-select` **adds to** the configured selection rather than replacing it, so the new checker
+is linted under the full `E W F I B C4 UP S` set on a **blocking** line of `audit-pragma`. A UP
+violation there is exactly the day-one failure FR-015 exists to prevent.
+
+The resolution, and it is the only one that satisfies both:
+
+- Open the checker with `from __future__ import annotations`. Annotations then never evaluate at
+  runtime, so PEP 604 syntax (`str | None`) is valid back to 3.7 and UP045 is satisfied at the same
+  time. `tests/unit/scripts/test_consolidate_oauth_apply.py:6` and `conftest.py:10` already do this.
+- Keep PEP 604 and builtin generics **in annotations only**. Do not use them where they are
+  evaluated: no `isinstance(x, str | None)`, no runtime `typing.get_type_hints`.
+- Do **not** add a `sys.version_info` interpreter guard. UP036 flags it, the precedent needed
+  `# noqa: UP036` to carry one (`scripts/scan-waitforresponse-race.py:70-75`), and C1 forbids
+  version-gated syntax anyway. If one is ever added, C1 also forbids reusing exit code `2`.
+- The checker and its test file MUST be clean under `ruff check --extend-select RUF100 scripts/`
+  and `... tests/` before the widened line is left blocking. No artifact said this and it is not
+  implied by "stdlib only".
+
+**Scale/Scope**: One production line rewritten, two comment lines removed, one new checker file, one new test file, one Makefile recipe edited, one CI step added.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+The constitution governs the sentiment analyzer service itself: ingestion adapters, inference,
+persistence, deployment, the dashboard. This feature touches none of that. It changes a diagram
+utility script and the repository's own validation tooling. Most gates are therefore not
+applicable rather than passed, and that is recorded honestly below instead of being papered over
+with a column of ticks.
+
+| Gate | Applies? | Result |
+|---|---|---|
+| Functional requirements (ingest, dedup, sentiment output, admin API) | No | Untouched. No service code in the diff. |
+| Non-functional (availability, P90 latency, autoscale) | No | No runtime path changes. |
+| Security and access control (auth on admin endpoints, TLS, secrets in a managed store) | No | No endpoint, credential, or secret is touched. |
+| SQL injection and unsafe DB access | No | No database access anywhere in the diff. |
+| Data and model requirements (output schema, model versioning, reproducibility) | No | No model or data schema involved. |
+| Deployment (containerised, IaC, Terraform, TFC) | No | No infrastructure change. |
+| Observability and monitoring | No | No metrics or logging change. |
+| Dashboard and admin controls | No | Neither dashboard is touched. See CLAUDE.md's two-dashboard table: this feature is in neither. |
+| **"include SAST/secret scanning and dependency checks in CI"** | **Yes** | **PASS, and strengthened.** The feature closes a high-severity scanning finding and adds a new source scan to a merge-blocking CI context. |
+| **"CI/CD pipelines must ... include unit and integration tests, SAST, and IaC linting checks"** | **Yes** | **PASS.** The new checker runs in the required `Lint` job; the new regression test runs in the required `Run Tests` job. |
+| **Testing matrix: LOCAL and DEV run ONLY unit tests with mocks** | **Yes** | **PASS.** Every new test is a pure-stdlib unit test with no AWS and no network. No `preprod` marker. |
+| **External dependency mocking is mandatory in all environments** | **Yes** | **PASS, vacuously.** The diff has no external dependency to mock. |
+
+**Result: PASS. No gate failed. No gate required justification, so Complexity Tracking is empty
+and omitted.**
+
+One constitution-adjacent note that is not a gate failure but is worth recording: the constitution
+mandates SAST in CI, and the bandit half of `make audit-pragma` reports success unconditionally
+today. This feature does not fix that backlog (explicitly out of scope) but FR-013 does force the
+recipe to *declare* that half advisory rather than leave a reader to infer it from a pipe. That is
+a documentation-honesty improvement against the same clause, not a new gate.
+
+**Post-design re-check: PASS, unchanged.** Phase 1 introduced one new stdlib-only script and one
+new unit test file. Neither moves any constitution gate from "not applicable" to "applicable", and
+neither weakens a gate that was passing.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/001-bad-tag-filter-dead-suppression/
+├── spec.md                          # Input (existing, with Adversarial Review #1)
+├── plan.md                          # This file
+├── research.md                      # Phase 0: the seven decisions with their falsification evidence
+├── quickstart.md                    # Phase 1: how to run and verify each half
+├── contracts/
+│   └── dead-suppression-cli.md      # Phase 1: the checker's CLI contract, two consumers
+├── checklists/                      # Existing
+└── tasks.md                         # Phase 2 output (/speckit.tasks, NOT created here)
+```
+
+**data-model.md is deliberately not produced.** See "Artifacts deliberately skipped" below.
+
+### Source Code (repository root)
+
+```text
+scripts/
+├── regenerate-mermaid-url.py        # MODIFIED: line 82 rewritten, lines 80-81 replaced
+├── check_dead_suppressions.py       # NEW: the marker checker (stdlib only)
+├── scan-waitforresponse-race.py     # Reference precedent, untouched
+└── check-banned-terms.sh            # Reference precedent for exclusion, untouched
+
+tests/unit/scripts/
+├── conftest.py                      # Existing, untouched (moto fixtures for another script)
+├── test_regenerate_mermaid_url.py   # NEW: differential + regression tests for the arrow check
+└── test_check_dead_suppressions.py  # NEW: checker unit tests including the negative test
+
+Makefile                             # MODIFIED: audit-pragma recipe, lines 85-92
+.github/workflows/pr-checks.yml      # MODIFIED: one step appended to the `Lint` job
+```
+
+**Structure Decision**: Single project, existing layout, no new directories. The checker goes in
+`scripts/` alongside the two scanners it is modelled on. Both new test files go in
+`tests/unit/scripts/`, which already exists and already holds tests for another repository script,
+and which sits inside the configured `testpaths = ["tests"]` so the required `Run Tests` job
+collects them. That last point is FR-004's whole concern and it is satisfied by placement alone.
+
+---
+
+## Design decisions the spec requires this plan to make concrete
+
+The task brief asks for six things to be pinned down. They are pinned here, with the reasoning in
+`research.md` and the machine-readable form in `contracts/dead-suppression-cli.md`.
+
+### 1. Where the new check lives
+
+**`scripts/check_dead_suppressions.py`.** A dedicated file, satisfying FR-009a.
+
+Underscores, not hyphens, unlike its `scan-waitforresponse-race.py` sibling. The reason is
+testability: `tests/unit/scripts/test_consolidate_oauth_apply.py:13` already does
+`import scripts.consolidate_oauth_duplicates as mod`, which works because pytest puts the
+repository root on `sys.path` and PEP 420 makes `scripts/` an implicit namespace package. A
+hyphenated name would force `importlib.util.spec_from_file_location` gymnastics in every test.
+The CLI invocation is `python3 scripts/check_dead_suppressions.py` either way, so the naming
+choice costs the consumers nothing.
+
+Python rather than bash, unlike `check-banned-terms.sh`. Three reasons, all concrete. Exact-path
+exclusion (FR-009) is a set membership test on `Path.relative_to()` in Python and a fragile string
+comparison in `grep`. The precedent's own bash exclusion is the *bug* FR-009 was written to avoid.
+The FR-014 output (file, line, marker, why it is inert, what to do instead) is formatting work.
+And the `Lint` job already has a 3.13 interpreter from `setup-python`, so Python is free there.
+
+### 2. How the Makefile invokes it
+
+`make audit-pragma` gains a third section and all three sections gain an explicit status label
+(FR-013, SC-008). Target shape:
+
+```make
+audit-pragma: ## Audit pragma comments (# noqa, # nosec) and dead scanning suppressions
+	@echo "$(YELLOW)=== [BLOCKING] Unused # noqa comments (RUF100) ===$(NC)"
+	ruff check --extend-select RUF100 src/ tests/ scripts/
+	@echo ""
+	@echo "$(YELLOW)=== [BLOCKING] Dead inline scanning suppressions ===$(NC)"
+	@python3 scripts/check_dead_suppressions.py
+	@echo ""
+	@echo "$(YELLOW)=== [ADVISORY - never fails this target] # nosec usage (Bandit, suppressions disabled) ===$(NC)"
+	@bandit -r src/ scripts/ --ignore-nosec 2>/dev/null | grep -E "^(>>|Issue)" || true
+	@echo "$(YELLOW)(the line above is advisory by design; see FR-012)$(NC)"
+	@echo ""
+	@echo "$(GREEN)✓ Pragma audit complete$(NC)"
+```
+
+Three things changed and each maps to a requirement:
+
+- RUF100 path set widened to include `scripts/` (FR-010, FR-011). Verified clean today. It is safe
+  to leave blocking on day one **only if** the check is re-run against the exact tree being merged;
+  see "Re-verification immediately before merge (FR-015)" under Verification and the merge boundary.
+- The new check inserted as an explicitly blocking step (FR-008).
+- The bandit line's advisory status made a *declaration* rather than an accident (FR-013). Today
+  `... | grep -E "^(>>|Issue)" || echo "No issues found"` swallows failure because the recipe
+  inherits grep's exit status, which is a property a reader has to derive from `PIPESTATUS`
+  semantics. Replacing the `|| echo` with an explicit `|| true` plus a labelled banner makes the
+  contract readable without that derivation, which is exactly what SC-008 asks for. Its path set
+  widens to `src/ scripts/` (FR-012), which surfaces ten pre-existing findings that print and
+  block nobody, as the spec's assumption already records.
+
+Note that `make audit-pragma` as a whole still is not wired into `make validate` or into CI. That
+is deliberate and carded in Out of Scope. Only the marker check reaches CI, and it reaches it
+directly rather than through this target.
+
+### 3. How the required `Lint` job invokes it
+
+**This section is the feature's scope growth and it is owner-rejectable.** The original request was
+"rewrite an expression, delete a comment, extend `make audit-pragma`" (`spec.md:6`). FR-018 grows
+that into editing `.github/workflows/pr-checks.yml`, which carries one of the four contexts branch
+protection requires on `main`. The reasoning is in the spec's Overview and is not repeated here.
+What the Overview records and this plan previously did not is the fallout if the owner says no, and
+it belongs here because tasks are cut from this file:
+
+- **If FR-018 is accepted** (the assumption everything below is written under): this section, the
+  CI step, `quickstart.md` section 5, SC-011, and SC-012 all stand.
+- **If FR-018 is rejected**: FR-018, FR-019, SC-011, and SC-012 fall, US3 reduces to its first five
+  scenarios, this entire section is dropped along with its task, and the feature keeps only its
+  informational outcomes. Sections 1, 2, and 4 through 7 are unaffected: the checker still gets
+  built, still gets wired into `make audit-pragma`, and still has the same contract. What it loses
+  is the property of ever running against a change that is about to land.
+
+Neither outcome may be reached silently. Do not widen the CI footprint beyond the single step below
+(no new job, no new required context, no `make validate` prerequisite, all carded out of scope in
+the spec), and do not quietly drop the step on the grounds that it is "just tooling".
+
+A new final step in the `lint` job of `.github/workflows/pr-checks.yml`, appended after the
+existing waitForResponse guard at line 85-87, following that precedent exactly:
+
+```yaml
+      # Dead scanning-suppression guard (001-bad-tag-filter-dead-suppression, FR-018).
+      #
+      # Why this lives in `Lint` and not in `Pre-commit Hooks`: `Lint` is one of main's
+      # required status checks and `Pre-commit Hooks` is not, so this is the only place
+      # the guard can actually block a merge. Moving it silently downgrades it to
+      # advisory with no symptom until a dead suppression merges green. That is the
+      # precise failure this feature exists to delete: alert 147 survived six months
+      # behind a comment that could not suppress anything. Required contexts verified
+      # 2026-07-30:
+      #   gh api repos/traylorre/sentiment-analyzer-gsk/branches/main/protection \
+      #     --jq .required_status_checks.contexts
+      #   -> ["Secrets Scan","Lint","Run Tests","Playwright E2E Tests"]
+      #
+      # No pip install: the checker is stdlib-only and setup-python above already
+      # provides 3.13. This job installs only ruff==0.15.14 (FR-019).
+      #
+      # `if: always()` because steps are fail-fast and this one is last. Without it a
+      # ruff failure means the guard never runs and reports nothing.
+      - name: Check for dead scanning suppressions
+        if: always()
+        run: python3 scripts/check_dead_suppressions.py
+```
+
+**Why the step is `python3 scripts/check_dead_suppressions.py` and not `make audit-pragma`.**
+The `Lint` job installs `ruff` and nothing else. `bandit` is absent, so the target's third section
+would fail on a missing binary, and adding bandit to the job is exactly the tooling installation
+FR-019 forbids. Invoking the checker directly also means the `Pre-commit Hooks` job's `SKIP`
+environment cannot reach it, which is the same reasoning the waitForResponse precedent records
+in `.pre-commit-config.yaml:220-228`.
+
+**Optional, and recommended but not required by any FR:** a matching `pre-commit` hook with
+`pass_filenames: false, always_run: true`, mirroring `.pre-commit-config.yaml:206-212`. It gives
+contributors the failure locally instead of in CI. It is *additive only*. If the two ever
+disagree, the CI step is the gate. A task should carry this as explicitly optional so nobody reads
+its absence as an FR-018 miss.
+
+### 4. The exclusion mechanism
+
+**Exact repository-relative path membership, never a filename glob** (FR-009).
+
+```python
+SELF_EXCLUSIONS = frozenset({
+    Path("scripts/check_dead_suppressions.py"),
+    Path("tests/unit/scripts/test_check_dead_suppressions.py"),
+})
+```
+
+A candidate is skipped if and only if it resolves inside the repository root and its
+repository-relative path is in that set. Two files, both named, both of which genuinely must
+contain the marker strings verbatim.
+
+Do not write that as a bare `path.resolve().relative_to(repo_root())`. Under
+`DEAD_SUPPRESSION_ROOTS` the scan walks files outside the repository and `relative_to` raises
+`ValueError` on every one of them, which takes the negative test down with it. Use a containment
+test and treat "outside the repository" as "not excluded". Same for the reported path, which falls
+back to absolute. `contracts/dead-suppression-cli.md` C6 and C7 are normative here, and
+`scripts/scan-waitforresponse-race.py:418-423` is the working precedent.
+
+This is deliberately *not* the precedent's mechanism. `check-banned-terms.sh:32` uses
+`--exclude=check-banned-terms.sh`, which is a grep basename glob: any file anywhere in the tree
+called `check-banned-terms.sh` is exempt. Adversarial Review finding F6 called that out and FR-009
+now forbids it. Exact-path membership has no such hole.
+
+Deliberately not done: obfuscating the marker strings inside the checker so it never matches
+itself. That would remove the need for an exclusion, and it is the wrong trade. CLAUDE.md's SAST
+section says plainly "Do NOT rename variables to avoid detection", and a checker whose own
+patterns are assembled from fragments is unreadable to the next maintainer. Two named paths is
+cheaper and honest.
+
+### 5. The audited path set
+
+**Roots**: `src/`, `tests/`, `scripts/`. The two audited today plus the one holding the affected
+file (FR-010). The spec tree is out of range by construction, which is what makes SC-004
+satisfiable at all: this feature's `spec.md` alone holds fifteen marker occurrences, this feature's
+own directory holds thirty-two, and exactly one marker in the whole repository sits in source. The
+number in the spec tree only grows as planning, contract, and review artefacts are added, which is
+why no criterion is allowed to count it.
+
+**Extension allowlist**: `.py`, `.sh`, `.js`, `.ts`, `.tsx`, `.jsx`, `.html`, `.yml`, `.yaml`,
+`.tf`. A census of the three roots found `.py` (543), `.sh` (27), `.js` (7), `.html` (5), `.md`
+(10), `.txt` (7), `.yaml` (1), plus Dockerfiles and binaries. The allowlist covers every source
+language actually present and leaves headroom for the TypeScript that would arrive if a scanner
+were ever pointed at `frontend/`.
+
+**`.md` and `.txt` are excluded on purpose.** They are prose, and prose that describes a marker
+has to write it. Including them would recreate the F2 defect one directory down: `src/` and
+`tests/` between them hold ten markdown files, any of which could legitimately document this very
+feature. The exclusion is by extension allowlist rather than by a deny-list so that a new prose
+extension does not silently opt itself in.
+
+**Skipped regardless of extension**: `__pycache__`, `node_modules`, `.venv`, `.git`,
+`.pytest_cache`, `.hypothesis`, and anything that fails to decode as UTF-8 (read with
+`errors="replace"` rather than crashing, so one stray binary cannot take the gate down). That list
+is normative in `contracts/dead-suppression-cli.md` C3 and the two must stay identical.
+
+**Roots are overridable** via a `DEAD_SUPPRESSION_ROOTS` environment variable holding
+os.pathsep-separated paths, mirroring `SCAN_ROOT_ENV` in the waitForResponse precedent. This
+exists for one reason only, and it is the next section.
+
+### 6. Matching rule
+
+Positional, per the spec's "Marker matching is positional" assumption. A line matches when a
+marker (`lgtm[` or `codeql[`, case-insensitive) appears **after** a comment introducer on that
+same line. Introducers recognised: `#`, `//`, `<!--`, `/*`, `--`. That set covers Python, shell,
+YAML, HCL, JS/TS, and HTML, which is every language in the allowlist. `--` is carried for SQL,
+which is **not** in the allowlist (no `.sql` extension is scanned) and is the loosest introducer in
+the set: any line containing `--` before a marker matches, a `-->` arrow included. It is retained
+only so that adding `.sql` later needs no change to the rule, and it is a known false-positive
+source rather than an oversight.
+
+The consequence that matters: a marker inside a Python docstring, a URL, or a string literal does
+not match, because none of those lines carries an introducer before the marker. That is what keeps
+the checker's own *test* file honest even before the exclusion applies, since the test's markers
+live in string literals.
+
+The spec permits falling back to a whole-line match if positional proves unreliable. It should not
+be needed, and the fallback is worse: `tests/unit/scripts/test_consolidate_oauth_apply.py`-style
+files routinely carry bracketed identifiers in string literals. If the positional rule is dropped,
+that decision belongs in a spec amendment, not in an implementation shortcut.
+
+### 7. How the negative test materialises a marker without poisoning the audited set
+
+This is the trap the spec's "auditor's own test fixtures" edge case names, and it has a clean
+answer.
+
+The test writes a throwaway file carrying a real marker into pytest's `tmp_path`, then points the
+checker at `tmp_path` via `DEAD_SUPPRESSION_ROOTS` and asserts the non-zero exit and the reported
+file, line, and marker. `tmp_path` is outside the repository entirely, so:
+
+- the fixture never exists inside `src/`, `tests/`, or `scripts/`, so a default-root run never
+  sees it and FR-015 is not at risk;
+- no exclusion pattern is needed for it, so no hole is opened;
+- it is destroyed by pytest when the test ends, satisfying "the fixture must exist only for the
+  duration of the test" literally rather than by convention.
+
+**Correction, Adversarial Review #2.** An earlier draft of this section claimed the test file was
+protected twice over, by the exact-path exclusion and independently by the positional rule, on the
+grounds that its markers "live in Python string literals, not in comment position". That is false
+as stated, and the contract is what falsifies it. C5 (`contracts/dead-suppression-cli.md:120-124`)
+is a purely textual rule: a line matches when a marker appears anywhere after the **first**
+occurrence of a comment introducer on that line. It does not know what a string literal is. The
+negative test has to materialise a fixture line carrying an introducer and a marker together, and
+`quickstart.md:81` shows the natural shape of it:
+
+```python
+fixture.write_text("x = 1  # lgtm[py/some-rule]\n")   # WRONG: this source line matches C5
+```
+
+That single source line contains `#` before `lgtm[` and the checker flags it, string literal or
+not. So the second mechanism does not exist by default. It has to be built:
+
+```python
+INTRODUCER = "#"
+MARKER = "lgtm[py/some-rule]"
+fixture.write_text(f"x = 1  {INTRODUCER} {MARKER}\n")  # no source line carries both
+```
+
+The requirement, which a task must state literally: **no single source line of
+`test_check_dead_suppressions.py` may contain a comment introducer followed by a marker.** Split
+the introducer and the marker across separate expressions, as above. Do this for the `codeql[`
+case too. With that done the belt-and-braces property is real; without it the exact-path exclusion
+is the only thing holding the file, and it is one rename away from a permanently red gate.
+
+The test file must also **not** carry a marker in an actual `#` comment. A task should say so,
+because "add a comment showing what a bad line looks like" is exactly the well-meaning edit that
+turns the gate permanently red.
+
+---
+
+## The rewrite itself
+
+Current, `scripts/regenerate-mermaid-url.py:80-86`:
+
+```python
+    # Check for common Mermaid syntax errors (not HTML filtering)
+    # CodeQL py/bad-tag-filter: False positive - validates Mermaid arrow syntax, not HTML
+    if re.search(r"-->\s*$", code, re.MULTILINE):  # lgtm[py/bad-tag-filter]
+        errors.append("Arrow without target node (line ends with -->)")
+
+    if re.search(r"==>\s*$", code, re.MULTILINE):
+        errors.append("Thick arrow without target node (line ends with ==>)")
+```
+
+Target shape:
+
+```python
+    # Check for common Mermaid syntax errors (not HTML filtering)
+    # Deliberately not a regex. CodeQL's py/bad-tag-filter fires on any pattern that
+    # lexically resembles an HTML-tag filter, and no inline lgtm/codeql comment can
+    # suppress it in this repository's scanning setup. Rewriting this back into
+    # re.search reopens a high-severity alert that has already made two round trips.
+    # split("\n") and bare rstrip() are both load-bearing: splitlines() also breaks on
+    # \v \f \r \x85 U+2028 U+2029, which regex $ under MULTILINE does not.
+    if any(line.rstrip().endswith("-->") for line in code.split("\n")):
+        errors.append("Arrow without target node (line ends with -->)")
+
+    if re.search(r"==>\s*$", code, re.MULTILINE):
+        errors.append("Thick arrow without target node (line ends with ==>)")
+```
+
+Four things to hold onto:
+
+- `code.split("\n")`, never `code.splitlines()`. The spec records 0 mismatches for the former and
+  385 for the latter over an 8,057-input corpus. FR-003 first half.
+- Bare `rstrip()`, never `rstrip(" \t")`. Default trimming matches `\s` on every code point
+  checked from U+0000 to U+2FFF. FR-003 second half, and the half that is easy to lose because the
+  separator argument absorbs all the attention.
+- The `==>` line stays byte-identical. It is the control that proves the finding is lexical
+  (FR-002, SC-010), and `import re` therefore stays in the file. A task that "tidies up the now
+  unused import" breaks the build.
+- The note is FR-020 and is the only artefact in this feature addressing the third round trip.
+  A behavioural test cannot, because a regex implementation passes it identically.
+
+---
+
+## Testing plan
+
+Two new files, both under `tests/unit/scripts/`, both collected by the required `Run Tests` job.
+
+**`test_regenerate_mermaid_url.py`** (FR-001, FR-004, SC-003, SC-009). Imports the script under
+test. Note the filename is hyphenated (`regenerate-mermaid-url.py`) and therefore *not* directly
+importable, so this test loads it with `importlib.util.spec_from_file_location`. That is a real
+constraint on the task and is called out here so it is not discovered mid-implementation. Renaming
+the script to fix it is out of scope: it is referenced by path in docs and the Makefile.
+
+- A differential test rebuilding the original `re.search(r"-->\s*$", code, re.MULTILINE)` as a
+  local oracle and asserting agreement over at least 1,500 inputs. The corpus is generated in the
+  test, not committed as a fixture: exhaustive products over an atom set containing `-->`, `==>`,
+  `<!--`, space, tab, `\r`, `\n`, `\v`, `\f`, `\x85`, U+2028, U+2029, and a non-breaking space,
+  plus seeded random strings, plus the hand-chosen cases from Edge Cases. Fixed seed, so a failure
+  is reproducible.
+- Named regression tests for each Edge Case bullet: trailing whitespace after an arrow, CRLF
+  endings, empty input, whitespace-only input, trailing blank lines, arrow with a target, arrow
+  with a target on one line and a bare arrow on a later line.
+- A guard asserting the thick-arrow branch still fires, so SC-010's control is exercised and not
+  merely eyeballed.
+
+**`test_check_dead_suppressions.py`** (FR-008, FR-009, FR-014, SC-006). Imports
+`scripts.check_dead_suppressions` directly.
+
+- The negative test described above, via `tmp_path` plus `DEAD_SUPPRESSION_ROOTS`, for both
+  `lgtm[` and `codeql[` (US3 scenarios 1 and 2).
+- Output assertions: the failure names the file, the line number, the marker, why the form is
+  inert, and the supported alternative (FR-014). Assert on substrings, not on exact formatting.
+- A positional-rule test: a marker in a string literal and a marker in a URL do not fire; the same
+  marker after `#` does.
+- A self-exclusion test asserting the checker's own path and its own test path are in
+  `SELF_EXCLUSIONS`, and that a *different* file with the same basename in `tmp_path` is still
+  flagged. That second assertion is the whole point of FR-009 and the one that would have caught
+  the precedent's basename hole.
+- A zero-files-scanned test asserting exit code 2, not 0. If a root is ever moved or renamed,
+  "scanned nothing" must not read as "found nothing".
+- A clean-tree test running the checker against the real default roots and asserting exit 0
+  (SC-005, FR-015). This one is a canary: it goes red the day somebody adds a marker, which is the
+  behaviour being bought.
+- One subprocess test invoking the checker as a CLI to pin the exit-code contract. Use
+  `sys.executable`, not a bare `python3`. A bare `python3` resolves differently per machine and per
+  shell: on the reference machine `/usr/bin/python3` is 3.12.3 while `python3` reaches 3.13.0
+  through a pyenv shim, and CLAUDE.md records 3.10 as the Ubuntu system interpreter.
+  `scripts/scan-waitforresponse-race.py:72-74` documents the same spread. The test must pin the
+  interpreter it is running under rather than gamble on `PATH`. CI is unaffected either way,
+  because `setup-python` puts 3.13 on `PATH` there.
+
+---
+
+## Verification and the merge boundary
+
+The spec is unusually clear that half of this cannot be verified before merge, and the plan
+inherits that shape.
+
+**Before merge**, everything except the alert. `make audit-pragma` exits zero. `pytest
+tests/unit/scripts/` passes. The `Lint` job runs the new step and passes. A scratch commit adding
+a marker to a source file turns `Lint` red, which is SC-011 measured by observation rather than by
+reading the recipe. Note that the scratch commit also turns `Run Tests` red, through the clean-tree
+canary in the Testing plan. Two red contexts is the expected result, not a second defect.
+
+### Re-verification immediately before merge (FR-015)
+
+FR-015 does not stop at "the audit exits zero against the post-change tree". It requires that
+cleanliness to be **re-verified against the exact tree being merged, immediately before the
+blocking behaviour lands**, and explicitly forbids inferring it from a measurement taken during
+planning. The planning measurement is `research.md` R-0a, taken 2026-07-30. It is not evidence
+about the merge commit.
+
+This is not ceremony. This worktree is shared with concurrent work, `scripts/` has never been
+inside the RUF100 path set before, and a single `# noqa` arriving there between planning and merge
+converts FR-011 into a day-one failure for everybody who runs the target. The same exposure applies
+to the checker's own source, which lands in `scripts/` for the first time in this feature and is
+linted under the full configured ruleset by the widened line (see Constraints).
+
+Run on the merge commit, after the final rebase, before the target's blocking line is left in:
+
+```bash
+source .venv/bin/activate
+ruff check --extend-select RUF100 src/ tests/ scripts/   # expect "All checks passed!", exit 0
+grep -rnE "lgtm\[|codeql\[" src/ tests/ scripts/         # expect only the two auditor files
+make audit-pragma; echo "exit=$?"                        # expect exit=0
+```
+
+Scope note, so the exposure is not overstated. This reaches `make audit-pragma` only. The `Lint`
+job runs `ruff check src/ tests/` (`.github/workflows/pr-checks.yml:61-62`) and never sees
+`scripts/`, so a stray `# noqa` there cannot redden a required check. It can only redden the local
+target, which is precisely the "gate that blocks contributors on introduction" FR-015 names.
+
+`research.md`'s "Open items carried forward" item 2 belongs to the same boundary: re-confirm the
+required contexts with the R-0d command before merging the CI step. The precedent's own comment at
+`.pre-commit-config.yaml:214-229` says plainly not to trust that list without re-checking.
+`quickstart.md` section 4 carries the operator-facing form of both.
+
+**After merge**, the alert. Per FR-016 and FR-022, evidence comes from the branch-level analysis,
+never from a green pull request check, because pull request analysis is diff-informed.
+
+```bash
+# --paginate is MANDATORY. The default page size is 30 and the all-states alert corpus on this
+# repository is 137, so an unpaginated read truncates, and truncation renders as CLEAN. Measured
+# 2026-07-30: the unpaginated form with a client-side `select(.state == "open")` returns ZERO
+# open alerts while the paginated form returns FIVE (144, 147, 148, 149, 150). That unpaginated
+# form is step 1 of the mandatory pre-push checklist in CLAUDE.md, and it has been printing a
+# clean bill of health over five open alerts, one of which is alert 147. Carded at campaign level.
+#
+# --slurp cannot be combined with --jq, so the pages are written out and filtered separately.
+# That is not a workaround, it is the point: it makes gh's exit status readable instead of
+# hiding it downstream of a pipe, which is the same defect class this feature exists to remove.
+gh api --paginate --slurp \
+  "repos/traylorre/sentiment-analyzer-gsk/code-scanning/alerts?ref=refs/heads/main&state=open&per_page=100" \
+  > /tmp/alerts-open.json
+echo "gh_exit=$?"
+jq 'add | {count: length, alerts: map({n:.number, rule:.rule.id, path:.most_recent_instance.location.path})}' \
+  /tmp/alerts-open.json
+echo "jq_exit=$?"
+
+# Corpus floor. The pass condition below is an EMPTY result, so the read must independently prove
+# it reached the API and saw the whole corpus. Without this, a failed or truncated read is
+# indistinguishable from a clean repository.
+gh api --paginate --slurp \
+  "repos/traylorre/sentiment-analyzer-gsk/code-scanning/alerts?ref=refs/heads/main&per_page=100" \
+  > /tmp/alerts-all.json
+echo "gh_exit=$?"
+jq 'add | length' /tmp/alerts-all.json
+```
+
+Key the result on **path plus rule id**, never on the number. CodeQL demonstrably closes an alert
+and opens a fresh number at the same site, so `147` is not a stable identifier and a check written
+against it can report success while the finding is still there under a new number. The pass
+condition is: both `gh_exit=0`, the corpus floor at or above 137, no open alert with rule
+`py/bad-tag-filter` at path `scripts/regenerate-mermaid-url.py`, and the total open count down by
+exactly one (SC-002). A corpus floor of `0`, or a non-zero `gh_exit`, means the read failed and
+proves nothing about the alert.
+
+If the alert is still open after merge, the response is a follow-up change to the same line, not a
+revert (FR-022). The rewrite is behaviour-preserving by FR-001, so reverting restores a pattern and
+buys nothing.
+
+No scanning result is a required check here, so none of this holds a merge. That is a stated
+property of the repository, not a gap in the plan.
+
+---
+
+## Artifacts deliberately skipped
+
+**`data-model.md` is not produced.** The spec's "Key Entities" section lists Alert 147, the inline
+suppression marker, the audit path set, and the audit check. None of those is a data structure this
+feature designs, persists, or serialises. Alert 147 is a record in a third-party system this
+feature only reads. The marker is a substring. The path set is a tuple of directory names, already
+pinned above. The audit check is a shell line. Writing a data model for them would produce a page
+restating the plan in table form, which is padding, and the task brief asked for it to be named
+rather than manufactured.
+
+**`contracts/` is produced, with one file, against the brief's default.** The brief said no API
+contracts, and there is no API. But the checker has two independent consumers, the Makefile recipe
+and the CI `Lint` step, and its invocation, exit codes, and root-override variable are a real
+interface between them. This repository has already been burned by exactly that gap: the
+waitForResponse detector needed
+`specs/002-waitforresponse-lint-guard/contracts/detector-cli.md` written for the same reason, and
+that document records four requirements that turned out to contradict the owning spec. A CLI
+contract here is the same object, not an API contract, and it is one page.
+
+**`quickstart.md` is produced** and is short. It is the runbook for the post-merge verification,
+which happens on a different day from the implementation and possibly by a different person.
+
+**The agent-context update script is not run.** `.specify/scripts/bash/update-agent-context.sh`
+writes to `CLAUDE.md` at the repository root, which is outside this task's write scope
+(`specs/001-bad-tag-filter-dead-suppression/` only) and is shared with three sibling agents in the
+same worktree. There is also nothing to add: this feature introduces no technology. Python 3.13 is
+already listed many times over, and the checker imports only the standard library.
+
+---
+
+## Adversarial Review #2
+
+Reviewer did not author the spec or the plan. This is not a re-run of Adversarial Review #1, which
+gated at 0 CRITICAL / 0 HIGH on `spec.md` alone. The subject here is **drift**: Stage 4 clarify
+writes answers into `spec.md` and revisits nothing else, so `plan.md`, `research.md`,
+`contracts/`, and `quickstart.md` were checked against the five clarification answers and against
+each other. Every claim below was reproduced with a command before being written down. Line
+references were taken with `grep -n` on 2026-07-30, before the fixes in this section were applied.
+
+### Findings
+
+| Sev | ID | Finding | Resolution |
+|---|---|---|---|
+| HIGH | D1 | **FR-015 drift.** Clarify Q2 turned "re-check the widened path set before it becomes blocking" from a `research.md` planning note into an FR, and wrote the operator step into `quickstart.md:97-100`. `plan.md` was never revisited. Worse, `plan.md:163` already pointed forward at "the re-verification section below" and no such section existed: verified against the file's complete heading list. The plan therefore promised a step it did not contain, and tasks are cut from the plan. | FIXED. New "Re-verification immediately before merge (FR-015)" subsection under Verification and the merge boundary, with the three commands, the shared-worktree reason, the scope note that the exposure is `make audit-pragma` only, and the R-0d re-confirmation. `plan.md`'s §2 bullet repointed at it. |
+| HIGH | D2 | **Q4 drift, plus an implementability collision nobody caught.** Clarify Q4 relaxed contract C1 to a **3.9 floor** and forbade version-gated syntax (`contracts/dead-suppression-cli.md:30,38-46`). `plan.md:25` still declared "Python 3.13" and `research.md:132` still read "**Decision**: ... Python 3.13, standard library only", contradicting a normative contract clause. The collision underneath is the real finding: `pyproject.toml` sets `target-version = "py313"` and selects `UP`, and §2 widens `ruff check --extend-select RUF100` to `scripts/` on a **blocking** line, with `--extend-select` adding to the configured selection rather than replacing it. Reproduced against the pinned ruff 0.15.14: 3.9-shaped source trips UP035, UP006, UP045, and UP036. A checker written to C1's floor reddens the blocking line on day one, which is the exact failure FR-015 exists to prevent. No artifact recorded the reconciliation. | FIXED. `plan.md` Technical Context rewritten to name the 3.9 floor as the checker's exception, plus a new "Reconciling the 3.9 floor with ruff" block under Constraints giving the four rules that satisfy both (`from __future__ import annotations`; PEP 604 in annotations only; no `sys.version_info` guard; checker and its test must be ruff-clean under the full configured set before the widened line is left blocking). `research.md` D-2 decision line corrected. |
+| HIGH | D3 | **A load-bearing claim, falsified against the contract.** `plan.md:314-317` and `research.md:309-313` asserted the negative test is protected twice over, by the exact-path exclusion and independently by the positional rule, because its markers "live in Python string literals, not in comment position". C5 (`contracts/dead-suppression-cli.md:120-124`) is a purely textual rule and does not know what a string literal is: a line matches when a marker appears after the first comment introducer on it. The negative test must materialise a fixture line carrying both, and `quickstart.md:81` shows the natural shape, `printf 'x = 1  # lgtm[py/some-rule]\n'`. Written as one source line, that line matches. The second mechanism did not exist. Same shape as the AR#1 F5 finding: a confident claim drawn from cases that could only confirm it. | FIXED. `plan.md` §7 now carries the correction, the wrong and right forms side by side, and a literal requirement a task can copy: no single source line of the test file may contain a comment introducer followed by a marker, for `lgtm[` or `codeql[`. `research.md` D-7 corrected to match. |
+| HIGH | D4 | **`spec.md` keys its primary outcome on an unstable identifier, and the plan forbids exactly that.** SC-001 read "Alert 147 reports a state other than open", and Key Entities calls that state "the feature's primary outcome measure". `plan.md:441-443` and `quickstart.md:168-170` both say the opposite in terms: "Key the result on path plus rule id, never on the number ... a check written against `147` can report success while the finding is still there under a new number." Remediation demonstrably closes a number and opens a fresh one at the rewritten line. SC-002 and `quickstart.md`'s pass condition 1 give defence in depth, but the criterion the spec calls primary was keyed the one way the plan bans. | FIXED. SC-001 rekeyed onto rule plus path, with the number demoted to a locating label and the reason stated. US1's Independent Test rekeyed to match. US1 scenario 1 and Key Entities still name 147; left alone deliberately, as narrative identification rather than measurement. |
+| MEDIUM | D5 | **Stale census.** `plan.md:262` gave `.py` (563) for the three roots. Measured: 543 (`src` 135, `tests` 393, `scripts` 15), which is what `research.md:212-214` records and what makes the 583 allowlisted total in `plan.md:31` and `contracts/dead-suppression-cli.md:184` arithmetically correct (543+27+7+5+1). The 563 was the only outlier. | FIXED, single line. |
+| MEDIUM | D6 | **Phase 1 self-invalidation.** `research.md:56` read "Tree-wide the only other file holding markers is this feature's own `spec.md`". True when written, false the moment `plan.md`, the contract, and `quickstart.md` were produced. Measured across the feature directory: 32 occurrences at review start, in five files. This is FR-021's own thesis demonstrating itself inside the artifact that argues for it. | FIXED, one paragraph, with the per-file breakdown and a note that the number only grows. |
+| MEDIUM | D7 | **Q1 drift.** Clarify Q1 recorded the scope growth into a required status check as an owner-rejectable decision and put the fallout in `spec.md:22`. `plan.md` §3 presented the CI step as settled and carried none of it. Tasks are cut from the plan, so a rejection would have had no plan-level landing point, and the campaign constraint is that the growth is neither silently expanded nor silently retracted. | FIXED. `plan.md` §3 now opens with the accept/reject fallout, names exactly what falls (FR-018, FR-019, SC-011, SC-012, US3 scenarios beyond the fifth, this section and its task), states that sections 1, 2, and 4 through 7 are unaffected, and forbids widening the CI footprint beyond the single step. |
+| MEDIUM | D8 | **Inaccurate isolation claim.** `plan.md:28` says the new tests are "No AWS, no moto, no network" and `plan.md:102` lists `tests/unit/scripts/conftest.py` as "Existing, untouched". That conftest imports `boto3` and `moto` at module level (`tests/unit/scripts/conftest.py:12-16`), and pytest imports a directory's conftest for every test collected in it. Both new files therefore pull moto in at collection. Not a breakage: `requirements-ci.txt:50` pins `moto[all]==5.2.2` and the `Run Tests` job installs it. But the Constitution Check row at `plan.md:57` rests on a claim that is inaccurate as written, and the tests are not runnable in a bare stdlib environment. | RECORDED, not fixed. Needs a wording call rather than a one-line correction, and no gate result changes. |
+| LOW | D9 | `plan.md:287` claimed the introducer set covers "Python, shell, YAML, HCL, JS/TS, HTML, and SQL, which is every language in the allowlist". `.sql` is not in the allowlist (`contracts/dead-suppression-cli.md:85`). `--` is the loosest introducer in the set and matches any line with `--` before a marker, a `-->` arrow included. | FIXED, single edit: SQL dropped from the coverage claim, `--` retained with its false-positive cost stated. |
+| LOW | D10 | Four artifacts cite four different line ranges for the same `.pre-commit-config.yaml` comment block: `spec.md:238` says 214-225, `spec.md:259` says 214-229, `plan.md:211` says 220-228, `research.md:287` says 214-228. Measured, the block spans 214-229. All four land inside it, so nothing is misdirected. | RECORDED, not fixed. Four edits across three files for zero behavioural gain. |
+| LOW | D11 | `quickstart.md:126-134` tells the verifier to push a scratch marker commit and "confirm `Lint` reports failure". It also turns `Run Tests` red, through the clean-tree canary the plan mandates in the Testing plan. A verifier seeing two red contexts should not go hunting for a second defect. | FIXED opportunistically, one sentence in `plan.md`'s "Before merge" paragraph. `quickstart.md` left alone. |
+
+Counts: 0 CRITICAL, 4 HIGH, 4 MEDIUM, 3 LOW. All four HIGH fixed by direct edit. D5, D6, D9, and
+D11 were single-line or single-paragraph and were fixed opportunistically. D8 and D10 are recorded
+unfixed.
+
+### Verification performed
+
+| Claim under test | Method | Result |
+|---|---|---|
+| `plan.md` contains a re-verification section | Full heading extraction, `grep -n "^#\+ "` | Absent. 17 headings, none of them it. `plan.md:163` pointed at nothing |
+| Contract C1's 3.9 floor is reachable under the repo's ruff config | Wrote a 3.9-shaped file, ran the pinned ruff 0.15.14 with `--select UP,F --target-version py313` | 4 errors: UP035, UP006, UP045, UP036. Floor reachable only via `from __future__ import annotations` |
+| `--extend-select` adds to the configured selection | `pyproject.toml` `[tool.ruff.lint] select` read directly | `E W F I B C4 UP S RUF100`. The widened blocking line lints the new checker under all of it |
+| The precedent needed a UP036 suppression for a version guard | `scripts/scan-waitforresponse-race.py:70-81` | `# noqa: UP036` present, with the same reasoning in a comment |
+| C5 fires on an introducer inside a string literal | Read C5 against the `quickstart.md:81` fixture line | Matches. `#` precedes `lgtm[` on that line; the rule is textual |
+| `.py` census across the three roots | `find src tests scripts -name '*.py' -not -path '*/__pycache__/*' \| wc -l` | 543, not 563 |
+| Allowlisted-file total | `find` over the ten allowlisted extensions | 583. Confirms `plan.md:31` and contract C7 |
+| Marker population, audited roots | `grep -rnE "lgtm\[\|codeql\[" src/ tests/ scripts/` | Exactly one, `scripts/regenerate-mermaid-url.py:82`. SC-004 holds |
+| Marker population, feature directory | Per-file count across the five artifacts | 32: spec 15, contract 8, plan 6, quickstart 2, research 1 |
+| `Makefile` audit-pragma line range | `sed -n '82,95p' Makefile` | 85-92. `plan.md:105` correct |
+| `make validate` prerequisites | `Makefile:42` | Seven, `audit-pragma` absent. Confirmed |
+| Required contexts asserted in-repo | `.pre-commit-config.yaml:214-229` | `["Secrets Scan","Lint","Run Tests","Playwright E2E Tests"]`, with "do not trust that list" |
+| `Lint` job installs | `.github/workflows/pr-checks.yml:52-55` | `ruff==0.15.14` only. FR-019 satisfiable |
+| waitForResponse guard placement | `.github/workflows/pr-checks.yml:67-87` | Comment 67-84, step 85-87. `plan.md` §3 correct |
+| `Lint` job's ruff scope | `.github/workflows/pr-checks.yml:61-62` | `ruff check src/ tests/`. `scripts/` never linted by a required check |
+| `Run Tests` can collect the new tests | `pyproject.toml` `testpaths`, `pr-checks.yml:119-127`, `requirements-ci.txt` | `testpaths = ["tests"]`, no ignore covering `tests/unit/scripts/`, moto and boto3 present |
+| Coverage gate reaches `scripts/` | `[tool.coverage.run] source` | `["src"]`. The new checker is not measured, `--fail-under=80` unaffected |
+| The import precedent works as claimed | `tests/unit/scripts/test_consolidate_oauth_apply.py:13`, absence of `scripts/__init__.py` | `import scripts.consolidate_oauth_duplicates as mod`, PEP 420. `plan.md` §1 correct |
+| `split("\n")` appears everywhere the rewrite is specified | Read all five artifacts | Consistent. No `splitlines()` recommended anywhere; it appears only as the rejected form |
+| Differential corpus floor stated at >= 1,500 | spec SC-003, `plan.md` Testing plan, `quickstart.md:27` | Present in all three |
+| Subprocess test pins `sys.executable` | `plan.md` Testing plan, final bullet | Present, with the corrected per-machine reason |
+| Banned terms in the feature directory | Case-insensitive scan for all seven | Clean |
+| `plan.md` line 21 is a real value | `sed -n '21p'` | Prose, no template placeholder |
+
+### Gate
+
+**GATE: 0 CRITICAL, 0 HIGH remaining.**

--- a/specs/001-bad-tag-filter-dead-suppression/quickstart.md
+++ b/specs/001-bad-tag-filter-dead-suppression/quickstart.md
@@ -1,0 +1,214 @@
+# Quickstart: verifying this feature
+
+**Feature**: `001-bad-tag-filter-dead-suppression`
+
+Half of this feature can be verified before merge and half cannot. The split is a stated property
+of the repository, not a gap. Sections 1 through 4 run locally today. Section 5 runs only after the
+change is on `main`, possibly on a different day and by a different person, which is why it is
+written down here rather than left in somebody's head.
+
+Activate the virtual environment first. A bare `python3` resolves differently per machine, so do
+not assume the shell's interpreter is the project's.
+
+```bash
+cd /home/zeebo/projects/sentiment-analyzer-gsk
+source .venv/bin/activate
+python --version   # expect 3.13.x
+```
+
+---
+
+## 1. The rewrite preserved behaviour (FR-001, SC-003, SC-009)
+
+```bash
+pytest tests/unit/scripts/test_regenerate_mermaid_url.py -v
+```
+
+Expect all green, including the differential test over at least 1,500 inputs reporting zero
+mismatches against the original expression.
+
+If the differential test fails, read which input diverged before touching anything. The two known
+traps both show up as a specific class of input:
+
+- divergence on `\v`, `\f`, `\r`, `\x85`, U+2028, or U+2029 means somebody used `splitlines()`
+  instead of `split("\n")`;
+- divergence on a non-breaking space or a vertical tab immediately after an arrow means somebody
+  used `rstrip(" \t")` instead of a bare `rstrip()`.
+
+## 2. The dead suppression is gone (FR-005, FR-006, SC-004)
+
+```bash
+grep -rnE "lgtm\[|codeql\[" src/ tests/ scripts/
+```
+
+Expect matches only inside `scripts/check_dead_suppressions.py` and
+`tests/unit/scripts/test_check_dead_suppressions.py`. Before this feature the same command
+returned one match, in `scripts/regenerate-mermaid-url.py`.
+
+Do not run this tree-wide. `specs/001-bad-tag-filter-dead-suppression/spec.md` alone holds fifteen
+markers, because describing a marker requires writing it.
+
+Confirm the control was not disturbed (SC-010):
+
+```bash
+git diff main -- scripts/regenerate-mermaid-url.py | grep -- "==>"
+```
+
+Expect no output. The thick-arrow line must be byte-identical.
+
+## 3. The checker works (FR-008, FR-014, FR-015, SC-005, SC-006)
+
+Clean run against the real tree:
+
+```bash
+python3 scripts/check_dead_suppressions.py; echo "exit=$?"
+```
+
+Expect `exit=0` and a non-zero file count in the output. An `exit=2` means zero files were
+scanned, which is a broken root rather than a clean tree.
+
+Its own test suite, including the negative test:
+
+```bash
+pytest tests/unit/scripts/test_check_dead_suppressions.py -v
+```
+
+Manual smoke test of the failure path, if you want to see the message a contributor will get. Note
+the fixture goes outside the repository, never inside an audited root:
+
+```bash
+mkdir -p /tmp/dsfix
+printf 'x = 1  # lgtm[py/some-rule]\n' > /tmp/dsfix/bad.py
+DEAD_SUPPRESSION_ROOTS=/tmp/dsfix python3 scripts/check_dead_suppressions.py; echo "exit=$?"
+rm -rf /tmp/dsfix
+```
+
+Expect `exit=1`, and output naming `bad.py`, line 1, the marker, why the form is inert, and the
+dismissal workflow as the supported alternative.
+
+## 4. The audit target (FR-011, FR-012, FR-013, SC-007, SC-008)
+
+```bash
+make audit-pragma; echo "exit=$?"
+```
+
+Expect `exit=0`. Three labelled sections in the output, two `[BLOCKING]` and one `[ADVISORY]`.
+
+Run this again on the exact tree being merged, after the final rebase, not just once during
+implementation (FR-015). The widened unused-pragma path set is clean today, but this worktree is
+shared with concurrent work and one `# noqa` landing in `scripts/` in the meantime makes the target
+red for everybody on day one. The isolated form is `ruff check --extend-select RUF100 scripts/`.
+
+Two things about that output that are correct and look wrong:
+
+- The bandit wall is roughly twice as long as it used to be. Widening its path set to include
+  `scripts/` surfaced ten pre-existing findings on top of the fifteen already there. All
+  twenty-five are advisory, all predate this feature, and none is fixed by it. This is recorded in
+  the specification's assumptions.
+- `make validate` is red on `main` today through the banned-terms scanner, unrelated to this
+  feature and carded out of scope. Do not read that as a regression from this change, and do not
+  fix it here.
+
+## 5. CI actually enforces it (FR-018, SC-011, SC-012)
+
+Reading the workflow file is not evidence. SC-011 requires an observed check result.
+
+First re-confirm the required contexts, because the whole design rests on them:
+
+```bash
+gh api repos/traylorre/sentiment-analyzer-gsk/branches/main/protection \
+  --jq .required_status_checks.contexts
+echo "gh_exit=$?"
+```
+
+Expect `gh_exit=0` and `["Secrets Scan","Lint","Run Tests","Playwright E2E Tests"]`. If `Lint` is no
+longer in that list, the gate is advisory and FR-018 is unsatisfied regardless of what the workflow
+says.
+
+The exit check is not decoration. This endpoint returns a single object rather than a page, so
+`--paginate` does not apply, but the failure mode it shares with the alert queries does: a 404, an
+expired token, or a permissions change all produce **empty output**, which reads identically to
+"branch protection requires nothing". Empty must never be read as an answer here, because the answer
+it would imply is the one that invalidates FR-018's entire premise.
+
+Then, on the feature branch, prove the gate bites. Push a scratch commit adding a marker to a
+source file:
+
+```bash
+printf '\n# lgtm[py/scratch-do-not-merge]\n' >> scripts/regenerate-mermaid-url.py
+```
+
+Push it, confirm `Lint` reports failure and names the file and line, then revert the scratch commit
+before merging. Confirm `Lint` goes green again on the reverted state.
+
+SC-012 comes free from reading the job log: the new step runs immediately after the waitForResponse
+guard with no preceding install step, so it costs no setup time.
+
+---
+
+## 6. After merge: the alert (FR-016, FR-022, SC-001, SC-002)
+
+**This cannot be done before merge.** The branch-level analysis does not refresh until the change
+is on `main`, and no scanning result is a required check, so nothing holds the merge while you
+wait.
+
+**Never query the alert list without `--paginate`.** The default page size is 30 and this
+repository's all-states alert corpus is 137, so an unpaginated read truncates and **truncation
+renders as clean**. Measured 2026-07-30: the unpaginated form with a client-side
+`select(.state == "open")` returns ZERO open alerts while the paginated form returns FIVE. A
+sibling feature in this campaign is expected to raise the open count substantially on purpose, at
+which point even a server-side `state=open` filter overflows one page and this section starts
+reporting success because the read was cut short rather than because the finding is gone.
+
+Record the open-alert count **before** merging. `--slurp` cannot be combined with `--jq`, so the
+pages are written out and filtered separately, which keeps `gh`'s exit status readable instead of
+hiding it downstream of a pipe:
+
+```bash
+gh api --paginate --slurp \
+  "repos/traylorre/sentiment-analyzer-gsk/code-scanning/alerts?ref=refs/heads/main&state=open&per_page=100" \
+  > /tmp/alerts-open-before.json
+echo "gh_exit=$?"
+jq 'add | length' /tmp/alerts-open-before.json
+```
+
+After the merge lands and the `Analyze` job has run on `main`:
+
+```bash
+gh api --paginate --slurp \
+  "repos/traylorre/sentiment-analyzer-gsk/code-scanning/alerts?ref=refs/heads/main&state=open&per_page=100" \
+  > /tmp/alerts-open-after.json
+echo "gh_exit=$?"
+jq 'add | map({n: .number, rule: .rule.id, path: .most_recent_instance.location.path})' \
+  /tmp/alerts-open-after.json
+
+# Corpus floor. Pass condition 1 below is an EMPTY result, so the read must independently prove it
+# reached the API and saw the whole corpus. Run this both before and after.
+gh api --paginate --slurp \
+  "repos/traylorre/sentiment-analyzer-gsk/code-scanning/alerts?ref=refs/heads/main&per_page=100" \
+  > /tmp/alerts-all.json
+echo "gh_exit=$?"
+jq 'add | length' /tmp/alerts-all.json
+```
+
+Pass conditions, all required:
+
+0. Every `gh_exit` is `0` and the corpus floor is at least 137. A corpus of `0`, or a non-zero
+   `gh_exit`, means the read failed, and a failed read proves nothing about condition 1. Emptiness
+   is only evidence when the reader has been shown to be working.
+1. No open alert has rule `py/bad-tag-filter` at path `scripts/regenerate-mermaid-url.py`.
+2. The total open count is exactly one lower than the pre-merge count (SC-002). Exactly one, not
+   at most one: a criterion phrased as "no worse than before" is satisfied by the change achieving
+   nothing. Caveat: if a sibling feature that changes the analysis matrix merges between the two
+   measurements, the total moves for reasons unrelated to this change and condition 2 becomes
+   unmeasurable. In that case record both counts, fall back to condition 1 alone, and note why.
+
+**Key on path plus rule id, never on the alert number.** CodeQL demonstrably closes an alert and
+opens a fresh number at the same site. A check written against `147` can report success while the
+finding is still sitting there under a new number.
+
+**If the alert is still open**, the response is a follow-up change to the same line, not a revert
+(FR-022). The rewrite is behaviour-preserving by FR-001, so reverting restores a pattern and buys
+nothing. Record the query output either way. It is the evidence FR-016 asks for, and a green pull
+request check is explicitly not acceptable in its place, because pull request analysis is
+diff-informed and covers only changed lines.

--- a/specs/001-bad-tag-filter-dead-suppression/research.md
+++ b/specs/001-bad-tag-filter-dead-suppression/research.md
@@ -1,0 +1,370 @@
+# Phase 0 Research: Close py/bad-tag-filter and Kill the Dead Suppression
+
+**Feature**: `001-bad-tag-filter-dead-suppression` | **Date**: 2026-07-30
+
+The Technical Context in `plan.md` carries no NEEDS CLARIFICATION markers. That is not because the
+questions were waved through: the spec's Adversarial Review #1 resolved one CRITICAL and five HIGH
+findings by measurement, and every remaining open question was closed here by running the command
+rather than by reasoning about it. Each decision below records what was run and what came back.
+
+---
+
+## Re-verification of inherited claims
+
+The task brief supplied a set of facts and said not to re-derive them. Two of them gate whether
+this feature can land green on day one, so they were re-run rather than trusted. Both hold.
+
+### R-0a. RUF100 on the widened path set
+
+```bash
+source .venv/bin/activate
+ruff check --extend-select RUF100 scripts/          # -> "All checks passed!", exit 0
+ruff check --extend-select RUF100 src/ tests/ scripts/  # -> "All checks passed!", exit 0
+```
+
+Both clean. The second command is the one the Makefile will actually run, and it is the one that
+matters: a per-directory clean result would not rule out a cross-directory interaction. It is
+clean under the full configured rule set from `pyproject.toml`, not merely under RUF100 in
+isolation, because `--extend-select` adds to the configured selection rather than replacing it.
+
+**Conclusion**: FR-011 can be satisfied immediately. No baseline file, no allowlist, no
+grandfathering. The spec's assumption holds.
+
+### R-0b. Bandit on the widened path set
+
+```bash
+source .venv/bin/activate
+bandit -r scripts/ --ignore-nosec 2>/dev/null | grep -cE "^>>"   # -> 10
+bandit -r src/     --ignore-nosec 2>/dev/null | grep -cE "^>>"   # -> 15
+```
+
+Ten and fifteen, matching the spec's assumption exactly. Twenty-five total after widening, all
+pre-existing, all advisory, none fixed by this feature.
+
+**Conclusion**: FR-012 holds and the spec's warning about the output roughly doubling is accurate.
+Anybody reading the target's output after this lands should not read the longer wall as a
+regression.
+
+### R-0c. Marker population in the audited path set
+
+```bash
+grep -rnE "lgtm\[|codeql\[" src/ tests/ scripts/
+# -> scripts/regenerate-mermaid-url.py:82 only
+```
+
+Exactly one, which is what SC-004 says. Every other marker in the tree is inside this feature's own
+specification directory. Re-measured at the start of Adversarial Review #2: 32 occurrences across
+`spec.md` (15), `contracts/dead-suppression-cli.md` (8), `plan.md` (6), `quickstart.md` (2), and
+this file (1). Re-measured again after that review's own edits landed: 41, across the same five
+files. Two measurements four hours apart, nine apart in value, which is the point. The number only
+grows and no criterion may be written against it. The earlier wording named `spec.md` as the only
+other holder, which was true when
+this file was written and stopped being true the moment the plan and the contract were produced,
+which is itself the clearest possible demonstration of why no criterion may count tree-wide. That
+asymmetry is the entire justification for scoping the path set to source, and it is measured rather
+than asserted.
+
+### R-0d. Required status checks
+
+```bash
+gh api repos/traylorre/sentiment-analyzer-gsk/branches/main/protection \
+  --jq .required_status_checks.contexts
+# -> ["Secrets Scan","Lint","Run Tests","Playwright E2E Tests"]
+```
+
+Four contexts. Neither `Analyze` (CodeQL) nor `Pre-commit Hooks` is among them. This is the fact
+FR-018 is built on and it was re-confirmed today rather than inherited.
+
+### R-0e. What the `Lint` job installs
+
+`.github/workflows/pr-checks.yml:52-56`:
+
+```yaml
+      - name: Install linting tools
+        run: |
+          python -m pip install --upgrade pip
+          pip install ruff==0.15.14
+```
+
+Ruff and nothing else, on top of `setup-python` at 3.13. Bandit is absent. This single fact
+decides two things at once: a stdlib-only Python checker costs zero setup time there (FR-019 is
+satisfiable), and `make audit-pragma` as a whole cannot be moved there (its bandit half would die
+on a missing binary, and installing bandit is the tooling addition FR-019 forbids).
+
+---
+
+## D-1. The rewrite form
+
+**Decision**: `any(line.rstrip().endswith("-->") for line in code.split("\n"))`.
+
+**Rationale**: Two independent differential runs over an 8,057-input corpus put
+`split("\n")` at 0 mismatches against `re.search(r"-->\s*$", code, re.MULTILINE)` and
+`splitlines()` at 385. The mechanism is understood, not merely observed: `str.splitlines()` breaks
+on `\v`, `\f`, `\r`, `\x85`, U+2028, and U+2029, none of which regex `$` treats as a line boundary
+under `re.MULTILINE`. Bare `rstrip()` matches `\s` on every code point checked from U+0000 to
+U+2FFF, so the default trim is correct and a narrowed `rstrip(" \t")` is not.
+
+Worth spelling out why the two forms agree even though `\s*` can consume newlines: in
+`-->\n\n\nfoo`, the regex backtracks `\s*` down to zero characters and `$` then matches at the
+position immediately before the first `\n`. The split form sees a line that is exactly `-->` and
+matches too. Every path where `\s*` spans a newline has a shorter path where it does not, so the
+extra reach never produces a match the split form misses.
+
+**Alternatives considered**:
+
+- `code.splitlines()`. Rejected on 385 measured mismatches. This is the obvious rewrite and it is
+  wrong, which is why FR-003 exists as a requirement rather than as a code comment.
+- `rstrip(" \t")`. Rejected. Diverges on vertical tab, form feed, and non-breaking space after an
+  arrow. Same class of defect as the separator case, one level down, and much easier to miss.
+- Keep the regex and add `# codeql[py/bad-tag-filter]`. Rejected by FR-005. No inline form is
+  honoured by this repository's scanning setup, so this swaps one decorative comment for another.
+  This is precisely what the second round trip did in January.
+- Dismiss the alert through the scanning product's own workflow. Not rejected in principle, and
+  FR-007 records it as the supported route for a genuine false positive. Rejected here because the
+  rewrite is a one-line behaviour-preserving change and dismissal leaves a pattern in the code that
+  a future edit can re-flag.
+
+### Why the thick-arrow sibling is not rewritten
+
+`==>` sits on the very next line in the same identical shape and carries no alert. Leaving it
+byte-identical (FR-002, SC-010) keeps the control intact: if the analyzer's finding really is
+driven by lexical resemblance to an HTML-tag filter, the `-->` form is flagged and `==>` is not,
+which is exactly the observed state. Rewriting both would destroy the evidence for that hypothesis
+and would widen a four-line diff for no gain. It also means `import re` stays live, so no import
+cleanup is warranted.
+
+---
+
+## D-2. Language and location of the checker
+
+**Decision**: `scripts/check_dead_suppressions.py`, standard library only, written to a **3.9
+language floor** rather than to the project's 3.13. Corrected by Adversarial Review #2: an earlier
+draft of this line said "Python 3.13", which contradicts `contracts/dead-suppression-cli.md` C1.
+C1 is normative and its reason is the Makefile consumer, which runs under whatever `python3` the
+contributor's shell resolves. The floor is not free, because `pyproject.toml` sets
+`target-version = "py313"` and selects `UP`; see "Reconciling the 3.9 floor with ruff" in
+`plan.md`'s Technical Context for the constraints that follow. The `Lint` job still gets 3.13 from
+`setup-python`, which is why the checker being stdlib-only is what matters there, not its floor.
+
+**Rationale**: FR-009a requires a dedicated file. The three-way choice was bash (following
+`check-banned-terms.sh`), Python (following `scan-waitforresponse-race.py`), or an inline Makefile
+recipe.
+
+Inline is out by FR-009a: self-exclusion by path only stays narrow if the excluded file is small,
+and excluding the Makefile would exempt the one file every contributor edits.
+
+Bash is out on three counts. Exact-path exclusion (FR-009) in grep means comparing output strings,
+which is the fragile construction the precedent already got wrong. The FR-014 message needs
+structure. And the positional matching rule needs per-line logic that is awkward in a grep
+pipeline and readable in Python.
+
+Python is free in the `Lint` job (R-0e) and matches the precedent that FR-018 explicitly cites.
+
+**Alternatives considered**:
+
+- Extend `scripts/check-banned-terms.sh` with the two markers. Rejected. It would inherit that
+  script's basename-glob exclusion, which is the F6 defect, and it would couple two unrelated
+  gates so that a red banned-terms scan hides a marker finding. Also `make validate` is already
+  red through that scanner today, so anything folded into it starts life invisible.
+- A ruff or semgrep rule. Rejected under FR-019: semgrep is not installed in the `Lint` job and
+  installing it is a tooling addition. A custom ruff rule is not a thing ruff supports.
+- A `.gitignore`-style deny list consumed by an existing generic scanner. There is no such generic
+  scanner in this repository.
+
+### Underscores in the filename
+
+`scan-waitforresponse-race.py` uses hyphens; `consolidate_oauth_duplicates.py` uses underscores.
+Both live in `scripts/`. The underscore form is directly importable
+(`tests/unit/scripts/test_consolidate_oauth_apply.py:13` does exactly that, via PEP 420 implicit
+namespace packages with the repository root on `sys.path`), which makes the checker's own unit
+tests plain function calls instead of `importlib` plumbing. The CLI invocation is identical either
+way. Underscores chosen.
+
+This cuts the other way for the script under test: `regenerate-mermaid-url.py` is hyphenated and
+cannot be renamed inside this feature's scope (it is referenced by path in documentation), so its
+regression test does need `importlib.util.spec_from_file_location`. That cost is one helper
+function and is called out in the plan so it is not a surprise.
+
+---
+
+## D-3. The self-exclusion mechanism
+
+**Decision**: a frozenset of exact repository-relative `Path` objects, containing the checker and
+its test file. A candidate is skipped if and only if its resolved repository-relative path is a
+member.
+
+**Rationale**: FR-009 requires exact-path exclusion after Adversarial Review finding F6 established
+that the precedent's `--exclude=check-banned-terms.sh` is a basename glob exempting any
+identically named file anywhere in the tree. Set membership on a normalised relative path has no
+such hole, and it fails safe: a moved or renamed checker stops being excluded and immediately
+flags itself, which is a loud failure rather than a silent one.
+
+**Alternatives considered**:
+
+- Basename exclusion, matching the precedent. Rejected by FR-009 for the reason above.
+- A directory-level exclusion such as skipping all of `tests/unit/scripts/`. Rejected. That is the
+  "broad pattern exclusion" FR-009 forbids and it would hide a real suppression added to any of the
+  other test files in that directory.
+- An opt-out comment in the checker's own source, along the lines of a `# audit-exempt` line.
+  Rejected as self-defeating: this feature exists because an inline comment claiming to suppress
+  something is worthless. Reintroducing the same pattern as the fix would be an unusually direct
+  irony.
+- Constructing the marker strings by concatenation so the checker never literally contains them.
+  Rejected. CLAUDE.md's SAST guidance says not to restructure code to dodge detection, and the
+  resulting source is harder to read for a reviewer who wants to know exactly what is matched.
+
+---
+
+## D-4. The audited path set and extension allowlist
+
+**Decision**: roots `src/`, `tests/`, `scripts/`. Extensions `.py .sh .js .ts .tsx .jsx .html .yml
+.yaml .tf`. Prose extensions excluded. Roots overridable through `DEAD_SUPPRESSION_ROOTS`.
+
+**Rationale**: FR-010 fixes the roots. The extension allowlist came from a census:
+
+| Root | Extensions found |
+|---|---|
+| `src/` | 135 `.py`, 8 `.md`, 7 `.txt`, 6 `.js`, 5 `.html`, 1 `.yaml`, 3 Dockerfiles, 1 bootstrap, 1 `.ico` |
+| `tests/` | 393 `.py`, 2 `.md`, 1 `.js` |
+| `scripts/` | 27 `.sh`, 15 `.py` |
+
+The allowlist covers every source language present and adds the TypeScript extensions for headroom.
+`.md` and `.txt` are excluded because prose describing a marker has to write it, which is the F2
+defect that made the original SC-004 false at the moment it was written. There are ten markdown
+files inside the audited roots, any of which could legitimately document this feature.
+
+An allowlist rather than a deny list, so a new prose extension arriving in `src/` does not silently
+opt itself in. Binary and undecodable files are read with `errors="replace"` so one stray file
+cannot take the gate down.
+
+**Alternatives considered**:
+
+- Tree-wide scan. Rejected by FR-021 and SC-004. Unsatisfiable on the day it is written: this
+  feature's `spec.md` alone holds fifteen markers.
+- All files regardless of extension. Rejected. Pulls in `.md`, `.txt`, Dockerfiles, and an `.ico`.
+- Adding `frontend/` to the roots. Rejected as scope creep, but the `.ts`/`.tsx` entries in the
+  allowlist mean the change would be a one-line edit if somebody later wants it.
+
+---
+
+## D-5. The matching rule
+
+**Decision**: positional. A marker fires only when it appears after a comment introducer (`#`,
+`//`, `<!--`, `/*`, `--`) on the same line. Case-insensitive on the marker itself.
+
+**Rationale**: the spec's "Marker matching is positional" assumption prefers this and permits a
+whole-line fallback. Positional is achievable in a few lines and its payoff is concrete: markers in
+docstrings, URLs, and string literals do not fire, which is what keeps the checker's own test file
+clean independently of the exclusion. The introducer set covers every language in the allowlist.
+
+**Alternatives considered**:
+
+- Whole-line substring match. Permitted by the spec as a fallback and rejected here because it is
+  not needed. Test files in this repository routinely carry bracketed identifiers inside string
+  literals, so the noise is real rather than theoretical. If positional matching is ever abandoned,
+  that belongs in a spec amendment, not in an implementation shortcut.
+- Full per-language comment parsing, tracking multi-line strings and block comments. Rejected as
+  disproportionate. The current match count in the audited set is one. A false negative from a
+  marker hidden inside a block comment is an acceptable risk for a check whose job is to catch the
+  well-meaning contributor who typed a suppression they believed would work, not to defeat an
+  adversary.
+
+---
+
+## D-6. Where the gate is wired
+
+**Decision**: a dedicated step in the `Lint` job of `.github/workflows/pr-checks.yml`, invoking the
+checker directly. Optionally, additionally, a `pre-commit` hook.
+
+**Rationale**: FR-018 requires a merge-blocking context, and R-0d shows there are exactly four.
+`Lint` is the only one of the four where a text scan belongs. `Run Tests` would work mechanically
+but buries a lint concern in pytest; `Secrets Scan` is Gitleaks; `Playwright E2E Tests` is the
+customer dashboard suite.
+
+The precedent is followed deliberately and completely, including the explanatory comment. The
+waitForResponse guard sits in `Lint` at lines 69-87 with a comment stating that moving it to
+`Pre-commit Hooks` would silently downgrade it to advisory. That comment exists because the
+downgrade has no symptom until a violation merges green, which is the same failure mode as the
+comment this feature is deleting. Repeating the note is cheap insurance against a future tidy-up.
+
+`if: always()` matters here for a reason that is easy to miss: steps are fail-fast, this step is
+last, and without it any ruff failure means the guard silently does not run. The job still goes
+red either way, so the flag costs nothing and buys both failures being visible in one run.
+
+**Alternatives considered**:
+
+- Invoke `make audit-pragma` from the `Lint` job. Rejected on R-0e: bandit is not installed there
+  and installing it violates FR-019. Also drags in a 25-finding advisory wall on every PR.
+- Add `audit-pragma` to `make validate`'s prerequisites. Rejected, and carded in the spec's Out of
+  Scope. `make validate` is already red on `main` through the banned-terms scanner, so a gate added
+  there starts life invisible, which is the exact failure being fixed.
+- Pre-commit hook only. Rejected by FR-018. `Pre-commit Hooks` is not a required context, verified
+  at R-0d, and `.pre-commit-config.yaml:214-228` already documents that in a comment.
+- A new dedicated CI job. Rejected. A new job is a new context, and a context that is not in the
+  required list is advisory. Adding it to the required list is a branch protection change, which
+  the spec cards as out of scope.
+
+---
+
+## D-7. The negative test without a persistent fixture
+
+**Decision**: write the marker-carrying fixture into pytest's `tmp_path` and point the checker at
+it through `DEAD_SUPPRESSION_ROOTS`.
+
+**Rationale**: the spec's "auditor's own test fixtures" edge case sets two constraints that look
+contradictory. The fixture must be real enough to prove the check fires, and it must not persist
+inside the audited set nor be exempted by a broad pattern. `tmp_path` satisfies both by putting the
+fixture outside the repository entirely: a default-root run never sees it, no exclusion is needed,
+and pytest destroys it at test end, so "exists only for the duration of the test" is literally
+true rather than a convention somebody has to remember.
+
+The root override variable exists for this and only this. It mirrors `SCAN_ROOT_ENV` in the
+waitForResponse precedent, which was introduced for the same testing reason.
+
+One rule for the test file that a task should state explicitly, **corrected by Adversarial Review
+#2**: no single source line may contain a comment introducer followed by a marker. The earlier
+wording ("its marker strings live in Python string literals, never in a `#` comment") was too weak,
+and the reasoning attached to it was wrong. The D-5 positional rule is textual and does not know
+what a string literal is, so the obvious fixture line
+`fixture.write_text("x = 1  # lgtm[py/some-rule]\n")` has `#` before the marker and **does** fire.
+The introducer and the marker must be assembled from separate expressions, and only then is the
+positional rule a second mechanism independent of the exact-path exclusion. `plan.md` §7 carries
+the worked form. The well-meaning edit that adds "here is what a bad line looks like" as a real
+comment is still the one that turns the gate permanently red.
+
+**Alternatives considered**:
+
+- A committed fixture under `tests/fixtures/`. Rejected. `tests/` is an audited root, so the
+  fixture would fail the audit permanently unless excluded, and excluding it opens a hole.
+- A fixture written into the repository and deleted in a teardown. Rejected. A crashed or
+  interrupted test leaves a marker in the tree and the gate red for everyone.
+- Feeding the checker a string rather than a file. Rejected as insufficient: SC-006 requires the
+  output to name the file and the line, which only a real filesystem walk exercises.
+
+---
+
+## D-8. Exit codes and the zero-files case
+
+**Decision**: 0 clean, 1 marker found, 2 zero files scanned.
+
+**Rationale**: taken directly from the waitForResponse precedent, whose contract records the
+reasoning: "No violations found" and "no files found" must not share an exit code, or moving the
+scan root reads as a clean tree. That failure is not hypothetical for this checker, whose roots are
+three hard-coded directory names that a future repository reorganisation could move.
+
+Full detail in `contracts/dead-suppression-cli.md`.
+
+---
+
+## Open items carried forward
+
+Nothing blocks implementation. Two things are worth a task-time re-check rather than a plan-time
+assumption:
+
+1. **Re-run R-0a immediately before making the RUF100 line blocking on the widened set.** It is
+   clean today. A sibling agent working in this shared worktree could land a `# noqa` in `scripts/`
+   between now and then, and FR-015 turns that into a day-one failure. Cheap to re-run, expensive
+   to discover in CI.
+2. **Re-confirm the required contexts before merging the CI step.** The plan's comment block
+   asserts them and the precedent's comment says plainly not to trust the list without re-checking.
+   Same command as R-0d.

--- a/specs/001-bad-tag-filter-dead-suppression/spec.md
+++ b/specs/001-bad-tag-filter-dead-suppression/spec.md
@@ -1,0 +1,268 @@
+# Feature Specification: Close py/bad-tag-filter and Kill the Dead Suppression
+
+**Feature Branch**: `001-bad-tag-filter-dead-suppression`
+**Created**: 2026-07-30
+**Status**: Draft
+**Input**: User description: "Close CodeQL alert 147 (py/bad-tag-filter), delete dead lgtm suppression, extend make audit-pragma"
+
+## Overview
+
+CodeQL alert 147 (`py/bad-tag-filter`, severity high) has been open on `refs/heads/main` since 2026-01-31 against `scripts/regenerate-mermaid-url.py:82`. The flagged line validates Mermaid diagram arrow syntax. It carries a `# lgtm[py/bad-tag-filter]` comment that does nothing at all: the alert is open on the exact line carrying the comment.
+
+This feature does three things. It rewrites the flagged expression so the analyzer has no pattern to complain about, it deletes the decorative comment rather than swapping in another inert form, and it adds a check so a suppression that suppresses nothing is caught the next time somebody writes one.
+
+The third part carries the real design risk and gets the most attention here. The first is a one-line change whose only difficulty is proving behaviour did not shift.
+
+Two facts about this repository shape the whole design and are stated up front because every requirement below depends on them.
+
+**No scanning result blocks a merge here.** The branch protection required checks are exactly four, and none of them is the code scanning analysis. A high-severity alert can sit open on the default branch indefinitely without any check going red, which is precisely how alert 147 survived six months. Closing the alert is therefore an informational outcome, valuable for review honesty, but it carries no enforcement. Only a check that runs inside one of the four required contexts can actually stop the next dead suppression from landing. FR-018 exists because of this.
+
+**The pragma audit target is not currently wired to anything.** It is not a prerequisite of the aggregate validation target, it appears in no continuous integration workflow, and it appears in no commit hook. It runs only when a person types it. Separately, its security-linter portion pipes output into a filter and therefore reports success whether or not findings exist; it exits zero today with fifteen findings outstanding. Adding a new check to that target without addressing either fact would replace a decorative comment with a decorative gate, which is the same defect this feature exists to remove. FR-018 and FR-013 address this directly.
+
+**Scope decision for the reviewer: this feature edits a required status check.** The original request was to rewrite one expression, delete a dead comment, and extend the pragma audit target. FR-018 grows that into adding a step to the `Lint` job, which is one of the four contexts branch protection requires on `main`. The growth follows from the fact above rather than from ambition: the pragma audit target is invoked by nothing, so a check placed only there enforces nothing, and FR-008 through FR-015 would all be satisfiable by an object with the same enforcement power as the comment being deleted. It is stated here so a reviewer accepts or rejects it deliberately instead of meeting it in a diff. If it is rejected, FR-018, FR-019, SC-011, and SC-012 fall with it, US3 reduces to its first five scenarios, and the feature keeps only its informational outcomes. That trade belongs to the reviewer, not to the implementer.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Security reviewer sees a genuinely clean alert list (Priority: P1)
+
+A reviewer opens the repository code scanning list to judge whether the codebase is clean. Today alert 147 sits there at high severity with a suppression comment next to it, so the reviewer cannot tell whether it is handled, ignored, or forgotten. After this change the alert is closed at the branch level and the list reflects reality.
+
+**Why this priority**: This is the reason the work exists. A high-severity alert that has been open for six months is either a real finding or noise that is training people to ignore the list. Both outcomes are bad, and only closing it resolves the ambiguity. Note that no merge is gated on this outcome, so the value is review honesty rather than enforcement.
+
+**Independent Test**: Query the alert state directly from the alert-state API against the branch analysis and confirm no open alert carries the `py/bad-tag-filter` rule at the diagram script's path. Key on path plus rule, not on the number 147, per SC-001. This is verifiable without touching any other part of the feature. The branch analysis only refreshes after the change is on the default branch, so this test is necessarily performed after merge, not before it. See FR-022.
+
+**Acceptance Scenarios**:
+
+1. **Given** an open `py/bad-tag-filter` alert against `scripts/regenerate-mermaid-url.py:82` (numbered 147 today), **When** the arrow check is rewritten without a regular expression literal, **Then** the branch analysis for `refs/heads/main` reports **no open alert whose rule is `py/bad-tag-filter` at that path**. Keyed on path plus rule identifier, never on the number, for the reason recorded in SC-001: remediation demonstrably closes a number and opens a fresh one at the same site, so a **Then** clause written against `147` can be satisfied while the same finding sits there under a new number.
+2. **Given** the rewritten arrow check, **When** the diagram validator runs against Mermaid source that ends a line with an arrow and no target, **Then** it still reports "Arrow without target node" exactly as before.
+3. **Given** the rewritten arrow check, **When** the validator runs against every input in the differential test corpus, **Then** its verdict matches the previous implementation on every input with zero mismatches.
+4. **Given** the sibling thick-arrow check on the following line, **When** this change lands, **Then** that line is untouched and remains free of any alert.
+
+---
+
+### User Story 2 - Maintainer is not misled by a comment that does nothing (Priority: P2)
+
+A maintainer reading the diagram script sees a suppression comment and an explanatory note claiming the finding is a false positive. Both suggest somebody assessed and handled this. Neither is true in any operational sense, because the suppression form has no effect on the scanning pipeline. After this change the misleading comments are gone rather than replaced with a different inert marker.
+
+**Why this priority**: Independent of whether the alert closes, a comment that claims to suppress something it cannot suppress is worse than no comment. It cost this repository six months of a stale high-severity alert. It ranks below P1 only because the alert closure is the outcome people are actually waiting on.
+
+**Independent Test**: Scan the audited source directories for inline scanning-suppression comments and confirm none remain outside the auditor that implements the check. The scan is scoped to source, not to the whole tree, because specification and review prose necessarily quotes the marker strings in order to describe them.
+
+**Acceptance Scenarios**:
+
+1. **Given** the `# lgtm[py/bad-tag-filter]` comment on the flagged line, **When** this change lands, **Then** that comment is deleted and is not replaced by a `# codeql[...]` comment or any other inline suppression form.
+2. **Given** the adjacent comment describing the finding as a false positive, **When** the regular expression it refers to no longer exists, **Then** that comment is removed or rewritten so it does not describe code that is gone.
+3. **Given** the audited source directories, **When** they are scanned for `lgtm[` and `codeql[` markers, **Then** the only matches are inside the auditor implementation and its own tests. Documentation and specification files are out of this scan's scope by design, since describing the markers requires writing them.
+
+---
+
+### User Story 3 - The gate catches the next dead suppression automatically (Priority: P3)
+
+Somebody adds an inline scanning-suppression comment believing it will silence a finding. Today nothing objects and the repository accumulates another decorative marker plus a permanently open alert. After this change the pragma audit fails on that comment and explains why the form does not work.
+
+**Why this priority**: This is the durable part of the fix and the reason the same defect will not recur. It is P3 only because it prevents future instances rather than resolving the current one.
+
+**Independent Test**: Introduce a throwaway file carrying an inline suppression comment, run the pragma audit, and confirm it fails and names the file, line, and offending marker. Remove the file and confirm the audit passes. Then confirm the same check is reachable from a merge-blocking context, because a check reachable only by typing a command by hand prevents nothing.
+
+**Acceptance Scenarios**:
+
+1. **Given** a file anywhere in the audited paths carrying a `# lgtm[...]` comment, **When** the pragma audit runs, **Then** it exits non-zero and identifies the file, the line number, and the marker.
+2. **Given** the same situation with a `# codeql[...]` comment, **When** the pragma audit runs, **Then** it also exits non-zero, because that form is honoured only by a CLI path this repository does not use.
+3. **Given** the repository as it stands immediately after this feature lands, **When** the pragma audit runs, **Then** it exits zero, so the new gate does not block anybody on the day it is introduced.
+4. **Given** the audited path set, **When** the pragma audit runs, **Then** it covers the diagram script's directory in addition to the two directories it covers today.
+5. **Given** the auditor's own source, which necessarily contains the literal marker strings it searches for, **When** the pragma audit runs, **Then** the auditor does not flag itself.
+6. **Given** a pull request that adds an inline suppression marker to a source file, **When** the required checks run on that pull request, **Then** at least one required check reports failure. Without this scenario the preceding five are satisfied by a target nothing invokes.
+
+---
+
+### Edge Cases
+
+- **Exotic line separators.** The obvious string-method rewrite splits input into lines using the general line-splitting behaviour, which treats vertical tab, form feed, carriage return, and several Unicode separators as line breaks. The original expression treated only the newline character as a line break. On input such as an arrow followed by a bare carriage return and more text, the two disagree: the general form reports an error where the original did not. The rewrite MUST split on the newline character only, so behaviour is preserved exactly. This case is not hypothetical and is covered by FR-003.
+- **Carriage-return line endings.** Diagram source saved with CRLF endings must produce the same verdict as the same source with LF endings, and the same verdict the original produced.
+- **Empty and whitespace-only input.** Empty diagram source, source that is only whitespace, and source ending in several blank lines must all produce no arrow error, matching current behaviour.
+- **Trailing whitespace after an arrow.** An arrow followed by spaces or tabs to end of line must still be reported as an error.
+- **The trailing-whitespace character class.** This is the same trap as the line-separator case, one level down, and it is easy to miss because the line-separator case gets all the attention. The original expression's trailing-whitespace match accepts the full whitespace class, which includes vertical tab, form feed, and non-breaking space. A rewrite that trims only spaces and tabs disagrees with the original on an arrow followed by any of those characters. The rewrite MUST trim the full whitespace class. This was verified during review: the language's default trimming behaviour and the expression's whitespace class agree on every code point checked, so the default is correct and a narrowed trim set is not. Covered by FR-003.
+- **Arrow that is not at end of line.** An arrow with a target after it must not be reported, including when a later line does end with a bare arrow.
+- **Suppression markers in non-code positions.** A marker appearing inside a documentation string, a URL, or prose is not a real suppression. The audit must not produce noise that pushes people toward blanket exclusions. See FR-009 and the assumption on comment-position matching.
+- **Markers in specification and review prose.** Any document that describes this feature has to quote the marker strings in order to name them. This specification alone contains fifteen occurrences across both markers, and its plan, tasks, and review artefacts will add more. A scan defined as repository-wide can therefore never come back clean, no matter how the code is written. The audited path set is source directories only, and every criterion that counts markers is scoped to that set rather than to the tree. Covered by FR-021 and SC-004.
+- **The auditor's own test fixtures.** The negative test required by SC-006 has to materialise a file carrying a real marker in order to prove the check fires. If that fixture is written to a path inside the audited set and left there, the audit fails permanently; if it is excluded by a broad pattern, the exclusion becomes a hole a real suppression can hide in. The fixture must exist only for the duration of the test.
+- **The auditor matching itself.** Any implementation of the marker check contains the marker strings verbatim. Without explicit self-exclusion the gate fails permanently the moment it is introduced. This is the same trap the existing banned-terms scanner already solves by excluding its own filename.
+- **Pre-existing findings surfaced by the widened path set.** Widening the scanned paths can reveal findings that predate the change. A gate that fails the moment it lands blocks every contributor. FR-010 through FR-013 resolve this explicitly.
+- **Alert reopening, for the third time.** This alert has already made one full round trip. A change in January deleted the expression and closed it; a change eleven days later re-added the expression "with proper lgtm suppression comment" and reopened it. The second author believed they were handling the finding. Because the analyzer flags this construct on lexical resemblance, any future edit that reintroduces an arrow-like literal into an expression reopens the alert, and the regression test required by FR-004 does not prevent that, since a regular expression and a string rewrite both satisfy the same behavioural tests. The marker gate blocks only the dead-suppression response, not the reintroduction itself. FR-020 addresses the reintroduction with the cheapest thing that has any chance of working: a note on the line telling the next author why it is written the way it is.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+#### Closing the alert
+
+- **FR-001**: The arrow-without-target validation MUST produce an identical verdict to the current implementation for all diagram source inputs, demonstrated by a differential test rather than asserted.
+- **FR-002**: The arrow-without-target validation MUST NOT be expressed as a regular expression pattern, so the analyzer has no pattern to evaluate. The sibling thick-arrow check MUST be left unchanged, since it carries no alert and serves as the control that proves the finding is driven by lexical resemblance.
+- **FR-003**: The replacement MUST treat only the newline character as a line boundary, and MUST match trailing whitespace using the full whitespace character class rather than a narrowed set such as spaces and tabs. General-purpose line splitting is prohibited here because it recognises additional separators and changes the verdict on those inputs. Narrowing the trailing-whitespace class is prohibited for the same reason one level down. Both halves of this requirement are load-bearing and both were falsified empirically before being written, not assumed.
+- **FR-004**: A regression test MUST cover the arrow-without-target validation, including the trailing-whitespace, empty-input, multi-line, and carriage-return cases named in Edge Cases, so a future rewrite cannot silently change behaviour. That test MUST be placed where the repository's required test check collects it. A test that lives beside the script but outside the collected test root runs nowhere and protects nothing, and the diagram script has no existing test suite to inherit this from.
+
+#### Removing the dead suppression
+
+- **FR-005**: The `# lgtm[...]` comment on the flagged line MUST be deleted. It MUST NOT be converted to `# codeql[...]` or any other inline suppression form, because no inline form is honoured by the scanning pipeline this repository runs.
+- **FR-006**: The adjacent explanatory comment that describes the flagged expression as a false positive MUST be removed or rewritten, so no comment describes code that no longer exists.
+- **FR-007**: If a finding genuinely warrants suppression in future, the supported route is the scanning product's own dismissal workflow, recorded with a reason. The specification records this so the deletion is not read as "suppression is forbidden", only as "this inline form does not work".
+
+#### Extending the pragma audit
+
+- **FR-008**: The pragma audit MUST detect inline `lgtm[...]` and `codeql[...]` suppression comments and MUST fail when any is present, treating them as unsupported and inert.
+- **FR-009**: The marker detection MUST NOT flag the auditor's own implementation or its tests, which necessarily contain the marker strings. Self-exclusion MUST be explicit and narrow, scoped to the auditor's own files rather than achieved by broad path or pattern exclusions, and MUST be expressed as an exact path rather than a bare filename pattern that would silently exempt any identically named file anywhere in the tree.
+- **FR-009a**: The marker detection MUST live in a dedicated file of its own rather than inline in the build recipe. Two reasons, both concrete. Self-exclusion by path is only narrow if there is a small file to exclude; excluding the build recipe wholesale would exempt the one file every contributor edits. And the check has to be invocable from the merge-blocking context required by FR-018 without dragging the rest of the audit target's tooling in with it, which the existing precedent in this repository already does for the same reason.
+- **FR-010**: The audited path set MUST include the directory containing the diagram script, in addition to the two directories audited today. The current path set is why this defect went unnoticed for six months: the affected file was never scanned.
+- **FR-011**: The unused-pragma check MUST remain a blocking check and MUST apply to the widened path set. This is safe to make blocking immediately, because the widened path set currently reports clean.
+- **FR-012**: The security-linter portion of the audit MUST remain advisory and MUST NOT gain blocking behaviour as a side effect of widening its path set. It reports findings for human attention and does not fail the build today, and this feature does not change that contract.
+- **FR-013**: The audit recipe MUST make each check's blocking or advisory status explicit and intentional, and that declaration MUST be accurate rather than aspirational. Today the advisory behaviour of the security-linter portion is an accident of how its output is piped, which means a routine edit to that line could silently turn it into a blocking gate carrying pre-existing findings. It also means the target as a whole reports success unconditionally on that half. Verified during review: the target exits zero with fifteen findings outstanding.
+- **FR-014**: When the audit fails, its output MUST name the offending file, the line number, and the marker found, and MUST state both why the form is inert and what the supported alternative is. A failure that only says "found a bad comment" will be worked around rather than fixed.
+- **FR-015**: The pragma audit MUST exit zero against the repository as it stands immediately after this feature lands, so the gate does not block contributors on introduction. That cleanliness MUST be re-verified against the exact tree being merged, immediately before the blocking behaviour lands, and not inferred from a measurement taken during planning. The widened unused-pragma path set is clean today, but this worktree is shared with concurrent work and a single `# noqa` arriving in the newly audited directory between planning and merge converts FR-011 into a day-one failure for everybody who runs the target.
+
+#### Making the gate real
+
+- **FR-018**: The marker detection MUST execute in a context that can fail a merge. Today the pragma audit target satisfies none of the three ways that could happen: it is not a prerequisite of the aggregate validation target, it appears in no continuous integration workflow, and it appears in no commit hook. It runs only when a person chooses to type it. Satisfying FR-008 through FR-015 while leaving that unchanged produces a check that has never once run against a change that was about to land, which is the same category of object as the comment this feature is deleting. This repository already has a precedent for exactly this problem and its resolution: an earlier guard was deliberately placed inside a required check rather than a commit-hook job, with an in-file note explaining that moving it would silently downgrade it to advisory with no symptom until a violation merged green. The same reasoning applies here and the same placement is expected.
+- **FR-019**: The wiring required by FR-018 MUST NOT introduce new tooling installation into the merge-blocking context. The check is a text scan over source files; it requires nothing that is not already available where it will run. This constraint exists so that satisfying FR-018 cannot be argued down on the grounds that it slows the required checks or adds a dependency.
+- **FR-020**: The rewritten arrow check MUST carry a short note stating that it is deliberately not a pattern match and why. The behavioural regression test required by FR-004 cannot enforce this, because a pattern-based implementation passes exactly the same tests. This alert has already made one full round trip through delete and reintroduce, and the reintroduction was performed by somebody who believed they were handling the finding properly. The note is the only thing in this feature that speaks to the author of the third round trip.
+- **FR-021**: Every requirement and criterion that counts marker occurrences MUST be scoped to the audited source path set, never to the whole tree. Specification, planning, and review documents necessarily quote the markers in order to describe them, so a tree-wide count can never reach zero and any criterion phrased that way is unsatisfiable on the day it is written.
+
+#### Verifying closure
+
+- **FR-016**: Closure of alert 147 MUST be evidenced from the branch-level analysis or the alert-state API. A green pull request check MUST NOT be accepted as evidence, because pull request analysis is diff-informed and covers only changed lines. A recent pull request in this repository passed its scanning check with five alerts open.
+- **FR-017**: The change MUST NOT increase the total count of open alerts. The rewrite is verified not to introduce a new finding in place of the old one.
+- **FR-022**: The closure evidence required by FR-016 MUST be gathered after the change reaches the default branch, and the specification MUST name the outcome if it fails there. The branch analysis does not refresh until the change is on the branch, and no scanning result is a required check, so there is no point before merge at which closure can be confirmed and no check that would hold the merge if it were not. If the alert remains open after merge, the response is a follow-up change to the same line, not a revert, because the rewrite is behaviour-preserving by FR-001 and reverting would restore a pattern for no gain.
+
+### Key Entities
+
+- **The `py/bad-tag-filter` finding at `scripts/regenerate-mermaid-url.py`**: the open high-severity alert this feature exists to close, numbered 147 at the time of writing. **Its identity is path plus rule identifier.** The number is a locating label with a shorter life than the finding: remediation closes a number and opens a fresh one at the same site, so anything that treats the number as the identity can report success over a finding that never moved. Its state on the branch analysis, read that way, is the feature's primary outcome measure.
+- **Inline suppression marker**: A source comment of the form `lgtm[rule]` or `codeql[rule]`. Has no effect on this repository's scanning pipeline. The audit's job is to make its presence a failure rather than a silent no-op.
+- **Pragma audit path set**: The set of directories the audit walks. Currently excludes the directory holding the affected file, which is the root cause of the six-month blind spot.
+- **Audit check**: A single check within the audit, carrying an explicit blocking or advisory status.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: When the alert-state API is queried against the branch analysis after the change is on the default branch, **no open alert exists with the `py/bad-tag-filter` rule at the diagram script's path**, and the query output is recorded as the evidence. The criterion is keyed on path plus rule identifier, never on the alert number: remediation demonstrably closes a number and opens a fresh one at the same site, so a criterion written against `147` can report success while the same finding sits there under a new number. The number is a label for locating the finding today, not the thing being measured. This criterion is measured after merge, not before it, and no required check enforces it.
+- **SC-002**: The count of open alerts after this change is exactly one lower than the count before, confirming both that alert 147 closed and that nothing new was introduced. A criterion phrased as less than or equal would be satisfied by the change achieving nothing at all.
+- **SC-003**: A differential test comparing old and new arrow validation over a corpus of at least 1,500 generated and hand-chosen inputs reports zero mismatches. The corpus includes arrows with trailing whitespace, arrows at end of input, multi-line input, empty input, CRLF endings, the exotic line separators named in Edge Cases, and the non-newline whitespace characters named in the trailing-whitespace-class edge case. An 8,057-input differential run during review reported zero mismatches for the newline-only split and 385 mismatches for the general-purpose split, so the corpus is known to be capable of separating a correct implementation from the obvious incorrect one.
+- **SC-004**: A scan of the audited source path set for `lgtm[` and `codeql[` markers returns matches only inside the auditor implementation and its tests. Before this change the same scan returns one match, in the diagram script. The scan is deliberately not tree-wide: this specification alone contains fifteen marker occurrences because describing a marker requires writing it, and a tree-wide criterion would be false at the moment of writing.
+- **SC-005**: The pragma audit exits zero against the post-change tree.
+- **SC-006**: The pragma audit exits non-zero when a file carrying an inline suppression marker is added, and its output names that file and line. This negative test is automated, not performed by hand once.
+- **SC-007**: The pragma audit's unused-pragma check runs against the widened path set and passes.
+- **SC-008**: The audit recipe declares a blocking or advisory status for every check it runs, verifiable by reading the recipe without inferring behaviour from shell pipeline semantics.
+- **SC-009**: The repository's unit test suite passes, including the net-new regression test required by FR-004. The diagram script has no pre-existing test suite of its own, so there is nothing there to pass unchanged and the FR-004 test is the first coverage the script has ever had. Any criterion asserting an existing suite for this script would be unmeasurable.
+- **SC-010**: The thick-arrow sibling check is byte-identical to its pre-change form, confirming the control was not disturbed.
+- **SC-011**: A change that adds an inline suppression marker to a source file causes at least one required status check to report failure. Measured by observing the check result, not by reasoning about the recipe. Without this, SC-005 through SC-008 are all satisfiable by a target that no automated process invokes, and the feature ships a gate with the same enforcement power as the comment it removes: none.
+- **SC-012**: The marker check is reachable from the merge-blocking context without installing tooling that is not already present there, so wiring it costs no additional setup time in the required checks.
+
+## Assumptions
+
+- **Advisory findings stay advisory, and there are ten of them.** Widening the security-linter path set surfaces pre-existing findings in the newly scanned directory. The count was measured during review: ten, on top of the fifteen already reported for the existing path set. Because that check does not fail the build today, all twenty-five print for attention and block nobody. Anybody running the target after this lands sees a longer wall of output than before and should not read it as a regression. This feature deliberately does not convert them into a blocking gate, and does not fix them. Making that check blocking, with its existing backlog, is a separate decision with a separate cost.
+- **The unused-pragma check can be blocking immediately.** The widened path set was checked during review and reports clean under the full configured rule set, not merely under the unused-pragma rule in isolation, so no grandfathering mechanism, baseline file, or allowlist is needed for it. If that assumption fails at implementation time, the fallback is to fix the findings rather than to introduce a baseline, since the count is small.
+- **"Blocking" and "runs" are different properties, and the audit target has only the first.** The unused-pragma check does fail the target when it finds something. The target is invoked by nothing automated, so that failure has never once reached a change under review. This is stated separately because the phrase "blocking check" appears throughout the requirements above and would otherwise be read as meaning enforced. It means enforced only once FR-018 is satisfied.
+- **Marker matching is positional.** Detection targets markers appearing in comment position rather than anywhere in a line, to avoid flagging prose and URLs. If the implementation cannot do this reliably, the simpler whole-line match is acceptable given the current match count in the audited path set is one, but the noise risk moves to Edge Cases as a known limitation. Either way the path set is source only, so the largest source of prose false positives, the specification tree, is out of range before the positional question is even reached.
+- **No supported inline suppression exists here.** The audit treats every inline suppression form as inert. If the scanning configuration later adopts a path where an inline form is honoured, this gate becomes wrong and must be revisited. The scanning setup is driven by a configuration file rather than a workflow this repository maintains, so that change could arrive without a visible diff in this repository at all.
+- **The rewrite closes the alert.** This is strongly evidenced rather than certain: a prior change that deleted the same expression closed this same alert, and the analyzer's own message complains specifically about the pattern's handling of comment-end syntax. Confirmation comes from SC-001 and arrives only after merge, per FR-022. The diff-scoped pull request analysis is corroborating rather than sufficient here, and is never accepted as the evidence FR-016 requires, even though the change touches the exact flagged line.
+
+## Out of Scope
+
+- Fixing the pre-existing advisory security-linter findings in any directory, including those newly surfaced by the widened path set.
+- Converting the advisory security-linter check into a blocking gate.
+- The four other open alerts in this repository.
+- Any change to the diagram script beyond the flagged arrow check and its comments, including the thick-arrow check, which is the control.
+- Retiring or replacing the security linter itself.
+- Changing the scanning workflow configuration, its query pack selection, or its trigger conditions.
+- Adopting a dismissal workflow for any current finding.
+- Adding the scanning analysis to the branch protection required checks. This would give SC-001 real enforcement, but it is a branch protection change affecting every contributor and carrying the existing open-alert backlog. Out of scope, carded.
+- Wiring the pragma audit target as a whole into the aggregate validation target or the required checks. FR-018 requires only the marker check to reach a merge-blocking context, not the target's other halves, because the security-linter half carries a twenty-five finding backlog and the aggregate validation target has its own pre-existing failure. Out of scope, carded.
+- Repairing the pre-existing failure in the banned-term scanner, which makes the aggregate validation target red on the default branch today and is one reason nobody noticed the pragma audit was missing from it. Unrelated to this feature. Out of scope, carded.
+- Reconciling the scanning configuration file's internal contradiction, where a path exclusion for the test tree is followed by a query filter whose comment states the test tree is still scanned. One of the two is redundant. Out of scope, carded.
+
+## Adversarial Review #1
+
+Reviewer did not author the spec. Every claim below was reproduced locally before being written down. Nothing was taken from the prior agent's notes on trust.
+
+### Findings
+
+| Sev | Finding | Resolution |
+|---|---|---|
+| CRITICAL | F1: The pragma audit target is invoked by nothing automated. It is absent from the aggregate validation target's prerequisite list, absent from every continuous integration workflow, and absent from the commit hook configuration. Separately its security-linter half pipes into a filter and reports success unconditionally: verified exit zero with fifteen findings outstanding. US3 and FR-008 through FR-015 therefore specified a gate with the same enforcement power as the comment being deleted. | FIXED. New FR-018 requires the marker check to execute in a merge-blocking context, citing the in-repository precedent where an earlier guard was deliberately placed in a required check for exactly this reason. New FR-019 forbids that wiring from adding tooling installation, removing the usual argument against it. New US3 scenario 6, new SC-011 and SC-012 measure it by observed check result rather than by reading the recipe. New assumption separates "blocking" from "runs". Overview states both facts up front. |
+| HIGH | F2: SC-004 was already false when written. A tree-wide scan for the two markers returns fifteen matches inside this specification file alone, because naming a marker requires writing it. Plan, tasks, and this review add more. The criterion could never reach its stated state. | FIXED. SC-004, US2 independent test, and US2 scenario 3 rescoped to the audited source path set. New FR-021 makes the scoping rule general so the next criterion is not written the same way. New edge case records the cause. |
+| HIGH | F3: SC-009 required "the diagram script's own test suite" to pass unchanged. No such suite exists. There is no test file anywhere referencing the script. The criterion was unmeasurable and it concealed that FR-004's regression test is net-new, with no established home. | FIXED. SC-009 rewritten to state the script has no prior coverage. FR-004 extended to require the new test live where the required test check collects it, since the collected test root is configured and a test outside it runs nowhere. |
+| HIGH | F4: Closure evidence is obtainable only after merge, and no scanning result is a required check. SC-001 could not gate anything and the spec did not say so, nor what happens if the alert stays open post-merge. | FIXED. New FR-022 states the post-merge timing and names follow-up rather than revert as the failure response, with the reason. SC-001 and US1 amended. Overview states plainly that no scanning result blocks a merge here. |
+| HIGH | F5: FR-003 constrained the line-boundary character but said nothing about the trailing-whitespace character class. The original expression accepts the full whitespace class; a rewrite trimming only spaces and tabs diverges on vertical tab, form feed, and non-breaking space. Identical in kind to the defect FR-003 was written to prevent, one level down, and invisible because the line-separator case absorbs all the attention. | FIXED. FR-003 now constrains both. New edge case documents it. SC-003's corpus now required to include those characters. Verified during review that the default trimming behaviour and the expression's whitespace class agree on every code point from U+0000 to U+2FFF, so the default is correct and only a narrowed set is dangerous. |
+| HIGH | F6: FR-009's self-exclusion was underspecified. The cited precedent excludes by bare filename, which exempts any identically named file anywhere in the tree. And the spec never said where the check lives; hosted inline in the build recipe, self-exclusion would mean exempting the single file every contributor edits. | FIXED. FR-009 now requires exact-path exclusion rather than a filename pattern. New FR-009a requires the check to live in a dedicated file, with both reasons stated. New edge case covers the negative test's fixture, which must not persist inside the audited set nor be exempted by a broad pattern. |
+| MEDIUM | F7: SC-002 read "less than or equal to the count before", which is satisfied by the change accomplishing nothing. | FIXED. Now requires the count to drop by exactly one, with the reason for the change recorded in the criterion. |
+| MEDIUM | F8: FR-016 forbade accepting a pull request check as evidence while the closing assumption called the same analysis "meaningful here", which reads as a licence to accept it. | FIXED. Assumption reworded to corroborating rather than sufficient, and cross-referenced to FR-022. |
+| MEDIUM | F9: Widening the security-linter path set adds ten pre-existing findings, unquantified in the spec. The target's output roughly doubles and a reader could mistake that for a regression this feature caused. | FIXED. Count measured and recorded in the assumption alongside the existing fifteen. |
+| MEDIUM | F10: Nothing prevented a third round trip. FR-004's behavioural test passes identically for a pattern-based and a string-based implementation, so it cannot stop reintroduction. The second round trip was performed by somebody who believed they were handling the finding. | FIXED. New FR-020 requires a short note on the line stating it is deliberately not a pattern match. Edge case rewritten with the full round-trip history and an explicit statement that the regression test does not cover this. |
+| LOW | F11: The scanning configuration file excludes the test tree by path and then carries a query filter whose comment asserts the test tree is still scanned. One of the two is dead. | Out of scope, carded in Out of Scope. |
+| LOW | F12: The banned-term scanner is red on the default branch today, so the aggregate validation target already fails. Relevant only as the likely reason nobody noticed the pragma audit is not one of its prerequisites. | Out of scope, carded in Out of Scope. |
+
+Counts: 1 CRITICAL, 5 HIGH, 4 MEDIUM, 2 LOW. All CRITICAL and HIGH resolved by direct edit. Both LOW carded without fixing, since fixing either means touching files this feature does not own.
+
+### Verification performed
+
+| Claim under test | Method | Result |
+|---|---|---|
+| Audit target cannot fail on its security-linter half | Ran the target, captured exit status | Exit 0 with 15 findings printed. Confirmed |
+| Audit target is wired into the aggregate validation target | Read the prerequisite list | Absent. Seven prerequisites, none of them the audit |
+| Audit target is wired into continuous integration | Searched the workflow tree | Zero occurrences |
+| Audit target is wired into commit hooks | Searched the hook configuration | Zero occurrences |
+| Unused-pragma check is clean on the widened path set | Ran it against the new directory under the full rule set | Clean. FR-011 assumption holds |
+| Security-linter findings in the new directory | Ran it against the new directory | 10 |
+| Marker count, tree-wide | Two searches across the tree | 9 for one marker, 7 for the other, 15 of the 16 inside the spec itself |
+| The script has an existing test suite | Searched for any file referencing it | None outside specification documents |
+| Newline-only split is equivalent to the original expression | Independent differential run, 8,057 inputs | 0 mismatches |
+| General-purpose split is not equivalent | Same run, same corpus | 385 mismatches |
+| Default trimming matches the expression's whitespace class | Compared both across U+0000 to U+2FFF | 0 divergences |
+
+The differential corpus was built from exhaustive one, two, and three element products over a twenty element atom set containing both arrow forms, the comment-end form the analyzer complains about, spaces, tabs, carriage return, newline, vertical tab, form feed, file separator, next line, and the Unicode line separator, plus three thousand random four to five element strings under a fixed seed, plus fourteen hand-chosen cases. This is an independent construction, not a rerun of the prior corpus. It agrees with the prior result in direction and mechanism: the general-purpose split fails on exotic separators, the newline-only split does not. The mismatch counts differ because this corpus is denser in exotic separators, which is why it produces 385 rather than 23.
+
+### Gate
+
+**0 CRITICAL, 0 HIGH remaining.**
+
+## Clarifications
+
+### Session 2026-07-30
+
+Five questions raised, five self-answered from the codebase, artifacts, and git history. None
+deferred and none put to the owner as an open question, though Q1 records a decision the owner
+still has to accept or reject at review. Evidence is a file and line, a commit, or the output of a
+command that was actually run.
+
+- **Q: This started as "rewrite a regex, delete a comment, extend a make target" and now edits a required status check. Is that recorded as a scope decision the owner can reject, or does it only appear in the diff? → A: It was not recorded. Now stated in the Overview as an explicit scope decision, with what falls if it is rejected.**
+  - Evidence that the growth is real: the Input line of this spec (line 6) names only the alert, the dead comment, and `make audit-pragma`. `plan.md:106` and `plan.md:179-204` add a step to `.github/workflows/pr-checks.yml`.
+  - Evidence that `Lint` is required: `gh api repos/traylorre/sentiment-analyzer-gsk/branches/main/protection --jq .required_status_checks.contexts` returns `["Secrets Scan","Lint","Run Tests","Playwright E2E Tests"]`, recorded at `research.md:61-67` and re-asserted in `.pre-commit-config.yaml:214-225`.
+  - Evidence that the target is unwired: `Makefile:42` lists seven prerequisites for `validate` and `audit-pragma` is not among them; a repository-wide search for `audit-pragma` outside `specs/` returns only `Makefile:1`, `Makefile:85`, and `CLAUDE.md:243`.
+  - Changed: the Overview gained a third bold paragraph. No requirement text changed. FR-018 already carried the technical reasoning; what was missing was the framing that lets a reviewer say no.
+
+- **Q: FR-015 rests on the widened unused-pragma path set being clean. Do the artifacts require re-checking that immediately before the check becomes blocking, or only at planning time? → A: Only at planning time, and at research level. Now a requirement.**
+  - Current state re-measured: `ruff check --extend-select RUF100 scripts/` and `ruff check --extend-select RUF100 src/ tests/ scripts/` both print "All checks passed!" and exit 0 (run 2026-07-30 under `.venv`, ruff 0.15.14). `grep -rnE "lgtm\[|codeql\[" src/ tests/ scripts/` returns exactly one line, `scripts/regenerate-mermaid-url.py:82`.
+  - The re-check instruction existed only at `research.md:341-350` ("Open items carried forward"), which is a planning note, not a requirement, and is not reproduced in `spec.md` or `quickstart.md`.
+  - Changed: FR-015 now requires re-verification against the exact tree being merged. `quickstart.md` section 4 gained the matching step. Scope note: the exposure is `make audit-pragma` only, since the `Lint` job runs `ruff check src/ tests/` (`.github/workflows/pr-checks.yml:61-62`) and never sees `scripts/`, so a stray `# noqa` there cannot redden a required check.
+
+- **Q: The negative test points the checker at `tmp_path`, which is outside the repository. Does the contract's exclusion and output handling survive a root that has no repository-relative path? → A: No. `relative_to` raises, and both C6 and C7 needed the fallback the precedent already uses.**
+  - Reproduced: `Path("/tmp/dsfix/bad.py").resolve().relative_to(Path("/home/zeebo/projects/sentiment-analyzer-gsk"))` raises `ValueError: '/tmp/dsfix/bad.py' is not in the subpath of ...`. As written, C6's "skipped if and only if its resolved repository-relative path is a member" would crash the checker on every file the SC-006 negative test creates, and C7's repo-relative output has nothing to print.
+  - The precedent already solved this: `scripts/scan-waitforresponse-race.py:418-423` wraps `path.relative_to(root)` in `try/except ValueError` and falls back to the absolute path for display.
+  - Changed: `contracts/dead-suppression-cli.md` C6 now specifies a containment test that returns false for out-of-repo paths rather than raising, and C7 specifies the display fallback. No spec requirement changed; SC-006 and the "auditor's own test fixtures" edge case were both unsatisfiable against the contract as written, and are now satisfiable.
+
+- **Q: The plan's `importlib` and `sys.executable` constraints, and the contract's "any CPython 3.13 reachable as python3" line. Spec-level or plan-level, and is the stated reason accurate? → A: Plan-level, both. The reason given was wrong and the contract's interpreter requirement was too strong.**
+  - `importlib.util.spec_from_file_location` is forced by the hyphen in `regenerate-mermaid-url.py`, which this feature cannot rename. That is a test mechanic with no observable behaviour attached, so it stays in `plan.md` (Testing plan, "test_regenerate_mermaid_url.py") and needs no requirement.
+  - The stated reason for `sys.executable` was "the repository's system interpreter is 3.10" (`plan.md` Testing plan, subprocess-test bullet, and `quickstart.md:10`). Measured on this machine: `/usr/bin/python3` is 3.12.3 and `python3` resolves through `/home/zeebo/.pyenv/shims/python3` to 3.13.0. The conclusion still holds and is in fact stronger, because a bare `python3` resolves differently per machine and per shell. `scripts/scan-waitforresponse-race.py:72-74` already records the same discrepancy in a comment.
+  - Contract C1 required "any CPython 3.13 reachable as `python3`". Nothing in the design needs 3.13, and the Makefile consumer runs under whatever `python3` the contributor has, which is demonstrably 3.12 on a stock path here. Changed: C1 now states a 3.9 floor and forbids version-gated syntax. If a runtime interpreter guard is ever added in imitation of the precedent, which exits 2 at `scan-waitforresponse-race.py:75-81`, it MUST NOT reuse exit code 2, because C2 assigns that to "zero files scanned" and the precedent has that collision today.
+  - Changed: `plan.md` and `quickstart.md` corrected to the accurate reason. Contract C1 relaxed. No FR or SC changed.
+
+- **Q: Contract C8 forbids reaching the checker through `pre-commit run`, and the plan recommends an optional pre-commit hook. Which is it? → A: Both, once C8 is scoped to the merge-blocking consumer, which is what it was written about.**
+  - The prohibition's actual target is the CI step: the `Pre-commit Hooks` job sets `SKIP` and is not a required context, so a required check must never route through it. That reasoning is at `.pre-commit-config.yaml:214-229`.
+  - The precedent carries all three wirings simultaneously: a pre-commit hook at `.pre-commit-config.yaml:206-212`, a direct step in the required `Lint` job at `.github/workflows/pr-checks.yml:85-87`, and a `make validate` prerequisite at `Makefile:42` and `Makefile:45-47`. A local hook alongside a direct CI step is the established pattern, not a violation of it.
+  - Changed: C8's bullet now says the merge-blocking invocation must not route through `pre-commit run`, and that an additive local hook is permitted. The plan's "optional and recommended" wording at `plan.md:213-217` stands unchanged. No FR or SC changed.
+
+Line references into `plan.md` above point at section headings and quoted phrases where the exact
+line could drift; references into repository files were taken with `grep -n` on 2026-07-30.
+
+Also corrected without spending a question, since both are clerical rather than decisions: `plan.md`'s
+skip list omitted `.pytest_cache` and `.hypothesis`, which `contracts/dead-suppression-cli.md` C3
+lists, and the two are now identical.

--- a/specs/001-bad-tag-filter-dead-suppression/tasks.md
+++ b/specs/001-bad-tag-filter-dead-suppression/tasks.md
@@ -1,0 +1,1573 @@
+# Tasks: Close py/bad-tag-filter and Kill the Dead Suppression
+
+**Feature**: `001-bad-tag-filter-dead-suppression`
+**Input**: `spec.md`, `plan.md`, `research.md`, `contracts/dead-suppression-cli.md`, `quickstart.md`
+**Date**: 2026-07-30
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: can run in parallel. Different files, no dependency on another unfinished task.
+- **[Story]**: `US1`, `US2`, `US3`. `[GATE]` additionally marks the owner-rejectable FR-018 block.
+- Every task names exact paths. Every verification task names the exact command and the exact pass
+  condition.
+
+## Conventions that every verification task inherits
+
+Three of these come from defects this feature exists to remove. They are stated once here and are
+binding on every task below.
+
+1. **Never read an exit code from downstream of a pipe.** `Makefile:90` is why this feature exists:
+   `bandit ... | grep -E "^(>>|Issue)" || echo "No issues found"` makes the recipe inherit `grep`'s
+   status, so the line cannot fail. Any verification command containing a pipe MUST assert on
+   `${PIPESTATUS[0]}` (or on the specific element being tested), never on `$?`.
+2. **"Empty output" and "exit 0" are not pass conditions on their own.** A check that has never been
+   observed failing has not been shown capable of failing. Every gate introduced here has a paired
+   red-test: T013 for the differential oracle, T029 for the checker, T040 for the Makefile wiring,
+   T044 for the CI step.
+3. **Never key an outcome on a code-scanning alert number.** Alert 147 is a locating label. The
+   analyzer demonstrably closes a number and opens a fresh one at the same site, so every criterion
+   is keyed on **path plus rule id**. This applies to acceptance scenarios and Independent Test
+   lines too, not only to the SC block.
+4. **`make validate` cannot pass on this tree.** `scripts/check-banned-terms.sh` exits 1 on
+   pre-existing matches from concurrent features. No task requires it to be green. Mirror the
+   required `Lint` job's individual steps instead (T050).
+5. **Run everything under the project virtual environment**: `source .venv/bin/activate` first,
+   except where a task deliberately tests a bare `python3` or `sys.executable`.
+6. **Never read the code-scanning alert list without `--paginate`, and never accept an absence from
+   a read that has not proven itself.** The default page size is 30 and this repository's all-states
+   alert corpus is 137, so an unpaginated read truncates and truncation renders as clean. Measured
+   2026-07-30: unpaginated returns zero open alerts, paginated returns five. `--slurp` cannot be
+   combined with `--jq`, so write the pages out and filter with a separate `jq`; that also keeps
+   `gh`'s exit status readable rather than hidden downstream of a pipe. Wherever the pass condition
+   is an absence, pair it with an all-states corpus floor, because a failed or truncated read looks
+   exactly like a clean repository. This is convention 2 applied to a remote reader.
+
+---
+
+## Phase 1: Pre-flight baselines
+
+**Purpose**: capture the numbers that later criteria are measured against. All five are read-only
+and none modifies the tree.
+
+- [ ] **T001** [P] Record the pre-merge open-alert baseline for SC-002 and FR-017.
+  - Command:
+    ```bash
+    gh api --paginate --slurp \
+      "repos/traylorre/sentiment-analyzer-gsk/code-scanning/alerts?ref=refs/heads/main&state=open&per_page=100" \
+      > /tmp/alerts-open-before.json
+    echo "gh_exit=$?"
+    jq 'add | {count: length, alerts: map({n:.number, rule:.rule.id, path:.most_recent_instance.location.path, line:.most_recent_instance.location.start_line})}' \
+      /tmp/alerts-open-before.json
+    echo "jq_exit=$?"
+
+    gh api --paginate --slurp \
+      "repos/traylorre/sentiment-analyzer-gsk/code-scanning/alerts?ref=refs/heads/main&per_page=100" \
+      > /tmp/alerts-all-before.json
+    echo "gh_exit=$?"
+    jq 'add | length' /tmp/alerts-all-before.json
+    echo "jq_exit=$?"
+    ```
+  - Pass condition: every `gh_exit=0` and `jq_exit=0`; the all-states corpus count is **at least
+    137**; the open set contains exactly one entry whose `rule` is `py/bad-tag-filter` and whose
+    `path` is `scripts/regenerate-mermaid-url.py`; and the output is pasted verbatim into the pull
+    request description. Record the open `count` as **N**; SC-002 later requires `N - 1`.
+  - **`--paginate` is mandatory and this is not defensive padding.** The default page size is 30 and
+    the all-states corpus is 137. Measured 2026-07-30: the unpaginated form with a client-side
+    `select(.state == "open")` returns **zero** open alerts while the paginated form returns **five**
+    (144, 147, 148, 149, 150). Truncation renders as clean. A sibling feature in this campaign
+    extends the analysis matrix over tens of thousands of previously unanalyzed lines and is expected
+    to raise the open count substantially on purpose, at which point even the server-side
+    `state=open` filter overflows one page and SC-001 starts passing because the read was cut short
+    rather than because the finding is gone. This is the same defect class as `Makefile:90`: a check
+    that structurally cannot report dirty.
+  - **`--slurp` cannot be combined with `--jq`.** Write the pages out and filter with `jq`
+    separately. That keeps `gh`'s exit status readable rather than hidden downstream of a pipe;
+    `gh` failing and `gh` returning nothing are otherwise indistinguishable.
+  - **The corpus floor is load-bearing.** SC-001's pass condition is an absence, so the read must
+    independently prove it reached the API and saw the whole corpus. A floor of `0` means the read
+    failed, and a failed read is evidence of nothing.
+  - Note: the rule id is `py/bad-tag-filter`. It is a Python file and the CodeQL Python pack owns
+    the finding. Any task or note reading `js/bad-tag-filter` is wrong.
+
+- [ ] **T002** [P] Re-confirm the four required status check contexts (research R-0d, precondition
+      for FR-018 and Phase 6).
+  - Command:
+    ```bash
+    gh api repos/traylorre/sentiment-analyzer-gsk/branches/main/protection \
+      --jq .required_status_checks.contexts
+    echo "exit=$?"
+    ```
+  - Pass condition: `exit=0` **and** the output contains `"Lint"`. Both halves are required, in that
+    order. This endpoint returns a single object rather than a page, so `--paginate` does not apply,
+    but it shares the alert queries' failure mode: a 404, an expired token, or a permissions change
+    all produce **empty output**, which reads identically to "branch protection requires nothing".
+    Never read empty as an answer here, because the answer it would imply is the one that
+    invalidates FR-018's premise. If `Lint` is genuinely absent, Phase 6 cannot satisfy FR-018 as
+    designed and the whole phase is blocked pending an owner decision.
+
+- [ ] **T003** [P] Re-confirm the widened unused-pragma path set is clean (research R-0a, FR-011,
+      FR-015 baseline).
+  - Command:
+    ```bash
+    source .venv/bin/activate
+    ruff check --extend-select RUF100 src/ tests/ scripts/; echo "exit=$?"
+    ```
+  - Pass condition: `All checks passed!` and `exit=0`. `--extend-select` **adds to** the configured
+    `select` in `pyproject.toml` (`E W F I B C4 UP S RUF100`), so this is a full-ruleset result, not
+    a RUF100-only one. Re-run at T047 against the merge commit; this measurement is not evidence
+    about that commit.
+
+- [ ] **T004** [P] Record the baseline marker population in the audited path set (SC-004 "before"
+      state).
+  - Command:
+    ```bash
+    grep -rnE "lgtm\[|codeql\[" src/ tests/ scripts/; echo "exit=$?"
+    ```
+  - Pass condition: exactly one line of output, `scripts/regenerate-mermaid-url.py:82`, and
+    `exit=0`. Do **not** run this tree-wide: this feature's own artifacts contain dozens of marker
+    occurrences by necessity, which is FR-021's entire subject.
+
+- [ ] **T005** [P] Record the advisory bandit baseline the widened path set will surface (FR-012,
+      spec assumption "Advisory findings stay advisory").
+  - Command:
+    ```bash
+    source .venv/bin/activate
+    bandit -r scripts/ --ignore-nosec 2>/dev/null | grep -cE "^>>"; echo "bandit_exit=${PIPESTATUS[0]}"
+    bandit -r src/     --ignore-nosec 2>/dev/null | grep -cE "^>>"; echo "bandit_exit=${PIPESTATUS[0]}"
+    ```
+  - Pass condition: `10` for `scripts/` and `15` for `src/`. Record both. If either differs, the
+    spec assumption's count is stale and the difference is recorded in the pull request rather than
+    silently absorbed. These findings are pre-existing, advisory, and explicitly out of scope.
+
+---
+
+## Phase 2: Foundational
+
+**Purpose**: pin the one shared fact both new test files depend on. Blocks Phase 3 and Phase 5's
+test tasks.
+
+- [ ] **T006** Confirm `tests/unit/scripts/` is the correct home for both new test files, and record
+      the collection-time dependency it carries.
+  - Both new tests go in `tests/unit/scripts/`. `pyproject.toml:142` sets `testpaths = ["tests"]`,
+    and the required `Run Tests` job's ignore list does not cover that directory, so placement alone
+    satisfies FR-004's "where the repository's required test check collects it".
+  - **Known constraint, must not be restated as an isolation claim**: `tests/unit/scripts/conftest.py`
+    imports `boto3` and `moto` at module level, and pytest imports a directory's conftest for every
+    test collected in it. Both new files therefore pull `moto` in at collection. This is not a
+    breakage (`requirements-ci.txt` pins `moto[all]` and the `Run Tests` job installs it), but the
+    new tests are **not** runnable in a bare standard-library environment. `plan.md`'s Technical
+    Context "No AWS, no moto" line is inaccurate as written; see Cross-Artifact Analysis F3.
+  - Command:
+    ```bash
+    source .venv/bin/activate
+    pytest tests/unit/scripts/ -q --collect-only >/dev/null; echo "exit=$?"
+    ```
+  - Pass condition: `exit=0`. A collection error naming `boto3` or `moto` means the environment is
+    incomplete, not that the placement is wrong.
+
+**Checkpoint**: US1, US2, and US3 core can now proceed.
+
+---
+
+## Phase 3: User Story 1 - Security reviewer sees a genuinely clean alert list (P1)
+
+**Goal**: the arrow-without-target check is no longer a pattern, and behaviour is proven unchanged.
+
+**Independent Test**: `pytest tests/unit/scripts/test_regenerate_mermaid_url.py -v` passes,
+including a differential run over at least 1,500 inputs with zero mismatches. The alert-state half
+of US1 is measured post-merge in Phase 8, per FR-022.
+
+- [ ] **T007** [US1] Rewrite the arrow-without-target check at `scripts/regenerate-mermaid-url.py:82`
+      (FR-001, FR-002, FR-003, FR-020).
+  - Replace `if re.search(r"-->\s*$", code, re.MULTILINE):  # lgtm[py/bad-tag-filter]` with:
+    ```python
+    if any(line.rstrip().endswith("-->") for line in code.split("\n")):
+    ```
+  - **`code.split("\n")`, never `code.splitlines()`.** This is the single highest-risk line in the
+    feature. `str.splitlines()` also breaks on `\v`, `\f`, `\r`, `\x85`, U+2028 and U+2029, none of
+    which regex `$` treats as a line boundary under `re.MULTILINE`. Three independent differential
+    runs (1,572 / 8,057 / 8,852 inputs) put `split("\n")` at 0 mismatches and `splitlines()` at
+    23 / 385 / 194. Worked counterexample: on `"A -->\rB"` the original expression is False, a
+    `splitlines()` rewrite is True.
+  - **Bare `rstrip()`, never `rstrip(" \t")`.** The narrowed form measured 694 mismatches. Default
+    trimming and the expression's `\s` class agree on every code point checked from U+0000 to
+    U+2FFF.
+  - Add the FR-020 note directly above the line, stating that it is deliberately not a pattern
+    match, that no inline suppression form works in this repository's scanning setup, and that
+    `split("\n")` and bare `rstrip()` are both load-bearing. The note MUST NOT itself contain a
+    marker in bracket form (`lgtm[`, `codeql[`), or the new checker flags the file it just fixed.
+  - Do **not** touch the `==>` line on the following line. Do **not** remove `import re`: the
+    control line still uses it and an unused-import tidy-up would break the build under ruff's `F`
+    rules.
+  - Depends on: T006 (nothing else).
+
+- [ ] **T008** [P] [US1] Create `tests/unit/scripts/test_regenerate_mermaid_url.py` with a module
+      loader (FR-004, SC-009).
+  - The script under test is hyphenated (`regenerate-mermaid-url.py`) and therefore not importable
+    by name. Load it with `importlib.util.spec_from_file_location`, resolving the path from the test
+    file rather than from the current working directory. Renaming the script is out of scope: it is
+    referenced by path in documentation and elsewhere.
+  - The file must open with `from __future__ import annotations` and must be clean under
+    `ruff check src/ tests/` and `ruff format --check src/ tests/`, both of which are steps in the
+    required `Lint` job (`.github/workflows/pr-checks.yml:57-62`). Verified at T037 and T050.
+  - Parallel with T007: different file, and the loader does not depend on the rewrite.
+
+- [ ] **T009** [US1] Differential test over at least 1,500 inputs (FR-001, SC-003).
+  - Rebuild the original expression as a local oracle inside the test:
+    `re.search(r"-->\s*$", code, re.MULTILINE)`. Assert the rewritten check agrees with it on every
+    input.
+  - Corpus is generated in the test, not committed as a fixture. Build it from exhaustive one, two
+    and three element products over an atom set containing at minimum: `-->`, `==>`, `<!--`, `--!>`,
+    space, tab, `\r`, `\n`, `\v`, `\f`, `\x85`, U+2028, U+2029, a non-breaking space, and a plain
+    letter. Add seeded random four to five element strings under a fixed seed so a failure is
+    reproducible, plus the hand-chosen cases from the spec's Edge Cases.
+  - The test MUST assert its own corpus size: `assert len(corpus) >= 1500`. Without that assertion
+    the criterion is unfalsifiable, since a corpus that silently shrank to 12 inputs still reports
+    zero mismatches.
+  - On mismatch, the failure message must print the offending input with `repr()`, so an exotic
+    separator is visible rather than invisible.
+  - Depends on: T007, T008.
+
+- [ ] **T010** [US1] Named regression tests for every Edge Case bullet (FR-004).
+  - One named test each, so a failure identifies the case rather than the corpus index: trailing
+    spaces after an arrow; trailing tabs after an arrow; a trailing non-breaking space and a
+    trailing vertical tab after an arrow; CRLF line endings producing the same verdict as LF; empty
+    input; whitespace-only input; input ending in several blank lines; an arrow with a target
+    present (must not fire); an arrow with a target on one line and a bare arrow on a later line
+    (must fire); the `"A -->\rB"` counterexample (must **not** fire, which is what separates
+    `split("\n")` from `splitlines()`).
+  - Depends on: T007, T008.
+
+- [ ] **T011** [US1] Control test for the thick-arrow sibling (FR-002, SC-010).
+  - Assert the `==>` branch still fires on input ending with a bare `==>`, so the control is
+    exercised rather than eyeballed, and assert the validator still reports both messages
+    independently.
+  - Depends on: T008.
+
+- [ ] **T012** [US1] VERIFY the US1 test module passes.
+  - Command:
+    ```bash
+    source .venv/bin/activate
+    pytest tests/unit/scripts/test_regenerate_mermaid_url.py -v; echo "exit=$?"
+    ```
+  - Pass condition: `exit=0`, zero failures, zero errors, and the differential test present in the
+    passing list by name.
+  - Depends on: T009, T010, T011.
+
+- [ ] **T013** [US1] VERIFY the differential test can actually fail (red-test for the oracle).
+  - A green differential test proves nothing until it has been observed separating a correct
+    implementation from the known-incorrect one.
+  - Procedure: temporarily change `code.split("\n")` to `code.splitlines()` in
+    `scripts/regenerate-mermaid-url.py`, run the command from T012, then revert.
+  - Pass condition: the mutated run exits **non-zero** with the differential test failing and the
+    failure message showing a `repr()` containing one of `\r`, `\v`, `\f`, `\x85`, ` ` or
+    ` `. Then `git diff -- scripts/regenerate-mermaid-url.py` after the revert must show the
+    `split("\n")` form restored, and T012 must pass again.
+  - Repeat once with `rstrip(" \t")` in place of `rstrip()`: the mutated run must also fail, with
+    **some whitespace character other than a space or a tab** visible in the `repr()`. Do **not**
+    hold out for a non-breaking space or a vertical tab specifically. Reproduced over a corpus
+    built to T009's atom set (6,629 inputs): the narrowed trim produces 441 mismatches, but the
+    *first* of them is `'-->\r'`, so a test that reports only the first mismatch shows a carriage
+    return, and an operator waiting for a non-breaking space would record a correctly-red red-test
+    as not having gone red. See Adversarial Review #3 finding G4. Revert.
+  - Depends on: T012.
+
+- [ ] **T014** [US1] VERIFY no pattern literal remains on the arrow-without-target check (FR-002).
+  - Command:
+    ```bash
+    grep -n 're\.search' scripts/regenerate-mermaid-url.py; echo "grep_exit=$?"
+    grep -c -- '-->' scripts/regenerate-mermaid-url.py
+    ```
+  - Pass condition: exactly one `re.search` line remains and it is the `==>` control line. No
+    `re.search` line mentions `-->`.
+  - Depends on: T007.
+
+**Checkpoint**: US1 is complete and independently verifiable. The alert-state half is deferred to
+Phase 8 by FR-022.
+
+---
+
+## Phase 4: User Story 2 - Maintainer is not misled by a comment that does nothing (P2)
+
+**Goal**: the inert suppression and the stale explanatory note are gone, and nothing inline replaces
+them.
+
+**Independent Test**: `grep -rnE "lgtm\[|codeql\[" src/ tests/ scripts/` returns matches only inside
+the auditor and its test (or nothing at all, if US3 has not landed yet).
+
+- [ ] **T015** [US2] Delete the dead suppression and the stale note in
+      `scripts/regenerate-mermaid-url.py` (FR-005, FR-006).
+  - Delete the trailing `# lgtm[py/bad-tag-filter]` comment. Do **not** convert it to
+    `# codeql[...]` or to any other inline suppression form: no inline form is honoured by this
+    repository's scanning setup, and swapping one for the other is exactly what the January
+    reintroduction did.
+  - Delete or rewrite the adjacent `# CodeQL py/bad-tag-filter: False positive ...` line, which
+    describes an expression that no longer exists. In practice it is replaced by the FR-020 note
+    written in T007.
+  - Same file and same line range as T007. Not parallel with it.
+  - Depends on: T007.
+
+- [ ] **T016** [US2] VERIFY the marker is gone from the file and was not replaced (FR-005, FR-006,
+      US2 scenarios 1 and 2).
+  - Command:
+    ```bash
+    grep -nE "lgtm\[|codeql\[|False positive" scripts/regenerate-mermaid-url.py; echo "grep_exit=$?"
+    ```
+  - Pass condition: no output and `grep_exit=1`. `grep_exit=0` means something is still there.
+  - Depends on: T015.
+
+- [ ] **T017** [US2] VERIFY the thick-arrow control is byte-identical (SC-010, US1 scenario 4).
+  - **Do not use the form in `quickstart.md` section 2.** `git diff main -- <file> | grep -- "==>"`
+    prints the control line as a *context* line, because the control sits exactly three lines below
+    the changed line and git's default context is three. That command produces output on a
+    correct change, so its stated pass condition ("expect no output") is false by construction. See
+    Cross-Artifact Analysis F2.
+  - Command:
+    ```bash
+    git diff main -- scripts/regenerate-mermaid-url.py | grep -E '^[+-].*==>'
+    echo "git_exit=${PIPESTATUS[0]} grep_exit=${PIPESTATUS[1]}"
+    ```
+  - Pass condition: `git_exit=0` and `grep_exit=1` (no added or removed line mentions `==>`). Any
+    output at all means the control was disturbed.
+  - Depends on: T015.
+
+- [ ] **T018** [US2] VERIFY the audited-path marker scan (SC-004, FR-021, US2 scenario 3).
+  - Command:
+    ```bash
+    grep -rnE "lgtm\[|codeql\[" src/ tests/ scripts/; echo "grep_exit=$?"
+    ```
+  - Pass condition, two states depending on ordering:
+    - Run after US2 but **before** US3's checker exists: no output, `grep_exit=1`.
+    - Run after US3 has landed: output lines **only** from `scripts/check_dead_suppressions.py` and
+      `tests/unit/scripts/test_check_dead_suppressions.py`. No other path may appear.
+  - Never run tree-wide. This feature's own artifacts hold dozens of markers and always will.
+  - Depends on: T015. Re-run after T036.
+
+**Checkpoint**: US2 is complete. US1 and US2 together are the informational half of the feature and
+stand regardless of the Phase 6 owner decision.
+
+---
+
+## Phase 5: User Story 3 core - the checker, its tests, and the local target (P3)
+
+**Goal**: a dedicated, standard-library-only checker that detects inert inline suppression markers,
+fails on them with an actionable message, and is wired into `make audit-pragma` with explicit
+blocking status.
+
+**Everything in this phase survives a rejection of FR-018.** Only Phase 6 falls.
+
+**Independent Test**: seed a marker into a throwaway file outside the repository, point the checker
+at it, and confirm it exits 1 naming file, line and marker. Remove it and confirm exit 0.
+
+**Note on file ordering**: T019 through T025 all edit the same new file
+(`scripts/check_dead_suppressions.py`) and are therefore strictly sequential, not parallel. They are
+listed separately because each maps to a distinct normative contract clause and each is
+independently checkable.
+
+### The checker (contract clauses C1 through C7)
+
+- [ ] **T019** [US3] Create `scripts/check_dead_suppressions.py` satisfying **C1** (invocation) and
+      FR-009a (dedicated file).
+  - Module docstring stating purpose, the exit codes, and the standard-library-only constraint.
+  - **First line of code: `from __future__ import annotations`.** This is not stylistic. See the
+    ruff reconciliation block below.
+  - Standard library only: `argparse`, `os`, `sys`, `pathlib`. No import of anything from
+    `requirements*.txt`. `.github/workflows/pr-checks.yml:52-56` installs `ruff==0.15.14` and
+    nothing else in the `Lint` job, so a single third-party import puts a required check
+    permanently red.
+  - Positional arguments accepted and **ignored**, parsed with `parse_known_args`, so a pre-commit
+    hook handing over a file list cannot narrow the scan.
+  - Repository root resolved from `Path(__file__).resolve().parent.parent`, never from the current
+    working directory. No `.venv` requirement. No executable bit assumed.
+  - No network access, no filesystem writes.
+  - **Reconciling C1's 3.9 floor with the repository's ruff configuration. This is the feature's
+    biggest implementation risk and it has been reproduced, not theorised.** T038 widens
+    `ruff check --extend-select RUF100` to `scripts/` on a **blocking** line of `audit-pragma`.
+    `--extend-select` adds to `pyproject.toml`'s configured `select` (`E W F I B C4 UP S RUF100`)
+    rather than replacing it, and `target-version = "py313"`. A 3.9-shaped file therefore trips
+    `UP035`, `UP006`, `UP045` and `UP036` under the pinned ruff 0.15.14, reproduced against a
+    purpose-written file. That is the exact day-one failure FR-015 exists to prevent. The binding
+    resolution, all four parts:
+    1. `from __future__ import annotations` at the top. Annotations then never evaluate at runtime,
+       so PEP 604 (`str | None`) is valid back to 3.7 and `UP045` is satisfied at the same time.
+    2. PEP 604 unions and builtin generics (`list[Path]`) **in annotations only**. Never where they
+       are evaluated: no `isinstance(x, str | None)`, no runtime `typing.get_type_hints`.
+    3. **No `sys.version_info` interpreter guard.** `UP036` flags it, the precedent needed
+       `# noqa: UP036` to carry one (`scripts/scan-waitforresponse-race.py`), and C1 forbids
+       version-gated syntax anyway. If one is ever added later, C1 also forbids it reusing exit code
+       `2`, which C2 assigns to "zero files scanned".
+    4. The file must be ruff-clean under the full configured set before T038 leaves the widened line
+       blocking. Verified at T026.
+  - Depends on: T006.
+
+- [ ] **T020** [US3] Implement **C3**: default roots, extension allowlist, skip list, decoding.
+  - Roots: `src/`, `tests/`, `scripts/`, resolved against the repository root (FR-010). A root that
+    does not exist contributes zero files.
+  - Extension allowlist, case-insensitive, exactly: `.py .sh .js .ts .tsx .jsx .html .yml .yaml .tf`.
+    `.md` and `.txt` are absent on purpose: prose describing a marker has to write it, which is the
+    defect that made the specification's original tree-wide criterion false at the moment it was
+    written.
+  - Skipped unconditionally at any depth: `__pycache__`, `node_modules`, `.venv`, `.git`,
+    `.pytest_cache`, `.hypothesis`. This list is normative in C3 and `plan.md` section 5 carries the
+    identical list; they must stay identical.
+  - Read files as UTF-8 with `errors="replace"`, so one undecodable file cannot raise and take the
+    gate down.
+  - Depends on: T019.
+
+- [ ] **T021** [US3] Implement **C4**: the `DEAD_SUPPRESSION_ROOTS` override.
+  - `os.pathsep`-separated paths. Relative entries resolve against the repository root. The override
+    **replaces** the default set entirely rather than extending it. The extension allowlist and the
+    skip list still apply under an override.
+  - This is a testing seam and nothing else. Neither consumer sets it (C8).
+  - Depends on: T019.
+
+- [ ] **T022** [US3] Implement **C5**: the positional detection rule.
+  - A line matches when both hold: it contains `lgtm[` or `codeql[` compared case-insensitively,
+    **and** the marker's position is after the first occurrence of a comment introducer on that
+    line. Introducers: `#`, `//`, `<!--`, `/*`, `--`.
+  - Matching is per line; markers spanning a line break are out of scope by design.
+  - `--` is the loosest introducer in the set and matches any line carrying `--` before a marker, an
+    arrow included. It is retained deliberately for the `.sql` extension that is **not** currently in
+    the allowlist, and is a known false-positive source rather than an oversight.
+  - The rule is purely textual. It does not know what a string literal is. That fact is load-bearing
+    for T028 and was a falsified claim in an earlier draft of the plan.
+  - Depends on: T019.
+
+- [ ] **T023** [US3] Implement **C6**: exact-path self-exclusion.
+  - ```python
+    SELF_EXCLUSIONS = frozenset({
+        Path("scripts/check_dead_suppressions.py"),
+        Path("tests/unit/scripts/test_check_dead_suppressions.py"),
+    })
+    ```
+  - A candidate is skipped **if and only if** it resolves inside the repository root **and** its
+    repository-relative path is a member of that set. Exactly two members. Adding a third is a
+    requirements change.
+  - **Do not write a bare `path.resolve().relative_to(repo_root)`.** Under a
+    `DEAD_SUPPRESSION_ROOTS` override the scan walks files outside the repository and `relative_to`
+    raises `ValueError` on every one of them, which takes the T029 negative test down with it. Use a
+    containment test (`Path.is_relative_to`, or `relative_to` inside `try/except ValueError`) and
+    treat "outside the repository" as "not excluded".
+  - Explicitly **not** the precedent's mechanism: `scripts/check-banned-terms.sh` uses a grep
+    basename glob, which exempts any identically named file anywhere in the tree. FR-009 forbids
+    that form.
+  - Do **not** obfuscate the marker strings inside the checker to avoid matching itself. CLAUDE.md's
+    SAST section says plainly not to restructure code to dodge detection.
+  - Depends on: T019.
+
+- [ ] **T024** [US3] Implement **C7**: output format, both paths (FR-014, FR-007).
+  - Clean run to stdout, stating the roots and **the number of files scanned**, so a root that
+    quietly shrank is visible in a passing log rather than only in an exit `2`.
+  - Failing run to stdout, per finding: the **file**, the **line number**, the **marker**, and the
+    offending source line. Then two blocks: **why the form is inert** (inline `lgtm[...]` and
+    `codeql[...]` comments are not honoured by this repository's scanning setup and suppress
+    nothing; a high-severity alert sat open on the default branch for six months behind exactly this
+    comment, on the exact line the comment was on) and **what to do instead** (change the code so the
+    finding does not arise; or dismiss it through the scanning product's own dismissal workflow with
+    a recorded reason, which is the only suppression route with any effect here (FR-007); and do not
+    swap one marker form for the other, because neither works).
+  - Paths printed repository-relative when the file is inside the repository, **absolute when it is
+    not**. Same reason as C6's containment test: under an override there is no repository-relative
+    path to print, and `relative_to` would raise.
+  - Depends on: T020, T022, T023.
+
+- [ ] **T025** [US3] Implement **C2**: exit codes.
+  - `0`: at least one file scanned, no marker found.
+  - `1`: one or more markers found.
+  - `2`: zero files scanned, for any reason.
+  - `2` is separate from `0` deliberately. A scan that examined nothing must not report the same
+    result as a scan that found nothing, or a moved root reads as a clean tree. The default roots
+    are three hard-coded directory names, so this is live rather than theoretical.
+  - Depends on: T020, T024.
+
+### Static checks on the checker itself
+
+- [ ] **T026** [P] [US3] VERIFY the real new file is ruff-clean under the full configured rule set.
+  - This is the task that closes the 3.9-floor / ruff collision. It runs the real command against
+    the real file, not a proxy.
+  - Command:
+    ```bash
+    source .venv/bin/activate
+    ruff check --extend-select RUF100 scripts/check_dead_suppressions.py; echo "exit=$?"
+    ruff check --extend-select RUF100 src/ tests/ scripts/; echo "exit=$?"
+    ```
+  - Pass condition: `All checks passed!` and `exit=0` for **both** commands. Any `UP035`, `UP006`,
+    `UP045` or `UP036` result means the file was written to the 3.9 floor without the four
+    reconciliation rules from T019 and would redden the blocking line T038 introduces.
+  - Depends on: T025.
+
+- [ ] **T027** [P] [US3] VERIFY the 3.9 syntax floor and the standard-library-only constraint
+      (C1, FR-019).
+  - Command:
+    ```bash
+    source .venv/bin/activate
+    python - <<'PY'
+    import ast, pathlib, sys
+    src = pathlib.Path("scripts/check_dead_suppressions.py").read_text(encoding="utf-8")
+    try:
+        ast.parse(src, feature_version=(3, 9))
+    except SyntaxError as exc:
+        sys.exit(f"FAIL: not parseable under 3.9: {exc.msg}")
+    tree = ast.parse(src)
+    mods = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            mods.update(a.name.split(".")[0] for a in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+            mods.add(node.module.split(".")[0])
+    extra = mods - set(sys.stdlib_module_names) - {"__future__"}
+    if extra:
+        sys.exit(f"FAIL: non-stdlib imports: {sorted(extra)}")
+    print("PASS: 3.9-parseable, stdlib-only:", sorted(mods))
+    PY
+    echo "exit=$?"
+    ```
+  - Pass condition: `exit=0` and a `PASS:` line. Known limitation, stated so it is not oversold:
+    `feature_version` catches *syntax* newer than 3.9, not standard-library APIs added after 3.9.
+    `Path.is_relative_to` is 3.9, so C6's suggested form is inside the floor.
+  - Depends on: T025.
+
+### The checker's tests
+
+- [ ] **T028** [US3] Create `tests/unit/scripts/test_check_dead_suppressions.py`, observing the one
+      rule that keeps the gate from going permanently red.
+  - Import the checker directly: `import scripts.check_dead_suppressions as mod`. This works because
+    pytest puts the repository root on `sys.path` and PEP 420 makes `scripts/` an implicit namespace
+    package; `tests/unit/scripts/test_consolidate_oauth_apply.py` already does exactly this. The
+    underscore filename was chosen for this reason.
+  - **Binding rule, copied literally from `plan.md` section 7: no single source line of this test
+    file may contain a comment introducer followed by a marker.** C5 is purely textual and does not
+    know what a string literal is, so the natural fixture line
+    `fixture.write_text("x = 1  # lgtm[py/some-rule]\n")` **matches C5 as source** and the checker
+    flags the test file itself. Build fixtures from separated expressions instead:
+    ```python
+    INTRODUCER = "#"
+    MARKER = "lgtm[py/some-rule]"
+    fixture.write_text(f"x = 1  {INTRODUCER} {MARKER}\n")
+    ```
+    Do the same for the `codeql[` case. The test file must also never carry a marker in a real `#`
+    comment: "here is what a bad line looks like" is precisely the well-meaning edit that turns the
+    gate permanently red.
+  - With that rule observed, the exact-path exclusion and the positional rule are two independent
+    mechanisms holding this file. Without it, only the exclusion holds it, and the file is one
+    rename away from a permanently red gate.
+  - `from __future__ import annotations` at the top. The file lives under `tests/` and is therefore
+    linted **and format-checked** by the required `Lint` job (`ruff check src/ tests/` and
+    `ruff format --check --diff src/ tests/`).
+  - Depends on: T025, T006.
+
+- [ ] **T029** [US3] Negative test: prove the checker fails on a seeded violation (SC-006, US3
+      scenarios 1 and 2, C2, C4, C5, C7). **This is the red-test. Without it the checker has never
+      been observed failing and is not a check.**
+  - Write a fixture file with an allowlisted extension (`.py`) into pytest's `tmp_path`, carrying a
+    real marker assembled per T028's rule. Point the checker at `tmp_path` through
+    `DEAD_SUPPRESSION_ROOTS`. `tmp_path` is outside the repository, so the fixture never exists
+    inside an audited root, no exclusion is needed for it, and pytest destroys it at test end.
+  - Assert exit code **1**, and that the output names the fixture file, line **1**, and the marker
+    text.
+  - Two cases: one for `lgtm[`, one for `codeql[`. Both must exit 1. The `codeql[` case exists
+    because that form is honoured only by a command-line path this repository does not use, and
+    swapping to it is the obvious wrong workaround.
+  - A control case in the same test: the same fixture with the marker but **no** introducer must
+    exit `0`, proving the failure came from the rule and not from the file merely existing.
+  - Depends on: T028.
+
+- [ ] **T030** [US3] Zero-files test: exit code `2`, not `0` (C2).
+  - Point `DEAD_SUPPRESSION_ROOTS` at an empty `tmp_path` directory. Assert exit code is exactly
+    `2`. Also assert it is not `0`, with a message explaining that "scanned nothing" must never read
+    as "found nothing".
+  - Depends on: T028.
+
+- [ ] **T031** [US3] Self-exclusion tests (FR-009, C6).
+  - Assert `SELF_EXCLUSIONS` has exactly two members and that they are
+    `scripts/check_dead_suppressions.py` and
+    `tests/unit/scripts/test_check_dead_suppressions.py`.
+  - Assert a file with the **same basename** placed in `tmp_path` and carrying a marker is still
+    flagged (exit 1). This is the assertion that would have caught the precedent's basename hole and
+    is the whole point of FR-009.
+  - Assert the exclusion path does not raise for files outside the repository: a `tmp_path` run must
+    complete rather than propagate `ValueError`.
+  - Depends on: T028.
+
+- [ ] **T032** [US3] Positional-rule tests (C5).
+  - A marker inside a Python string literal with no introducer earlier on the line does not fire.
+  - A marker inside a URL with no introducer earlier on the line does not fire.
+  - The same marker after `#` fires.
+  - The same marker after each of `//`, `<!--`, `/*` and `--` fires.
+  - Case-insensitivity: `LGTM[` and `CodeQL[` after an introducer both fire.
+  - A file whose extension is not on the allowlist (`.md`) carrying a marker after an introducer
+    does **not** fire.
+  - Depends on: T028.
+
+- [ ] **T033** [US3] Output-content tests (FR-014, C7).
+  - On a failing run assert the output contains: the reported path, the line number, the marker
+    text, a distinctive phrase from the "why this is inert" block, and a distinctive phrase from the
+    "what to do instead" block naming the dismissal workflow (FR-007).
+  - On a clean run assert the output states a file count greater than zero.
+  - Assert on **substrings only**, never on exact whitespace or a verbatim block, or every wording
+    improvement becomes a test failure (C7's closing paragraph).
+  - Depends on: T028.
+
+- [ ] **T034** [US3] Subprocess command-line test pinning the exit-code contract (C1, C2).
+  - Invoke the checker as a command line with `subprocess.run([sys.executable, "scripts/check_dead_suppressions.py"], ...)`.
+  - **Use `sys.executable`, never a bare `python3`.** A bare `python3` resolves differently per
+    machine and per shell: on the reference machine `/usr/bin/python3` is 3.12.3 while `python3`
+    reaches 3.13.0 through a pyenv shim, and CLAUDE.md records a different number again. The test
+    must pin the interpreter it is running under rather than gamble on `PATH`.
+  - Assert all three codes through the command-line surface: `0` against the real tree, `1` against
+    a seeded `tmp_path` root, `2` against an empty `tmp_path` root.
+  - Also assert that passing positional file arguments does **not** narrow the scan (C1, C8): a run
+    with a single positional path must scan the same number of files as the bare run.
+  - **The `subprocess.run(` call MUST carry `# noqa: S603` with a one-line justification comment
+    above it, or this task reddens the required `Lint` job.** `pyproject.toml` selects `S`
+    (flake8-bandit) and its `[tool.ruff.lint.per-file-ignores]` entry for `tests/**/*.py` lists
+    `S101 S105 S106 S108 S110 S311 E402 C420` and **not** `S603`, so `ruff check src/ tests/`, a
+    step in the required `Lint` job, flags every `subprocess.run` under `tests/`. Reproduced:
+    `ruff check --select S --ignore-noqa tests/e2e/test_log_visibility.py` reports
+    `S603 subprocess call: check for execution of untrusted input`, and the one existing test in
+    this repository that shells out (`tests/e2e/test_log_visibility.py:115`) carries exactly that
+    suppression plus a two-line justification. That suppression is provably load-bearing rather
+    than decorative: `RUF100` is selected too, so if `S603` did not fire the `# noqa` would itself
+    be an error and `ruff check src/ tests/` would not be passing today. Put the directive on the
+    `subprocess.run(` line and nowhere else, for the same RUF100 reason. `S607` does not apply,
+    because `sys.executable` is an absolute path. No other artifact in this feature mentions
+    `S603`; see Adversarial Review #3 finding G1.
+  - Depends on: T028.
+
+- [ ] **T035** [US3] Clean-tree canary test (SC-005, FR-015).
+  - Run the checker against the real default roots and assert exit `0`.
+  - This is a canary by design: it goes red the day somebody adds a marker to `src/`, `tests/` or
+    `scripts/`, which is exactly the behaviour being bought. It also means a scratch marker commit
+    turns **two** required contexts red, `Lint` and `Run Tests`, which is the expected result at
+    T044 and not a second defect.
+  - **Cross-story dependency, stated rather than hidden**: this test cannot pass until T015 has
+    deleted the marker in `scripts/regenerate-mermaid-url.py`. US3 is therefore not fully
+    independently testable ahead of US2, contrary to the template's default claim.
+  - Depends on: T028, T015.
+
+- [ ] **T036** [US3] VERIFY the checker's test module passes and that it does not flag itself.
+  - Command:
+    ```bash
+    source .venv/bin/activate
+    pytest tests/unit/scripts/test_check_dead_suppressions.py -v; echo "exit=$?"
+    ```
+  - Pass condition: `exit=0`, zero failures, zero errors.
+  - Second command, which proves T028's binding rule was actually observed rather than intended. It
+    copies the test file outside the repository so the exact-path exclusion cannot apply, leaving
+    only the positional rule to hold it:
+    ```bash
+    TMPD=$(mktemp -d)
+    cp tests/unit/scripts/test_check_dead_suppressions.py "$TMPD/copy_of_test.py"
+    DEAD_SUPPRESSION_ROOTS="$TMPD" python3 scripts/check_dead_suppressions.py; echo "exit=$?"
+    rm -rf "$TMPD"
+    ```
+  - Pass condition: `exit=0`. An `exit=1` means at least one source line of the test file carries a
+    comment introducer followed by a marker, and the file is being held by the exclusion alone.
+  - Depends on: T029, T030, T031, T032, T033, T034, T035.
+
+### The local target
+
+- [ ] **T037** [US3] VERIFY both new test files satisfy the required `Lint` job's own steps.
+  - The `Lint` job runs `ruff format --check --diff src/ tests/` as well as `ruff check src/ tests/`.
+    No artifact in this feature mentions the format step, and a format-dirty new test file reddens a
+    required context. See Cross-Artifact Analysis F1.
+  - Command:
+    ```bash
+    source .venv/bin/activate
+    ruff format --check --diff src/ tests/; echo "fmt_exit=$?"
+    ruff check src/ tests/; echo "lint_exit=$?"
+    ```
+  - Pass condition: `fmt_exit=0` and `lint_exit=0`.
+  - Depends on: T012, T036.
+
+- [ ] **T038** [US3] Rewrite the `audit-pragma` recipe in `Makefile` (FR-010, FR-011, FR-012,
+      FR-013, SC-008, C9).
+  - Target shape:
+    ```make
+    audit-pragma: ## Audit pragma comments (# noqa, # nosec) and dead scanning suppressions
+    	@echo "$(YELLOW)=== [BLOCKING] Unused # noqa comments (RUF100) ===$(NC)"
+    	ruff check --extend-select RUF100 src/ tests/ scripts/
+    	@echo ""
+    	@echo "$(YELLOW)=== [BLOCKING] Dead inline scanning suppressions ===$(NC)"
+    	@python3 scripts/check_dead_suppressions.py
+    	@echo ""
+    	@echo "$(YELLOW)=== [ADVISORY - never fails this target] # nosec usage (Bandit, suppressions disabled) ===$(NC)"
+    	@bandit -r src/ scripts/ --ignore-nosec 2>/dev/null | grep -E "^(>>|Issue)" || true
+    	@echo "$(YELLOW)(the line above is advisory by design; see FR-012)$(NC)"
+    	@echo ""
+    	@echo "$(GREEN)✓ Pragma audit complete$(NC)"
+    ```
+  - Three changes, each mapped: RUF100 path set widened to include `scripts/` (FR-010, FR-011);
+    the new check inserted as an explicitly blocking step (FR-008); the bandit line's advisory status
+    turned into a *declaration* rather than an accident of pipeline semantics, with its path set
+    widened to `src/ scripts/` (FR-012, FR-013). The existing `|| echo "No issues found"` is
+    replaced by `|| true` plus a labelled banner, so a reader does not have to derive the contract
+    from `PIPESTATUS` semantics (SC-008).
+  - The checker line MUST NOT be piped, wrapped in `|| true`, or otherwise have its status swallowed
+    (C8). That would recreate the exact defect this feature exists to remove.
+  - **Ordering is load-bearing: this task must come after T026.** Widening the RUF100 line to
+    `scripts/` puts the new checker under the full configured rule set on a blocking line. Doing it
+    before T026 passes means introducing a day-one failure, which is what FR-015 forbids.
+  - `make audit-pragma` as a whole remains unwired from `make validate` and from CI. That is
+    deliberate and carded out of scope. Only the marker check reaches CI, and it reaches it directly.
+  - Depends on: T026, T036.
+
+- [ ] **T039** [US3] VERIFY the target passes and declares its statuses (SC-005, SC-007, SC-008).
+  - Command:
+    ```bash
+    source .venv/bin/activate
+    make audit-pragma; echo "exit=$?"
+    ```
+  - Pass condition: `exit=0`, and the output contains exactly three section banners, two labelled
+    `[BLOCKING]` and one labelled `[ADVISORY`. The bandit wall will be roughly twice as long as
+    before (25 findings rather than 15) because the path set widened; that is expected and is not a
+    regression this feature caused.
+  - Depends on: T038.
+
+- [ ] **T040** [US3] VERIFY the target actually fails on a seeded violation (red-test for the
+      Makefile wiring, C8).
+  - T039 proves the target can pass. This proves it can fail, which is the property that was missing
+    from the bandit half for its entire existence.
+  - Procedure:
+    ```bash
+    source .venv/bin/activate
+    printf 'X = 1  %s %s\n' '#' 'lgtm[py/redtest-do-not-commit]' > scripts/_redtest_tmp.py
+    make audit-pragma; echo "exit=$?"
+    rm -f scripts/_redtest_tmp.py
+    make audit-pragma; echo "exit=$?"
+    git status --porcelain; echo "status_exit=$?"
+    ```
+  - Pass condition: the first `make audit-pragma` exits **non-zero** and its output names
+    `scripts/_redtest_tmp.py`, line 1, and the marker. The second exits `0`. `git status --porcelain`
+    shows no leftover `_redtest_tmp.py`.
+  - Note the `printf` form: the marker and the introducer are separate arguments, so no source line
+    of any committed file carries both.
+  - Depends on: T039.
+
+- [ ] **T041** [P] [US3] VERIFY no consumer swallows the checker's exit status (C8).
+  - Command:
+    ```bash
+    grep -n 'check_dead_suppressions' Makefile .github/workflows/pr-checks.yml .pre-commit-config.yaml
+    echo "grep_exit=$?"
+    ```
+  - Pass condition: every line that invokes the checker is a bare invocation. No line contains
+    `|| true`, `| grep`, `| echo`, `|| echo`, or `; true` on the same line as the invocation. The
+    `.pre-commit-config.yaml` match is expected only if T043 was done, and is optional.
+  - Depends on: T038.
+
+**Checkpoint**: US3's core is complete. The checker exists, is proven able to fail, and blocks the
+local target. It does not yet block a merge. That is Phase 6.
+
+---
+
+## Phase 6: FR-018 - making the gate real (OWNER-REJECTABLE, separable)
+
+> **This entire phase is the feature's scope growth and the owner may reject it.**
+>
+> The original request was "rewrite an expression, delete a comment, extend `make audit-pragma`"
+> (`spec.md` Input line). FR-018 grows that into editing `.github/workflows/pr-checks.yml`, which
+> carries one of the four contexts branch protection requires on `main`. The reasoning is that
+> `make audit-pragma` is invoked by nothing automated: it is not among `make validate`'s seven
+> prerequisites (`Makefile:42`), it appears in no workflow, and it appears in no commit hook. A check
+> placed only there has never once run against a change that was about to land, which is the same
+> category of object as the comment being deleted.
+>
+> **If the owner rejects FR-018, exactly these tasks die: T042, T043, T044, T045, T046.** With them
+> fall FR-018, FR-019, SC-011, SC-012, and US3 acceptance scenario 6. Everything in Phases 1 through
+> 5 and 7 through 9 stands unchanged: the checker still gets built, still gets wired into
+> `make audit-pragma`, still has the same contract, and still has its red-test. What it loses is the
+> property of ever running against a change that is about to land, and the feature keeps only its
+> informational outcomes.
+>
+> Neither outcome may be reached silently. Do not widen the CI footprint beyond the single step in
+> T042 (no new job, no new required context, no `make validate` prerequisite, all carded out of
+> scope), and do not quietly drop the step on the grounds that it is "just tooling".
+
+- [ ] **T042** [US3] [GATE] Append one step to the `lint` job in `.github/workflows/pr-checks.yml`
+      (FR-018, FR-019, C9).
+  - Placed after the existing waitForResponse guard step, following that precedent exactly,
+    including its explanatory comment block. The step:
+    ```yaml
+          - name: Check for dead scanning suppressions
+            if: always()
+            run: python3 scripts/check_dead_suppressions.py
+    ```
+  - The comment block above it must state: why the guard lives in `Lint` and not in
+    `Pre-commit Hooks` (`Lint` is required, `Pre-commit Hooks` is not, so moving it silently
+    downgrades the guard to advisory with no symptom until a violation merges green); the command
+    that verifies the required contexts and the date it was last run; that there is no `pip install`
+    because the checker is standard-library only and `setup-python` already provides an interpreter
+    (FR-019); and why `if: always()` is needed (steps are fail-fast and this one is last, so without
+    it a ruff failure means the guard never runs and reports nothing).
+  - **`python3 scripts/check_dead_suppressions.py`, not `make audit-pragma`.** The `Lint` job
+    installs `ruff==0.15.14` and nothing else. `bandit` is absent, so the target's third section
+    would fail on a missing binary, and adding bandit is precisely the tooling installation FR-019
+    forbids. Invoking directly also means the `Pre-commit Hooks` job's `SKIP` environment cannot
+    reach it (C8).
+  - No `|| true`, no pipe, no wrapper (C8).
+  - Depends on: T002, T038, T040.
+
+- [ ] **T043** [US3] [GATE] **OPTIONAL, not required by any FR**: add a matching local `pre-commit`
+      hook.
+  - Mirroring the `scan-waitforresponse-race` hook, with `language: system`,
+    `pass_filenames: false`, `always_run: true`, `stages: [pre-commit]`.
+  - It gives contributors the failure locally rather than in CI. It is **additive only**. If the two
+    ever disagree, the CI step is the gate. C8 permits an additive local hook and forbids only the
+    required check depending on the hook runner.
+  - This task is explicitly optional so that its absence is never read as an FR-018 miss.
+  - **MUST come after T044, and this ordering is not cosmetic.** Mirroring the precedent means
+    `always_run: true` with `pass_filenames: false` (`.pre-commit-config.yaml:206-212`), so the
+    hook runs on **every** commit regardless of what that commit touches. T044 has to commit a
+    marker inside an audited root in order to observe the gate biting, and this hook rejects that
+    commit locally. `--no-verify` is not an escape: CLAUDE.md forbids it outright and a
+    machine-level pre-tool hook denies `git … --no-verify` before it reaches git. If T043 has
+    already landed when T044 runs, the only legitimate route is
+    `SKIP=check-dead-suppressions git commit -S …`, which pre-commit honours per hook id. Do T044
+    first and the question does not arise. See Adversarial Review #3 finding G3.
+  - Depends on: T042, T044.
+
+- [ ] **T044** [US3] [GATE] VERIFY SC-011 by observed check result, not by reading the workflow file.
+  - Reading the workflow is not evidence. SC-011 requires an observed failure.
+  - Procedure, on the feature branch: commit a scratch change adding a marker to a file inside an
+    audited root, using the split-argument form so no committed source line of this feature's own
+    files carries both an introducer and a marker:
+    ```bash
+    printf 'X = 1  %s %s\n' '#' 'lgtm[py/scratch-do-not-merge]' > scripts/_gatetest_tmp.py
+    git add scripts/_gatetest_tmp.py
+    git commit -S -m "scratch: prove the gate bites (reset before merge)"
+    git push
+    gh pr checks --watch
+    ```
+    Then remove the scratch commit and push again:
+    ```bash
+    git reset --hard HEAD~1
+    git push --force-with-lease
+    ```
+  - **Three corrections to the obvious way of doing this, each of which has a concrete failure
+    mode.** See Adversarial Review #3 finding G5.
+    1. **A throwaway file, not `scripts/regenerate-mermaid-url.py`.** Seeding the marker into the
+       very file this feature exists to clean means a botched cleanup silently restores a marker to
+       that file. `X = 1  # lgtm[…]` in a throwaway is verified ruff-clean under the repository
+       config, so nothing upstream of the checker can fail first and mask the result.
+    2. **`git add <path>`, never `git add -A`.** This worktree is shared with concurrent sibling
+       features whose `specs/` directories are untracked; `-A` sweeps them into the scratch commit.
+    3. **`git reset --hard HEAD~1`, not `git revert`.** A revert leaves the scratch commit in
+       history, which makes the stated `git log --oneline` confirmation below unsatisfiable and
+       leaves a commit carrying a marker permanently reachable on the branch.
+  - Pass condition: on the scratch commit, `Lint` reports **failure** and the job log names
+    `scripts/_gatetest_tmp.py` and line 1. **`Run Tests` also reports failure**, through the T035
+    clean-tree canary. Two red contexts is the expected result, not a second defect. After the
+    reset, both go green.
+  - The scratch commit MUST NOT be merged. Confirm with `git log --oneline` that it is gone, and
+    with `git status --porcelain` that `scripts/_gatetest_tmp.py` is gone, before Phase 7.
+  - Depends on: T042.
+
+- [ ] **T045** [US3] [GATE] VERIFY SC-012 and FR-019 from the job log.
+  - **The workflow file is the evidence for FR-019 and for step adjacency; the job log is the
+    evidence that no install step actually ran.** They are two different reads and the second one
+    needs a **job** id, which `gh run list` does not return.
+  - Command:
+    ```bash
+    grep -n 'pip install' .github/workflows/pr-checks.yml; echo "grep_exit=$?"
+    grep -n 'name: Check' .github/workflows/pr-checks.yml; echo "grep_exit=$?"
+
+    RID=$(gh run list --workflow pr-checks.yml --limit 1 --json databaseId --jq '.[0].databaseId')
+    JID=$(gh run view "$RID" --json jobs --jq '.jobs[] | select(.name=="Lint") | .databaseId')
+    echo "RID=$RID JID=$JID"
+    gh run view --job "$JID" --log > /tmp/lint-job.log; echo "log_exit=$?"
+    grep -c '' /tmp/lint-job.log
+    ```
+  - Pass condition: the `lint` job in the workflow file contains exactly one install step and it
+    installs `ruff==0.15.14` only; T042 added none; and the new step is the one immediately
+    following `Check waitForResponse race ordering` with nothing between them. `log_exit=0` and a
+    non-zero line count, so the log read is known to have worked before anything is concluded from
+    its contents.
+  - **Do not write `gh run view --job "$(gh run list … --json databaseId …)"`.** That is the form
+    this task carried before Adversarial Review #3 and it is broken: `gh run list --json databaseId`
+    returns a **run** id, `--job` expects a **job** id, and the two id spaces do not overlap.
+    Reproduced 2026-07-30 against this repository: run `30597680512` yields
+    `failed to get job: HTTP 404: Not Found (…/actions/jobs/30597680512)`, exit 1. The two-step
+    resolution above returns job `91053515417` and a 322-line log. A 404 piped into `head -5` with
+    `2>/dev/null` prints nothing at all, which an operator reads as "no install steps", which is the
+    answer the task wants. A verification that passes by failing. See Adversarial Review #3
+    finding G2.
+  - Depends on: T042.
+
+- [ ] **T046** [US3] [GATE] Re-confirm the required contexts immediately before merging the CI step.
+  - Same command as T002. The precedent's own comment at `.pre-commit-config.yaml` says plainly not
+    to trust that list without re-checking.
+  - Pass condition: `"Lint"` is still among the returned contexts. If it is not, the step is
+    advisory regardless of what the workflow file says, and FR-018 is unsatisfied.
+  - Depends on: T044.
+
+---
+
+## Phase 7: Pre-merge re-verification (FR-015)
+
+**Purpose**: FR-015 requires the cleanliness that makes the new blocking behaviour safe to be
+re-verified **against the exact tree being merged**, and explicitly forbids inferring it from a
+measurement taken during planning. This worktree is shared with concurrent work, and `scripts/` has
+never been inside the RUF100 path set before, so a single `# noqa` arriving there between planning
+and merge converts FR-011 into a day-one failure for everybody who runs the target.
+
+Run all of Phase 7 on the merge commit, after the final rebase.
+
+- [ ] **T047** [P] Re-run the widened unused-pragma check on the merge commit (FR-011, FR-015,
+      SC-007).
+  - Command:
+    ```bash
+    source .venv/bin/activate
+    ruff check --extend-select RUF100 src/ tests/ scripts/; echo "exit=$?"
+    ```
+  - Pass condition: `All checks passed!` and `exit=0`. This supersedes T003; T003 is not evidence
+    about this commit.
+
+- [ ] **T048** [P] Re-run the audited-path marker scan on the merge commit (SC-004, FR-021).
+  - Command:
+    ```bash
+    grep -rnE "lgtm\[|codeql\[" src/ tests/ scripts/; echo "grep_exit=$?"
+    ```
+  - Pass condition: output lines come **only** from `scripts/check_dead_suppressions.py` and
+    `tests/unit/scripts/test_check_dead_suppressions.py`. Any other path is a failure. If FR-018 was
+    rejected and Phase 6 dropped, this condition is unchanged.
+
+- [ ] **T049** [P] Re-run the local target on the merge commit (FR-015, SC-005, SC-008).
+  - Command:
+    ```bash
+    source .venv/bin/activate
+    make audit-pragma; echo "exit=$?"
+    ```
+  - Pass condition: `exit=0` and three labelled sections.
+
+- [ ] **T050** [P] Mirror the required `Lint` job's steps locally (SC-011 precondition, and the only
+      safe substitute for `make validate`).
+  - `make validate` cannot pass on this tree: `scripts/check-banned-terms.sh` exits 1 on
+    pre-existing matches belonging to other features. Do not require it to be green. Run the `Lint`
+    job's own steps instead.
+  - Command:
+    ```bash
+    source .venv/bin/activate
+    ruff format --check --diff src/ tests/; echo "fmt_exit=$?"
+    ruff check src/ tests/; echo "lint_exit=$?"
+    ruff check src/ --select S --output-format=github; echo "sec_exit=$?"
+    python3 scripts/scan-waitforresponse-race.py; echo "race_exit=$?"
+    python3 scripts/check_dead_suppressions.py; echo "dead_exit=$?"
+    ```
+  - Pass condition: all five exit `0`. The last line exists only if FR-018 was accepted; if it was
+    rejected, run it anyway as a local check, but its result gates nothing.
+
+- [ ] **T051** [P] Run the unit test suite (SC-009).
+  - Command:
+    ```bash
+    source .venv/bin/activate
+    pytest tests/unit -q; echo "exit=$?"
+    ```
+  - Pass condition: `exit=0`, and both new test modules appear in the collected set. SC-009's
+    wording is satisfied by this: the diagram script had no prior coverage of any kind, so the
+    FR-004 test is the first coverage it has ever had and there is no pre-existing suite for it to
+    pass unchanged.
+
+---
+
+## Phase 8: Post-merge verification (FR-016, FR-017, FR-022, SC-001, SC-002)
+
+**Purpose**: the alert half of US1. **This cannot be done before merge.** The branch-level analysis
+does not refresh until the change is on `main`, and no scanning result is among the four required
+checks, so nothing holds the merge while you wait.
+
+- [ ] **T052** Query the branch-level alert state after the `Analyze` job has run on `main`
+      (FR-016, SC-001).
+  - Command (identical shape to T001, and `--paginate` plus the corpus floor are mandatory for the
+    reasons recorded there):
+    ```bash
+    gh api --paginate --slurp \
+      "repos/traylorre/sentiment-analyzer-gsk/code-scanning/alerts?ref=refs/heads/main&state=open&per_page=100" \
+      > /tmp/alerts-open-after.json
+    echo "gh_exit=$?"
+    jq 'add | {count: length, alerts: map({n:.number, rule:.rule.id, path:.most_recent_instance.location.path})}' \
+      /tmp/alerts-open-after.json
+    echo "jq_exit=$?"
+
+    gh api --paginate --slurp \
+      "repos/traylorre/sentiment-analyzer-gsk/code-scanning/alerts?ref=refs/heads/main&per_page=100" \
+      > /tmp/alerts-all-after.json
+    echo "gh_exit=$?"
+    jq 'add | length' /tmp/alerts-all-after.json
+    echo "jq_exit=$?"
+    ```
+  - Pass condition, in this order and all required: every `gh_exit=0` and `jq_exit=0`; the
+    all-states corpus count is **at least 137**; and only then, **no** returned entry has `rule`
+    equal to `py/bad-tag-filter` at `path` `scripts/regenerate-mermaid-url.py`.
+  - **The order is the point.** This criterion is satisfied by an absence, and an absence produced
+    by a truncated or failed read looks exactly like an absence produced by a fixed finding. The
+    corpus floor is what separates them. Without it, this task is a check that cannot report dirty,
+    which is the defect the whole feature exists to remove.
+  - **Keyed on path plus rule id, never on the number.** The analyzer demonstrably closes a number
+    and opens a fresh one at the same site, so a check written against `147` can report success
+    while the same finding sits there under a new number. This applies to US1 acceptance scenario 1
+    as well, whose wording still names the number; treat that wording as narrative identification
+    and measure it this way.
+  - A green pull request check is **not** acceptable as evidence (FR-016). Pull request analysis is
+    diff-informed and covers only changed lines; a recent pull request in this repository passed its
+    scanning check with five alerts open.
+  - Depends on: merge, and the `Analyze` job completing on `main`.
+
+- [ ] **T053** VERIFY the open-alert count dropped by exactly one (SC-002, FR-017).
+  - Pass condition: `count` from T052 equals **N - 1**, where N is the baseline recorded at T001.
+    Exactly one lower, not at most one lower: a criterion phrased as "no worse than before" is
+    satisfied by the change achieving nothing, and "exactly one" simultaneously confirms the old
+    finding closed and that no new finding was introduced in its place.
+  - **Both counts must come from paginated reads whose corpus floor passed.** Comparing a paginated
+    baseline against a truncated post-merge read produces a drop that is an artefact of the read.
+  - **Known campaign-level confound.** A sibling feature extends the analysis matrix over previously
+    unanalyzed source and is expected to raise the open-alert count deliberately. If it merges
+    between T001 and T052, the total moves for reasons unrelated to this change and SC-002 becomes
+    unmeasurable as literally phrased. In that case: record both counts and the sibling's merge
+    commit, fall back to SC-001 (T052's path-plus-rule condition) as the operative criterion, and
+    say so explicitly rather than reporting a pass. Do not silently reinterpret "exactly one lower"
+    as "no worse than before"; that reinterpretation is the exact weakening Adversarial Review #1
+    finding F7 removed from this spec.
+  - Depends on: T052.
+
+- [ ] **T054** Record the outcome and, if the alert is still open, take the named response (FR-022).
+  - Paste the T052 output into the pull request or the follow-up issue either way. It is the
+    evidence FR-016 asks for.
+  - If an open alert with rule `py/bad-tag-filter` remains at that path, the response is a
+    **follow-up change to the same line, not a revert**. The rewrite is behaviour-preserving by
+    FR-001, so reverting restores a pattern and buys nothing.
+  - Depends on: T052.
+
+---
+
+## Phase 9: Traceability and close-out
+
+- [ ] **T055** [P] VERIFY FR-021 across everything this feature added.
+  - Every command in `tasks.md` and `quickstart.md` that counts marker occurrences must be scoped to
+    `src/ tests/ scripts/` and never to the tree.
+  - Command:
+    ```bash
+    grep -n 'grep -r' specs/001-bad-tag-filter-dead-suppression/tasks.md \
+                      specs/001-bad-tag-filter-dead-suppression/quickstart.md
+    echo "grep_exit=$?"
+    ```
+  - Pass condition: every recursive **marker** scan listed (any line containing `lgtm\[` or
+    `codeql\[` as a pattern) ends in `src/ tests/ scripts/`. None scans `.`, the repository root, or
+    `specs/`. A tree-wide count can never reach zero, because describing a
+    marker requires writing it, and any criterion phrased that way is unsatisfiable on the day it is
+    written.
+
+- [ ] **T056** [P] VERIFY no inline suppression form was introduced anywhere in the diff (FR-005,
+      FR-007).
+  - Command:
+    ```bash
+    git diff main --unified=0 -- . ':(exclude)specs/**' | grep -nE '^\+.*(lgtm\[|codeql\[)'
+    echo "diff_exit=${PIPESTATUS[0]} grep_exit=${PIPESTATUS[1]}"
+    ```
+  - Pass condition: `diff_exit=0`, and the only added lines matching are inside
+    `scripts/check_dead_suppressions.py` (its own pattern constants) and
+    `tests/unit/scripts/test_check_dead_suppressions.py`. Nothing else may add a marker. Note that
+    the checker's own constants are added lines and will appear here; check the file each hit
+    belongs to rather than requiring `grep_exit=1`.
+
+- [ ] **T057** Walk `quickstart.md` end to end as the operator would, and record any step whose
+      stated pass condition does not hold.
+  - Pass condition: every section from 1 through 4 runs as written and produces the stated result,
+    **with one known exception already identified**: section 2's control check
+    (`git diff main -- ... | grep -- "==>"`, "expect no output") is false by construction, because
+    the control line falls inside the diff's default three-line context window and prints as a
+    context line. Use T017's corrected form. Section 5 applies only if FR-018 was accepted. Section
+    6 is Phase 8.
+
+- [ ] **T058** Card the adjacent defects found during this feature. **Do not fix any of them here.**
+  - They are listed in the Cross-Artifact Analysis below under "Adjacent defects". Each is outside
+    this feature's scope and belongs on the board, not in this diff.
+
+---
+
+## Dependencies and execution order
+
+### Phase order
+
+1. **Phase 1 (baselines)**: no dependencies, all five parallel.
+2. **Phase 2 (foundational)**: after Phase 1. Blocks the test tasks in Phases 3 and 5.
+3. **Phase 3 (US1)** and **Phase 5 (US3 core)**: can proceed in parallel by different people, with
+   one caveat below.
+4. **Phase 4 (US2)**: T015 depends on T007 (same lines of the same file).
+5. **Phase 6 (FR-018 gate)**: after Phase 5 and after T002. **Owner-gated. May be dropped entirely.**
+6. **Phase 7 (pre-merge re-verification)**: after every preceding phase, on the merge commit.
+7. **Phase 8 (post-merge)**: after merge, after `Analyze` runs on `main`.
+8. **Phase 9**: T055 and T056 any time after Phase 5; T057 after Phase 7; T058 last.
+
+### Cross-story dependencies (stated, not hidden)
+
+The template's default claim that stories are independently testable does not fully hold here:
+
+- **T035 (US3 clean-tree canary) depends on T015 (US2)**. Until the marker in
+  `scripts/regenerate-mermaid-url.py` is deleted, the canary fails against the real roots. US3
+  cannot be fully green before US2 lands.
+- **T018 (US2 marker scan) has two valid pass states** depending on whether US3 has landed, and both
+  are written into the task.
+- **T038 (Makefile widening) depends on T026 (checker ruff-clean)**. Reversing that order introduces
+  a day-one blocking failure, which is exactly what FR-015 forbids.
+- **T042 (CI step) depends on T040 (Makefile red-test)**. Wiring a gate into a required context
+  before it has been observed failing is how the original defect happened.
+
+### Parallel opportunities
+
+`[P]` tasks: T001, T002, T003, T004, T005, T008, T026, T027, T041, T047, T048, T049, T050, T051,
+T055, T056. Sixteen of fifty-eight.
+
+T019 through T025 all edit `scripts/check_dead_suppressions.py` and are strictly sequential.
+T028 through T035 all edit `tests/unit/scripts/test_check_dead_suppressions.py` and are strictly
+sequential. T007 and T015 edit the same three lines of `scripts/regenerate-mermaid-url.py` and are
+sequential.
+
+---
+
+## Requirement coverage
+
+### Functional requirements
+
+| FR | Subject | Implementing task(s) | Verifying task(s) |
+|---|---|---|---|
+| FR-001 | Identical verdict, proven by differential test | T007 | T009, T012, T013 |
+| FR-002 | Not expressed as a pattern; control unchanged | T007 | T011, T014, T017 |
+| FR-003 | Newline-only split; full whitespace trim | T007 | T009, T010, T013 |
+| FR-004 | Regression test in the collected test root | T008, T010 | T006, T012, T051 |
+| FR-005 | Delete the marker, do not substitute another form | T015 | T016, T048, T056 |
+| FR-006 | Remove or rewrite the stale explanatory comment | T015, T007 | T016 |
+| FR-007 | Dismissal workflow is the supported route | T024 | T033 |
+| FR-008 | Detect both marker forms and fail on them | T022, T025 | T029, T040 |
+| FR-009 | Narrow, exact-path self-exclusion | T023 | T031, T036 |
+| FR-009a | Dedicated file, not inline in the recipe | T019 | T026, T041 |
+| FR-010 | Widen the audited path set to include `scripts/` | T020, T038 | T039, T047 |
+| FR-011 | Unused-pragma check stays blocking, widened | T038 | T003, T039, T047 |
+| FR-012 | Security-linter half stays advisory | T038 | T005, T039 |
+| FR-013 | Blocking or advisory status explicit and accurate | T038 | T039, T041 |
+| FR-014 | Failure names file, line, marker, why, what instead | T024 | T029, T033, T040 |
+| FR-015 | Exits zero on the tree as it lands, re-verified at merge | T038 | T035, T047, T048, T049 |
+| FR-016 | Closure evidenced from branch analysis, not a PR check | (verification only) | T052, T054 |
+| FR-017 | Open-alert count must not increase | (verification only) | T001, T053 |
+| FR-018 | Marker check executes in a merge-blocking context | **T042** [GATE] | **T044, T046** [GATE] |
+| FR-019 | No new tooling installation in that context | **T042** [GATE] | **T027, T045** [GATE] |
+| FR-020 | Note on the line saying it is deliberately not a pattern | T007 | T014, T057 |
+| FR-021 | Counting criteria scoped to the audited path set | T020 | T004, T018, T048, T055 |
+| FR-022 | Closure gathered post-merge; named failure response | (verification only) | T052, T054 |
+
+No FR is uncovered. FR-016, FR-017 and FR-022 have no implementing task by their nature: they
+constrain how evidence is gathered, not what is built.
+
+### Success criteria
+
+| SC | Subject | Task(s) |
+|---|---|---|
+| SC-001 | No open alert with that rule at that path, post-merge | T052 |
+| SC-002 | Open count exactly one lower | T001, T053 |
+| SC-003 | Differential test, >= 1,500 inputs, zero mismatches | T009, T012, T013 |
+| SC-004 | Audited-path marker scan clean but for the auditor | T004, T018, T048 |
+| SC-005 | Audit exits zero on the post-change tree | T035, T039, T049 |
+| SC-006 | Audit exits non-zero on a seeded marker, names file and line | T029, T040 |
+| SC-007 | Unused-pragma check runs on the widened set and passes | T039, T047 |
+| SC-008 | Recipe declares status for every check | T038, T039 |
+| SC-009 | Unit suite passes including the net-new regression test | T012, T051 |
+| SC-010 | Thick-arrow control byte-identical | T011, T017 |
+| SC-011 | A marker-adding change turns a required check red | **T044** [GATE] |
+| SC-012 | Reachable from the blocking context with no extra tooling | **T027, T045** [GATE] |
+
+No SC is uncovered.
+
+### Contract clauses
+
+`contracts/dead-suppression-cli.md` is normative. The contract carries **nine** clauses, C1 through
+C9, not eight.
+
+| Clause | Subject | Implementing task | Verifying task(s) |
+|---|---|---|---|
+| C1 | Invocation, interpreter floor, stdlib only, ignored positionals | T019 | T026, T027, T034 |
+| C2 | Exit codes 0 / 1 / 2 | T025 | T029, T030, T034, T040 |
+| C3 | Default roots, extension allowlist, skip list, decoding | T020 | T032, T036, T039 |
+| C4 | `DEAD_SUPPRESSION_ROOTS` override | T021 | T029, T030, T036 |
+| C5 | Positional detection rule | T022 | T032, T036 |
+| C6 | Exact-path self-exclusion, no raise outside the repository | T023 | T031, T036 |
+| C7 | Output, both paths, relative with absolute fallback | T024 | T033, T029, T040 |
+| C8 | What consumers must not do | T038, T042 | T034, T041 |
+| C9 | Consumer wiring, verbatim | T038, T042 | T039, T041, T045 |
+
+Every clause has both an implementing task and at least one verifying task. Every exit code in C2
+has a dedicated assertion: `0` at T034 and T035, `1` at T029 and T040, `2` at T030 and T034.
+
+---
+
+## Cross-Artifact Analysis
+
+Scope: `spec.md`, `plan.md`, `research.md`, `contracts/dead-suppression-cli.md`, `quickstart.md`,
+and this `tasks.md`. Every claim below was reproduced with a command on 2026-07-30 before being
+written down. This is a consistency pass, not a re-run of Adversarial Review #1 (which gated on
+`spec.md`) or #2 (which gated on drift between the spec's clarifications and the design artifacts).
+
+### Findings
+
+| Sev | ID | Finding | Disposition |
+|---|---|---|---|
+| HIGH | F1 | **An unmentioned required-check step can redden `Lint` on day one.** The `Lint` job runs `ruff format --check --diff src/ tests/` as its first check, before `ruff check`. Both new test files land under `tests/`. No artifact in this feature mentions the format step: `plan.md`'s Constraints block requires the checker and its test to be clean under `ruff check --extend-select RUF100`, and `research.md` R-0e quotes only the install step. A format-dirty new test file turns a required context red for a reason no artifact predicts. | COVERED by T037 and T050, which run the format check explicitly. Recorded here because the plan's Constraints block is incomplete as written. |
+| HIGH | F2 | **`quickstart.md` section 2's control check is false by construction.** It says to run `git diff main -- scripts/regenerate-mermaid-url.py \| grep -- "==>"` and "expect no output". The control line sits exactly three lines below the changed line, and git's default context is three, so the control prints as a context line on a correct change. The command therefore fails a correct implementation, and its status is read from downstream of a pipe on top of that. | COVERED by T017, which pins the corrected form (`grep -E '^[+-].*==>'` with `PIPESTATUS`). `quickstart.md` itself is left unedited; T057 records the discrepancy for the operator. |
+| MEDIUM | F3 | **`plan.md` Technical Context overstates the new tests' isolation.** It reads "Testing: pytest, collected under `tests/unit/scripts/`. No AWS, no moto, no network." That directory's `conftest.py` imports `boto3` and `moto` at module level, and pytest imports a directory's conftest for every test collected in it, so both new files pull moto in at collection. The Constitution Check's "LOCAL and DEV run ONLY unit tests with mocks" row rests on the inaccurate sentence. Not a breakage: `requirements-ci.txt` pins `moto[all]` and the `Run Tests` job installs it. `plan.md`'s own Adversarial Review #2 recorded this as D8 and left it unfixed pending a wording call. | RECORDED. T006 states the constraint accurately and verifies collection. No gate result changes. |
+| MEDIUM | F4 | **`spec.md` US1 acceptance scenario 1 and Key Entities still key the primary outcome on an alert number.** Scenario 1's **Then** clause reads "the branch analysis for `refs/heads/main` reports alert 147 as no longer open", and Key Entities says the state of alert 147 "is the feature's primary outcome measure". Adversarial Review #2 finding D4 rekeyed SC-001 and US1's Independent Test onto path plus rule but deliberately left these two, calling them narrative identification. Scenario 1's **Then** clause is not narrative: it is the acceptance condition, and it is keyed the one way `plan.md` and `quickstart.md` both forbid in terms. | COVERED by T052, which measures path plus rule and states explicitly that the scenario's wording is to be treated as narrative. Left in `spec.md` unedited; the measurement is unambiguous. |
+| MEDIUM | F5 | **This briefing's own framing carried two errors.** (a) The alert is stated as "`js/bad-tag-filter` class". The live alert is `py/bad-tag-filter`, confirmed against the alert-state API: alert 147, rule `py/bad-tag-filter`, severity high, `scripts/regenerate-mermaid-url.py:82`. Every artifact in the feature has it right. (b) The contract is described as having clauses "C1 through C8". It has nine, C1 through C9, and C9 (Consumer wiring, verbatim) is the clause that pins the two consumer invocations the feature actually edits. Verifying only C1 through C8 would leave the Makefile and CI wiring text unverified against the contract. | FIXED in this document. The coverage table runs C1 through C9 and T001 records the correct rule id. |
+| MEDIUM | F6 | **Cross-story dependency contradicts the tasks template's independence claim.** US3's clean-tree canary (SC-005, FR-015) asserts exit `0` against the real default roots, which cannot hold until US2 has deleted the marker in the diagram script. So US3 is not independently deliverable ahead of US2, though the spec presents the three stories as independently testable. Similarly SC-004's post-state depends on both US2 and US3. | RECORDED and made explicit in T035, T018 and the Cross-story dependencies section, rather than left for an implementer to hit. |
+| LOW | F7 | **C1's 3.9 floor has no runtime enforcement and no interpreter available to test it.** The contract sets a 3.9 floor, `plan.md` forbids a `sys.version_info` guard (because `UP036` flags it), and no 3.9 interpreter exists on the reference machine. So nothing would catch a 3.10-only construct until a contributor on an old interpreter hit it. | MITIGATED by T027, which uses `ast.parse(..., feature_version=(3, 9))`. Stated limitation: this catches syntax newer than 3.9, not standard-library APIs added after 3.9. `Path.is_relative_to` is 3.9, so C6's suggested form is inside the floor. |
+| LOW | F8 | **C7's example output is already arithmetically stale.** It shows "Scanned 583 files." A census over the three roots and the ten allowlisted extensions returns 583 today, but this feature adds two allowlisted files, so the real first clean run prints 585. | RECORDED, not fixed. The example is illustrative and C7's normative requirement is only that a count be printed. T033 asserts "greater than zero", not a literal. |
+| LOW | F9 | **`plan.md`'s Adversarial Review #2 cites its own line numbers inaccurately in D8.** It points at "`plan.md:57`" for the Constitution Check row and "`plan.md:102`" for the conftest listing; the actual lines are 82 and 126. All the substance is correct and locatable; only the labels drifted, which is the same class as D10's four different citations of one comment block. | RECORDED, not fixed. Four edits for zero behavioural gain, and every citation still lands in the right document. |
+| LOW | F10 | **`make audit-pragma`'s advisory bandit section becomes unreachable when a blocking section fails.** Make stops at the first failing recipe line, and the new checker sits above the bandit line. A contributor whose run fails on a marker never sees the advisory output. | RECORDED, not fixed. It is the correct behaviour for a blocking gate and the advisory half is explicitly not this feature's product. |
+| CRITICAL | F11 | **The feature's own closure query is a check that cannot report dirty.** Every code-scanning query in this feature's artifacts was written without `--paginate`: `plan.md`'s post-merge block, `quickstart.md` section 6 (twice), and three sites in this document. GitHub's default page size is 30 and this repository's all-states alert corpus is 137. Measured 2026-07-30: the unpaginated form with a client-side `select(.state == "open")` returns **zero** open alerts while the paginated form returns **five** (144, 147, 148, 149, 150). Truncation renders as clean. A server-side `state=open` filter masks this only while fewer than 30 alerts are open, and a sibling feature in this campaign extends the analysis matrix over tens of thousands of previously unanalyzed lines with the deliberate intent of raising that count. The moment it lands, SC-001's pass condition, an absence, starts being satisfied by a truncated read, and this feature can be marked complete by a blind query. This is precisely the defect the feature exists to remove, in a third costume: `Makefile:90` cannot fail, the `lgtm[...]` comment cannot suppress, and this query cannot report dirty. | FIXED. All six sites rewritten to `gh api --paginate --slurp ... --per_page=100` with the pages written out and filtered by a separate `jq`, an explicit `gh_exit` check at every site, and an all-states corpus floor of 137 wherever the pass condition is an absence. `--slurp` cannot be combined with `--jq`, which is why the filter is separated; that separation is also what makes the exit status readable instead of hiding it downstream of a pipe. |
+| MEDIUM | F12 | **SC-002 is confounded by the same sibling feature.** "The count of open alerts after this change is exactly one lower than the count before" assumes nothing else moves the total between the two measurements. A sibling feature in this campaign is expected to raise the open count deliberately. If it merges between T001 and T052, SC-002 becomes unmeasurable as literally phrased, through no fault of this change. | FIXED in T053, which names the confound, requires both counts and the sibling's merge commit to be recorded, and falls back to SC-001 as the operative criterion rather than silently weakening "exactly one lower" into "no worse than before". That weakening is what Adversarial Review #1 finding F7 removed from the spec. |
+
+Counts: 1 CRITICAL, 2 HIGH, 5 MEDIUM, 4 LOW. The CRITICAL and both HIGH findings are closed inside
+this document. F11 was surfaced by a campaign-level correction, independently reproduced here
+against the live API before being applied, and the same evidence produced F12.
+
+### Requirement coverage gaps
+
+None. All 23 functional requirements (FR-001 through FR-022, including FR-009a) and all 12 success
+criteria map to at least one task, per the tables above. FR-016, FR-017 and FR-022 are
+verification-only by construction and are marked as such rather than being given a fabricated
+implementing task.
+
+### Contract clauses with no implementing or verifying task
+
+None, across C1 through C9. Every exit code in C2 has a dedicated assertion in at least two tasks.
+C8's four prohibitions are each covered: status-swallowing at T041, `pre-commit run` from the
+blocking context at T042 and T041, positional narrowing at T034, and override-setting by consumers
+at T041 (the grep would surface any consumer line setting `DEAD_SUPPRESSION_ROOTS`).
+
+### Tasks with no requirement behind them
+
+Three, each justified rather than removed:
+
+- **T013** (red-test for the differential oracle) traces to no FR. It exists because SC-003's zero
+  mismatches is unfalsifiable until the corpus has been observed separating the correct
+  implementation from the known-incorrect one. Without it, a corpus that quietly stopped containing
+  exotic separators still reports success.
+- **T036**'s second command (scanning a copy of the test file from outside the repository) traces to
+  `plan.md` section 7 rather than to an FR. It is the only way to prove the "no source line carries
+  both an introducer and a marker" rule was observed rather than intended.
+- **T043** (local pre-commit hook) is explicitly optional and is marked as required by no FR, so
+  that its absence is never read as an FR-018 miss.
+
+### Ordering hazards
+
+Four, all made explicit in the Dependencies section:
+
+1. **T038 before T026** would put a checker that has not been proven ruff-clean onto a blocking line
+   linted under the full configured rule set. This is the feature's single most likely
+   self-inflicted failure and is the exact day-one break FR-015 exists to prevent.
+2. **T042 before T040** would wire an unproven gate into a required context.
+3. **T035 before T015** fails for a reason that looks like a checker bug and is not.
+4. **T044's scratch commit** turns two required contexts red, not one. An operator expecting one
+   will hunt for a second defect. Stated in the task.
+
+### Unfalsifiable pass conditions
+
+Four were found and all four are corrected in this document:
+
+- `quickstart.md` section 2's `git diff | grep` control check (F2). Corrected in T017.
+- Any "differential test passes" condition without a corpus-size assertion. T009 requires
+  `assert len(corpus) >= 1500` inside the test, and T013 requires the test to have been observed
+  failing.
+- Any "`make audit-pragma` exits 0" condition standing alone. The whole feature exists because
+  `Makefile:90` exits 0 unconditionally. T040 pairs T039 with a seeded-violation red-test, and every
+  piped command in this document reads `${PIPESTATUS[0]}`.
+- **Any alert-absence condition read from an unpaginated query (F11).** An absence produced by a
+  truncated or failed read is indistinguishable from an absence produced by a fixed finding. T001
+  and T052 now require `--paginate`, an explicit `gh_exit` check, and an all-states corpus floor of
+  137 evaluated *before* the absence is read. The general rule, which generalises past this feature:
+  **when the pass condition is emptiness, the reader must independently prove it was working.**
+
+### Contradictions between artifacts
+
+- **F1** (format check unmentioned) and **F3** (moto isolation claim) are the two live ones.
+- **F4** is a residual internal contradiction inside `spec.md` between US1 scenario 1 and SC-001,
+  both post-Adversarial-Review-#2.
+- `plan.md`'s skip list and C3's skip list were checked character by character and are identical
+  (`__pycache__`, `node_modules`, `.venv`, `.git`, `.pytest_cache`, `.hypothesis`).
+- `plan.md`, `research.md`, `spec.md`, `quickstart.md` and this document all specify
+  `split("\n")` and reject `splitlines()`. No artifact recommends the incorrect form anywhere.
+- The 3.9 floor is now consistent across `contracts/` C1, `plan.md` Technical Context and
+  `research.md` D-2, after Adversarial Review #2's D2 fix.
+
+### Independent re-verification performed for this analysis
+
+| Claim under test | Method | Result |
+|---|---|---|
+| The alert's rule id and location | `gh api --paginate --slurp ".../code-scanning/alerts?ref=refs/heads/main&state=open&per_page=100"`, filtered with a separate `jq` | Alert 147, `py/bad-tag-filter`, high, `scripts/regenerate-mermaid-url.py:82`. Five open alerts (144, 147, 148, 149, 150), so SC-002's target is four |
+| An unpaginated alert query truncates, and truncation renders as clean | Ran `gh api ".../code-scanning/alerts" --jq '[.[] \| select(.state=="open")] \| length'` against the paginated form | Unpaginated: `0`. Paginated: `5`. All-states corpus: `137`, against a default page size of 30 |
+| `--slurp` can carry the `--jq` filter | `gh api --paginate --slurp ... --jq ...` | Refused: "the `--slurp` option is not supported with `--jq` or `--template`". Pages must be written out and filtered separately, which is also what keeps `gh`'s exit status readable |
+| Widened unused-pragma set is clean | `ruff check --extend-select RUF100 src/ tests/ scripts/` | `All checks passed!`, exit 0 |
+| Marker population in the audited roots | `grep -rnE "lgtm\[\|codeql\[" src/ tests/ scripts/` | Exactly one line, `scripts/regenerate-mermaid-url.py:82` |
+| Allowlisted-file census | `find` over the ten allowlisted extensions across the three roots | 583, matching `plan.md` and C7 |
+| The 3.9-floor / ruff collision is real | Wrote a 3.9-shaped file, ran the pinned ruff 0.15.14 with the repo config plus `--extend-select RUF100` | 4 errors: UP035, UP006, UP045, UP036 |
+| The reconciliation actually works | Same command against a file opening with `from __future__ import annotations` and using PEP 604 in annotations only | `All checks passed!`, exit 0 |
+| `--extend-select` adds rather than replaces | `pyproject.toml` `[tool.ruff.lint] select` | `E W F I B C4 UP S RUF100`, `target-version = "py313"` |
+| Advisory bandit counts | `bandit -r scripts/ --ignore-nosec \| grep -cE "^>>"` and the same for `src/` | 10 and 15, matching the spec assumption |
+| `Lint` job contents | `.github/workflows/pr-checks.yml` steps 52 onward | Installs `ruff==0.15.14` only; runs `ruff format --check --diff src/ tests/`, `ruff check src/ tests/`, `ruff check src/ --select S`, then the waitForResponse guard with `if: always()` |
+| `audit-pragma` is invoked by nothing | `grep -rn audit-pragma` excluding `specs/` | `Makefile:1` (PHONY), `Makefile:85` (the target), `CLAUDE.md:243` (prose), plus archived docs. Absent from `make validate`'s prerequisites, from every workflow, from the hook config |
+| The control line falls inside the diff context window | Line positions in `scripts/regenerate-mermaid-url.py`: change at 80-82, control at 85, git default context 3 | Control prints as a context line. `quickstart.md` section 2's check is false by construction |
+| `ast.parse(feature_version=(3, 9))` discriminates | Parsed a `match` statement and a future-annotated PEP 604 file | `match` raises "only supported in Python 3.10 and greater"; the annotated file parses. Usable as a floor check |
+| Test collection home | `tests/unit/scripts/` contents and `pyproject.toml testpaths` | `__init__.py`, `conftest.py` importing `boto3`/`moto` at module level, two existing test modules; `testpaths = ["tests"]` |
+| Banned terms in this document | Case-insensitive scan for all seven | Clean |
+
+### Verdict
+
+**PASS with one CRITICAL and two HIGH findings, all closed inside this document rather than
+deferred.**
+
+The CRITICAL (F11) is the one worth reading twice. This feature's own post-merge closure query could
+not report dirty, for the same structural reason `make audit-pragma` cannot fail and the same
+structural reason a `lgtm[...]` comment cannot suppress. Three costumes, one defect: a check whose
+negative result is indistinguishable from a check that did not run. Every alert query in the feature
+now carries `--paginate`, an exit-code assertion, and a corpus floor.
+
+Coverage is complete: 23 of 23 functional requirements, 12 of 12 success criteria, 9 of 9 contract
+clauses, each with at least one implementing and one verifying task where both apply. Every gate this
+feature introduces has a paired red-test, so none of them ships in the "structurally unable to fail"
+state that produced the defect in the first place. The FR-018 block is separable and named, so an
+owner rejection removes exactly five tasks and leaves the rest standing.
+
+The single largest implementation risk is ordering: T038 before T026 puts a checker written to a 3.9
+floor onto a blocking line linted under a `py313` ruleset, which is a reproducible day-one failure
+rather than a theoretical one.
+
+### Adjacent defects, outside this feature's scope. Card, do not fix
+
+1. **`make audit-pragma`'s bandit half has been structurally unable to fail since it was written**
+   (`Makefile:90`). This feature makes the advisory status a *declaration* but does not fix the
+   backlog or convert the check. The 25 findings remain unaddressed. Already carded in Out of Scope.
+2. **`make validate` is red on `main`** through `scripts/check-banned-terms.sh`, which exits 1 on 17
+   pre-existing matches from other features. That is one reason nobody noticed `audit-pragma` was
+   missing from its prerequisite list. Already carded.
+3. **`scripts/scan-waitforresponse-race.py` collides on exit code 2**: it uses `2` both for "zero
+   files scanned" and for "interpreter too old", so a wrong-interpreter run is indistinguishable
+   from a vanished scan root. The new checker deliberately avoids the collision; the precedent still
+   has it.
+4. **`scripts/check-banned-terms.sh` excludes itself by grep basename glob**, exempting any
+   identically named file anywhere in the tree. Adversarial Review finding F6 identified it; FR-009
+   forbids the form for the new checker but the existing script is untouched.
+5. **`scripts/` is linted by no required check.** The `Lint` job runs `ruff check src/ tests/`. After
+   this feature, `scripts/` is linted only by `make audit-pragma`, which nothing invokes
+   automatically. The new checker's own source is therefore never linted by CI.
+6. **Three `py/clear-text-logging-sensitive-data` alerts, all high severity, sit open on
+   `src/lambdas/ingestion/handler.py`** (lines 264, 271, 276), plus one on
+   `src/lambdas/shared/auth/oauth_state.py:104`. Four of the five open alerts. Explicitly out of
+   scope here.
+7. **The code scanning configuration contradicts itself**: a path exclusion for the test tree is
+   followed by a query filter whose comment states the test tree is still scanned. One of the two is
+   dead. Already carded.
+8. **`bandit` is installed in CI via `requirements-ci.txt` but invoked by no workflow step**, per
+   `docs/cleanup/validator-inventory.md`. A binary shipped to CI and never run.
+9. **The mandatory pre-push security check in `CLAUDE.md` is an unpaginated alert query and has been
+   reporting a clean bill of health over five genuinely open alerts.** Step 1 of the Pre-Push
+   Checklist runs `gh api repos/{owner}/{repo}/code-scanning/alerts --jq '.[] | select(.state ==
+   "open") | ...'` with no `--paginate`. Reproduced 2026-07-30: it returns nothing while five alerts
+   are open, three of which belong to another feature in this campaign. Every contributor and agent
+   following that checklist has been getting a false all-clear. **Already carded and routed at
+   campaign level; deliberately not touched by this feature.** Recorded here because it is the same
+   defect as F11 and because this feature's artifacts inherited the query shape from it.
+
+---
+
+## Adversarial Review #3
+
+Final gate before implementation. The reviewer authored none of these artifacts. Every claim below
+was **run**, not read, on 2026-07-30 under `.venv` (ruff 0.15.14, gh 2.89, Python 3.13). Where a
+finding contradicts an earlier review, the earlier text is left standing: prior appendices are
+history and are not rewritten.
+
+The question this gate answers is narrower than "is the design right". It is: **can an implementer
+execute this task list start to finish without getting stuck, misled, or silently passing?** Three
+places the answer was no.
+
+### Findings
+
+| Sev | ID | Finding | Disposition |
+|---|---|---|---|
+| HIGH | G1 | **T034's subprocess test reddens the required `Lint` job, and no artifact says so.** `pyproject.toml` selects `S` (flake8-bandit) and its `per-file-ignores` entry for `tests/**/*.py` lists `S101 S105 S106 S108 S110 S311 E402 C420`, with **no** `S603`. `ruff check src/ tests/` is a step in the required `Lint` job, and T034 mandates a `subprocess.run([sys.executable, …])` call in a file under `tests/`. Reproduced: `ruff check --select S --ignore-noqa tests/e2e/test_log_visibility.py` reports `S603 subprocess call: check for execution of untrusted input`, exit 1. The suppression on that precedent line is provably load-bearing, not decorative: `RUF100` is also selected, so an unnecessary `# noqa: S603` would itself be an error and `ruff check src/ tests/` would not be passing today. This is the same class as Cross-Artifact F1 (unmentioned `ruff format` step) and is graded the same way: an artifact-invisible cause of a red required context on day one. | **FIXED** in T034, which now requires `# noqa: S603` on the `subprocess.run(` line with a justification comment, states why it must be on exactly that line (RUF100), and records that `S607` does not apply because `sys.executable` is absolute. |
+| HIGH | G2 | **T045, a `[GATE]` verification task, cannot execute, and its failure mode is to report the answer it was looking for.** The command was `gh run view --job "$(gh run list … --json databaseId --jq '.[0].databaseId')" --log 2>/dev/null \| head -5`. `gh run list --json databaseId` returns a **run** id; `--job` requires a **job** id. Reproduced: run `30597680512` gives `failed to get job: HTTP 404: Not Found (…/actions/jobs/30597680512)`, exit 1. With `2>/dev/null` and `head -5`, that 404 prints **nothing**, and nothing is exactly what "no extra install step" looks like. A verification of SC-012 that passes when it fails, inside a feature whose entire thesis is that such objects are worse than nothing. | **FIXED** in T045: two-step id resolution (`gh run view "$RID" --json jobs --jq '.jobs[] \| select(.name=="Lint") \| .databaseId'`), verified working against this repository (job `91053515417`, 322 log lines), plus an explicit `log_exit` and line-count check before anything is read from the log, and the workflow-file read named as the authoritative evidence for step adjacency. |
+| HIGH | G3 | **T043 can make T044 unexecutable, and nothing ordered them.** Both declared only `Depends on: T042`. T043 mirrors the precedent hook, which is `always_run: true` with `pass_filenames: false` (`.pre-commit-config.yaml:206-212`), so it runs on every commit whatever it touches. T044 must commit a marker inside an audited root to observe the gate biting, and that hook rejects the commit. The hook-bypass flag is not available either: CLAUDE.md forbids it and a machine-level pre-tool hook denies it before git sees it. An implementer doing the optional task first hits a wall with no documented way through. | **FIXED**: T043 now declares `Depends on: T042, T044`, states the mechanism, and names `SKIP=check-dead-suppressions` on the commit as the only legitimate route if the ordering is inverted anyway. |
+| MEDIUM | G4 | **T013's second red-test would be recorded as not having gone red.** It required "a non-breaking space or vertical tab visible in the failure output" after mutating to `rstrip(" \t")`. Reproduced over a corpus built to T009's atom set (6,629 inputs): the narrowed trim produces **441** mismatches, but the first one is `'-->\r'`. A test that reports the first mismatch shows a carriage return. The red-test goes red correctly and its stated pass condition says it did not. | **FIXED**: T013 now requires "some whitespace character other than a space or a tab", with the reproduction recorded. |
+| MEDIUM | G5 | **T044's mechanics carried three separate hazards.** (a) `git add -A` in a worktree shared with concurrent sibling features sweeps their untracked `specs/` directories into the scratch commit; four such directories are untracked right now. (b) "revert the scratch commit … confirm with `git log --oneline` that it is gone" is self-contradictory: a revert leaves the commit in history, so the stated confirmation can never pass, and a commit carrying a marker stays reachable. (c) The marker was appended to `scripts/regenerate-mermaid-url.py`, the one file this feature exists to clean, so a botched cleanup restores a marker to it. | **FIXED**: T044 now seeds a throwaway `scripts/_gatetest_tmp.py` (verified ruff-clean under the repository config, so nothing upstream can fail first and mask the result), stages it by path, signs the commit, and removes it with `git reset --hard HEAD~1` plus a lease-checked force push. |
+| MEDIUM | G6 | **`spec.md` was still alert-number-keyed in two places, contradicting this document's own binding convention 3**, which says in terms that the path-plus-rule rule "applies to acceptance scenarios and Independent Test lines too, not only to the SC block". US1 acceptance scenario 1's **Then** clause read "reports alert 147 as no longer open" and Key Entities named the entity "Alert 147" and identified it "by number, rule, file path, line, and state". Cross-Artifact F4 saw this and left it, calling the measurement unambiguous. That is true of T052 and false of the scenario, which is the acceptance condition a reader checks the feature against. | **FIXED by direct edit to `spec.md`.** Scenario 1's **Then** is now "no open alert whose rule is `py/bad-tag-filter` at that path", with the number kept only as a locator. Key Entities is now keyed on path plus rule with the number named as a label. Cross-Artifact F4's disposition line ("Left in `spec.md` unedited") is now stale and is deliberately not rewritten. |
+| LOW | G7 | **T027's heredoc does not survive being copied out of the raw file.** The fenced block sits at four spaces of list indentation and the `PY` terminator carries them, so bash never closes the here-document. Reproduced by extracting the block verbatim and running it: `warning: here-document at line 1 delimited by end-of-file (wanted 'PY')`, then `IndentationError: unexpected indent` from the interpreter. A markdown renderer strips the list indentation, so this bites an implementer working from the raw file and not one working from a rendered view. | RECORDED, not fixed. De-indenting one fence would leave it inconsistent with every other fence in the document. Implementer note: if T027 hangs or reports an indentation error, strip the leading four spaces from the block. |
+| LOW | G8 | **`--extend-select RUF100` adds nothing, and FR-011 is doing less work than it reads as doing.** `RUF100` is already a member of `pyproject.toml`'s `select`. Every statement the artifacts make about the flag is accurate ("adds to the configured select"), but the flag itself is a no-op, and a reader can come away thinking the unused-pragma check is otherwise off. The operative consequence: the required `Lint` job's `ruff check src/ tests/` **already** enforces RUF100 over `src/` and `tests/`, so the only coverage FR-011's widening actually buys is `scripts/`, inside a target that nothing automated invokes. | RECORDED, not fixed. No command changes; removing the flag would be a gratuitous diff and keeping it is harmless. Worth a sentence in the pull request so the widening is not oversold. |
+| LOW | G9 | **`plan.md`'s Constraints block names the wrong path set for the test file.** It requires "the checker and its test file MUST be clean under `ruff check --extend-select RUF100 scripts/`". The test file lives under `tests/`, which that command never reaches. | RECORDED, not fixed. T026 runs `src/ tests/ scripts/` and closes the gap. Same class as Cross-Artifact F9: a citation drift with no behavioural consequence. |
+| LOW | G10 | **The corpus-floor `jq` had no exit check** at the last site in T001 and in T052, while both pass conditions read "every `gh_exit=0` and `jq_exit=0`". The floor read is the one whose silent failure matters most, since the whole point of the floor is to prove the reader was working. | **FIXED**: `echo "jq_exit=$?"` added at both sites. |
+| LOW | G11 | **T014's second command has no pass condition.** `grep -c -- '-->' scripts/regenerate-mermaid-url.py` is run and its output is never given a criterion. After T007 the count is necessarily non-zero (the rewritten check and the FR-020 note both contain the arrow), so it can neither pass nor fail. | RECORDED, not fixed. The first command carries the whole criterion and is sufficient. |
+
+Counts: 3 HIGH, 3 MEDIUM, 5 LOW, 0 CRITICAL. All three HIGH and all three MEDIUM are closed by
+direct edit in this feature directory. No LOW was fixed.
+
+### The four red-tests: does each actually go red?
+
+| Red-test | Verdict | Evidence |
+|---|---|---|
+| **T013** (differential oracle, two mutations) | **YES, both.** The pass condition for the second mutation was wrong and is fixed (G4) | Independently rebuilt the oracle and the corpus to T009's specification: 6,629 inputs (exhaustive 1, 2 and 3 element products over the 15 atom set, 3,000 seeded random 4 to 5 element strings, 14 hand-chosen). `split("\n")` with bare `rstrip()`: **0 mismatches**. `splitlines()`: **134**, first `'-->\r==>'`. `rstrip(" \t")`: **441**, first `'-->\r'`. Direction matches all three prior runs; the counts differ because the corpora differ |
+| **T029** (checker exits 1 on a seeded fixture) | **YES by design, conditional on T023** | Cannot be run before the checker exists. The mechanism was checked end to end and holds: `.py` is on the C3 allowlist, `tmp_path` is outside the repository so the fixture never enters an audited root, `DEAD_SUPPRESSION_ROOTS` replaces the root set, and the C6 containment test is what stops `relative_to` raising on every file under that override. The one way this goes wrong is a bare `path.resolve().relative_to(repo_root)` in the exclusion check, which T023 forbids in terms. The no-introducer control case is what makes it a real red-test rather than "the file exists" |
+| **T040** (`make audit-pragma` non-zero on a marker seeded into `scripts/`) | **YES, and the reason it works is not obvious** | The seeded line matters. `make` stops at the first failing recipe line, and the widened `ruff check --extend-select RUF100 src/ tests/ scripts/` runs **above** the checker. Ran the exact T040 line through the real configuration: `X = 1  # lgtm[py/redtest-do-not-commit]` gives `All checks passed!` and `1 file already formatted`, so control reaches the checker and the failure output names the file. Had the seeded line been ruff-dirty, the target would still have exited non-zero, T040's pass condition ("names the file, line 1, and the marker") would have failed, and the operator would have been hunting a checker bug that was not there |
+| **T044** (observed `Lint` failure) | **YES on mechanism, and the two-red-contexts prediction is correct. Executability was the problem** | `Lint` is required, confirmed live: `["Secrets Scan","Lint","Run Tests","Playwright E2E Tests"]`, exit 0. `Run Tests` does collect `tests/unit/scripts/` (`testpaths = ["tests"]`, and the job's seven ignore flags cover `tests/integration/*preprod*`, `tests/integration/timeseries` and `tests/e2e`, none of them this directory), so T035's canary reddens the second context exactly as the task predicts. What did not hold was the procedure: G3 (a local hook can block the scratch commit) and G5 (`git add -A`, revert versus reset, and seeding the feature's own file). All three fixed |
+
+### The 3.9-floor / ruff collision: reproduced
+
+Ran both halves against the real configuration with the pinned ruff 0.15.14.
+
+| Input | Command | Result |
+|---|---|---|
+| 3.9-shaped: `from typing import List, Optional`, `Optional[str]` and `List[int]` in annotations, a `sys.version_info < (3, 9)` guard | `ruff check --config pyproject.toml --extend-select RUF100 <file>` | **4 errors: UP035, UP045, UP006, UP036.** Exit 1 |
+| `from __future__ import annotations`, PEP 604 (`str \| None`) and builtin generics (`list[Path]`) in annotations only, no version guard | same command | **`All checks passed!`** Exit 0 |
+| `pyproject.toml` `[tool.ruff.lint]` | read directly | `select = E W F I B C4 UP S RUF100`, `target-version = "py313"`, `required-version = "==0.15.14"` |
+
+**T019's four reconciliation rules are correct and sufficient**, and each of the four is load-bearing
+against a specific rule: rule 1 against `UP045` (and it is what makes rule 2 safe), rule 2 against
+`UP035` and `UP006`, rule 3 against `UP036`, rule 4 is the verification. **The T038-after-T026
+ordering is justified and is the single most important line in the dependency section.** T038 puts
+`scripts/` on a blocking line linted under a `py313` ruleset; a checker written to C1's 3.9 floor
+without the four rules produces exactly the four errors above, on a line that fails the target for
+everybody, on day one. That is the failure FR-015 exists to prevent, and it is reproducible rather
+than hypothetical.
+
+One caveat on rule 2 that is implicit in T019 and worth making explicit for the implementer: PEP 604
+in annotations is only safe because `from __future__ import annotations` stops them evaluating.
+`isinstance(x, str | None)` and any runtime `typing.get_type_hints` call would still break on 3.9,
+and neither ruff nor T027's `ast.parse(feature_version=(3, 9))` would catch it, because both are
+valid 3.9 *syntax*. T027's own "known limitation" note covers the general case; this is the specific
+instance most likely to be written by accident.
+
+### The `ruff format` ordering (Cross-Artifact F1): closed
+
+Read the required job directly. `.github/workflows/pr-checks.yml` `lint` job, in order: checkout,
+`setup-python`, install (`pip install ruff==0.15.14`, one step, nothing else),
+**`ruff format --check --diff src/ tests/`**, `ruff check src/ tests/`,
+`ruff check src/ --select S --output-format=github`, then `Check waitForResponse race ordering` with
+`if: always()`. The format check is indeed first, and both new test files land under `tests/`.
+
+T037 and T050 both run `ruff format --check --diff src/ tests/` explicitly, so F1 is closed. Two
+notes the implementer should not have to rediscover. First, T037 depends on T012 and T036, so the
+format check runs only after both test modules are complete, which is the right place. Second,
+`scripts/` is **not** format-checked by anything, so the new checker's own formatting is
+unconstrained; only its lint cleanliness matters, and only through T026 and the widened
+`audit-pragma` line.
+
+### FR-018 separability: holds
+
+Traced every reference to Phase 6 from outside it. T042 through T046 are the only tasks that touch
+`.github/workflows/pr-checks.yml` or depend on a task that does. Outside Phase 6, three tasks mention
+the CI step and all three are written to survive its absence: T041's grep spans three files and still
+exits 0 on the `Makefile` match alone; T050's fifth command is explicitly marked as gating nothing if
+FR-018 is rejected; T057 scopes quickstart section 5 to the accepted case. T048's pass condition is
+stated as unchanged either way. The coverage tables isolate the casualties correctly: FR-018, FR-019,
+SC-011, SC-012, US3 scenario 6. **Rejecting FR-018 removes exactly five tasks and nothing else
+breaks.**
+
+One labelling wrinkle, not worth an edit: the coverage tables mark **T027** with `[GATE]` under
+FR-019 and SC-012, but T027 lives in Phase 5, is not marked `[GATE]` at its definition, and survives
+a rejection. It is a verification of C1's stdlib-only property that happens to also evidence FR-019.
+Reading the table alone, an implementer might drop T027 along with Phase 6. Do not.
+
+### Highest-risk task, and the most likely source of rework
+
+**Highest risk: T019.** It is the only task where getting it wrong produces a failure that looks like
+somebody else's problem. It writes a file to a 3.9 floor that will be linted under a `py313` ruleset
+on a blocking line, and all four reconciliation rules have to be right at once. Three of the four are
+invisible in the finished file: a reader sees `from __future__ import annotations` and reads it as
+house style rather than as the thing holding `UP045` off, and the absence of a version guard reads as
+an omission rather than as a decision. The failure surfaces at T026 or, if the ordering slips, at
+T038 as a target that fails for every contributor. T007 is the more famous line and it is
+better protected: it has a 6,629-input differential test and two mutation red-tests standing over it.
+
+**Most likely source of rework: T028, the checker's test file.** It is the one place where three
+constraints collide and each of them is discovered by a red required check rather than by reasoning.
+It has to satisfy C5 as *source* (no single line carrying a comment introducer followed by a marker,
+or the checker flags the file it is testing), `ruff format --check --diff src/ tests/`, and
+`ruff check src/ tests/` with `S` selected and `S603` unignored. G1 was exactly this and was invisible
+to every artifact until it was run. Expect at least one round trip here, and expect it to arrive as
+a red `Lint` job rather than as a failing test.
+
+### What was RUN (not read)
+
+| Command | Result |
+|---|---|
+| `gh api --paginate --slurp ".../code-scanning/alerts?ref=refs/heads/main&state=open&per_page=100"` then `jq add` | `gh_exit=0`, **5 open**: 150/149/148 `py/clear-text-logging-sensitive-data` on `src/lambdas/ingestion/handler.py`, **147 `py/bad-tag-filter` on `scripts/regenerate-mermaid-url.py:82`**, 144 on `src/lambdas/shared/auth/oauth_state.py:104` |
+| the same query, all states | **137**. T001's and T052's corpus floor is exact, not padded |
+| `gh api --paginate --slurp … --jq length` | Refused: "the `--slurp` option is not supported with `--jq` or `--template`", exit 1. Convention 6 is correct |
+| `gh api …/branches/main/protection --jq .required_status_checks.contexts` | `["Secrets Scan","Lint","Run Tests","Playwright E2E Tests"]`, exit 0 |
+| `ruff check --extend-select RUF100 src/ tests/ scripts/` (T003) | `All checks passed!`, exit 0. FR-011's premise holds today |
+| `grep -rnE "lgtm\[\|codeql\[" src/ tests/ scripts/` (T004) | Exactly one line, `scripts/regenerate-mermaid-url.py:82` |
+| `bandit -r scripts/ --ignore-nosec \| grep -cE "^>>"` and the same for `src/` (T005) | **10** and **15**, matching the spec assumption exactly |
+| `pytest tests/unit/scripts/ -q --collect-only` (T006) | exit 0 |
+| `make audit-pragma` on the current tree | **exit 0**, with 15 bandit findings printed. The recipe's structural inability to fail is real |
+| `find` census over the three roots and the ten allowlisted extensions | **583**, matching C7's example and `plan.md` |
+| `ruff check --select S --ignore-noqa tests/e2e/test_log_visibility.py` | `S603`, 1 error, exit 1. Basis of G1 |
+| `ruff check --config pyproject.toml --extend-select RUF100` on `X = 1  # lgtm[py/redtest-do-not-commit]` | `All checks passed!`, `1 file already formatted`. T040's seeded line reaches the checker |
+| Differential oracle, 6,629 inputs, three implementations | 0 / 134 / 441 mismatches (see the red-test table) |
+| `rstrip()` versus regex `\s`, every code point U+0000 to U+2FFF | **0 divergences.** The bare-`rstrip()` half of FR-003 is confirmed independently |
+| T027's heredoc, extracted verbatim from the fence | Unterminated here-document plus `IndentationError`. Basis of G7 |
+| `gh run view --job "$(gh run list … databaseId)" --log` | `HTTP 404: Not Found (…/actions/jobs/30597680512)`, exit 1. Basis of G2 |
+| `gh run view "$RID" --json jobs --jq '.jobs[] \| select(.name=="Lint") \| .databaseId'` then `gh run view --job "$JID" --log` | job `91053515417`, 322 lines, exit 0. The corrected form |
+| `import scripts.<module>` from a test under `tests/unit/scripts/` | Confirmed by precedent at `tests/unit/scripts/test_consolidate_oauth_apply.py:12`. `__init__.py` present at `tests/`, `tests/unit/`, `tests/unit/scripts/`; absent at `scripts/`, which is the PEP 420 namespace package T028 relies on |
+| `.github/workflows/pr-checks.yml` `lint` and `test` jobs | Read directly. Step order as recorded above; `Run Tests` ignores nothing covering `tests/unit/scripts/` |
+| `Makefile` `validate` prerequisites | Seven: `fmt lint security sast check-banned-terms check-test-target-headers check-waitforresponse-race`. `audit-pragma` absent, as every artifact says |
+
+What was **read** and not run: `plan.md`, `research.md`, `quickstart.md`, `checklists/requirements.md`,
+`.pre-commit-config.yaml`, `pyproject.toml`, `scripts/regenerate-mermaid-url.py`.
+
+### Errors found in the briefing that commissioned this review
+
+1. **The fuzz counts do not reproduce, and cannot.** The briefing cites `splitlines()` at
+   "23/385/194" and `rstrip(" \t")` at "694". This review's independent corpus gives **134** and
+   **441**. The direction and the mechanism are identical and the conclusion is unchanged, but those
+   numbers are properties of a corpus, not of the code, and quoting them without the corpus invites
+   an implementer to treat a different count as a discrepancy worth investigating. Any future
+   citation should say "many mismatches for both mutations, zero for the specified form" and name
+   the counterexample `"A -->\rB"` instead, which is stable: the original expression is False on it,
+   a `splitlines()` rewrite is True, and the specified rewrite is False. Verified again here.
+2. **The briefing's own corrections were accepted rather than re-derived, and both check out.** The
+   rule is `py/bad-tag-filter` and the contract has nine clauses, both re-confirmed here against the
+   live API and the contract file rather than taken on trust. Cross-Artifact F5 already carries both.
+   Nothing to change, recorded so the verification is on the record.
+
+Nothing else in the briefing was falsified. `make validate` is red, `Makefile:90` cannot fail,
+`audit-pragma` is invoked by nothing, `tests/unit/scripts/conftest.py` imports `boto3` and `moto` at
+module level, the system interpreter is 3.12.3, and the canonical alerts query behaves exactly as
+described, all confirmed above.
+
+### Adjacent defects found outside this feature's scope. Card, do not fix
+
+The nine already listed under Cross-Artifact Analysis stand. Two more, both surfaced by G1:
+
+10. **`[tool.ruff.lint.per-file-ignores]` for the test tree omits `S603` and `S607`**, so every test
+    in this repository that shells out needs a hand-written `# noqa`, and the requirement is recorded
+    nowhere. Exactly one test does it today (`tests/e2e/test_log_visibility.py:115`), this feature
+    will add the second, and the third author will rediscover it from a red required check. Either
+    add the ignore with a scoping comment or write the convention down. Not this feature's diff.
+11. **`ruff format` covers `src/` and `tests/` but not `scripts/`**, while `ruff check` covers
+    `scripts/` only through `make audit-pragma`, which nothing invokes. So `scripts/` is
+    format-unconstrained and, after this feature, lint-constrained only by a target no automated
+    process runs. This sharpens existing card 5 rather than replacing it: the new checker's own
+    source is neither linted nor formatted by any required check.
+
+### Verdict
+
+Three HIGH findings existed and all three were executability defects rather than design defects: a
+required-check rule nobody had named (G1), a `[GATE]` verification command that returns 404 and reads
+as a pass (G2), and an optional task that can lock the implementer out of a mandatory one (G3). All
+three are closed by direct edit, along with three MEDIUM. Five LOW are recorded and left.
+
+The design underneath survived every test put to it. The rewrite is equivalent over 6,629
+independently generated inputs and both mutations of it are not. The ruff collision is real,
+reproduced, and correctly reconciled by four rules each of which earns its place. Every gate this
+feature introduces has a red-test that goes red. The FR-018 block is genuinely separable: five tasks,
+no hidden dependents.
+
+**READY FOR IMPLEMENTATION**, with two conditions that are execution conditions rather than open
+questions. First, the FR-018 scope growth into the required `Lint` job is still owner-rejectable and
+has not been accepted; Phase 6 must not be started until it is decided, in either direction, and
+neither outcome may be reached by drifting into it. Second, the ordering constraints are binding:
+T038 must not precede T026, T042 must not precede T040, and T043 must not precede T044.

--- a/tests/unit/scripts/test_check_dead_suppressions.py
+++ b/tests/unit/scripts/test_check_dead_suppressions.py
@@ -1,0 +1,342 @@
+"""Tests for the dead-suppression checker.
+
+BINDING RULE FOR THIS FILE: no single source line may contain a comment
+introducer followed by a suppression marker. The checker's detection rule is
+purely textual and does not know what a string literal is, so the natural way
+to write a fixture would make the checker flag the file that tests it. Every
+fixture is therefore assembled from separated constants, and no marker is ever
+written in a real comment here.
+
+Two independent mechanisms keep this file clean: the checker's exact-path
+self-exclusion, and the rule above. Without the rule, only the exclusion holds
+it, and the file would be one rename away from a permanently red gate.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+import scripts.check_dead_suppressions as mod
+
+SCRIPT = mod.REPO_ROOT / "scripts" / "check_dead_suppressions.py"
+
+# Fixture building blocks, kept apart so no line below carries both halves.
+HASH = "#"
+SLASHES = "//"
+HTML_OPEN = "<!--"
+C_OPEN = "/*"
+DASHES = "--"
+
+LGTM = "lgtm[py/some-rule]"
+CODEQL = "codeql[py/some-rule]"
+LGTM_UPPER = "LGTM[py/some-rule]"
+CODEQL_MIXED = "CodeQL[py/some-rule]"
+
+
+def seed(directory: Path, name: str, body: str) -> Path:
+    """Write a fixture file and return its path."""
+    target = directory / name
+    target.write_text(body, encoding="utf-8")
+    return target
+
+
+def run_in_process(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    roots: str | None,
+) -> tuple[int, str]:
+    """Run the checker in process against *roots*, returning code and stdout."""
+    if roots is None:
+        monkeypatch.delenv(mod.ROOTS_ENV, raising=False)
+    else:
+        monkeypatch.setenv(mod.ROOTS_ENV, roots)
+    code = mod.main([])
+    return code, capsys.readouterr().out
+
+
+def run_cli(
+    args: list[str],
+    roots: str | None = None,
+    cwd: Path | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Run the checker as a command line, pinning the current interpreter.
+
+    A bare ``python3`` resolves differently per machine and per shell, so the
+    interpreter this test is running under is used instead.
+    """
+    env = dict(os.environ)
+    if roots is None:
+        env.pop(mod.ROOTS_ENV, None)
+    else:
+        env[mod.ROOTS_ENV] = roots
+    # S603: argv is sys.executable plus a repository-fixed script path, and no
+    # untrusted input reaches the subprocess.
+    return subprocess.run(  # noqa: S603
+        [sys.executable, str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=str(cwd) if cwd is not None else None,
+        check=False,
+        timeout=300,
+    )
+
+
+def scanned_count(output: str) -> int:
+    """Pull the file count out of a run's output."""
+    for line in output.split("\n"):
+        if line.startswith("Scanned "):
+            return int(line.split()[1])
+    raise AssertionError(f"no scanned-count line in output:\n{output}")
+
+
+# ---------------------------------------------------------------------------
+# T029: the red-test. The checker must be observed failing.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("marker", [LGTM, CODEQL])
+def test_seeded_marker_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    marker: str,
+) -> None:
+    """A marker in a comment exits 1 and names file, line and marker."""
+    fixture = seed(tmp_path, "bad.py", f"x = 1  {HASH} {marker}\n")
+
+    code, out = run_in_process(monkeypatch, capsys, str(tmp_path))
+
+    assert code == 1
+    resolved = str(fixture.resolve())
+    assert resolved in out
+    assert f"{resolved}:1" in out
+    assert marker in out
+
+
+def test_marker_without_introducer_passes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Control: the failure must come from the rule, not from the file."""
+    seed(tmp_path, "ok.py", f'text = "{LGTM}"\n')
+
+    code, out = run_in_process(monkeypatch, capsys, str(tmp_path))
+
+    assert code == 0, out
+
+
+# ---------------------------------------------------------------------------
+# T030: scanned nothing is not the same as found nothing.
+# ---------------------------------------------------------------------------
+
+
+def test_zero_files_exits_two(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    empty = tmp_path / "empty"
+    empty.mkdir()
+
+    code, _ = run_in_process(monkeypatch, capsys, str(empty))
+
+    assert code == 2
+    assert code != 0, (
+        "a scan that examined nothing must not report the same result as a "
+        "scan that found nothing, or a moved root reads as a clean tree"
+    )
+
+
+# ---------------------------------------------------------------------------
+# T031: self-exclusion is by exact path and by nothing else.
+# ---------------------------------------------------------------------------
+
+
+def test_self_exclusions_are_exactly_two_exact_paths() -> None:
+    assert mod.SELF_EXCLUSIONS == frozenset(
+        {
+            Path("scripts/check_dead_suppressions.py"),
+            Path("tests/unit/scripts/test_check_dead_suppressions.py"),
+        }
+    )
+    assert len(mod.SELF_EXCLUSIONS) == 2
+
+
+def test_same_basename_elsewhere_is_still_flagged(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The exclusion is a path, not a basename glob."""
+    seed(tmp_path, "check_dead_suppressions.py", f"x = 1  {HASH} {LGTM}\n")
+
+    code, out = run_in_process(monkeypatch, capsys, str(tmp_path))
+
+    assert code == 1, out
+
+
+def test_paths_outside_the_repository_do_not_raise(tmp_path: Path) -> None:
+    outside = tmp_path / "somewhere.py"
+    outside.write_text("x = 1\n", encoding="utf-8")
+
+    assert mod.repo_relative(outside) is None
+    assert mod.is_self_excluded(outside) is False
+    assert mod.display_path(outside) == str(outside.resolve())
+
+
+# ---------------------------------------------------------------------------
+# T032: the positional detection rule.
+# ---------------------------------------------------------------------------
+
+
+def test_marker_in_a_string_literal_does_not_fire() -> None:
+    assert mod.marker_in_comment(f'value = "{LGTM}"') is None
+
+
+def test_marker_in_a_url_does_not_fire() -> None:
+    assert mod.marker_in_comment(f'link = "example.com/rules/{LGTM}"') is None
+
+
+def test_scheme_prefixed_url_is_a_known_false_positive() -> None:
+    """Documented consequence of keeping the loosest introducers.
+
+    An absolute URL carries a slash pair, which is a comment introducer, so a
+    marker later on that line matches. The contract's own summary claims URLs
+    never match; that claim holds only for scheme-less URLs. Pinned here so the
+    behaviour is a recorded limitation rather than a surprise.
+    """
+    assert mod.marker_in_comment(f'link = "https:{SLASHES}x.dev/{LGTM}"') == LGTM
+
+
+@pytest.mark.parametrize("introducer", [HASH, SLASHES, HTML_OPEN, C_OPEN, DASHES])
+def test_every_introducer_fires(introducer: str) -> None:
+    assert mod.marker_in_comment(f"x = 1  {introducer} {LGTM}") == LGTM
+
+
+@pytest.mark.parametrize("marker", [LGTM_UPPER, CODEQL_MIXED])
+def test_detection_is_case_insensitive(marker: str) -> None:
+    assert mod.marker_in_comment(f"x = 1  {HASH} {marker}") == marker
+
+
+def test_extension_outside_the_allowlist_is_not_scanned(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Prose describing a marker has to write it, so docs stay out."""
+    seed(tmp_path, "notes.md", f"x = 1  {HASH} {LGTM}\n")
+    seed(tmp_path, "real.py", "x = 1\n")
+
+    code, out = run_in_process(monkeypatch, capsys, str(tmp_path))
+
+    assert code == 0, out
+    assert scanned_count(out) == 1
+
+
+def test_skip_list_applies_under_an_override(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    cache = tmp_path / "__pycache__"
+    cache.mkdir()
+    seed(cache, "bad.py", f"x = 1  {HASH} {LGTM}\n")
+    seed(tmp_path, "real.py", "x = 1\n")
+
+    code, out = run_in_process(monkeypatch, capsys, str(tmp_path))
+
+    assert code == 0, out
+    assert scanned_count(out) == 1
+
+
+# ---------------------------------------------------------------------------
+# T033: the failure has to be actionable.
+# ---------------------------------------------------------------------------
+
+
+def test_failure_output_explains_itself(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    fixture = seed(tmp_path, "bad.py", f"x = 1  {HASH} {LGTM}\n")
+
+    code, out = run_in_process(monkeypatch, capsys, str(tmp_path))
+
+    assert code == 1
+    assert str(fixture.resolve()) in out
+    assert ":1" in out
+    assert LGTM in out
+    assert "suppress nothing" in out
+    assert "dismissal workflow" in out
+
+
+def test_clean_output_states_a_file_count(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    seed(tmp_path, "fine.py", "x = 1\n")
+
+    code, out = run_in_process(monkeypatch, capsys, str(tmp_path))
+
+    assert code == 0
+    assert scanned_count(out) > 0
+
+
+# ---------------------------------------------------------------------------
+# T034: the exit-code contract through the command-line surface.
+# ---------------------------------------------------------------------------
+
+
+def test_cli_exits_zero_against_the_real_tree() -> None:
+    result = run_cli([])
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_cli_exits_one_on_a_seeded_root(tmp_path: Path) -> None:
+    seed(tmp_path, "bad.py", f"x = 1  {HASH} {LGTM}\n")
+    result = run_cli([], roots=str(tmp_path))
+    assert result.returncode == 1, result.stdout + result.stderr
+
+
+def test_cli_exits_two_on_an_empty_root(tmp_path: Path) -> None:
+    result = run_cli([], roots=str(tmp_path))
+    assert result.returncode == 2, result.stdout + result.stderr
+
+
+def test_cli_runs_from_any_working_directory(tmp_path: Path) -> None:
+    """The repository root comes from the script's own location."""
+    result = run_cli([], cwd=tmp_path)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_positional_arguments_do_not_narrow_the_scan() -> None:
+    bare = run_cli([])
+    narrowed = run_cli([str(SCRIPT)])
+
+    assert bare.returncode == 0, bare.stdout + bare.stderr
+    assert narrowed.returncode == 0, narrowed.stdout + narrowed.stderr
+    assert scanned_count(narrowed.stdout) == scanned_count(bare.stdout)
+
+
+# ---------------------------------------------------------------------------
+# T035: the canary. Red the day somebody adds a marker to an audited root.
+# ---------------------------------------------------------------------------
+
+
+def test_default_roots_are_clean(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    code, out = run_in_process(monkeypatch, capsys, None)
+
+    assert code == 0, out
+    assert scanned_count(out) > 0

--- a/tests/unit/scripts/test_regenerate_mermaid_url.py
+++ b/tests/unit/scripts/test_regenerate_mermaid_url.py
@@ -1,0 +1,208 @@
+"""Regression tests for ``scripts/regenerate-mermaid-url.py``.
+
+The subject is the arrow-without-target check, which used to be a regex
+pattern match and is now a plain line scan. The differential test rebuilds
+the original expression as a local oracle and asserts the shipped check
+agrees with it over several thousand generated inputs, so the rewrite is
+proven behaviour-preserving rather than assumed to be.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import itertools
+import random
+import re
+import sys
+from pathlib import Path
+from types import ModuleType
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "regenerate-mermaid-url.py"
+
+ARROW_MSG = "Arrow without target node (line ends with -->)"
+THICK_ARROW_MSG = "Thick arrow without target node (line ends with ==>)"
+
+
+def _load_script() -> ModuleType:
+    """Load the script by path.
+
+    The filename is hyphenated and therefore not importable by name, and
+    renaming it is out of scope: it is referenced by path in documentation.
+    The path is resolved from this file rather than from the cwd.
+    """
+    spec = importlib.util.spec_from_file_location("regenerate_mermaid_url", SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+script = _load_script()
+
+
+def fires(code: str) -> bool:
+    """True when the shipped validator reports arrow-without-target."""
+    return ARROW_MSG in script.validate_mermaid_syntax(code)
+
+
+def thick_fires(code: str) -> bool:
+    """True when the shipped validator reports thick-arrow-without-target."""
+    return THICK_ARROW_MSG in script.validate_mermaid_syntax(code)
+
+
+def oracle(code: str) -> bool:
+    """The original expression the check replaced, rebuilt verbatim."""
+    return bool(re.search(r"-->\s*$", code, re.MULTILINE))
+
+
+# Atom set for the generated corpus. Every exotic line separator that
+# str.splitlines() honours and regex ``$`` does not is present, because that
+# difference is the whole reason the rewrite uses split("\n").
+ATOMS = (
+    "-->",
+    "==>",
+    "<!--",
+    "--!>",
+    " ",
+    "\t",
+    "\r",
+    "\n",
+    "\v",
+    "\f",
+    "\x85",
+    "\u2028",
+    "\u2029",
+    "\xa0",
+    "A",
+)
+
+HAND_PICKED = (
+    "",
+    "   ",
+    "\n\n\n",
+    "-->",
+    "-->   ",
+    "-->\t\t",
+    "-->\xa0",
+    "-->\v",
+    "-->\n\n\n",
+    "A --> B",
+    "A --> B\nC -->",
+    "A -->\rB",
+    "A -->\r\n",
+    "graph TD\nA-->B\n",
+    "==>",
+    "flowchart LR\nA ==> ",
+)
+
+RANDOM_SEED = 20260730
+RANDOM_SAMPLES = 3000
+
+
+def build_corpus() -> list[str]:
+    """Exhaustive short products, seeded random longer strings, hand cases."""
+    corpus: list[str] = []
+    for size in (1, 2, 3):
+        corpus.extend("".join(parts) for parts in itertools.product(ATOMS, repeat=size))
+    rng = random.Random(RANDOM_SEED)
+    for _ in range(RANDOM_SAMPLES):
+        length = rng.randint(4, 5)
+        corpus.append("".join(rng.choice(ATOMS) for _ in range(length)))
+    corpus.extend(HAND_PICKED)
+    return corpus
+
+
+def test_corpus_is_large_enough() -> None:
+    """Without this the differential result is unfalsifiable.
+
+    A corpus that silently shrank to a dozen inputs still reports zero
+    mismatches.
+    """
+    corpus = build_corpus()
+    assert len(corpus) >= 1500, (
+        f"differential corpus shrank to {len(corpus)} inputs; zero mismatches "
+        "over a tiny corpus proves nothing"
+    )
+
+
+def test_differential_against_original_expression() -> None:
+    """The rewrite must agree with the original expression on every input."""
+    corpus = build_corpus()
+    assert len(corpus) >= 1500
+    mismatches = [code for code in corpus if fires(code) != oracle(code)]
+    assert not mismatches, (
+        f"{len(mismatches)} of {len(corpus)} inputs disagree with the original "
+        f"expression; first five: {[repr(code) for code in mismatches[:5]]}"
+    )
+
+
+def test_trailing_spaces_after_arrow_fire() -> None:
+    assert fires("graph TD\nA -->   ")
+
+
+def test_trailing_tabs_after_arrow_fire() -> None:
+    assert fires("graph TD\nA -->\t\t")
+
+
+def test_trailing_nbsp_and_vertical_tab_after_arrow_fire() -> None:
+    assert fires("graph TD\nA -->\xa0")
+    assert fires("graph TD\nA -->\v")
+
+
+def test_crlf_and_lf_agree() -> None:
+    assert fires("graph TD\nA -->\r\n") == fires("graph TD\nA -->\n")
+    assert fires("graph TD\nA -->\r\n")
+
+
+def test_empty_input_does_not_fire() -> None:
+    assert not fires("")
+
+
+def test_whitespace_only_input_does_not_fire() -> None:
+    assert not fires("   \t\n  ")
+
+
+def test_trailing_blank_lines_after_arrow_fire() -> None:
+    assert fires("graph TD\nA -->\n\n\n")
+
+
+def test_arrow_with_target_does_not_fire() -> None:
+    assert not fires("graph TD\nA --> B\n")
+
+
+def test_arrow_with_target_then_bare_arrow_fires() -> None:
+    assert fires("graph TD\nA --> B\nC -->\n")
+
+
+def test_carriage_return_separator_does_not_fire() -> None:
+    """The counterexample that separates split("\\n") from splitlines().
+
+    The original expression is False on this input because regex ``$`` under
+    MULTILINE does not treat a bare carriage return as a line boundary. A
+    splitlines() rewrite would return True.
+    """
+    assert not fires("A -->\rB")
+    assert not oracle("A -->\rB")
+
+
+def test_thick_arrow_control_still_fires() -> None:
+    """The sibling check is untouched and must still work."""
+    assert thick_fires("graph TD\nA ==>")
+    assert not thick_fires("graph TD\nA ==> B\n")
+
+
+def test_both_arrow_checks_report_independently() -> None:
+    both = script.validate_mermaid_syntax("graph TD\nA -->\nB ==>\n")
+    assert ARROW_MSG in both
+    assert THICK_ARROW_MSG in both
+
+    thin_only = script.validate_mermaid_syntax("graph TD\nA -->\nB ==> C\n")
+    assert ARROW_MSG in thin_only
+    assert THICK_ARROW_MSG not in thin_only
+
+    thick_only = script.validate_mermaid_syntax("graph TD\nA --> B\nC ==>\n")
+    assert ARROW_MSG not in thick_only
+    assert THICK_ARROW_MSG in thick_only


### PR DESCRIPTION
Feature C of a four-part CodeQL burndown. Closes `py/bad-tag-filter` alert 147 on
`scripts/regenerate-mermaid-url.py`, and stops the same dead-suppression pattern
coming back.

## What is here

- The `lgtm[py/bad-tag-filter]` suppression and its false-positive comment are removed.
  Inline `lgtm[...]` / `codeql[...]` markers are NOT honoured by GitHub code scanning,
  so the suppression was inert and the comment was wrong about why.
- The expression is rewritten, with a differential test against the original across
  6631 inputs.
- New `scripts/check_dead_suppressions.py` (standard library only) plus 27 tests.
- `make audit-pragma` rewritten into three labelled sections, two blocking and one
  explicitly advisory. Its `RUF100` line is widened to `scripts/`, which is the only
  `RUF100` coverage `scripts/` has anywhere: the `Lint` job runs ruff over `src/ tests/`.
- One new step in the `Lint` job invoking the checker directly.

## The new CI step

This is the only feature of the four that adds a CI step, and it has never run on a
real runner. It calls `python3 scripts/check_dead_suppressions.py` directly rather than
`make audit-pragma`, because the `Lint` job installs `ruff` and nothing else, so the
target's bandit section would fail on a missing binary. No `|| true`, no pipe, no wrapper.

## Not verified

SC-011 wants the gate observed FAILING, which needs a scratch commit pushed and then
removed with a force push. That was not done and no scratch commit exists. The local
red-test did fire correctly (`make audit-pragma` exits 2, naming the file, line and
marker), but a local red-test is not the observed-in-CI evidence SC-011 asks for.

Two mutation tests on the rewritten expression bite as intended: `splitlines()` produces
113 disagreements, `rstrip(" \t")` produces 430, both first surfacing at a carriage return.

Draft on purpose.