### PR TITLE
fix(tests): remove the three retry/skip escapes that let e2e failures read as green

### DIFF
--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -64,7 +64,7 @@ jobs:
             --grep "@external-api" \
             --project="Desktop Chrome" \
             --workers=1 \
-            --retries=1 \
+            --retries=0 \
             --reporter=html,list
         env:
           CI: 'true'

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
   globalSetup: './tests/e2e/global-setup.ts',
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
-  retries: process.env.CI ? 2 : 0,
+  retries: 0,
   workers: 4,
   reporter: 'html',
   use: {

--- a/frontend/tests/e2e/sentiment-visibility.spec.ts
+++ b/frontend/tests/e2e/sentiment-visibility.spec.ts
@@ -15,7 +15,7 @@ test.describe('Sentiment Data Visibility', { tag: '@external-api' }, () => {
     await searchInput.clear();
     await searchInput.fill(ticker);
 
-    // Handle 429 rate limiting on search endpoint
+    // Retry within the test on 429. Exhausting the retries is a break, not a skip.
     let retries = 0;
     const maxRetries = 3;
     let rateLimited = false;
@@ -38,7 +38,10 @@ test.describe('Sentiment Data Visibility', { tag: '@external-api' }, () => {
           retries++;
           rateLimited = false;
           if (retries >= maxRetries) {
-            test.skip(true, `Rate limited (429) after ${maxRetries} retries on search endpoint`);
+            throw new Error(
+              `Suggestion for ${ticker} did not appear: search endpoint returned 429 ` +
+                `after ${maxRetries} retries`
+            );
           }
           await page.waitForTimeout(2000);
           await searchInput.clear();


### PR DESCRIPTION
Nightly external-api runs retried once, PR CI retried twice, and the
sentiment-visibility spec skipped itself after three 429s. All three convert a
failing signal into a passing one: a flake that passes on retry never surfaces,
and a rate-limited run reports skipped instead of broken. Retries drop to zero
in both configs and exhausting the in-test 429 retries now throws.

Rejected: keeping one CI retry as flake insurance. The board's false-pass cards
exist because that insurance hid real breaks; if a test flakes it should fail
loudly and get fixed or quarantined explicitly. What would change the call: a
quarantine mechanism that records the flake instead of hiding it.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
