### PR TITLE
fix(ci): teach the secrets gate the wrapper's volatile-vs-substantive distinction

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -324,12 +324,39 @@ jobs:
         run: pre-commit run --all-files --show-diff-on-failure
 
       - name: Detect secrets (non-mutating, blocking)
-        # Substitute for the skipped autostage wrapper. Read-only: compares secret
-        # hashes against the committed baseline, exits 1 on any NEW secret. Excludes
-        # tests/ (matches the local hook scope; gitleaks still scans tests/).
+        # Substitute for the skipped autostage wrapper. Fails on any NEW secret and on
+        # any substantive baseline change (those belong in the commit). The raw hook
+        # also exits 3 when its only rewrite is line_number/generated_at churn, which
+        # the local wrapper deliberately keeps out of commits, so that class is excused
+        # here via the same shared comparison the wrapper uses
+        # (scripts/baseline-volatile-compare.py). The checkout mutation stays inside
+        # this ephemeral runner; nothing is committed. Excludes tests/ (matches the
+        # local hook scope; gitleaks still scans tests/).
         run: |
           FILES="$(git ls-files | grep -vE '^tests/|^\.secrets\.baseline$')"
-          detect-secrets-hook --baseline .secrets.baseline $FILES
+          cp .secrets.baseline "${RUNNER_TEMP}/baseline.before"
+          HOOK_EXIT=0
+          detect-secrets-hook --baseline .secrets.baseline $FILES || HOOK_EXIT=$?
+          if [ "$HOOK_EXIT" -eq 0 ]; then
+            exit 0
+          fi
+          if [ "$HOOK_EXIT" -eq 3 ]; then
+            COMPARE_EXIT=0
+            python3 scripts/baseline-volatile-compare.py "${RUNNER_TEMP}/baseline.before" .secrets.baseline || COMPARE_EXIT=$?
+            if [ "$COMPARE_EXIT" -eq 0 ]; then
+              echo "Baseline rewrite is volatile-only (line_number/generated_at); the committed baseline is deliberately stable. Passing."
+              exit 0
+            fi
+            if [ "$COMPARE_EXIT" -eq 1 ]; then
+              echo "Baseline rewrite is SUBSTANTIVE. Commit the updated .secrets.baseline:"
+              echo "run pre-commit locally and include the staged baseline change in the PR."
+              git --no-pager diff .secrets.baseline
+              exit 1
+            fi
+            echo "Baseline comparison crashed (exit $COMPARE_EXIT); failing closed. See the error above."
+            exit 1
+          fi
+          exit "$HOOK_EXIT"
 
   # ========================================================================
   # JOB 4: CodeQL Analysis

--- a/scripts/baseline-volatile-compare.py
+++ b/scripts/baseline-volatile-compare.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Classify the difference between two detect-secrets baselines.
+
+Exit 0 when the two differ only in per-finding line_number values and the
+top-level generated_at stamp (or not at all); exit 1 when the difference is
+substantive; exit 2 on a comparison crash, so a broken comparison can never
+masquerade as a verdict.
+
+Shared by scripts/detect-secrets-autostage.sh (local pre-commit) and the
+"Detect secrets" step in .github/workflows/pr-checks.yml, so the two gates
+cannot drift apart on what counts as volatile.
+
+Usage: baseline-volatile-compare.py BEFORE AFTER
+"""
+
+import json
+import sys
+
+
+def stripped(path):
+    with open(path) as f:
+        doc = json.load(f)
+    doc.pop("generated_at", None)
+    for findings in doc.get("results", {}).values():
+        for finding in findings:
+            finding.pop("line_number", None)
+    return doc
+
+
+try:
+    sys.exit(0 if stripped(sys.argv[1]) == stripped(sys.argv[2]) else 1)
+except SystemExit:
+    raise
+except Exception as exc:
+    print(f"baseline comparison error: {exc}", file=sys.stderr)
+    sys.exit(2)

--- a/scripts/detect-secrets-autostage.sh
+++ b/scripts/detect-secrets-autostage.sh
@@ -22,8 +22,11 @@ fail() {
     exit 1
 }
 
+COMPARE=scripts/baseline-volatile-compare.py
+
 command -v python3 >/dev/null 2>&1 || fail "python3 not found; it performs the volatile-vs-substantive baseline comparison"
 command -v detect-secrets-hook >/dev/null 2>&1 || fail "detect-secrets-hook not found on PATH; install the pinned bc-detect-secrets before committing"
+[ -f "$COMPARE" ] || fail "$COMPARE not found; it performs the volatile-vs-substantive baseline comparison (shared with CI)"
 [ -f "$BASELINE" ] || fail "$BASELINE not found; the hook needs the committed baseline"
 python3 -c 'import json,sys; json.load(open(sys.argv[1]))' "$BASELINE" 2>/dev/null \
     || fail "$BASELINE is not valid JSON; repair or regenerate it before committing"
@@ -37,28 +40,10 @@ run_hook() {
 
 # Exit 0 when the two baselines differ only in per-finding line_number values and the
 # top-level generated_at stamp; exit 1 when the difference is substantive; exit 2 on a
-# comparison crash, so a broken comparison can never masquerade as a verdict.
+# comparison crash, so a broken comparison can never masquerade as a verdict. The logic
+# lives in $COMPARE so CI's non-mutating step classifies with the same code.
 volatile_only() {
-    python3 - "$1" "$2" <<'PY'
-import json, sys
-
-def stripped(path):
-    with open(path) as f:
-        doc = json.load(f)
-    doc.pop("generated_at", None)
-    for findings in doc.get("results", {}).values():
-        for finding in findings:
-            finding.pop("line_number", None)
-    return doc
-
-try:
-    sys.exit(0 if stripped(sys.argv[1]) == stripped(sys.argv[2]) else 1)
-except SystemExit:
-    raise
-except Exception as exc:
-    print(f"baseline comparison error: {exc}", file=sys.stderr)
-    sys.exit(2)
-PY
+    python3 "$COMPARE" "$1" "$2"
 }
 
 for attempt in $(seq 1 "$MAX_RETRIES"); do


### PR DESCRIPTION
The local wrapper keeps `line_number`/`generated_at` churn out of commits by design (F3), but CI's blocking step ran `detect-secrets-hook` raw, and the raw hook exits 3 on exactly that drift, so any PR shifting lines above a baselined finding failed the Pre-commit Hooks job. #1009 was the first victim; #1010 patched it by refreshing the baseline once, and this closes the recurrence. Operator approved this direction over the alternative (wrapper staging the churn, which reintroduces the baseline noise F3 exists to kill).

The step now snapshots the baseline, runs the hook, and on exit 3 classifies the rewrite with the same comparison the wrapper uses: volatile-only passes, substantive fails showing the diff and the instruction to commit the updated baseline, a comparison crash fails closed with its own message. New secrets still fail via the hook's exit 1, which precedes any baseline write in pinned bc-detect-secrets 1.5.45. The comparison moved out of the wrapper's heredoc into `scripts/baseline-volatile-compare.py` so the two gates share one definition of volatile and cannot drift.

Verification: 25/25 stub-rig classes across the comparison script, the wrapper (including the adversarial exit-1-plus-volatile-rewrite case), and the CI step body executed under `bash -eo pipefail`. Independent refuter verdict PASS-WITH-NOTES: all five claims reproduced, including real-tool runs proving a new high-entropy secret still fails both gates and a genuine line-shift is excused by both. Its one actionable finding (compare crash mislabeled as substantive in CI) is fixed in this diff; its second (wrapper cwd-sensitivity on the script path) is accepted, since the wrapper was already cwd-sensitive on the baseline and pre-commit invokes from repo root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)