### PR TITLE
ci: point nightly-e2e at frontend/.nvmrc for Node version

### DIFF
--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '18'
+          node-version-file: 'frontend/.nvmrc'
           cache: 'npm'
           cache-dependency-path: frontend/package-lock.json
 


### PR DESCRIPTION
Nightly External-API E2E has been failing at webServer startup: the workflow pins Node 18 (`nightly-e2e.yml:50`) while `frontend/package.json` engines require >=20.9.0, so Next.js refuses to boot and every test aborts before running. Failed run: https://github.com/traylorre/sentiment-analyzer-gsk/actions/runs/31073678628/job/92526787995

Fix reads the version from `frontend/.nvmrc` (currently 20), the same source pr-checks.yml uses, so nightly cannot drift from pr-checks again. deploy.yml still pins '20' inline; left alone, it is not broken.

One thing to watch after merge: nightly has been red at the webServer step, so tonight's run is the first in a while to actually execute the suite and may surface accumulated e2e breakage. Card: specs/001-nightly-e2e-node-fix/ (local).

🤖 Generated with [Claude Code](https://claude.com/claude-code)