### PR TITLE
docs(quarrysome): promote terraform-patterns, bootstrap README, interview.md to CANON (batch 8)

### DIFF
--- a/docs/interview.md
+++ b/docs/interview.md
@@ -1,6 +1,6 @@
 # Interview Demo Kit
 
-> **QUARRYSOME**: unaudited; verify against code before trusting.
+> **CANON**: verified against code.
 
 `interview/` holds interactive tooling for demonstrating this system's architecture in a
 technical interview: a browser dashboard for the walkthrough and a script that generates
@@ -11,7 +11,7 @@ synthetic traffic against a deployed environment.
 | File | What it is |
 |---|---|
 | `interview/index.html` | Single-page demo dashboard. Environment toggle (preprod/prod), an interview timer, live API calls from the browser, and an architecture walkthrough. Open it directly or serve it with `python -m http.server` from `interview/`. |
-| `interview/traffic_generator.py` | Synthetic traffic generator. `python3 traffic_generator.py --env preprod --scenario all` runs every scenario; individual scenarios cover the happy-path session flow, price-plus-sentiment shape validation, cache warmup latency, concurrent load, and rate-limit 429 behavior. `--users` and `--requests` size the load scenario. |
+| `interview/traffic_generator.py` | Synthetic traffic generator. `python3 traffic_generator.py --env preprod --scenario all` runs every scenario; individual scenarios cover the happy-path session flow, price-plus-sentiment shape validation, cache warmup latency, concurrent load, rate-limit 429 behavior, and circuit-breaker behavior. `--users` and `--requests` size the load scenario. |
 
 ## Cautions
 

--- a/docs/terraform-patterns.md
+++ b/docs/terraform-patterns.md
@@ -1,6 +1,6 @@
 # Terraform Patterns
 
-> **QUARRYSOME**: unaudited; verify against code before trusting.
+> **CANON**: verified against code.
 
 ## Split Definition/Wiring (Feature 1290)
 
@@ -12,7 +12,9 @@ Terraform modules that cross-reference each other's outputs through Lambda envir
 
 Split Lambda configuration into two phases within a single `terraform apply`:
 
-1. **Definition**: Create the Lambda with placeholder env vars (`""`) for cross-module values
+1. **Definition**: Create the Lambda with a placeholder for the cross-module value: an
+   empty string (`SCHEDULER_ROLE_ARN = ""`) or a variable-seeded interim value
+   (`DASHBOARD_URL = var.frontend_url`, overwritten by wiring)
 2. **Wiring**: After all modules exist, a `terraform_data` resource with `local-exec` reads current env vars, merges the cross-module value, and writes back
 
 ```
@@ -71,7 +73,7 @@ Split Lambda configuration into two phases within a single `terraform apply`:
 
 ### Tech Debt
 
-This pattern is a workaround. The long-term fix is to migrate cross-module env vars to SSM Parameter Store, where Lambdas read values at runtime instead of receiving them as env vars. This eliminates the Terraform dependency entirely. See GitHub issue for tracking.
+This pattern is a workaround. The long-term fix is to migrate cross-module env vars to SSM Parameter Store, where Lambdas read values at runtime instead of receiving them as env vars. This eliminates the Terraform dependency entirely. Tracked in issue #850.
 
 ### Related
 

--- a/infrastructure/terraform/bootstrap/README.md
+++ b/infrastructure/terraform/bootstrap/README.md
@@ -1,6 +1,6 @@
 # Terraform Backend Bootstrap
 
-> **QUARRYSOME**: unaudited; verify against code before trusting.
+> **CANON**: verified against code.
 
 Creates the S3 bucket that holds Terraform state. Run once per AWS account.
 


### PR DESCRIPTION
## 1. Subjects and terminal states

- `docs/terraform-patterns.md`: promoted, net +2 lines
- `infrastructure/terraform/bootstrap/README.md`: promoted, net +0 lines
- `docs/interview.md`: promoted, net +0 lines

interview.md folded into this batch per FR-004 (20-line file), operator approved in the
same adjudication.

## 2. Verdict summary

**docs/terraform-patterns.md**: 10 claims, 9 CONFIRMED, 1 REFUTED, 0 UNVERIFIABLE-FROM-REPO.

- terraform-patterns-c001 (REFUTED): the definition phase was described as seeding
  placeholders with `""` universally. True for `SCHEDULER_ROLE_ARN` (`main.tf:479`);
  `DASHBOARD_URL` seeds from `var.frontend_url` (`main.tf:610`) before wiring overwrites
  it with the amplify output. Rewritten to name both cases.
- Precision fix on a CONFIRMED claim: "See GitHub issue for tracking" now cites issue
  #850 (open, "Tech debt: Migrate cross-module env vars to SSM Parameter Store").

**infrastructure/terraform/bootstrap/README.md**: 6 claims, 6 CONFIRMED. First subject in
the campaign to survive audit with zero text changes; watermark flip only. The no-locking
negative was re-verified (zero `use_lockfile` hits, no lock table) and agrees with CANON
`terraform-state.md`.

**docs/interview.md**: 4 claims, 3 CONFIRMED, 1 REFUTED.

- interview-c003 (REFUTED): the scenario enumeration omitted `circuit-breaker`, one of
  the script's seven `--scenario` choices (`traffic_generator.py:573-586`). Added.

Completeness reviewer: waived by operator (subagent machinery waiver recorded in
`baseline.md` post-T003); orchestrator inline self-check only.

## 3. Reference gate (FR-005)

No deletions or renames in this batch.

## 4. Growth justification (SC-004)

`docs/terraform-patterns.md` grew by 2 net lines: naming both placeholder cases takes
three lines where the false universal took one. The other two files are net zero.

## 5. Defects (FR-003 / SC-005)

No defects found. The wiring script implements all four documented rules (output
suppression, read-back verify with exit 2, no temp files, merge-not-replace), and both
wired vars are guarded by `validate_critical_env_vars()` in their handlers.

## 6. Attestation (FR-010)

`docs/terraform-patterns.md` states rules (the four wiring rules, when-to-use criteria).
No exception clause was added. The other two documents state procedures, not rules.

## 7. Operator approval

Adjudicated in-session via AskUserQuestion with findings and citations presented; operator
selected "Promote all three". Executed exactly as approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
