### PR TITLE
fix(tests): close the five real findings the CodeQL exclusion was hiding

### DIFF
--- a/tests/unit/interview/test_interview_html.py
+++ b/tests/unit/interview/test_interview_html.py
@@ -10,6 +10,7 @@ Tests cover:
 
 import re
 from pathlib import Path
+from urllib.parse import urlparse
 
 
 def get_html_content() -> str:
@@ -165,9 +166,17 @@ class TestJavaScript:
     def test_preprod_url_defined(self):
         """Preprod URL should be defined with Amplify URL (Feature 1207: CloudFront removed)."""
         content = get_html_content()
-        assert "preprod:" in content
-        # Uses Amplify URL for frontend hosting
-        assert "amplifyapp.com" in content
+        # Scope to the ENVIRONMENTS object. The comment above it carries a
+        # `preprod: '...'` placeholder that matches an unscoped search first.
+        block = re.search(
+            r"const ENVIRONMENTS = Object\.assign\(\{(.*?)\}", content, re.DOTALL
+        )
+        assert block is not None, "ENVIRONMENTS object should be defined"
+        match = re.search(r"preprod:\s*'([^']+)'", block.group(1))
+        assert match is not None, "ENVIRONMENTS should define a preprod entry"
+        # Resolve the host from that entry rather than searching the whole document.
+        # A substring check passes on any stray mention and proves nothing about it.
+        assert urlparse(match.group(1)).netloc.endswith(".amplifyapp.com")
 
     def test_required_functions_defined(self):
         """All required JavaScript functions should be defined."""

--- a/tests/unit/test_oauth_provider_filter.py
+++ b/tests/unit/test_oauth_provider_filter.py
@@ -91,7 +91,7 @@ class TestOAuthOriginRedirect:
         params = parse_qs(parsed.query)
 
         assert "redirect_uri" in params
-        assert "localhost:3000" in params["redirect_uri"][0]
+        assert urlparse(params["redirect_uri"][0]).netloc == "localhost:3000"
 
     def test_evil_origin_does_not_leak_into_redirect(self):
         """Origin https://evil.com must NOT appear in redirect_uri (open redirect prevention)."""
@@ -109,9 +109,10 @@ class TestOAuthOriginRedirect:
 
         assert "redirect_uri" in params
         redirect_uri = params["redirect_uri"][0]
-        assert "evil.com" not in redirect_uri
-        # Should fall back to FRONTEND_URL
-        assert "example.com" in redirect_uri
+        # Compare the host exactly. A substring check passes on
+        # https://evil.com/?next=example.com, which is the open redirect this
+        # test exists to catch.
+        assert urlparse(redirect_uri).netloc == "example.com"
 
 
 class TestOAuthPKCENonRegression:

--- a/tests/unit/test_sentiment.py
+++ b/tests/unit/test_sentiment.py
@@ -767,7 +767,7 @@ class TestS3ModelDownloadWithMoto:
 
             # Extract (mirrors sentiment.py lines 115-127)
             with tarfile.open(str(tar_path), "r:gz") as tar:
-                tar.extractall(path="/tmp")  # noqa: S202 - test fixture
+                tar.extractall(path="/tmp", filter="data")
 
             # Verify model was extracted
             assert model_path.exists(), f"Model path {model_path} should exist"
@@ -868,7 +868,7 @@ class TestS3ModelDownloadWithMoto:
             import tarfile
 
             with tarfile.open(tar_path, "r:gz") as tar:
-                tar.extractall(path=str(tmp_path))  # noqa: S202 - test fixture
+                tar.extractall(path=str(tmp_path), filter="data")
 
             # Verify tar exists before cleanup
             assert Path(tar_path).exists(), "tar.gz should exist before cleanup"
@@ -928,7 +928,7 @@ class TestS3ModelDownloadWithMoto:
                 from pathlib import Path
 
                 with tarfile.open(tar_path, "r:gz") as tar:
-                    tar.extractall(path=str(tmp_path))  # noqa: S202 - test fixture
+                    tar.extractall(path=str(tmp_path), filter="data")
 
                 # Cleanup
                 Path(tar_path).unlink()


### PR DESCRIPTION
First scan of the test tree. Six alerts, five of them real defects.

py/tarslip x3, tests/unit/test_sentiment.py:770,871,931
  All three called tar.extractall() with no filter, and one of them is
  commented "mirrors sentiment.py lines 115-127". Production has used
  filter="data" since it was hardened. The tests had drifted off it, so they
  were exercising a weaker extraction than the code they claim to mirror and
  could not have caught a regression in the hardening. Now they match. The
  "# noqa: S202 - test fixture" riders came off with them: ruff stops flagging
  the call once the filter is present, so those suppressions were already dead.

py/incomplete-url-substring-sanitization, tests/unit/test_oauth_provider_filter.py:114
  test_evil_origin_does_not_leak_into_redirect asserted
  "example.com" in redirect_uri. That passes on
  https://evil.com/?next=example.com, which is precisely the open redirect the
  test exists to catch. Now compares urlparse(...).netloc exactly. The sibling
  localhost assertion three lines up had the same hole and is fixed with it;
  CodeQL flagged only one of the two.

py/incomplete-url-substring-sanitization, tests/unit/interview/test_interview_html.py:170
  Asserted "amplifyapp.com" in content against a 1700-line HTML document, which
  any stray mention satisfies. Now resolves the preprod entry out of the
  ENVIRONMENTS object and checks the host. Scoping to that object is load
  bearing: the comment directly above it carries a preprod: '...' placeholder
  that an unscoped search matches first, which is how the first version of this
  fix failed.

Not fixed, dismissed as a false positive with the reason recorded:
py/bad-tag-filter on tests/unit/scripts/test_regenerate_mermaid_url.py:58. That
regex is a differential oracle holding the pre-#996 Mermaid arrow expression
verbatim so 1500+ generated inputs can prove the rewrite equivalent. Rewriting
it by hand would compare the rewrite against another rewrite; building the
pattern from fragments would only hide it from the scanner. The rule targets
HTML sanitisation (CWE-693) and its recommendation is to use a well-tested HTML
library, which cannot apply to code that parses no HTML.

Verified: 4226 unit tests pass; make validate 6/6 blocking stages pass.
