### PR TITLE
docs(quarrysome): batch 2, promote operations.md to CANON

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,6 +1,6 @@
 # Operations
 
-> **QUARRYSOME**: unaudited; verify against code before trusting.
+> **CANON**: verified against code.
 
 Two procedures: diagnosing ingestion failures and rolling back a deployment. CI deploys
 preprod only; every production job in `.github/workflows/deploy.yml` carries `if: false`.
@@ -12,8 +12,10 @@ Commands below use `preprod-` names. Environment names come from
 The ingestion Lambda is `preprod-sentiment-ingestion`. EventBridge rule
 `preprod-sentiment-ingestion-schedule` fires it every 5 minutes, around the clock; there is
 no market-hours gate anywhere in the schedule or the handler
-(`infrastructure/terraform/modules/eventbridge/main.tf:3-6`). It pulls from Tiingo as
-primary and fails over to Finnhub (`src/lambdas/ingestion/parallel_fetcher.py`).
+(`infrastructure/terraform/modules/eventbridge/main.tf:3-6`). It fetches Tiingo and Finnhub
+in parallel (`src/lambdas/ingestion/parallel_fetcher.py`): `PARALLEL_INGESTION_ENABLED`
+defaults to true and Terraform does not override it (`src/lambdas/ingestion/handler.py:152-153`).
+Sequential Tiingo-then-Finnhub failover is only the fallback when that flag is off.
 
 ### What actually alerts
 
@@ -38,9 +40,11 @@ Work from the Lambda outward: its own logs, then its upstreams, then its downstr
    aws logs tail /aws/lambda/preprod-sentiment-ingestion --since 30m --filter-pattern "ERROR"
    ```
 
-2. Source APIs second. Check the Tiingo and Finnhub status pages. Failover is automatic; a
-   nonzero `FailoverCount` metric means the primary is the problem even while collection
-   still succeeds.
+2. Source APIs second. Check the Tiingo and Finnhub status pages. Parallel fetch tolerates
+   one source failing: the failing source logs an error and emits `SilentFailure/Count`
+   (dimension `FailurePath: parallel_fetcher_aggregate`) in `SentimentAnalyzer/Reliability`
+   (`src/lambdas/ingestion/parallel_fetcher.py:163-169`) while collection continues on the
+   other source.
 
 3. Circuit breaker third. State lives in the items table under `CIRCUIT#<service>`
    (`src/lambdas/ingestion/handler.py:801-806`); it opens after 5 failures and resets after
@@ -61,10 +65,11 @@ Work from the Lambda outward: its own logs, then its upstreams, then its downstr
      --query SecretString --output text | head -c 10
    ```
 
-5. Storage last. Write throttles have their own alarm,
-   `preprod-sentiment-dynamodb-write-throttles`
-   (`infrastructure/terraform/modules/dynamodb/main.tf:223`). If that alarm is quiet, the
-   problem is upstream of DynamoDB.
+5. Storage last. Despite its name, the alarm `preprod-sentiment-dynamodb-write-throttles`
+   (`infrastructure/terraform/modules/dynamodb/main.tf:222`) measures consumed write
+   capacity (`ConsumedWriteCapacityUnits` over 1000 per minute), not throttle events. A
+   quiet alarm means writes are not spiking; for actual throttles query the
+   `WriteThrottleEvents` metric in `AWS/DynamoDB` directly.
 
 ### Metrics
 
@@ -73,8 +78,10 @@ Namespace `SentimentAnalyzer/Ingestion` (`src/lambdas/ingestion/metrics.py:26-42
 - `CollectionSuccess` / `CollectionFailure` ratio
 - `CollectionLatencyMs` (alert threshold 30000 ms, `metrics.py:45`)
 - `ItemsCollected` and `ItemsDuplicate` per run
-- `FailoverCount` (normally 0)
 - `NotificationLatencyMs` (30 second SLA to downstream SNS)
+
+`FailoverCount` is declared (`metrics.py:29`) but nothing on the live path emits it;
+`record_failover` has no callers outside its own docstring. Do not wait on it.
 
 ```bash
 aws cloudwatch get-metric-statistics \


### PR DESCRIPTION
## 1. Subjects and terminal states

- `docs/operations.md`: promoted, net +7 lines (198 to 205).

## 2. Verdict summary

`docs/operations.md`: 15 claims. 12 CONFIRMED, 3 REFUTED, 0 UNVERIFIABLE-FROM-REPO. Record: `specs/001-quarrysome-promotion/verdicts/operations.json` (untracked campaign artifact).

- c003 (REFUTED): "pulls from Tiingo as primary and fails over to Finnhub." `PARALLEL_INGESTION_ENABLED` defaults to true (`handler.py:152-153`) and Terraform never sets it, so the live path fetches both sources in parallel. Rewritten to state parallel fetch with sequential failover as the flag-off fallback.
- c008 (REFUTED): "write throttles have their own alarm." The alarm named `preprod-sentiment-dynamodb-write-throttles` measures `ConsumedWriteCapacityUnits` over 1000 per minute (`modules/dynamodb/main.tf:222-230`), not throttle events. Rewritten to state what it measures and to point at `WriteThrottleEvents` for actual throttles.
- c011 (REFUTED): "`FailoverCount` (normally 0)" as a metric to watch. `record_failover` (`metrics.py:110`) has no call site outside its own docstring, so the metric is never emitted. Removed from the watch list with an explicit do-not-wait-on-it note; diagnosis step 2 now points at `SilentFailure/Count` in `SentimentAnalyzer/Reliability` (`parallel_fetcher.py:163-169`), which the parallel path does emit.

Completeness review: waived by operator (subagent-machinery waiver recorded in `baseline.md` post-T003). Orchestrator inline self-check only.

## 3. Reference gate (FR-005)

No deletions or renames in this batch.

## 4. Growth justification (SC-004)

`docs/operations.md` +7: stating the parallel-mode gate and its fallback, the real per-source failure signal, the write-capacity alarm's actual metric, and the never-emitted-metric warning takes more lines than the three false sentences they replace. Each added line is a verified claim with a citation.

## 5. Defects (FR-003 / SC-005)

- Misnamed alarm: `preprod-sentiment-dynamodb-write-throttles` (`infrastructure/terraform/modules/dynamodb/main.tf:222`) watches `ConsumedWriteCapacityUnits`, not `WriteThrottleEvents`. An operator reading the alarm name during an incident would draw the wrong conclusion from its silence.
- Dead metric plumbing: `FailoverCount` and `record_failover` (`src/lambdas/ingestion/metrics.py:29,110`) are declared and tested by docstring example only; nothing on the live path calls the publisher, so the metric can never tick.

No pre-existing card covers either finding (board grep for failover / write-throttle terms: zero hits). No new cards were created (First-Feature Gate decision).

## 6. Attestation (FR-010)

No rule-bearing documents touched. `docs/operations.md` states operational procedures, not campaign or change-binding rules.

## 7. Operator approval

- Adjudication: operator chose "Promote with 2 rewrites" in-session on the audit evidence (~30 claims checked, 2 refuted at decision time). A third refuted claim (c011, the never-emitted `FailoverCount`) surfaced while verifying the step-2 rewrite target and was folded into the same rewrite scope, since the approved step-2 rewrite pivoted on that metric.
- FR-004 draft-diff annotation page: waived by standing operator decision; diff presented in-session.
- Test evidence: `make validate` all 8 blocking stages pass; CI-mirror suite (`pr-checks.yml` ignore set) 4907 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
