### PR TITLE
fix(secrets): refresh baseline line numbers left stale by #1009

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -136,7 +136,7 @@
         "filename": ".github/workflows/pr-checks.yml",
         "hashed_secret": "03949ed2d94d19eba0e056d0445af62debbd851a",
         "is_verified": false,
-        "line_number": 283,
+        "line_number": 289,
         "is_added": false,
         "is_removed": false
       }
@@ -2517,5 +2517,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-04T23:33:39Z"
+  "generated_at": "2026-08-05T04:41:10Z"
 }


### PR DESCRIPTION
The #1009 workflow edit moved a baselined pseudo-secret in pr-checks.yml from
line 283 to 289. The repaired wrapper keeps line-number-only rewrites out of
commits by design, but CI's blocking step runs detect-secrets-hook raw, and
the raw hook exits 3 on exactly that drift, so the Pre-commit Hooks job fails
on any PR cut from current main. Auto-merge landed #1009 anyway because that
job is not a required context. The F3 spec scopes the CI step out of the
wrapper repair (FR-007, operator decision), so this refresh reconciles the
two; the structural conflict is carded on CLEANUP-BOARD.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
