### PR TITLE
fix(secrets): raise secrets cache TTL from 5 minutes to 24 hours

### DIFF
--- a/docs/cache.md
+++ b/docs/cache.md
@@ -79,7 +79,7 @@ unmeasured.
 | Configuration | per-container | oldest write | 100 users | 60s | explicit on mutation, plus TTL |
 | Ticker | per-container | single entry | 1 | 300s, then ETag check | ETag change; stale-serve on failure |
 | SSE ResolutionCache | per-container | true LRU | 256 | equals resolution duration | TTL, expiry on read |
-| Secrets | per-container | none | key space is the few secret ids | 300s | TTL or `force_refresh` |
+| Secrets | per-container | none | key space is the few secret ids | 86400s | TTL or `force_refresh` |
 | Quota tracker | per-container | none | key space is the few services | 10s | TTL only |
 | Circuit breaker | per-container | none | key space is the few services | 60s | TTL only |
 | Client (TanStack) | browser tab | library-managed | library-managed | staleTime 5min | refetch interval |
@@ -305,8 +305,9 @@ If metrics are missing entirely: confirm the log group name above, confirm `stre
 
 ## Secrets cache
 
-`src/lambdas/shared/secrets.py`. In-memory cache of Secrets Manager values, TTL 300s
-(`SECRETS_CACHE_TTL_SECONDS`, default `DEFAULT_CACHE_TTL_SECONDS = 300`). Fail-closed: once an
+`src/lambdas/shared/secrets.py`. In-memory cache of Secrets Manager values, TTL 24h
+(`SECRETS_CACHE_TTL_SECONDS`, default `DEFAULT_CACHE_TTL_SECONDS = 86400`; every fetch is a
+billed KMS Decrypt, so the TTL stays long while no secret rotates). Fail-closed: once an
 entry expires there is no stale-serving grace; a failed fetch raises immediately
 (`SecretNotFoundError`, `SecretAccessDeniedError`, or `SecretRetrievalError`,
 `secrets.py:180-217`). `force_refresh=True` bypasses the cache. Auth uses self-issued HMAC

--- a/src/lambdas/notification/sendgrid_service.py
+++ b/src/lambdas/notification/sendgrid_service.py
@@ -382,7 +382,7 @@ def _get_sendgrid_api_key(secret_arn: str) -> str:
 def clear_api_key_cache() -> None:
     """Clear the API key cache (for testing).
 
-    This clears the shared secrets cache which has a 5-minute TTL.
+    This clears the shared secrets cache which has a 24-hour TTL.
     """
     from src.lambdas.shared.secrets import clear_cache
 

--- a/src/lambdas/shared/secrets.py
+++ b/src/lambdas/shared/secrets.py
@@ -10,12 +10,15 @@ For On-Call Engineers:
     2. Lambda IAM role has secretsmanager:GetSecretValue permission
     3. Secret path format: ${environment}/sentiment-analyzer/<name>
 
-    Cache has 5-minute TTL. Lambda cold start refreshes cache automatically.
+    Cache has 24-hour TTL. Lambda cold start refreshes cache automatically.
     See SC-03, SC-05 in ON_CALL_SOP.md for secret-related incidents.
 
 For Developers:
     - Secrets are cached in memory to reduce API calls and latency
-    - Cache TTL is 5 minutes (configurable via SECRETS_CACHE_TTL_SECONDS)
+    - Cache TTL is 24 hours (configurable via SECRETS_CACHE_TTL_SECONDS);
+      in practice a warm container fetches each secret once, on cold start
+    - Every Secrets Manager fetch is a KMS Decrypt behind the scenes, and
+      KMS requests are billed; keep the TTL long unless rotation demands less
     - Use get_secret() for all secret retrieval
     - Never log secret values, only ARNs
 
@@ -41,8 +44,10 @@ from src.lib.cache_utils import CacheStats, get_global_emitter
 logger = logging.getLogger(__name__)
 
 # Cache configuration
-# On-Call Note: Reduce TTL if secrets need faster rotation pickup
-DEFAULT_CACHE_TTL_SECONDS = 300  # 5 minutes
+# On-Call Note: Reduce TTL (SECRETS_CACHE_TTL_SECONDS) if secrets need faster
+# rotation pickup. No secret currently rotates (rotation_lambda_arn = null in
+# infrastructure/terraform/main.tf), so the TTL is bounded by container lifetime.
+DEFAULT_CACHE_TTL_SECONDS = 86400  # 24 hours
 
 # Retry configuration
 RETRY_CONFIG = Config(
@@ -140,8 +145,8 @@ def get_secret(
     """
     Retrieve a secret from Secrets Manager with caching.
 
-    Secrets are cached in memory for 5 minutes to reduce API calls and latency.
-    Cache is automatically cleared on Lambda cold start.
+    Secrets are cached in memory for 24 hours to reduce API calls, latency, and
+    KMS Decrypt billing. Cache is automatically cleared on Lambda cold start.
 
     Args:
         secret_id: Secret name or ARN (e.g., "dev/sentiment-analyzer/tiingo")

--- a/tests/unit/test_cache_jitter_integration.py
+++ b/tests/unit/test_cache_jitter_integration.py
@@ -46,7 +46,7 @@ class TestSecretsJitter:
 
         entry = mod._secrets_cache["test-secret"]
         stored_ttl = entry["expires_at"] - time.time()
-        assert_jittered(stored_ttl, 300.0, "secrets")
+        assert_jittered(stored_ttl, float(mod.DEFAULT_CACHE_TTL_SECONDS), "secrets")
 
 
 class TestTiingoJitter:


### PR DESCRIPTION
Every GetSecretValue is a KMS Decrypt on the customer-managed key, and the 5-minute TTL had warm containers refetching every secret ~288 times a day each. At ~17k KMS requests in the first 6 days of August that clears the 20k/month free tier before mid-month.

No secret rotates (`rotation_lambda_arn = null` in `infrastructure/terraform/main.tf:104`), so staleness is bounded by container lifetime, not by the TTL. A Terraform env var per Lambda was considered and rejected: `SECRETS_CACHE_TTL_SECONDS` is already read at call time, so changing the code default covers every Lambda at once and the env var stays available as a per-Lambda override if rotation ever lands. What would change this call: enabling rotation on any secret, which needs the TTL dropped back below the rotation window for that secret.

Also updates `docs/cache.md` (inventory table + secrets section) and the jitter integration test, which now reads `DEFAULT_CACHE_TTL_SECONDS` instead of restating 300.

🤖 Generated with [Claude Code](https://claude.com/claude-code)