### PR TITLE
chore(tooling): destroy every live Black reference

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -67,7 +67,6 @@ updates:
       # Code quality tools together
       code-quality:
         patterns:
-          - "black"
           - "ruff"
           - "pre-commit"
         update-types:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -55,7 +55,6 @@ jobs:
           pip install ruff==0.15.14
 
       - name: Check formatting with ruff
-        # Note: Black removed in feat(057) - Ruff formatter preserves pragma comments
         run: ruff format --check --diff src/ tests/
 
       - name: Check linting with ruff

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,8 +53,8 @@ repos:
       - id: check-toml
 
   # Python formatter and linter (Ruff)
-  # Note: Black removed in feat(057) - Ruff formatter preserves pragma comments
-  # (# noqa, # nosec, # type:) by excluding them from line length calculations
+  # Ruff formatter preserves pragma comments (# noqa, # type:) by excluding them
+  # from line length calculations
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.14
     hooks:

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -136,7 +136,7 @@
         "filename": ".github/workflows/pr-checks.yml",
         "hashed_secret": "03949ed2d94d19eba0e056d0445af62debbd851a",
         "is_verified": false,
-        "line_number": 284,
+        "line_number": 283,
         "is_added": false,
         "is_removed": false
       }
@@ -167,7 +167,7 @@
         "filename": "CONTRIBUTING.md",
         "hashed_secret": "a44deac9fda7e2d6f5f26a2f40f6856199fa3762",
         "is_verified": false,
-        "line_number": 494,
+        "line_number": 493,
         "is_added": false,
         "is_removed": false
       },
@@ -176,7 +176,7 @@
         "filename": "CONTRIBUTING.md",
         "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
         "is_verified": false,
-        "line_number": 498,
+        "line_number": 497,
         "is_added": false,
         "is_removed": false
       }
@@ -267,7 +267,7 @@
         "filename": "docs/deployment/DEPLOYMENT.md",
         "hashed_secret": "92d61340371584156e74c456325081310bd079f8",
         "is_verified": false,
-        "line_number": 291,
+        "line_number": 290,
         "is_added": false,
         "is_removed": false
       }
@@ -1740,7 +1740,7 @@
         "filename": "pyproject.toml",
         "hashed_secret": "2c035ac06add3f441d7b835885958b03deac3d50",
         "is_verified": false,
-        "line_number": 109,
+        "line_number": 108,
         "is_added": false,
         "is_removed": false
       }
@@ -2517,5 +2517,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-04T22:55:14Z"
+  "generated_at": "2026-08-04T23:33:39Z"
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -244,7 +244,6 @@ git rebase main  # Or merge main into your branch
 ```bash
 # Lint (when linter configured)
 # terraform fmt -check
-# python -m black --check src/
 # python -m pylint src/
 
 # Run tests (when test suite exists)

--- a/docs/deployment/CI_CD_WORKFLOWS.md
+++ b/docs/deployment/CI_CD_WORKFLOWS.md
@@ -49,7 +49,6 @@ All PRs trigger the following required status checks:
 **Job Name**: `Code Quality`
 
 **What it does:**
-- Checks code formatting with black
 - Runs linting with ruff
 
 **Runs on:**
@@ -58,7 +57,6 @@ All PRs trigger the following required status checks:
 - Manual dispatch
 
 **Tools:**
-- `black==23.11.0` - Code formatting
 - `ruff==0.1.6` - Fast Python linter with security checks
 
 ---

--- a/docs/deployment/DEPLOYMENT.md
+++ b/docs/deployment/DEPLOYMENT.md
@@ -75,7 +75,7 @@ terraform workspace new dev  # or prod
 
 The project uses GitHub Actions for continuous integration and deployment. Three workflows run automatically on push to main:
 
-- **Lint** (`lint.yml`): Black formatting and ruff linting
+- **Lint** (`lint.yml`): ruff formatting and linting
 - **Tests** (`test.yml`): pytest with 80% coverage requirement
 - **Deploy Dev** (`deploy-dev.yml`): Automatic deployment to dev environment
 
@@ -133,9 +133,8 @@ The Deploy Dev workflow should now have access to AWS credentials.
 
 ### Troubleshooting CI Failures
 
-1. **Lint fails on black**: Install CI version locally: `pip3 install black==23.11.0`
-2. **Lint fails on ruff**: Install CI version locally: `pip3 install ruff==0.1.6`
-3. **Tests fail**: Ensure `requirements-dev.txt` is installed: `pip3 install -r requirements-dev.txt`
+1. **Lint fails on ruff**: Install CI version locally: `pip3 install ruff==0.1.6`
+2. **Tests fail**: Ensure `requirements-dev.txt` is installed: `pip3 install -r requirements-dev.txt`
 4. **Deploy fails on credentials**: Verify all three secrets are configured correctly
 
 ---

--- a/docs/security/BRANCH-PROTECTION.md
+++ b/docs/security/BRANCH-PROTECTION.md
@@ -20,7 +20,7 @@ Go to: **GitHub → Settings → Branches → Add rule** for `main`
   - [x] Require branches to be up to date before merging
   - Required status checks:
     - `Run Tests` - Unit tests with coverage validation
-    - `Code Quality` - Linting with ruff and black
+    - `Code Quality` - Linting with ruff
     - `Dependency Vulnerability Scan` - pip-audit security scanning
     - `Analyze` - CodeQL static analysis
 

--- a/docs/setup/PYTHON_VERSION_PARITY.md
+++ b/docs/setup/PYTHON_VERSION_PARITY.md
@@ -83,7 +83,6 @@ pytest tests/unit/ -v
 
 # Run linters
 ruff check .
-black --check .
 
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,8 +62,7 @@ dev = [
 # Tool Configuration
 # =============================================================================
 
-# Note: Black configuration removed in feat(057) - migrated to Ruff formatter
-# Ruff formatter preserves pragma comments (# noqa, # nosec, # type:) by excluding
+# Ruff formatter preserves pragma comments (# noqa, # type:) by excluding
 # them from line length calculations, preventing drift on long lines.
 
 [tool.ruff]

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -53,7 +53,6 @@ moto[all]==5.2.2
 responses==0.26.2
 
 # Code Quality
-black==26.5.1
 ruff==0.15.14
 pre-commit==4.6.1
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -32,7 +32,6 @@ moto[all]==5.2.2
 responses==0.26.2
 
 # Code Quality
-black==26.5.1          # Code formatter
 ruff==0.15.14             # Fast linter (replaces flake8, isort)
 pre-commit==4.6.1       # Git hooks framework
 semgrep==1.172.0        # Comprehensive SAST (make sast gate)


### PR DESCRIPTION
Fast-follow to #1007 under the same campaign authority: Black is named for destruction alongside bandit. Nothing invokes Black anywhere (no Makefile target, no hook, no workflow), yet CI still installed it via two requirement pins, dependabot still batched it, and four docs still claimed it gates formatting.

What was kept deliberately: the ruff-formatter fact buried inside the removal notes (pragma comments are excluded from line-length calculations, so long suppressed lines do not drift) survives in `pyproject.toml` and `.pre-commit-config.yaml`; only the feat(057) archaeology around it and the now-dead `# nosec` mention are gone. What would change the call: any consumer of the pins, and none exists.

Verification (evidence in `specs/001-black-destruction/`): tool-sense grep zero hits outside archival/process/color surfaces; `pre-commit run --all-files` all green; `make validate` verdict unchanged from its pre-sweep baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)