### PR TITLE
docs(quarrysome): promote chaos.md + preflight checklist to CANON (batch 6)

### DIFF
--- a/docs/chaos-testing/preflight-checklist.md
+++ b/docs/chaos-testing/preflight-checklist.md
@@ -1,6 +1,6 @@
 # Chaos GameDay Pre-Flight Checklist
 
-> **QUARRYSOME**: unaudited; verify against code before trusting.
+> **CANON**: verified against code.
 
 **Purpose**: Verify all pre-conditions before executing a chaos plan. Every item must be checked. Any No-Go condition aborts the GameDay.
 
@@ -33,28 +33,21 @@
   ```
   Expected: empty output (no alarms in ALARM state)
 
-- [ ] Composite alarm in OK state:
-  ```bash
-  aws cloudwatch describe-alarms \
-    --alarm-names "preprod-critical-composite" \
-    --query "CompositeAlarms[].StateValue" \
-    --output text
-  ```
-  Expected: `OK`
+The `preprod-critical-composite` alarm does not exist in preprod (the cloudwatch-alarms
+module is gated off there), so there is no composite state to check. The prefix sweep
+above is the whole alarm check.
 
 ### 3. Dashboard Accessibility
 
-- [ ] Dashboard Function URL is reachable:
+- [ ] Dashboard reachable through API Gateway:
   ```bash
-  curl -s -o /dev/null -w "%{http_code}" https://<DASHBOARD_FUNCTION_URL>/health
+  curl -s -o /dev/null -w "%{http_code}" <api-url>/health
   ```
   Expected: `200`
 
-- [ ] Chaos endpoint responds:
-  ```bash
-  curl -s -o /dev/null -w "%{http_code}" https://<DASHBOARD_FUNCTION_URL>/chaos
-  ```
-  Expected: `200`
+The dashboard Lambda has no Function URL; it is reached through API Gateway. The chaos
+API is not served on preprod at all: the handler's environment gate returns 404 outside
+`local`, `dev`, and `test`. Every preprod chaos operation goes through `scripts/chaos/`.
 
 ### 4. Chaos Gate State
 
@@ -67,12 +60,16 @@
   ```
   Expected: `disarmed` (will be armed in execution step)
 
-- [ ] No active chaos experiments:
+- [ ] No active chaos experiments. An active injection leaves its pre-chaos snapshot
+  in SSM, so an empty snapshot path means nothing is running:
   ```bash
-  # Via dashboard API
-  curl -s https://<DASHBOARD_FUNCTION_URL>/api/chaos/experiments?status=running | python3 -m json.tool
+  aws ssm get-parameters-by-path \
+    --path "/chaos/preprod/snapshot/" \
+    --query "Parameters[].Name" \
+    --output text
   ```
-  Expected: empty list
+  Expected: empty output. `scripts/chaos/status.sh preprod` reports the same thing as
+  `Active Scenarios: none`.
 
 ### 5. Recent Ingestion Baseline
 
@@ -129,7 +126,7 @@
 |---|-----------|-----|
 | NG-1 | Any dependency reported as "degraded" by `status.sh` | Cannot distinguish chaos-induced failures from pre-existing ones. Report verdict will be `COMPROMISED`. |
 | NG-2 | Any CloudWatch alarm in ALARM state | Pre-existing alarm masks chaos-induced alarms. |
-| NG-3 | Dashboard Function URL unreachable | Cannot create/monitor/stop experiments via API. Fallback (`inject.sh`) is available but reduces observability. |
+| NG-3 | Dashboard unreachable through API Gateway | Cannot watch the dashboard during the run. Injection is unaffected; `scripts/chaos/` is the only preprod path regardless. |
 | NG-4 | Kill switch is "triggered" | Previous chaos experiment did not clean up. Run `scripts/chaos/andon-cord.sh preprod` first. |
 | NG-5 | Active chaos experiment already running | Only one experiment at a time. Stop the existing experiment first. |
 | NG-6 | No buddy operator available | Safety requirement. Never run chaos alone. |

--- a/docs/chaos.md
+++ b/docs/chaos.md
@@ -1,6 +1,6 @@
 # Chaos Testing
 
-> **QUARRYSOME**: unaudited; verify against code before trusting.
+> **CANON**: verified against code.
 
 Current state: not operational.
 
@@ -68,9 +68,11 @@ Both declare `environment: preprod` and require the gate armed.
   `/chaos/<env>/snapshot/` before injection, and restoration reads from there.
 - **Andon cord**: `scripts/chaos/andon-cord.sh <env>` sets the switch to `triggered`,
   restores every snapshot, and detaches deny policies.
-- **Auto-restore Lambda**: SNS-triggered by the critical composite CloudWatch alarm.
-  Same restore steps as the andon cord, idempotent, then disarms the switch. On partial
-  failure it leaves the switch at `triggered` for manual investigation.
+- **Auto-restore Lambda**: code-complete but not deployed. The terraform module
+  invocation is still a TODO in `infrastructure/terraform/main.tf`, and its intended
+  trigger, the `preprod-critical-composite` alarm, does not exist in preprod because
+  the cloudwatch-alarms module is gated off there. Until both land, deployed safety is
+  the kill switch, the snapshots, and the andon cord.
 - **Buddy operator**: every gameday has a second operator watching alarms, ready to
   pull the andon cord.
 
@@ -122,12 +124,12 @@ aws iam detach-role-policy --role-name preprod-ingestion-lambda-role \
   --policy-arn "arn:aws:iam::${ACCOUNT_ID}:policy/preprod-chaos-deny-dynamodb-write" || true
 aws iam detach-role-policy --role-name preprod-analysis-lambda-role \
   --policy-arn "arn:aws:iam::${ACCOUNT_ID}:policy/preprod-chaos-deny-dynamodb-write" || true
-aws lambda update-function-configuration --function-name preprod-sentiment-analysis --memory-size 512
-aws lambda update-function-configuration --function-name preprod-sentiment-ingestion --timeout 30
+aws lambda update-function-configuration --function-name preprod-sentiment-analysis --memory-size 2048
+aws lambda update-function-configuration --function-name preprod-sentiment-ingestion --timeout 60
 aws events enable-rule --name preprod-sentiment-ingestion-schedule
 aws ssm put-parameter --name "/chaos/preprod/kill-switch" \
   --value "disarmed" --type String --overwrite
 ```
 
-Escalation: buddy pulls the cord; unresolved after 5 minutes goes to the on-call
-engineer; on-call unavailable goes to the engineering lead.
+Escalation: buddy pulls the cord; if the cord fails, operator and buddy run the manual
+restore above. There is no escalation chain beyond the two of them.


### PR DESCRIPTION
## 1. Subjects and terminal states

- `docs/chaos.md`: promoted, net +2 lines
- `docs/chaos-testing/preflight-checklist.md`: promoted, net -3 lines

Audited together and shipped as one PR: the checklist is the preflight step of the gameday procedure chaos.md defines, and both fail against the same deployment reality.

## 2. Verdict summary

**docs/chaos.md**: 12 claims, 9 CONFIRMED, 3 REFUTED, 0 UNVERIFIABLE-FROM-REPO.

- chaos-c010 (REFUTED): the auto-restore bullet described the Lambda as SNS-triggered by the critical composite alarm. It is code-complete but never deployed (module invocation is a TODO at `infrastructure/terraform/main.tf:1296-1297`) and `preprod-critical-composite` does not exist in preprod (cloudwatch-alarms module gated off, `preprod.tfvars:64`). Rewritten to state both, and that deployed safety is the kill switch, snapshots, and andon cord.
- chaos-c011 (REFUTED): the emergency manual restore carried wrong values that would leave both Lambdas misconfigured after an incident. Analysis memory 512 corrected to 2048 (`main.tf:381`), ingestion timeout 30 corrected to 60 (`main.tf:324`). Role and policy names in the same block verified correct and kept.
- chaos-c012 (REFUTED): the escalation chain named an on-call engineer and engineering lead that do not exist. Trimmed to operator plus buddy.

**docs/chaos-testing/preflight-checklist.md**: 10 claims, 5 CONFIRMED, 5 REFUTED, 0 UNVERIFIABLE-FROM-REPO.

- chaos-preflight-c003 (REFUTED): the composite-alarm OK check targets an alarm absent in preprod; the check can never report anything. Replaced with a note stating the absence; the prefix sweep is the whole alarm check.
- chaos-preflight-c004 (REFUTED): the dashboard has no Function URL (`create_function_url = false`, `main.tf:508/558/615`; only SSE has one at `:824`). Health check rewritten against API Gateway.
- chaos-preflight-c005 (REFUTED): the chaos endpoint check can never return 200 on preprod; the env gate 404s everything outside local/dev/test (`handler.py:144`). Section now states the chaos API is unavailable on preprod and `scripts/chaos/` is the only path.
- chaos-preflight-c007 (REFUTED): `/api/chaos/experiments?status=running` is the wrong route (real routes are `/chaos/experiments*`, `handler.py:1006-1237`) and unreachable on preprod regardless. Replaced with an SSM snapshot-path emptiness check, which is the invariant the scripts enforce (inject writes the snapshot pre-injection, restore deletes it) and what `status.sh` reports as Active Scenarios.
- chaos-preflight-c010 (REFUTED): NG-3 framed `inject.sh` as a reduced-observability fallback to the API. There is no API path on preprod to fall back from. Reworded.

Completeness reviewer: waived by operator (subagent machinery waiver recorded in `baseline.md` post-T003); orchestrator inline self-check only.

## 3. Reference gate (FR-005)

No deletions or renames in this batch.

## 4. Growth justification (SC-004)

`docs/chaos.md` grew by 2 net lines: the auto-restore bullet needed the extra lines to state that the Lambda is undeployed and its trigger alarm absent. The shorter original was shorter because it was fiction. The checklist shrank.

## 5. Defects (FR-003 / SC-005)

- `src/lambdas/dashboard/chaos.py:82`: `ALLOWED_ENVIRONMENTS` includes `preprod`, but the handler env gate (`handler.py:144`) makes preprod unreachable. Dead allowlist entry, and a footgun if the gate ever loosens: the inner check would then permit preprod silently.
- `scripts/chaos/status.sh:56`: the CloudWatch health check is vacuous. `describe-alarms --alarm-names preprod-critical-composite` exits 0 on a nonexistent alarm, so `CW_STATUS` can never report degraded.
- `src/lambdas/chaos_restore/` code-complete but never deployed (`main.tf:1296-1297` TODO). Covered by the existing board card on the undeployed chaos_restore Lambda; this batch appends the absent-trigger-alarm detail to that finding rather than carding it separately.

No new cards created (First-Feature Gate decision).

## 6. Attestation (FR-010)

Both documents state rules (safety constraints, no-go criteria). No exception clause was added to either. The rewrites narrow what the docs promise; nothing was weakened by exception.

## 7. Operator approval

Adjudicated in-session via AskUserQuestion with draft findings and per-edit citations presented; operator selected "Promote both with rewrites" verbatim. Executed exactly as approved, including the section 4 snapshot-check substitution flagged there as the one outstanding lookup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
