### PR TITLE
fix(make): migrate LocalStack recipes to Compose v2 behind a preflight

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: help install validate fmt fmt-check lint security sast audit-pragma audit-exemptions check-banned-terms test test-local test-unit test-integration test-e2e test-spec test-mutation \
         check-test-target-headers check-waitforresponse-race check-iam-patterns check-terraform-version \
-        localstack-up localstack-down localstack-wait localstack-logs localstack-status \
+        compose-preflight localstack-up localstack-down localstack-wait localstack-logs localstack-status \
         tf-init tf-plan tf-apply tf-destroy tf-init-local tf-plan-local tf-apply-local tf-destroy-local \
         cost cost-diff cost-baseline cost-check clean clean-all \
         check-annotation-budget check-annotation-pii regenerate-mermaid-url tf-output validate-mermaid \
@@ -233,16 +233,44 @@ test-mutation: ## Run mutation tests (requires mutmut)
 # ============================================================================
 
 LOCALSTACK_ENDPOINT ?= http://localhost:4566
+COMPOSE = docker compose
 
-localstack-up: ## Start LocalStack
-	docker-compose up -d localstack
+compose-preflight: ## Verify Docker CLI, daemon, and Compose v2 plugin before any Compose action
+	@command -v docker >/dev/null 2>&1 || { \
+		echo -e "$(RED)✗ Docker CLI not found.$(NC)"; \
+		echo "  Install Docker Engine first: https://docs.docker.com/engine/install/"; \
+		echo "  (Ubuntu/Debian: sudo apt-get install docker.io)"; \
+		exit 1; }
+	@docker info >/dev/null 2>&1 || { \
+		echo -e "$(RED)✗ Docker daemon unreachable (the CLI itself is installed).$(NC)"; \
+		echo "  Start it (e.g. sudo systemctl start docker) or check that your user is in the docker group."; \
+		exit 1; }
+	@docker compose version >/dev/null 2>&1 || { \
+		echo -e "$(RED)✗ Docker Compose v2 plugin missing (Docker daemon is healthy).$(NC)"; \
+		echo "  Ubuntu/Debian docker.io install: sudo apt-get install docker-compose-v2"; \
+		echo "  Docker CE repo install:          sudo apt-get install docker-compose-plugin"; \
+		echo "  Compose-free cleanup remains available via 'make clean'."; \
+		exit 1; }
+	@test -n "$$LOCALSTACK_AUTH_TOKEN" || { \
+		echo -e "$(RED)✗ LOCALSTACK_AUTH_TOKEN is not set (Docker and Compose are healthy).$(NC)"; \
+		echo "  LocalStack images v2026.3.1+ require an auth token (app.localstack.cloud)."; \
+		echo "  Plain:     export LOCALSTACK_AUTH_TOKEN=<token>"; \
+		echo "  1Password: export LOCALSTACK_AUTH_TOKEN=\$$(op read 'op://<vault>/LocalStack/auth-token')"; \
+		echo "  Compose-free cleanup remains available via 'make clean'."; \
+		exit 1; }
+
+localstack-up: compose-preflight ## Start LocalStack (on failure the output includes recovery steps)
+	@$(COMPOSE) up -d localstack || { \
+		echo -e "$(RED)✗ LocalStack start failed or was interrupted.$(NC)"; \
+		echo "  Recover by re-running 'make localstack-up' — it is safe to repeat."; \
+		exit 1; }
 	@echo "$(GREEN)LocalStack starting on :4566$(NC)"
 
-localstack-down: ## Stop LocalStack
-	docker-compose down
+localstack-down: compose-preflight ## Stop LocalStack
+	$(COMPOSE) down
 
-localstack-logs: ## Show LocalStack logs
-	docker-compose logs -f localstack
+localstack-logs: compose-preflight ## Show LocalStack logs
+	$(COMPOSE) logs -f localstack
 
 localstack-wait: ## Wait for LocalStack to be healthy
 	@echo "Waiting for LocalStack to be ready..."
@@ -343,6 +371,6 @@ clean: ## Clean generated files
 	find . -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true
 	@echo "$(GREEN)✓ Cleaned$(NC)"
 
-clean-all: clean localstack-down ## Clean everything including LocalStack
-	docker-compose down -v
+clean-all: compose-preflight clean localstack-down ## Clean everything including LocalStack
+	$(COMPOSE) down -v
 	rm -rf localstack-data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
       - "4566:4566"
       - "4510-4559:4510-4559"
     environment:
+      # Pass through from host env; never store token material here (FR-008).
+      - LOCALSTACK_AUTH_TOKEN=${LOCALSTACK_AUTH_TOKEN}
       - SERVICES=lambda,apigateway,dynamodb,s3,sns,sqs,secretsmanager,events,logs,iam,cognito
       - DEBUG=0
       - LAMBDA_EXECUTOR=docker


### PR DESCRIPTION
The four `docker-compose` call sites (`localstack-up`, `localstack-down`, `localstack-logs`, `clean-all`) become Compose v2 invocations gated on a shared `compose-preflight` that separates four failure diagnoses: docker CLI absent, daemon unreachable, Compose plugin missing, `LOCALSTACK_AUTH_TOKEN` unset. Each prints its install or recovery route instead of the old bare `command not found`. `docker-compose.yml` passes the token through from the host env, so no token material lives in any committed file.

Considered and rejected: keeping the bare invocations with a wrapper script (the Makefile is where the targets live and where developers look), and skipping the token diagnosis (LocalStack images v2026.3.1+ fail at container start without it, which reads as a Docker bug). What would change the call: LocalStack dropping the token requirement, which would delete diagnosis d.

Verified on this host: preflight walks diagnoses a-c and fails at d with Docker 2.40.3 healthy beneath it; `docker compose down -v` on a never-started stack exits 0; `make validate` passes all 8 blocking stages. The feature's SC-001 (integration verdict via `make test-local`) stays open until a real LocalStack token exists; evidence in `specs/001-makefile-compose-repair/evidence/` (untracked by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)