### PR TITLE
fix(chart): arm the zoom-out auto-upgrade by gesture, not by wall clock

### DIFF
--- a/frontend/src/components/charts/price-sentiment-chart.tsx
+++ b/frontend/src/components/charts/price-sentiment-chart.tsx
@@ -110,7 +110,13 @@ export function PriceSentimentChart({
   const dataLengthRef = useRef(0);
   const timeRangeRef = useRef<TimeRange>(initialTimeRange);
   const upgradeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const justFitContentRef = useRef(false);
+  // The zoom-out auto-upgrade may only ever follow a real zoom gesture. Programmatic
+  // setData/fitContent also fire visible-range events, and judged against a freshly
+  // shortened dataset they read as a zoom-out, which would silently revert a range the
+  // user just picked. A wall-clock guard cannot close that window on a slow renderer,
+  // so the arming is by gesture: pointer/wheel/touch on the chart arms it, a data swap
+  // disarms it.
+  const userZoomRef = useRef(false);
 
   const [isReady, setIsReady] = useState(false);
   const [tooltip, setTooltip] = useState<TooltipData | null>(null);
@@ -344,7 +350,7 @@ export function PriceSentimentChart({
     // 1318: Subscribe to visible logical range changes for zoom-out auto-upgrade
     const handleVisibleRangeChange = (logicalRange: { from: number; to: number } | null) => {
       if (!logicalRange) return;
-      if (justFitContentRef.current) return;
+      if (!userZoomRef.current) return;
       const dataLen = dataLengthRef.current;
       if (dataLen === 0) return;
       if (upgradeTimeoutRef.current) return;
@@ -358,8 +364,17 @@ export function PriceSentimentChart({
       }
     };
 
+    const armUpgrade = () => {
+      userZoomRef.current = true;
+    };
+    const container = containerRef.current;
     if (interactive) {
       chart.timeScale().subscribeVisibleLogicalRangeChange(handleVisibleRangeChange);
+      if (container) {
+        container.addEventListener('wheel', armUpgrade, { passive: true });
+        container.addEventListener('touchstart', armUpgrade, { passive: true });
+        container.addEventListener('mousedown', armUpgrade);
+      }
     }
 
     // Handle resize
@@ -378,6 +393,11 @@ export function PriceSentimentChart({
       // 1318: Clean up zoom-out auto-upgrade
       if (interactive) {
         chart.timeScale().unsubscribeVisibleLogicalRangeChange(handleVisibleRangeChange);
+        if (container) {
+          container.removeEventListener('wheel', armUpgrade);
+          container.removeEventListener('touchstart', armUpgrade);
+          container.removeEventListener('mousedown', armUpgrade);
+        }
       }
       if (upgradeTimeoutRef.current) {
         clearTimeout(upgradeTimeoutRef.current);
@@ -425,17 +445,23 @@ export function PriceSentimentChart({
       }
     });
 
+    // A data swap disarms the zoom-out auto-upgrade and cancels any pending one:
+    // the overshoot that armed it was judged against the previous dataset.
+    userZoomRef.current = false;
+    if (upgradeTimeoutRef.current) {
+      clearTimeout(upgradeTimeoutRef.current);
+      upgradeTimeoutRef.current = null;
+    }
+
     candleSeriesRef.current.setData(chartData);
 
-    // Feature 1316: fitContent immediately after setData in the SAME useEffect.
-    // A separate useEffect + rAF caused a race condition: the first render's rAF
-    // (with partial sentiment data) would set a narrow viewport, and the second
-    // render's rAF was cancelled by React's cleanup before it could expand it.
-    // Sibling charts (atr-chart, sentiment-chart) already use this pattern.
+    // fitContent immediately after setData in the SAME useEffect. A separate
+    // useEffect + rAF races: the first render's rAF (with partial sentiment data)
+    // sets a narrow viewport, and the second render's rAF is cancelled by React's
+    // cleanup before it can expand it. Sibling charts (atr-chart, sentiment-chart)
+    // use this same pattern.
     if (chartRef.current) {
-      justFitContentRef.current = true;
       chartRef.current.timeScale().fitContent();
-      setTimeout(() => { justFitContentRef.current = false; }, 100);
     }
 
     // 1318: Track data length for zoom-out auto-upgrade threshold calculation
@@ -463,19 +489,21 @@ export function PriceSentimentChart({
       value: point.score,
     }));
 
+    // Same disarm as the price-data effect: sentiment can arrive late, and its
+    // fitContent below fires range events that must not read as a user zoom.
+    userZoomRef.current = false;
+    if (upgradeTimeoutRef.current) {
+      clearTimeout(upgradeTimeoutRef.current);
+      upgradeTimeoutRef.current = null;
+    }
+
     sentimentSeriesRef.current.setData(chartData);
 
-    // Feature 1316: fitContent after sentiment data too (may arrive after price data)
+    // fitContent after sentiment data too (it may arrive after price data)
     if (chartRef.current) {
-      justFitContentRef.current = true;
       chartRef.current.timeScale().fitContent();
-      setTimeout(() => { justFitContentRef.current = false; }, 100);
     }
   }, [sentimentData, resolution]);
-
-  // Note: fitContent() is now called inside the setData useEffect above (Feature 1316).
-  // A separate useEffect + rAF had a race condition where React's cleanup cancelled
-  // the rAF before it could fire with the full dataset.
 
   // Update series visibility
   useEffect(() => {

--- a/frontend/tests/unit/components/charts/price-sentiment-chart.test.tsx
+++ b/frontend/tests/unit/components/charts/price-sentiment-chart.test.tsx
@@ -358,14 +358,38 @@ describe('PriceSentimentChart', () => {
       expect(visibleRangeCallbacks.length).toBe(0);
     });
 
+    it('should NOT upgrade on an overshooting range event with no user gesture (phantom upgrade)', async () => {
+      // Programmatic setData/fitContent fire range events too. Ungated, an event
+      // reflecting the old viewport judged against a freshly shortened dataset reads
+      // as a zoom-out and silently reverts the range the user just picked.
+      sessionStorageData['ohlc_preferred_time_range'] = '1W';
+
+      render(<PriceSentimentChart ticker="AAPL" interactive={true} />);
+
+      // Overshooting range, but no wheel/touch/pointer gesture ever happened.
+      if (visibleRangeCallbacks.length > 0) {
+        visibleRangeCallbacks[0]({ from: -5, to: 10 });
+      }
+
+      // Wait past the 500ms upgrade debounce
+      await new Promise((resolve) => setTimeout(resolve, 700));
+
+      const setItemCalls = mockSessionStorage.setItem.mock.calls.filter(
+        (call: [string, string]) => call[0] === 'ohlc_preferred_time_range'
+      );
+      const lastTimeRangeSet = setItemCalls[setItemCalls.length - 1]?.[1];
+      expect(lastTimeRangeSet).toBe('1W');
+    });
+
     it('should upgrade from 1M to 3M when zoomed out past data bounds', async () => {
       // Start with 1M time range
       sessionStorageData['ohlc_preferred_time_range'] = '1M';
 
       render(<PriceSentimentChart ticker="AAPL" interactive={true} />);
 
-      // Wait for justFitContentRef to reset (100ms setTimeout in fitContent guard)
-      await new Promise((resolve) => setTimeout(resolve, 150));
+      // The upgrade is gesture-armed: only a wheel/touch/pointer gesture on the chart
+      // makes a subsequent range event upgrade-eligible.
+      fireEvent.wheel(screen.getByRole('img'));
 
       // Simulate zooming out past data bounds
       // With 2 data points, 30% threshold = 0.6
@@ -388,6 +412,10 @@ describe('PriceSentimentChart', () => {
 
       render(<PriceSentimentChart ticker="AAPL" interactive={true} />);
 
+      // Armed by a gesture, so the no-upgrade outcome exercises the overshoot
+      // threshold rather than the unarmed early-return.
+      fireEvent.wheel(screen.getByRole('img'));
+
       // Range within data bounds - no overshoot
       if (visibleRangeCallbacks.length > 0) {
         visibleRangeCallbacks[0]({ from: 0, to: 1 });
@@ -408,6 +436,9 @@ describe('PriceSentimentChart', () => {
       sessionStorageData['ohlc_preferred_time_range'] = '1Y';
 
       render(<PriceSentimentChart ticker="AAPL" interactive={true} />);
+
+      // Armed, so the no-upgrade outcome exercises the 1Y ceiling, not the arming.
+      fireEvent.wheel(screen.getByRole('img'));
 
       // Simulate zoom out past bounds while at 1Y
       if (visibleRangeCallbacks.length > 0) {


### PR DESCRIPTION
Clicking a narrower time range could silently revert half a second later.
The auto-upgrade judged every visible-range event, guarded only by a 100ms
window after programmatic fitContent. Data swaps fire range events too, and
on a slow renderer they escape that window and get scored against the new,
shorter dataset: old 22-candle viewport vs ~5 candles is a 300%+ overshoot
against a 30% threshold, so the pending upgrade timer fired and undid the
user's selection. Exposed by the retry-less e2e run on #1012 and root-caused
from its CI trace: click 1W, refetch fulfilled, then aria-pressed back on 1M.

The upgrade now arms only on a wheel/touch/pointer gesture on the chart and
disarms on every data swap, which also cancels a pending upgrade timer armed
against the previous dataset. The wall-clock guard is deleted: gesture arming
strictly subsumes it. lightweight-charts preventDefaults wheel events but
does not stop their propagation (verified in the library source), so the
container listener sees every real zoom.

Unit: 38/38 including a new phantom-upgrade regression test (overshooting
range event with no gesture must not change the range) and the three 1318
tests updated to arm explicitly so they still exercise the threshold logic.
Acceptance: #1012's Playwright rerun at retries=0 after this merges.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
