### PR TITLE
docs(quarrysome): promote frontend e2e README to CANON (batch 9)

### DIFF
--- a/frontend/tests/e2e/README.md
+++ b/frontend/tests/e2e/README.md
@@ -1,6 +1,6 @@
 # Customer Dashboard E2E Tests
 
-> **QUARRYSOME**: unaudited; verify against code before trusting.
+> **CANON**: verified against code.
 
 This directory contains Playwright E2E tests for the **customer-facing Next.js dashboard** hosted on AWS Amplify.
 
@@ -8,7 +8,7 @@ This directory contains Playwright E2E tests for the **customer-facing Next.js d
 
 All tests in this directory target the **Customer Dashboard (Next.js/Amplify)** — the app at `https://main.d29tlmksqcx494.amplifyapp.com/`.
 
-For admin dashboard (Lambda HTMX) tests, see `tests/e2e/` at the repository root.
+For admin dashboard tests (Lambda behind API Gateway), see `tests/e2e/` at the repository root.
 
 ## Running Tests
 
@@ -75,6 +75,6 @@ Rules:
 | Dashboard | Directory | URL | Tech |
 |-----------|-----------|-----|------|
 | Customer (this dir) | `frontend/tests/e2e/` | Amplify or localhost:3000 | Next.js/React |
-| Admin | `tests/e2e/` (repo root) | Lambda Function URL | HTMX/Chart.js |
+| Admin | `tests/e2e/` (repo root) | Lambda behind API Gateway | Vanilla JS/Chart.js |
 
 The `make check-test-target-headers` target enforces that all Playwright test files have a `Target:` header comment.


### PR DESCRIPTION
## 1. Subjects and terminal states

- `frontend/tests/e2e/README.md`: promoted, net +0 lines

This closes the campaign's active queue; SC-003 bound this file specifically.

## 2. Verdict summary

**frontend/tests/e2e/README.md**: 9 claims, 7 CONFIRMED, 2 REFUTED, 0
UNVERIFIABLE-FROM-REPO. The two refutations are exactly the SC-003 banned terms:

- frontend-e2e-readme-c002 (REFUTED): "admin dashboard (Lambda HTMX)". No HTMX exists in
  the admin dashboard; rewritten to "Lambda behind API Gateway".
- frontend-e2e-readme-c009 (REFUTED): architecture table row "Lambda Function URL" +
  "HTMX/Chart.js". The dashboard Lambda has no Function URL (`create_function_url = false`,
  `main.tf:508/558/615`, re-verified batch 6); the stack is vanilla JS with Chart.js 4.4.0
  from CDN (`src/dashboard/index.html:9`). Rewritten to "Lambda behind API Gateway" and
  "Vanilla JS/Chart.js".

Post-edit SC-003 check: `grep -ci "htmx\|function url"` on the file returns 0.

The verification-pipeline claims all held: `verify.shot()` (`helpers/verification.ts:113`),
manifest fields including `interception.clean` and `forbidden_requests` (`:107-108`),
trace forcing under VERIFICATION=1 (`playwright.config.ts:24`), artifact path
(`verification.ts:155`), schema file, trust-contract doc, and all three named specs exist.

Completeness reviewer: waived by operator (subagent machinery waiver recorded in
`baseline.md` post-T003); orchestrator inline self-check only.

Process note: the verdict-record schema's `batch` maximum was raised 8 to 12 (untracked
contract file) because operator-directed additions extended the campaign past its planned
8 batches.

## 3. Reference gate (FR-005)

No deletions or renames in this batch.

## 4. Growth justification (SC-004)

No file grew; net zero lines.

## 5. Defects (FR-003 / SC-005)

No defects found. The admin-dashboard misdescriptions were doc drift, and the underlying
facts were already established in prior batches.

## 6. Attestation (FR-010)

The README states rules (required Target header, verification-run rules). No exception
clause was added.

## 7. Operator approval

Adjudicated in-session via AskUserQuestion; operator selected "Promote with 2 rewrites".
Executed exactly as approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
