### PR TITLE
docs(backlog): add DOTFILES-01 treehouse worktree pool card

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,5 +1,8 @@
 # Feature Backlog
 
+Bare numbers (117, 118) are features of this repo. A `REPO-NN` prefix means the work
+lands somewhere else and this board is just tracking it.
+
 ## Queued Features
 
 ### 117 - Fix Keyboard Shortcuts Order
@@ -18,6 +21,29 @@ ONE URL dashboard shows "Disconnected" because SSE stream endpoint routes to wro
 - Dashboard Lambda has BUFFERED mode
 - SSE requires RESPONSE_STREAM mode
 - ~~Need CloudFront routing fix or graceful fallback~~ *(Superseded: CloudFront removed in Feature 1203)*
+
+### DOTFILES-01 - Treehouse: git worktree pool manager
+**Repo**: ~/dotfiles *(not this repo)*
+**Priority**: High
+**Spec**: dotfiles/specs/031-treehouse/spec.md *(not written yet)*
+
+Run parallel Claude sessions against the same repo without clobbering each other. Right
+now two sessions in one checkout share a working tree, an index, and a branch, so edits,
+stashes, and hook state collide.
+
+Treehouse hands each session its own worktree from a managed pool: lease one on session
+start, return it on rotate, GC the abandoned ones. Same shape as the handoff tree in 021,
+but for checkouts instead of carryovers.
+
+- Follow-on to 015, which listed multi-worktree carryover routing as out of scope and
+  called worktree orphans "mitigated, not eliminated" (specs/015-session-scoped-carryover/spec.md:142,
+  Race 3 at :20). Treehouse is the piece that closes it.
+- Needs to interact with carryover-rotate.sh and carryover-loader.sh, which resolve the
+  handoff dir per repo. Pooled worktrees mean the repo root is no longer stable per session.
+- Interacts with the battleplan worktree rule in 016 and the "never rebase live hooks in
+  the live worktree" hazard, so dotfiles itself is a first-class test case.
+- Open questions: pool size, lease identity (session id vs tmux pane), what happens to a
+  leased worktree with uncommitted work when the session dies.
 
 ---
 


### PR DESCRIPTION
Adds a backlog card for **treehouse**, a git worktree pool manager for `~/dotfiles`, so parallel Claude sessions can share one repo without colliding on working tree, index, and branch.

The card is intent, not a spec. The spec would land in `dotfiles/specs/031-treehouse/` when it gets written.

### Why it's on this board
`~/dotfiles` has no intake tracker. It runs pure speckit, where a numbered `specs/NNN-*` dir implies a spec already exists, so there's nowhere to park an idea that hasn't been committed to yet. This board is where that lives.

### Numbering
Cross-repo cards now carry a `REPO-NN` prefix (`DOTFILES-01`) to keep them visually distinct from this repo's own numbered features (117, 118). A short convention note at the top of `BACKLOG.md` explains the split. The card ID and the eventual speckit dir number are intentionally decoupled, since dotfiles numbers sequentially and knows nothing about this board.

### Prior art cited on the card
`specs/015-session-scoped-carryover/spec.md` deferred exactly this work: line 142 lists multi-worktree carryover routing as out of scope, and line 20 names the "worktree orphan ambush" race as mitigated but not eliminated.

Docs only. No code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)