### PR TITLE
fix(security): validate ticker input at the boundary, drop an oauth-named log field

### DIFF
--- a/src/dashboard/timeseries.js
+++ b/src/dashboard/timeseries.js
@@ -34,6 +34,59 @@ const DEFAULT_TICKER = 'AAPL';
 const DEFAULT_RESOLUTION = '5m';
 
 /**
+ * Ticker symbol allowlist.
+ *
+ * Anchored and length-bounded: 1-10 characters drawn from A-Z, 0-9, dot and dash. That
+ * covers class shares (BRK.B) and preferred series (BF-A) while admitting no angle
+ * bracket, quote, slash, percent, backtick or whitespace, and it cannot spell
+ * `__proto__` or `constructor`.
+ */
+const TICKER_PATTERN = /^[A-Z0-9.-]{1,10}$/;
+
+/**
+ * Coerce one untrusted value to a ticker symbol, or null if it is not one.
+ *
+ * Every ticker in this module arrives from `?ticker=` / `?tickers=` in the page URL or
+ * from a free-text input, so it is attacker-controlled. It then reaches four kinds of
+ * sink: interpolation into markup, an object property key, a request path segment, and
+ * a console format string. Validating once here is what keeps those sinks safe, so
+ * callers must route every externally supplied ticker through this function rather than
+ * escaping at each sink.
+ *
+ * @param {*} raw - Untrusted value
+ * @returns {string|null} The normalised symbol, or null if it fails the allowlist
+ */
+function sanitizeTicker(raw) {
+    if (typeof raw !== 'string') {
+        return null;
+    }
+    const candidate = raw.trim().toUpperCase();
+    return TICKER_PATTERN.test(candidate) ? candidate : null;
+}
+
+/**
+ * Coerce a comma-separated list of untrusted values to ticker symbols.
+ *
+ * Entries that fail the allowlist are dropped rather than rejecting the whole list, so
+ * one bad symbol in a shared link still renders the rest. Returns an empty array when
+ * nothing survives; callers decide whether to fall back to a default.
+ *
+ * @param {*} raw - Untrusted comma-separated string, or an array of untrusted values
+ * @returns {string[]} Symbols that passed the allowlist, deduplicated, order preserved
+ */
+function sanitizeTickerList(raw) {
+    const parts = Array.isArray(raw) ? raw : typeof raw === 'string' ? raw.split(',') : [];
+    const seen = [];
+    for (const part of parts) {
+        const ticker = sanitizeTicker(part);
+        if (ticker && !seen.includes(ticker)) {
+            seen.push(ticker);
+        }
+    }
+    return seen;
+}
+
+/**
  * Feature 1019: Latency tracking for SSE events
  * Exposes window.lastLatencyMetrics and window.latencySamples for E2E testing
  */
@@ -110,7 +163,7 @@ class TimeseriesManager {
         // Parse URL params
         const params = new URLSearchParams(window.location.search);
         if (params.has('ticker')) {
-            this.currentTicker = params.get('ticker').toUpperCase();
+            this.currentTicker = sanitizeTicker(params.get('ticker')) || DEFAULT_TICKER;
         }
         if (params.has('resolution')) {
             const res = params.get('resolution');
@@ -160,7 +213,6 @@ class TimeseriesManager {
                 <label for="ticker-input">Ticker:</label>
                 <input type="text"
                        id="ticker-input"
-                       value="${this.currentTicker}"
                        maxlength="10"
                        data-testid="ticker-input">
                 <span class="resolution-label">Resolution:</span>
@@ -189,6 +241,9 @@ class TimeseriesManager {
         // Ticker input handler
         const tickerInput = document.getElementById('ticker-input');
         if (tickerInput) {
+            // Assigned as a property rather than interpolated into the markup above, so
+            // the symbol is never parsed as HTML.
+            tickerInput.value = this.currentTicker;
             tickerInput.addEventListener('change', (e) => {
                 const ticker = e.target.value.toUpperCase().trim();
                 if (ticker && ticker !== this.currentTicker) {
@@ -318,13 +373,18 @@ class TimeseriesManager {
      * Switch to a new ticker
      */
     async switchTicker(ticker) {
-        if (ticker === this.currentTicker) {
+        const safeTicker = sanitizeTicker(ticker);
+        if (!safeTicker) {
+            console.warn('Ignoring ticker that failed the allowlist');
+            return;
+        }
+        if (safeTicker === this.currentTicker) {
             return;
         }
 
-        console.log(`Switching ticker: ${this.currentTicker} -> ${ticker}`);
+        console.log('Switching ticker: %s -> %s', this.currentTicker, safeTicker);
 
-        this.currentTicker = ticker;
+        this.currentTicker = safeTicker;
         this.updateSelectorUI();
         this.updateURL();
 
@@ -336,7 +396,7 @@ class TimeseriesManager {
 
         // Feature 1057: Update OHLC chart when ticker changes
         if (typeof updateOHLCTicker === 'function') {
-            await updateOHLCTicker(ticker);
+            await updateOHLCTicker(safeTicker);
         }
     }
 
@@ -358,7 +418,8 @@ class TimeseriesManager {
      */
     async loadData() {
         try {
-            const url = `${this.apiBaseUrl}/api/v2/timeseries/${this.currentTicker}?resolution=${this.currentResolution}`;
+            const url = `${this.apiBaseUrl}/api/v2/timeseries/${encodeURIComponent(this.currentTicker)}`
+                + `?resolution=${encodeURIComponent(this.currentResolution)}`;
             console.log(`Fetching: ${url}`);
 
             // Feature 1051: Include X-User-ID header for authentication
@@ -415,10 +476,12 @@ class TimeseriesManager {
                 chartContainer.id = 'timeseries-chart-container';
                 chartContainer.className = 'chart-container timeseries-chart';
                 chartContainer.innerHTML = `
-                    <h3>Sentiment Trend <span id="timeseries-ticker">${this.currentTicker}</span></h3>
+                    <h3>Sentiment Trend <span id="timeseries-ticker"></span></h3>
                     <canvas id="timeseries-chart" data-testid="timeseries-chart"></canvas>
                     <div id="chart-loaded" data-testid="chart-loaded" style="display:none;"></div>
                 `;
+                // textContent rather than interpolation: the symbol is never parsed as HTML.
+                chartContainer.querySelector('#timeseries-ticker').textContent = this.currentTicker;
                 chartsSection.appendChild(chartContainer);
             }
         }
@@ -692,8 +755,8 @@ class MultiTickerManager {
 
         this.tickers = [];  // Array of ticker symbols
         this.currentResolution = DEFAULT_RESOLUTION;
-        this.charts = {};   // ticker -> Chart instance
-        this.bucketData = {};  // ticker -> buckets array
+        this.charts = Object.create(null);   // ticker -> Chart instance
+        this.bucketData = Object.create(null);  // ticker -> buckets array
         this.eventSource = null;
 
         // Callbacks
@@ -705,7 +768,7 @@ class MultiTickerManager {
      * @param {string[]} tickers - Array of ticker symbols
      */
     async init(tickers = ['AAPL', 'MSFT', 'GOOGL']) {
-        this.tickers = tickers.map(t => t.toUpperCase());
+        this.tickers = sanitizeTickerList(tickers);
 
         // Initialize cache
         if (this.cache) {
@@ -715,7 +778,10 @@ class MultiTickerManager {
         // Parse URL params
         const params = new URLSearchParams(window.location.search);
         if (params.has('tickers')) {
-            this.tickers = params.get('tickers').toUpperCase().split(',').filter(t => t.trim());
+            const requested = sanitizeTickerList(params.get('tickers'));
+            if (requested.length > 0) {
+                this.tickers = requested;
+            }
         }
         if (params.has('resolution')) {
             const res = params.get('resolution');
@@ -763,7 +829,6 @@ class MultiTickerManager {
                     <label for="multi-ticker-input">Tickers (comma-separated):</label>
                     <input type="text"
                            id="multi-ticker-input"
-                           value="${this.tickers.join(', ')}"
                            placeholder="AAPL, MSFT, GOOGL"
                            data-testid="multi-ticker-input">
                     <button type="button" id="update-tickers-btn" data-testid="update-tickers">
@@ -810,6 +875,9 @@ class MultiTickerManager {
         // Allow Enter key to update
         const tickerInput = document.getElementById('multi-ticker-input');
         if (tickerInput) {
+            // Assigned as a property rather than interpolated into the markup above, so
+            // the symbols are never parsed as HTML.
+            tickerInput.value = this.tickers.join(', ');
             tickerInput.addEventListener('keypress', (e) => {
                 if (e.key === 'Enter') {
                     this.updateTickers();
@@ -829,7 +897,7 @@ class MultiTickerManager {
     initTickerChart(ticker) {
         const canvas = document.getElementById(`chart-${ticker}`);
         if (!canvas) {
-            console.warn(`Canvas not found for ticker: ${ticker}`);
+            console.warn('Canvas not found for ticker: %s', ticker);
             return;
         }
 
@@ -961,7 +1029,8 @@ class MultiTickerManager {
 
         const promises = this.tickers.map(async (ticker) => {
             try {
-                const url = `${this.apiBaseUrl}/api/v2/timeseries/${ticker}?resolution=${this.currentResolution}`;
+                const url = `${this.apiBaseUrl}/api/v2/timeseries/${encodeURIComponent(ticker)}`
+                    + `?resolution=${encodeURIComponent(this.currentResolution)}`;
                 // Feature 1051: Include X-User-ID header for authentication
                 const response = await fetch(url, {
                     headers: {
@@ -973,7 +1042,7 @@ class MultiTickerManager {
                 this.bucketData[ticker] = data.buckets || [];
                 this.updateTickerChart(ticker, data.buckets || []);
             } catch (error) {
-                console.error(`Failed to load ${ticker}:`, error);
+                console.error('Failed to load %s:', ticker, error);
                 this.updateTickerStatus(ticker, 'Error');
             }
         });
@@ -1100,10 +1169,7 @@ class MultiTickerManager {
         const input = document.getElementById('multi-ticker-input');
         if (!input) return;
 
-        const newTickers = input.value.toUpperCase()
-            .split(',')
-            .map(t => t.trim())
-            .filter(t => t.length > 0);
+        const newTickers = sanitizeTickerList(input.value);
 
         if (newTickers.length === 0) {
             console.warn('No valid tickers entered');
@@ -1182,7 +1248,7 @@ class MultiTickerManager {
         if (!this.tickers.includes(ticker)) return;
         if (bucket.resolution !== this.currentResolution) return;
 
-        console.log(`Bucket update for ${ticker}:`, bucket);
+        console.log('Bucket update for %s:', ticker, bucket);
 
         // Update bucket data
         if (!this.bucketData[ticker]) {
@@ -1213,7 +1279,7 @@ class MultiTickerManager {
         Object.values(this.charts).forEach(chart => {
             if (chart) chart.destroy();
         });
-        this.charts = {};
+        this.charts = Object.create(null);
     }
 }
 

--- a/src/lambdas/shared/auth/oauth_state.py
+++ b/src/lambdas/shared/auth/oauth_state.py
@@ -100,11 +100,17 @@ def store_oauth_state(
     # appear in this extra context. Removing the derived value, rather than
     # sanitizing it in place, is the shape that closed this rule in ebcc2f4.
     # See specs/001-oauth-provider-taint/research.md before adding a key here.
+    #
+    # Nor may any identifier containing "oauth" reach it. CodeQL's shared sensitive-data
+    # heuristic lists the bare substring "oauth" in its password pattern, so every such
+    # name is classified as a password whatever it holds; `OAUTH_STATE_TTL_SECONDS`, a
+    # module constant of 300, was reported that way. That query has no sanitizer, so a
+    # type assertion or an int() would not clear it. The constant is omitted here because
+    # it never varies and so carried no information in the first place.
     logger.info(
         "OAuth state stored",
         extra={
             "has_user_id": user_id is not None,
-            "ttl_seconds": OAUTH_STATE_TTL_SECONDS,
         },
     )
 

--- a/tests/unit/auth/test_oauth_state.py
+++ b/tests/unit/auth/test_oauth_state.py
@@ -45,6 +45,26 @@ class TestStoreOAuthState:
         assert state.used is False
         mock_table.put_item.assert_called_once()
 
+    def test_stores_ttl_derived_from_the_configured_lifetime(self, mock_table):
+        """The item is what actually expires, so the TTL is asserted on the item.
+
+        This previously rode on a log-field assertion, which only ever proved that a
+        constant had been copied into a log line.
+        """
+        before = datetime.now(UTC)
+        store_oauth_state(
+            mock_table, "state-ttl", "google", "https://example.com/callback"
+        )
+        after = datetime.now(UTC)
+
+        item = mock_table.put_item.call_args.kwargs["Item"]
+        assert isinstance(item["ttl_timestamp"], int)
+        assert (
+            int((before + timedelta(seconds=OAUTH_STATE_TTL_SECONDS)).timestamp())
+            <= item["ttl_timestamp"]
+            <= int((after + timedelta(seconds=OAUTH_STATE_TTL_SECONDS)).timestamp())
+        )
+
     def test_stores_with_user_id(self, mock_table):
         state = store_oauth_state(
             mock_table, "state-2", "github", "https://example.com/cb", user_id="u-1"
@@ -72,7 +92,12 @@ class TestStoreOAuthState:
         assert len(records) == 1
         assert not hasattr(records[0], "provider")
         assert records[0].has_user_id is False
-        assert records[0].ttl_seconds == OAUTH_STATE_TTL_SECONDS
+        # OAUTH_STATE_TTL_SECONDS is no longer logged. CodeQL's sensitive-data heuristic
+        # classifies any identifier containing "oauth" as a password, so the constant was
+        # reported as a cleartext credential; it never varied, so it was dropped rather
+        # than renamed. The TTL is asserted on the stored item instead, by
+        # test_stores_ttl_derived_from_the_configured_lifetime above.
+        assert not hasattr(records[0], "ttl_seconds")
 
 
 class TestGetOAuthState:

--- a/tests/unit/dashboard/test_ticker_sanitization.py
+++ b/tests/unit/dashboard/test_ticker_sanitization.py
@@ -1,0 +1,201 @@
+# Target: Admin Dashboard (Lambda HTMX)
+"""Allowlist tests for the ticker sanitizers in src/dashboard/timeseries.js.
+
+Every ticker in that module arrives from `?ticker=` / `?tickers=` in the page URL or
+from a free-text input, and then reaches markup, an object property key, a request path
+and a console format string. `sanitizeTicker` is the single boundary that keeps those
+sinks safe, so its allowlist is worth pinning.
+
+The functions are pure and depend on nothing but a module-level regex, so the test
+slices them out of the real file and runs them under node rather than reimplementing
+them in Python. Reimplementing would test the copy, not the code that ships.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+TIMESERIES_JS = REPO_ROOT / "src" / "dashboard" / "timeseries.js"
+
+# The sanitizers and the pattern they use, as one contiguous block.
+BLOCK_START = "const TICKER_PATTERN"
+BLOCK_END = "window.latencySamples = [];"
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("node") is None, reason="node is required to execute the sanitizers"
+)
+
+
+def _sanitizer_source() -> str:
+    """Return the sanitizer block from the shipping file.
+
+    Fails loudly rather than silently returning an empty string, because a test that
+    evaluates nothing would pass on every input.
+    """
+    source = TIMESERIES_JS.read_text(encoding="utf-8")
+    start = source.index(BLOCK_START)
+    end = source.index(BLOCK_END)
+    block = source[start:end]
+    assert "function sanitizeTicker(" in block, (
+        "sanitizeTicker missing from sliced block"
+    )
+    assert "function sanitizeTickerList(" in block, (
+        "sanitizeTickerList missing from block"
+    )
+    return block
+
+
+def _run(expression: str, argument: object) -> object:
+    """Evaluate one sanitizer call under node and return the parsed result.
+
+    The argument is embedded as a JSON literal rather than interpolated raw, so a probe
+    string carrying a quote or a backtick cannot terminate the surrounding script.
+    """
+    node = shutil.which("node")
+    assert node is not None, "guarded by the module-level skipif"
+    script = (
+        _sanitizer_source()
+        + f"\nconst __arg = {json.dumps(argument)};"
+        + f"\nprocess.stdout.write(JSON.stringify({expression}));"
+    )
+    completed = subprocess.run(  # noqa: S603 - fixed argv, absolute interpreter path
+        [node, "-e", script], capture_output=True, text=True, timeout=30, check=True
+    )
+    return json.loads(completed.stdout)
+
+
+class TestSanitizeTicker:
+    """The single-symbol allowlist."""
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("AAPL", "AAPL"),
+            ("aapl", "AAPL"),  # normalised to upper case
+            ("  MSFT  ", "MSFT"),  # surrounding whitespace trimmed
+            ("BRK.B", "BRK.B"),  # class share
+            ("BF-A", "BF-A"),  # preferred series
+            ("A", "A"),  # one character is the lower bound
+            ("ABCDEFGHIJ", "ABCDEFGHIJ"),  # ten characters is the upper bound
+        ],
+    )
+    def test_accepts_real_symbols(self, raw: str, expected: str) -> None:
+        assert _run("sanitizeTicker(__arg)", raw) == expected
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "",
+            "   ",
+            "ABCDEFGHIJK",  # eleven characters, over the bound
+            "AA PL",  # inner whitespace
+            "AA,PL",  # comma would split a list entry
+            "A/B",
+            "A%sB",  # console format specifier
+            "A`B",
+            "<script>",
+            '"><img src=x onerror=alert(1)>',
+            "<img src=x onerror=alert(1)>",
+            "javascript:alert(1)",
+            "__proto__",  # underscore is not in the character class
+            "constructor",  # eleven characters, over the bound
+            "../../etc/passwd",
+            "http://evil.example",
+        ],
+    )
+    def test_rejects_hostile_and_malformed_input(self, raw: str) -> None:
+        assert _run("sanitizeTicker(__arg)", raw) is None
+
+    @pytest.mark.parametrize("raw", [None, 42, True, {"ticker": "AAPL"}, ["AAPL"]])
+    def test_rejects_non_strings(self, raw: object) -> None:
+        assert _run("sanitizeTicker(__arg)", raw) is None
+
+    def test_rejects_prototype_polluting_keys_case_insensitively(self) -> None:
+        """`__proto__` is rejected on the character class, not on a name comparison.
+
+        The allowlist admits no underscore, so every casing fails for the same reason.
+        """
+        for candidate in ["__proto__", "__PROTO__", "__Proto__"]:
+            assert _run("sanitizeTicker(__arg)", candidate) is None
+
+    def test_output_can_never_be_a_dangerous_property_key(self) -> None:
+        """The survivors are used directly as object keys, so this is the property that matters.
+
+        `prototype` survives the character class, but the sanitizer upper-cases before it
+        tests, so what comes back is `PROTOTYPE` — a plain key with no meaning to the
+        runtime. Every dangerous key contains a lower-case letter or an underscore, so no
+        input can reach one. The keyed stores are additionally `Object.create(null)`, which
+        leaves nothing on the chain to reach even if this property were lost.
+        """
+        dangerous = ["__proto__", "constructor", "prototype"]
+        for candidate in dangerous + ["PROTOTYPE", "prototype", "AAPL"]:
+            result = _run("sanitizeTicker(__arg)", candidate)
+            assert result is None or result not in dangerous
+
+    def test_survivors_always_match_the_advertised_shape(self) -> None:
+        """A survivor is interpolated, keyed and pathed on, so its shape is the contract."""
+        probes = ["aapl", "BRK.B", "bf-a", "prototype", "  msft  ", "ABCDEFGHIJ"]
+        for probe in probes:
+            result = _run("sanitizeTicker(__arg)", probe)
+            if result is not None:
+                assert re.fullmatch(r"[A-Z0-9.\-]{1,10}", result), result
+
+
+class TestSanitizeTickerList:
+    """The comma-separated list allowlist."""
+
+    def test_accepts_a_plain_list(self) -> None:
+        assert _run("sanitizeTickerList(__arg)", "AAPL,MSFT,GOOGL") == [
+            "AAPL",
+            "MSFT",
+            "GOOGL",
+        ]
+
+    def test_trims_and_upper_cases_entries(self) -> None:
+        assert _run("sanitizeTickerList(__arg)", " aapl , msft ") == ["AAPL", "MSFT"]
+
+    def test_drops_bad_entries_and_keeps_good_ones(self) -> None:
+        """One hostile symbol in a shared link must not blank the whole view."""
+        assert _run("sanitizeTickerList(__arg)", "AAPL,<script>,MSFT") == [
+            "AAPL",
+            "MSFT",
+        ]
+
+    def test_deduplicates_while_preserving_order(self) -> None:
+        assert _run("sanitizeTickerList(__arg)", "MSFT,AAPL,msft") == ["MSFT", "AAPL"]
+
+    def test_accepts_an_array_argument(self) -> None:
+        """The multi-ticker init() passes an array rather than a string."""
+        assert _run("sanitizeTickerList(__arg)", ["AAPL", "bad symbol", "MSFT"]) == [
+            "AAPL",
+            "MSFT",
+        ]
+
+    @pytest.mark.parametrize("raw", ["", ",,,", "<script>", None, 42])
+    def test_returns_empty_when_nothing_survives(self, raw: object) -> None:
+        assert _run("sanitizeTickerList(__arg)", raw) == []
+
+
+class TestSlicing:
+    """Guards on the extraction itself, so a refactor cannot quietly empty this suite."""
+
+    def test_block_markers_still_exist(self) -> None:
+        source = TIMESERIES_JS.read_text(encoding="utf-8")
+        assert BLOCK_START in source
+        assert BLOCK_END in source
+        assert source.index(BLOCK_START) < source.index(BLOCK_END)
+
+    def test_pattern_is_anchored_at_both_ends(self) -> None:
+        """An unanchored pattern would match a hostile string that merely contains a symbol."""
+        block = _sanitizer_source()
+        pattern = re.search(r"const TICKER_PATTERN = /(.+)/;", block)
+        assert pattern is not None
+        assert pattern.group(1).startswith("^")
+        assert pattern.group(1).endswith("$")


### PR DESCRIPTION
Closes 12 of the 13 open code scanning alerts.

Admin dashboard ticker taint (11 alerts, one source)
----------------------------------------------------
Every one of alerts #182-#187 and #189-#193 traced to the same two reads of
`new URLSearchParams(window.location.search)` in src/dashboard/timeseries.js.
The `ticker` / `tickers` params reached four kinds of sink unvalidated: three
innerHTML interpolations (js/xss, js/xss-through-dom), two fetch URLs
(js/client-side-request-forgery), three object property writes
(js/remote-property-injection) and one console template literal
(js/tainted-format-string).

Fixed at the boundary with `sanitizeTicker` / `sanitizeTickerList`, an
anchored `^[A-Z0-9.-]{1,10}$` allowlist that covers class shares (BRK.B) and
preferred series (BF-A). All five ingress points now route through it: both
URL-param reads, `switchTicker`, the multi-ticker `init` default, and the
free-text input.

The sinks are hardened too, rather than resting on the validator alone.
CodeQL's `AdHocWhitelistCheckSanitizer` — the one that recognises a call named
`isValid...` as a barrier — is documented "not enabled by default", so a
validator it merely recognises by name buys nothing. Instead the dangerous
shapes are gone: ticker values are assigned to `input.value` / `textContent`
after the markup is set rather than interpolated into it, request paths use
`encodeURIComponent`, the keyed stores are `Object.create(null)`, and the
three console calls pass the symbol as an argument instead of splicing it
into the format string. The taint no longer reaches a dangerous sink whether
or not the barrier is recognised.

43 tests pin the allowlist. They slice the real functions out of the shipping
file and run them under node rather than reimplementing them, because a
reimplementation would test the copy. One of them corrected me: `prototype`
is 9 characters of A-Z and does survive the character class, but the sanitizer
upper-cases before it tests, so what comes back is the inert `PROTOTYPE`.

OAuth TTL constant (1 alert, a false positive)
----------------------------------------------
Alert #181 named its own source: the literal `300` on line 23,
`OAUTH_STATE_TTL_SECONDS`. The logged `extra` held that constant and one
boolean, neither of which can be sensitive.

The cause is that CodeQL's shared sensitive-data heuristic lists the bare
substring "oauth" in `maybePassword()`, so every identifier containing it is
classified as a password regardless of what it holds. `notSensitiveRegexp`
already carries `coauthor` as a patch for the same collision in an English
word. There is no way to assert the value away: `Sanitizer` in
CleartextLoggingCustomizations.qll is abstract with no concrete subclasses, so
that query has no sanitizer mechanism at all, and inline suppression comments
are inert here and blocked by check_dead_suppressions.py.

The field is dropped rather than the constant renamed. It never varied, so it
carried no information in a log line; renaming to dodge a name heuristic is
what the CodeQL maintainers advise against in github/codeql#6811. The
regression guard asserted on that log field, so the TTL is now asserted where
it actually matters — the stored item's ttl_timestamp, which nothing covered
before.

Not addressed: alert #188, OAuth state in sessionStorage, same "oauth"
substring cause but a real storage-location decision.

Verified: make validate 6/6 blocking stages pass; 4226 unit tests pass.
