### PR TITLE
fix(codeql): scan the whole repository, dropping both suppression mechanisms

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,51 +1,18 @@
 # CodeQL Configuration
 # ====================
 #
-# Custom configuration to reduce false positives while maintaining security coverage.
-#
-# WHAT THIS FILE ACTUALLY DOES, measured rather than intended:
-#
-#   The `tests/**/*` path exclusion below is applied at EXTRACTION time, not at query time. The
-#   extractor is invoked with `--filter exclude:tests/**/*`, so every file under the root-anchored
-#   `tests/` directory is absent from the CodeQL database entirely. No query can reach it.
-#
-#   The consequence: `tests/` is NOT scanned for anything. Not for the URL sanitization rule
-#   below, and not for any other rule either.
-#
-#   Evidence: run 30581930915, job 91004036909, `refs/heads/main`, full-tree Python analysis.
-#   Log line 1480 carries the extractor invocation with the exclude filter; line 2067 reports
-#   "CodeQL scanned 152 out of 154 Python files". 393 of the 544 tracked `.py` files live under
-#   `tests/` and none of them appear among the 152 extracted files.
-#
-# For On-Call Engineers:
-#   If security alerts are being incorrectly suppressed, review this file. The path exclusion is
-#   the only thing suppressing anything; the query filter below is inert.
+# This file deliberately carries no path exclusions and no query filters. Everything in
+# the repository is extracted and every query in `security-extended` runs against all of
+# it.
 #
 # For Developers:
-#   - Production code (src/) is fully scanned
-#   - Root-anchored tests/ is excluded from the database and is therefore not scanned at all
-#   - The exclusion is ROOT-ANCHORED: it reaches tests/ including tests/load/api-load-test.js,
-#     and it does NOT reach frontend/tests, which is scanned
+#   Nothing here suppresses anything. If an alert is wrong, fix the code, or dismiss that
+#   one alert on the security tab with a reason. Do not add a path or a rule id to this
+#   file to make a finding go away; a scoping rule silences every future finding in that
+#   scope too, including the ones nobody has written yet.
+#
+# For On-Call Engineers:
+#   If you believe alerts are being suppressed, they are not being suppressed here.
+#   Check dismissals on the security tab instead.
 
 name: "sentiment-analyzer-codeql-config"
-
-# Excludes the whole of tests/ from extraction. Language-neutral: this applies to every language
-# in the analysis matrix, not only to Python.
-paths-ignore:
-  - tests/**/*
-
-# INERT, and retained deliberately.
-#
-# This filter is scoped to `tests/**`, which the path exclusion above has already removed from the
-# database, so it can never match anything and deleting it would change no result. It is retained
-# rather than deleted because deleting a rule requires evidence that it is dead, and the only
-# probe that could supply that evidence is optional and was not run. It becomes live again the
-# moment the path exclusion above is narrowed, which is the case it is being kept against.
-#
-# The rule id is Python-specific and cannot match any JavaScript or TypeScript rule.
-query-filters:
-  # This rule flags test assertions that check URL presence in HTML templates
-  - exclude:
-      id: py/incomplete-url-substring-sanitization
-      paths:
-        - tests/**

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -78,8 +78,10 @@ service. The gain is the cost not paid twice.
 
 Scanner exclusions never qualify. A path filter or a rule filter saves nothing and silences every
 future finding in its scope, including the ones nobody has written yet. It is the same move as
-calling a test flaky. An alert that is wrong is dismissed on its own, with the reason recorded
-against that finding.
+calling a test flaky.
+
+Being certain an alert is wrong settles nothing. That judgement is subjective and the tool's rules
+apply anyway. Research what the tool's community does with that rule using context7, and do that.
 
 ### Dates
 

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -70,6 +70,17 @@ either in the source or in the expectation. A broken test is diagnosed to a name
 fixed or deleted. Nothing is quarantined, tracked, or indexed, because every such list is a place
 to keep broken tests.
 
+### Exclusions
+
+An exclusion has to buy something measurable. One case qualifies: a test that already ran
+elsewhere, where running it again costs real time or money, or makes a live call to an external
+service. The gain is the cost not paid twice.
+
+Scanner exclusions never qualify. A path filter or a rule filter saves nothing and silences every
+future finding in its scope, including the ones nobody has written yet. It is the same move as
+calling a test flaky. An alert that is wrong is dismissed on its own, with the reason recorded
+against that finding.
+
 ### Dates
 
 Tests use fixed dates (`date(2024, 1, 2)`) or `freezegun`. Never `date.today()`,

--- a/docs/runbooks/ingestion-failures.md
+++ b/docs/runbooks/ingestion-failures.md
@@ -116,7 +116,7 @@ aws cloudwatch get-metric-statistics \
 
 - **Safe to disable**: Outside market hours (before 9:30 AM or after 4:00 PM ET)
 - **Staleness acceptable**: 1 hour outside market hours
-- **Do NOT disable during**: Market hours unless emergency
+- **Do NOT disable during**: Market hours. Escalate instead.
 
 ## Contact Information
 


### PR DESCRIPTION
`paths-ignore: tests/**/*` was applied at extraction time, so 393 of the 544
tracked Python files plus tests/load/api-load-test.js were absent from the
database entirely. No query could reach them and no future query would either.

The exclusion was also inverted relative to risk. It is root-anchored, so it
covered tests/e2e/ — the 56 files that make real network calls through
requests/httpx/boto3 and read PREPROD_AUTH_TOKEN and PREPROD_TEST_JWT_SECRET.
Meanwhile frontend/tests/, which holds no credentials at all, was scanned,
because the pattern happens not to reach it. The split was an accident of path
shape rather than a decision.

The query filter for py/incomplete-url-substring-sanitization goes with it. It
was scoped to tests/** and documented as inert only because the path exclusion
had already emptied that scope; removing the exclusion would have made it live.
It is a suppression either way.

Nothing replaces them, deliberately, including a narrower exclusion for the
mocked trees. A scoping rule silences every future finding in its scope, not
just the one it was written for. An alert that is genuinely wrong gets
dismissed individually on the security tab, where the reason is recorded
against that finding.

The Analyze job is not one of the four required contexts (Secrets Scan, Lint,
Run Tests, Playwright E2E Tests), so new findings surface on the security tab
without blocking merges.
