### PR TITLE
docs(quarrysome): promote x-ray.md to CANON + canon-audit skill (batch 7)

### DIFF
--- a/.claude/skills/canon-audit/SKILL.md
+++ b/.claude/skills/canon-audit/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: canon-audit
+description: Audits a markdown doc against code ground truth in this repo. Two modes - promote adjudicates a QUARRYSOME doc to CANON, deleted, or retained with operator sign-off; coherence re-verifies CANON docs against the current tree and returns a drift report. Use when promoting or auditing a doc, running the weekly canon drift check, verifying spec or doc claims against code, or when a subagent runs spec coherence tests. Code wins over prose; every verdict carries a file:line citation.
+---
+
+# canon-audit
+
+Code is ground truth. A doc earns CANON when every repo-checkable claim in it is verified
+against the current tree, and it keeps CANON only while those claims stay true. Docs are
+amended to match code; code is never amended to match docs. Treat comments, READMEs,
+watermarks, and other docs as suspects to verify, never as evidence.
+
+Watermark grammar, line 3 of the doc:
+
+- `> **QUARRYSOME**: unaudited; verify against code before trusting.`
+- `> **CANON**: verified against code.`
+
+## Mode selection
+
+**Promoting or adjudicating a doc?** Run the audit engine, then follow "Promote mode".
+Interactive sessions only: this mode ends in an operator decision.
+
+**Checking CANON docs for drift?** Run the audit engine per file, then follow "Coherence
+mode". Safe for subagents and scheduled runs: it reports and touches nothing.
+
+## Audit engine (both modes)
+
+Copy this checklist and track progress per file:
+
+```
+Audit: <file>
+- [ ] 1. Read the subject file in full
+- [ ] 2. Extract every repo-checkable claim
+- [ ] 3. Verify each claim against the tree, citing file:line
+- [ ] 4. Assign verdicts (CONFIRMED / REFUTED / UNVERIFIABLE-FROM-REPO)
+- [ ] 5. Self-check completeness against the source file
+```
+
+**Step 2, what counts as a claim**: names (resources, tables, alarms, roles, routes, env
+vars), values (memory sizes, timeouts, TTLs, thresholds, defaults), mechanisms ("X
+triggers Y", "A falls back to B"), command blocks (every flag and value), architecture
+statements, and negatives ("no Z exists"). Command blocks in runbooks are the highest
+stakes: someone runs them mid-incident.
+
+**Step 3, verification standards.** Each of these earned its place by catching a real
+error in this repo:
+
+- Verify the deployed path, then the code. Code can be complete and undeployed: the
+  chaos_restore Lambda exists in full while its terraform module invocation is a TODO.
+  A claim that something runs needs the terraform wiring plus any env gate, then the code.
+- Env-specific claims need that env's tfvars. Module variable defaults describe prod;
+  preprod gates modules off (`preprod.tfvars`). A count-gated module exists in the tree
+  and is absent from the env.
+- Check callers, then the definition. A metric function with zero callers emits nothing
+  (`record_failover`). Two same-named functions can behave differently and only one is
+  live (`generate_dedup_key`, see CLAUDE.md).
+- Compare every command flag value to terraform. A restore command carrying stale values
+  (memory 512 where the deployed config is 2048) misconfigures the system mid-incident.
+- A health check must be able to fail. `aws cloudwatch describe-alarms --alarm-names X`
+  is a filter, exits 0 on a nonexistent alarm; a check built on it is vacuous. Confirm
+  the failure path exists before confirming the check.
+- A verified negative cites the search that returned nothing, scoped: "zero `etag` hits
+  in `src/lambdas/` and `frontend/src/`" is evidence; "no ETag machinery" alone is not.
+- State unknowns as unknowns, with the command that would resolve them. Invented
+  specifics are the failure mode this skill exists to prevent.
+- Routes do not discriminate between the two dashboards; check the caller (CLAUDE.md,
+  "Two Dashboards"). Both are served by `src/lambdas/dashboard/handler.py`.
+
+**Step 4, verdicts**: CONFIRMED carries its citation. REFUTED carries the refuting
+observation and the replacement text. UNVERIFIABLE-FROM-REPO carries either "rescoped"
+(claim narrowed to what the repo can support) or the retained inline verification
+command. Every REFUTED claim gets a resolution.
+
+**Step 5, self-check**: re-scan the source file top to bottom and count claims against
+your list. Sections skimmed on the first pass (tables, command blocks, footnote rows)
+are where misses live.
+
+## Promote mode
+
+Terminal states: **promoted** (watermark flips to CANON), **deleted**, or
+**retained-QUARRYSOME** (doc stays, with the reason recorded).
+
+```
+Promote: <file>
+- [ ] 1. Previous batch PR merged; branch off fresh main
+- [ ] 2. Audit engine (above)
+- [ ] 3. One AskUserQuestion: recommendation first; operator adjudicates
+- [ ] 4. Execute exactly what the operator chose
+- [ ] 5. Verdict record written and schema-validated
+- [ ] 6. Gates green
+- [ ] 7. PR body per contract; commit signed; push and open PR in one step
+```
+
+**Step 1**: `gh pr view <n> --json state` confirms the merge, then
+`git checkout main && git pull --ff-only`, delete the old branch, create
+`001-quarrysome-batch<N>`.
+
+**Step 3**: present the proposal with the recommended option first (promote with N
+rewrites / delete / keep QUARRYSOME), findings summarized with citations. Execute the
+choice verbatim; "keep QUARRYSOME" is a valid outcome and gets its audit preserved in
+the verdict record.
+
+**Step 5**: one record per subject at
+`specs/001-quarrysome-promotion/verdicts/<subject>.json`, validated with python
+`jsonschema` against `specs/001-quarrysome-promotion/contracts/verdict-record.schema.json`.
+
+**Step 6**, run exactly:
+
+```bash
+source .venv/bin/activate && make validate
+```
+
+then the CI-mirror suite (expect all tests passing; preprod suites need a live env and
+are excluded, matching CI):
+
+```bash
+AWS_REGION=us-east-1 AWS_ACCESS_KEY_ID=testing AWS_SECRET_ACCESS_KEY=testing \
+pytest --ignore=tests/integration/test_analysis_preprod.py \
+  --ignore=tests/integration/test_dashboard_preprod.py \
+  --ignore=tests/integration/test_canary_preprod.py \
+  --ignore=tests/integration/test_ingestion_preprod.py \
+  --ignore=tests/integration/test_e2e_lambda_invocation_preprod.py \
+  --ignore=tests/integration/test_observability_preprod.py \
+  --ignore=tests/integration/timeseries --ignore=tests/e2e -q
+```
+
+**Step 7**: PR body follows `specs/001-quarrysome-promotion/contracts/pr-body-contract.md`
+(7 numbered sections; a section with nothing to report says so). Defects found during the
+audit go in body section 5. Commit with `-S`, message states why, then push and open the
+PR in one Bash call with a 600000ms timeout (the pre-push hook runs pytest):
+
+```bash
+git push -u origin HEAD && gh pr create --title "..." --body-file <path>
+```
+
+## Coherence mode
+
+Scope: every file carrying the CANON watermark, or the file list the caller passes.
+
+```bash
+grep -rln '^> \*\*CANON\*\*' --include='*.md' . | grep -v node_modules
+```
+
+**Triage first** when time-boxed: rank files by how recently their subject code changed
+relative to the doc (`git log -1 --format=%ci -- <doc>` vs the same for the source dirs
+the doc cites). Audit the widest-gap files first; a doc untouched since its subject
+system was rewritten is the likeliest drift site.
+
+Run the audit engine per file. The report is the artifact: return it as the final
+message, or write it to the path the caller names. Report template:
+
+```markdown
+# Canon coherence report
+
+Scope: <N> files audited | Clean: <n> | Drifted: <n>
+
+## <file> - DRIFTED
+| Locus | Claim | Reality | Severity | Proposed rewrite |
+|---|---|---|---|---|
+| <doc>:<line> | <claim> | <evidence, file:line> | dangerous/misleading/stale-pointer | <replacement text> |
+
+## <file> - CLEAN
+<claim count> claims re-verified.
+```
+
+Severity: **dangerous** (following the doc causes harm: wrong runbook values, wrong
+safety claims), **misleading** (wrong mechanism or ownership; reader designs against
+fiction), **stale-pointer** (dead file:line references, renamed identifiers). Order
+findings by severity.
+
+Coherence mode reports only. Fixes happen in a follow-up the operator approves, per the
+standing rule that every md amendment needs owner sign-off.
+
+## Traps
+
+These are standing negatives. Each pairs with a positive rule above.
+
+- Never treat the doc's own cross-references, header comments, or watermarks as evidence;
+  header strings lie (`HTMX` appears in dozens of files and the admin dashboard has none).
+- Never create new tracking cards, labels, or tables; defects go in the PR body, or as an
+  append to an existing card that already covers the finding.
+- Never present a REFUTED claim without its replacement text; a bare refutation forces
+  re-derivation later.
+- Never run `make -n validate` (refused by design) and never read pip-audit green as
+  evidence (advisory stage, `|| true`).
+- Never let a doc grow without stating why honest promotion required it.
+- Never soften a rule-bearing doc with an exception clause during a rewrite.
+- Never skip the merge check before branching; the pre-push branch-collision hook is the
+  backstop, not the plan.

--- a/docs/x-ray.md
+++ b/docs/x-ray.md
@@ -1,6 +1,6 @@
 # X-Ray Tracing
 
-> **QUARRYSOME**: unaudited; verify against code before trusting.
+> **CANON**: verified against code.
 
 ## How tracing is set up
 
@@ -8,7 +8,7 @@ Two stacks, split by Lambda type.
 
 **Non-streaming Lambdas** (dashboard, ingestion, analysis, notification, metrics, canary):
 Powertools Tracer, instantiated at module level per file (`Tracer(service=...)` in each
-handler, plus bare `Tracer()` in shared modules). Exceptions are auto-captured as
+handler, plus bare `Tracer()` in shared and other non-handler modules). Exceptions are auto-captured as
 subsegment faults by `@tracer.capture_method`.
 
 **SSE streaming Lambda** (`src/lambdas/sse_streaming/`): dual framework. Powertools
@@ -38,18 +38,22 @@ The OTel side, all in `src/lambdas/sse_streaming/`:
 - `collector-config.yaml`: processor-less pipeline (`otlp` receiver straight to
   `awsxray` exporter). The ADOT Lambda Extension binary has zero processors compiled
   in, so span retention rides on the SDK-side flush.
-- Streaming spans and their attributes: `dynamodb_poll` (`item_count`,
+- Streaming spans and their attributes, three in total: `dynamodb_poll` (`item_count`,
   `changed_count`, `poll_duration_ms`, `cache_hit_rate`, `cache_hit`) in
   `polling.py`; `sse_event_dispatch` (`event_type`, `latency_ms`) in `stream.py`;
-  `cloudwatch_put_metric` in `metrics.py`; connection spans (`connection_id`,
-  `session_id`) in `connection.py`.
+  `cloudwatch_put_metric` in `metrics.py`. `connection.py` creates no spans;
+  `connection_id` and `session_id` are dataclass fields that ride on structured log
+  entries for correlation.
 - Lifecycle guards in `stream.py`: a deadline check flushes proactively when under
   3000ms remain, and a `flush_fired` flag stops span creation afterward, since spans
   created post-flush have no export path. Client disconnect (`BrokenPipeError`) is
   annotated `client.disconnected=true` with status OK, not treated as an error.
   Caught exceptions get the explicit dual call: `set_status(ERROR)` plus
   `record_exception()`.
-- Every SSE event JSON payload carries a `trace_id` field for frontend correlation.
+- The global stream's live events and heartbeats carry a `trace_id` field for frontend
+  correlation, injected at yield (`stream.py:279`). Replayed buffer events, deadline
+  events, and everything from `generate_config_stream` (`stream.py:566`) go out without
+  one.
 
 **Canary** (`src/lambdas/canary/handler.py`): submits synthetic traces on a 5-minute
 EventBridge schedule, queries `GetTraceSummaries` with 30/60/90s retries, computes a


### PR DESCRIPTION
Also in this PR, at operator direction: `.claude/skills/canon-audit/SKILL.md`, the audit
procedure from batches 1-6 codified as a two-mode skill (promote adjudication and a weekly
CANON coherence check). This batch was executed through it.

## 1. Subjects and terminal states

- `docs/x-ray.md`: promoted, net +7 lines

## 2. Verdict summary

**docs/x-ray.md**: 19 claims, 16 CONFIRMED, 3 REFUTED, 0 UNVERIFIABLE-FROM-REPO. The doc's
own inline line citations (`handler.py:32`, `handler.py:550`, `metrics.py:299`) are all
still exact, and all four open-work items verified as genuinely open.

- x-ray-c002 (REFUTED): bare `Tracer()` was placed only in "shared modules"; it also lives
  in per-Lambda non-handler modules (`dashboard/alerts.py:40`, `ingestion/storage.py:30`,
  and more). Wording widened.
- x-ray-c010 (REFUTED): the span inventory listed connection spans in `connection.py`.
  That file creates no spans; `connection_id` and `session_id` are dataclass fields riding
  on structured log entries. Inventory rewritten as three spans total with the log-field
  reality stated.
- x-ray-c012 (REFUTED): "every SSE event JSON payload carries a trace_id" is false three
  ways: the global stream's replay path (`stream.py:390`) and deadline event (`:419`)
  yield uninjected, and `generate_config_stream` (`:566`, live behind `handler.py:468`)
  injects nothing on any of its five yield paths. Claim scoped to the global stream's
  live events and heartbeats.

Completeness reviewer: waived by operator (subagent machinery waiver recorded in
`baseline.md` post-T003); orchestrator inline self-check only.

## 3. Reference gate (FR-005)

No deletions or renames in this batch.

## 4. Growth justification (SC-004)

`docs/x-ray.md` grew by 7 net lines: the span-inventory correction needs two lines to say
what `connection.py` actually does instead of naming phantom spans, and the trace_id claim
needs three to name the uninjected paths instead of overclaiming coverage. The corrected
statements are longer than the fictions they replace.

## 5. Defects (FR-003 / SC-005)

- `src/lambdas/sse_streaming/stream.py:566` (`generate_config_stream`): no trace_id
  injection on any yield path (:609,617,641,666,693), while `generate_global_stream`
  injects via `_inject_trace_id` (:279). Frontend trace correlation is impossible on the
  config-stream endpoint (`handler.py:468`). Same root gap covers the global stream's
  replay (:390) and deadline (:419) yields.

No new cards created (First-Feature Gate decision).

## 6. Attestation (FR-010)

`docs/x-ray.md` states rules (the env-var update procedure, the open-work preconditions).
No exception clause was added.

## 7. Operator approval

Adjudicated in-session via AskUserQuestion with findings and citations presented; operator
selected "Promote with 3 rewrites". Executed exactly as approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
