### PR TITLE
fix: implement context carryover death-loop guardrails

### DIFF
--- a/.pi/extensions/carryover-bridge.ts
+++ b/.pi/extensions/carryover-bridge.ts
@@ -1,0 +1,100 @@
+import { type ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { spawn } from "node:child_process";
+import { Type } from "typebox";
+import { StringEnum } from "@earendil-works/pi-ai";
+
+export default function (pi: ExtensionAPI) {
+  const evaluateFullness = (ctx: any) => {
+    const entries = ctx.sessionManager.getEntries();
+    return entries.length > 2000; // arbitrary threshold, increased to prevent annoying warnings
+  };
+
+  pi.on("session_start", async (event, ctx) => {
+    const paneId = process.env.HERDR_PANE_ID || "";
+    const tabId = process.env.HERDR_TAB_ID || "";
+    const sessionId = process.env.PI_SESSION_ID || "default";
+    const agentId = process.env.PI_AGENT_ID || "default";
+    
+    if (paneId && tabId) {
+      spawn("bash", ["scripts/bin/pi-carryover-loader.sh", paneId, tabId, sessionId, agentId], {
+        stdio: "ignore",
+        detached: true
+      }).unref();
+    }
+  });
+
+  pi.on("turn_end", async (event, ctx) => {
+    if (evaluateFullness(ctx)) {
+      if (ctx.hasUI) {
+         ctx.ui.notify("Session full. Please run /carryover to rotate context.", "warning");
+      }
+    }
+  });
+
+  pi.registerTool({
+    name: "execute_carryover",
+    label: "Execute Carryover",
+    description: "Rotate the terminal pane to a new session after writing the carryover document.",
+    parameters: Type.Object({
+      mode: Type.Optional(StringEnum(["live", "sealed"] as const)),
+      carryoverPath: Type.Optional(Type.String({ description: "Path to the written carryover markdown file" }))
+    }),
+    async execute(toolCallId, params, signal, onUpdate, ctx) {
+      const paneId = process.env.HERDR_PANE_ID || "";
+      const tabId = process.env.HERDR_TAB_ID || "";
+      const sessionId = process.env.PI_SESSION_ID || "default";
+      const agentId = process.env.PI_AGENT_ID || "default";
+
+      if (!paneId || !tabId) {
+        return { content: [{ type: "text", text: "Error: Not running in Herdr pane." }] };
+      }
+
+      const isSealed = params.mode === "sealed";
+      
+      if (isSealed) {
+        spawn("bash", ["scripts/bin/pi-carryover-seal.sh", paneId, tabId, sessionId, agentId, params.carryoverPath || ""], {
+          stdio: "ignore",
+          detached: true
+        }).unref();
+      } else {
+        spawn("python3", ["scripts/bin/pi-carryover-rotate.py", paneId, tabId, sessionId, agentId, params.carryoverPath || ""], {
+          stdio: "ignore",
+          detached: true
+        }).unref();
+      }
+
+      return {
+        content: [{ type: "text", text: isSealed ? "Session sealed." : "Carryover triggered. Pane will rotate shortly." }],
+        details: {},
+        terminate: true
+      };
+    }
+  });
+
+  pi.registerCommand("carryover", {
+    description: "Carry over context to a new session (optional arg: sealed)",
+    handler: async (args, ctx) => {
+      if (!ctx.isIdle()) {
+        ctx.ui.notify("Agent is busy.", "warning");
+        return;
+      }
+      
+      const mode = args.trim().toLowerCase() === "sealed" ? "sealed" : "live";
+      const sessionId = process.env.PI_SESSION_ID || "default";
+      const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+
+      const prompt = `We are doing a context carryover. 
+
+1. Generate a descriptive, session-scoped filename for the carryover document, formatted like \`context-carryover-<branch-or-topic>-${sessionId}.md\` (do NOT use a flat \`baton.md\` name). 
+2. Write a comprehensive carryover document to that file using the battle-tested Claude carryover template. It MUST include:
+   - Date, Branch, Feature/Topic
+   - Current Round / Next Round
+   - Spec Metrics & File Paths
+   - Exact Active State & Progress (What was just done, what broke)
+   - Exact Next Steps (What the next session needs to do immediately)
+3. After successfully writing the file using the \`write\` tool, call the \`execute_carryover\` tool with \`{ "mode": "${mode}", "carryoverPath": "<the-file-you-wrote>" }\`.`;
+
+      pi.sendUserMessage(prompt);
+    }
+  });
+}

--- a/scripts/bin/pi-carryover-loader.sh
+++ b/scripts/bin/pi-carryover-loader.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -e
+
+PANE_ID="$1"
+TAB_ID="$2"
+SESSION_ID="$3"
+AGENT_ID="$4"
+
+if [[ -z "$PANE_ID" || -z "$TAB_ID" || -z "$SESSION_ID" || -z "$AGENT_ID" ]]; then
+  echo "Usage: $0 <pane_id> <tab_id> <session_id> <agent_id>"
+  exit 1
+fi
+
+if [[ ! "$PANE_ID" =~ ^[a-zA-Z0-9_:-]+$ ]]; then echo "Invalid PANE_ID" && exit 1; fi
+if [[ ! "$TAB_ID" =~ ^[a-zA-Z0-9_:-]+$ ]]; then echo "Invalid TAB_ID" && exit 1; fi
+if [[ ! "$SESSION_ID" =~ ^[a-zA-Z0-9_:-]+$ ]]; then echo "Invalid SESSION_ID" && exit 1; fi
+if [[ ! "$AGENT_ID" =~ ^[a-zA-Z0-9_:-]+$ ]]; then echo "Invalid AGENT_ID" && exit 1; fi
+
+HANDOFF_DIR=".pi/handoff/$SESSION_ID/$AGENT_ID"
+mkdir -p "$HANDOFF_DIR"
+touch "$HANDOFF_DIR/journal.json" "$HANDOFF_DIR/dispatch.json"
+
+HERDR_BIN="herdr"
+if ! command -v herdr >/dev/null 2>&1; then
+  HERDR_BIN="$HOME/.local/share/mise/installs/herdr/0.8.0/herdr"
+fi
+
+"$HERDR_BIN" tab rename "$TAB_ID" "$AGENT_ID" >> "$HANDOFF_DIR/rotate.log" 2>&1 || true

--- a/scripts/bin/pi-carryover-rotate.py
+++ b/scripts/bin/pi-carryover-rotate.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+import sys
+import os
+import re
+import subprocess
+import shutil
+import json
+
+def validate_id(val):
+    if not re.match(r"^[a-zA-Z0-9_:-]+$", val):
+        return False
+    return True
+
+def run_rotation(pane_id, tab_id, session_id, agent_id, carryover_path=""):
+    if not all(validate_id(x) for x in [pane_id, tab_id, session_id, agent_id]):
+        print("Invalid input")
+        sys.exit(1)
+
+    import datetime
+    handoff_dir = f".pi/handoff/{session_id}/{agent_id}"
+    os.makedirs(handoff_dir, exist_ok=True)
+    
+    timestamp = datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%d-%H%M%S")
+
+    # Touch required files if they don't exist
+    for f in ["journal.json", "dispatch.json"]:
+        open(os.path.join(handoff_dir, f), 'a').close()
+        
+    # Write metadata
+    with open(os.path.join(handoff_dir, "dispatch.json"), "w") as f:
+        json.dump({
+            "status": "live", 
+            "timestamp": timestamp, 
+            "pane_id": pane_id, 
+            "tab_id": tab_id,
+            "carryover_path": carryover_path
+        }, f)
+        
+    herdr_bin = shutil.which("herdr") or os.path.expanduser("~/.local/share/mise/installs/herdr/0.8.0/herdr")
+    if not os.path.exists(herdr_bin):
+        herdr_bin = "/usr/local/bin/herdr"
+
+    try:
+        with open(os.path.join(handoff_dir, "rotate.log"), "a") as log:
+            subprocess.run([herdr_bin, "tab", "rename", tab_id, agent_id], check=False, stdout=log, stderr=log)
+            # Add a small delay to ensure terminal is ready
+            import time
+            time.sleep(0.5)
+            # Pass the carryover path to the new session if provided
+            if carryover_path:
+                msg = f"RESUMING FROM {carryover_path}"
+                # We can't easily type the whole message, but we can type /new and then tell the user 
+                # or inject a prompt. For now, just trigger /new and resume.
+                subprocess.run([herdr_bin, "pane", "send-keys", pane_id, "/", "n", "e", "w", "Enter"], check=False, stdout=log, stderr=log)
+                time.sleep(2.0)
+                # Instead of a generic "resume", let's be explicitly clear.
+                resume_text = f"resume context: {carryover_path} STOP DO NOT EXECUTE TASKS WAIT FOR ME".strip()
+                resume_keys = []
+                for c in resume_text:
+                    if c == " ":
+                        resume_keys.append("Space")
+                    elif c in ("-", ":", ".", "/", "_"):
+                        resume_keys.append(c)
+                    elif c.isalnum():
+                        resume_keys.append(c)
+                    else:
+                        # Drop unsupported characters to prevent herdr from crashing
+                        pass
+                
+                cmd = [herdr_bin, "pane", "send-keys", pane_id] + resume_keys + ["Enter"]
+                
+                # Log exactly what we are sending for debugging
+                log.write(f"Sending keys: {resume_keys}\n")
+                log.flush()
+                
+                subprocess.run(cmd, check=False, stdout=log, stderr=log)
+            else:
+                # If no carryover path, just trigger /new
+                subprocess.run([herdr_bin, "pane", "send-keys", pane_id, "/", "n", "e", "w", "Enter"], check=False, stdout=log, stderr=log)
+    except Exception as e:
+        with open(os.path.join(handoff_dir, "error.log"), "a") as f:
+            f.write(f"Failed to run herdr: {e}\n")
+
+if __name__ == "__main__":
+    if len(sys.argv) < 5:
+        sys.exit(1)
+    c_path = sys.argv[5] if len(sys.argv) > 5 else ""
+    run_rotation(sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4], c_path)

--- a/scripts/bin/pi-carryover-rotate.sh
+++ b/scripts/bin/pi-carryover-rotate.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -e
+
+PANE_ID="$1"
+TAB_ID="$2"
+SESSION_ID="$3"
+AGENT_ID="$4"
+
+if [[ -z "$PANE_ID" || -z "$TAB_ID" || -z "$SESSION_ID" || -z "$AGENT_ID" ]]; then
+  echo "Usage: $0 <pane_id> <tab_id> <session_id> <agent_id>"
+  exit 1
+fi
+
+if [[ ! "$PANE_ID" =~ ^[a-zA-Z0-9_:-]+$ ]]; then echo "Invalid PANE_ID" && exit 1; fi
+if [[ ! "$TAB_ID" =~ ^[a-zA-Z0-9_:-]+$ ]]; then echo "Invalid TAB_ID" && exit 1; fi
+if [[ ! "$SESSION_ID" =~ ^[a-zA-Z0-9_:-]+$ ]]; then echo "Invalid SESSION_ID" && exit 1; fi
+if [[ ! "$AGENT_ID" =~ ^[a-zA-Z0-9_:-]+$ ]]; then echo "Invalid AGENT_ID" && exit 1; fi
+
+HANDOFF_DIR=".pi/handoff/$SESSION_ID/$AGENT_ID"
+mkdir -p "$HANDOFF_DIR"
+touch "$HANDOFF_DIR/journal.json" "$HANDOFF_DIR/baton.md" "$HANDOFF_DIR/dispatch.json"
+
+HERDR_BIN="herdr"
+if ! command -v herdr >/dev/null 2>&1; then
+  HERDR_BIN="$HOME/.local/share/mise/installs/herdr/0.8.0/herdr"
+fi
+
+"$HERDR_BIN" tab rename "$TAB_ID" "$AGENT_ID" >> "$HANDOFF_DIR/rotate.log" 2>&1 || true
+"$HERDR_BIN" pane send-keys "$PANE_ID" "/" "n" "e" "w" "Enter" "r" "e" "s" "u" "m" "e" "Enter" >> "$HANDOFF_DIR/rotate.log" 2>&1 || true

--- a/scripts/bin/pi-carryover-seal.sh
+++ b/scripts/bin/pi-carryover-seal.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -e
+
+PANE_ID="$1"
+TAB_ID="$2"
+SESSION_ID="$3"
+AGENT_ID="$4"
+CARRYOVER_PATH="$5"
+
+if [[ -z "$PANE_ID" || -z "$TAB_ID" || -z "$SESSION_ID" || -z "$AGENT_ID" ]]; then
+  echo "Usage: $0 <pane_id> <tab_id> <session_id> <agent_id> [carryover_path]"
+  exit 1
+fi
+
+if [[ ! "$PANE_ID" =~ ^[a-zA-Z0-9_:-]+$ ]]; then echo "Invalid PANE_ID" && exit 1; fi
+if [[ ! "$TAB_ID" =~ ^[a-zA-Z0-9_:-]+$ ]]; then echo "Invalid TAB_ID" && exit 1; fi
+if [[ ! "$SESSION_ID" =~ ^[a-zA-Z0-9_:-]+$ ]]; then echo "Invalid SESSION_ID" && exit 1; fi
+if [[ ! "$AGENT_ID" =~ ^[a-zA-Z0-9_:-]+$ ]]; then echo "Invalid AGENT_ID" && exit 1; fi
+
+HANDOFF_DIR=".pi/handoff/$SESSION_ID/$AGENT_ID"
+mkdir -p "$HANDOFF_DIR"
+touch "$HANDOFF_DIR/journal.json" "$HANDOFF_DIR/dispatch.json"
+
+TIMESTAMP=$(date -u +"%Y%m%d-%H%M%S")
+
+# Write sealed state with pane metadata
+echo "{\"status\": \"sealed\", \"timestamp\": \"$TIMESTAMP\", \"pane_id\": \"$PANE_ID\", \"tab_id\": \"$TAB_ID\", \"carryover_path\": \"$CARRYOVER_PATH\"}" > "$HANDOFF_DIR/dispatch.json"
+
+HERDR_BIN="herdr"
+if ! command -v herdr >/dev/null 2>&1; then
+  HERDR_BIN="$HOME/.local/share/mise/installs/herdr/0.8.0/herdr"
+fi
+
+"$HERDR_BIN" tab rename "$TAB_ID" "${AGENT_ID}-sealed" >> "$HANDOFF_DIR/rotate.log" 2>&1 || true

--- a/scripts/tests/test_pi_carryover.py
+++ b/scripts/tests/test_pi_carryover.py
@@ -1,0 +1,165 @@
+import os
+import subprocess
+import pytest
+import uuid
+import time
+import tempfile
+import json
+import shutil
+
+@pytest.fixture
+def herdr_socket():
+    socket_path = f"/tmp/herdr-test-{uuid.uuid4().hex}.sock"
+    temp_home = tempfile.mkdtemp(prefix="herdr-test-home-")
+    
+    os.environ["HERDR_SOCKET"] = socket_path
+    os.environ["XDG_CONFIG_HOME"] = os.path.join(temp_home, ".config")
+    os.environ["XDG_DATA_HOME"] = os.path.join(temp_home, ".local", "share")
+    os.environ["XDG_STATE_HOME"] = os.path.join(temp_home, ".local", "state")
+    
+    herdr_bin = shutil.which("herdr") or "/usr/local/bin/herdr"
+    proc = subprocess.Popen([herdr_bin, "server", "--headless"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    time.sleep(1) 
+    
+    yield socket_path
+    
+    proc.terminate()
+    proc.wait()
+    if os.path.exists(socket_path):
+        os.remove(socket_path)
+        
+    shutil.rmtree(temp_home, ignore_errors=True)
+
+def test_shell_injection_rejection(herdr_socket):
+    env = os.environ.copy()
+    env["HERDR_SOCKET"] = herdr_socket
+    
+    result = subprocess.run(
+        ["bash", "scripts/bin/pi-carryover-loader.sh", "invalid; echo 'hacked'", "tab1", "sess1", "agent1"],
+        env=env,
+        capture_output=True,
+        text=True
+    )
+    assert result.returncode == 1
+    assert "Invalid PANE_ID" in result.stdout
+    assert "hacked" not in result.stdout
+
+def test_carryover_bridge_e2e(herdr_socket):
+    env = os.environ.copy()
+    env["HERDR_SOCKET"] = herdr_socket
+    env["HERDR_PANE_ID"] = "pane1"
+    env["HERDR_TAB_ID"] = "tab1"
+    env["PI_SESSION_ID"] = "sess1"
+    env["PI_AGENT_ID"] = "agent1"
+    
+    pi_bin = shutil.which("pi") or "/usr/local/bin/pi"
+    subprocess.run(
+        [pi_bin, "-e", ".pi/extensions/carryover-bridge.ts", "--print", "trigger carryover"],
+        env=env,
+        capture_output=True,
+        text=True
+    )
+    
+    time.sleep(1)
+    
+    handoff_dir = ".pi/handoff/sess1/agent1"
+    assert os.path.exists(handoff_dir)
+    assert os.path.exists(os.path.join(handoff_dir, "journal.json"))
+
+def test_tab_renamed_successfully(herdr_socket):
+    env = os.environ.copy()
+    env["HERDR_SOCKET"] = herdr_socket
+    
+    herdr_bin = shutil.which("herdr") or "/usr/local/bin/herdr"
+    workspace = subprocess.run(
+        [herdr_bin, "workspace", "create"],
+        env=env,
+        capture_output=True,
+        text=True
+    ).stdout.strip()
+    
+    ws_data = json.loads(workspace)
+    tab_id = ws_data["result"]["workspace"]["active_tab_id"]
+    pane_id = ws_data["result"]["root_pane"]["pane_id"]
+
+    result = subprocess.run(
+        ["python3", "scripts/bin/pi-carryover-rotate.py", pane_id, tab_id, "sess1", "agent1"],
+        env=env,
+        capture_output=True,
+        text=True
+    )
+    assert result.returncode == 0
+
+def test_seal_command_execution(herdr_socket):
+    env = os.environ.copy()
+    env["HERDR_SOCKET"] = herdr_socket
+    
+    herdr_bin = shutil.which("herdr") or "/usr/local/bin/herdr"
+    workspace = subprocess.run(
+        [herdr_bin, "workspace", "create"],
+        env=env,
+        capture_output=True,
+        text=True
+    ).stdout.strip()
+    
+    ws_data = json.loads(workspace)
+    tab_id = ws_data["result"]["workspace"]["active_tab_id"]
+    pane_id = ws_data["result"]["root_pane"]["pane_id"]
+
+    result = subprocess.run(
+        ["bash", "scripts/bin/pi-carryover-seal.sh", pane_id, tab_id, "sess2", "agent2"],
+        env=env,
+        capture_output=True,
+        text=True
+    )
+    assert result.returncode == 0
+    
+    handoff_dir = ".pi/handoff/sess2/agent2"
+    assert os.path.exists(handoff_dir)
+    
+    with open(os.path.join(handoff_dir, "dispatch.json"), "r") as f:
+        data = json.load(f)
+        assert data.get("status") == "sealed"
+
+def test_rotate_with_carryover_path(herdr_socket):
+    env = os.environ.copy()
+    env["HERDR_SOCKET"] = herdr_socket
+    
+    herdr_bin = shutil.which("herdr") or "/usr/local/bin/herdr"
+    workspace = subprocess.run(
+        [herdr_bin, "workspace", "create"],
+        env=env,
+        capture_output=True,
+        text=True
+    ).stdout.strip()
+    
+    ws_data = json.loads(workspace)
+    tab_id = ws_data["result"]["workspace"]["active_tab_id"]
+    pane_id = ws_data["result"]["root_pane"]["pane_id"]
+
+    session_id = "sess_with_path"
+    agent_id = "agent_with_path"
+    log_path = f".pi/handoff/{session_id}/{agent_id}/rotate.log"
+    
+    if os.path.exists(log_path):
+        os.remove(log_path)
+
+    result = subprocess.run(
+        ["python3", "scripts/bin/pi-carryover-rotate.py", pane_id, tab_id, session_id, agent_id, "my-carryover-file.md"],
+        env=env,
+        capture_output=True,
+        text=True
+    )
+    assert result.returncode == 0
+    assert os.path.exists(log_path), "rotate.log was not created"
+    
+    with open(log_path, "r") as f:
+        log_content = f.read()
+        
+    for line in log_content.strip().split('\n'):
+        if not line.strip(): continue
+        try:
+            data = json.loads(line)
+            assert "error" not in data, f"Herdr command failed: {data['error']}"
+        except json.JSONDecodeError:
+            pass

--- a/scripts/tests/test_pi_carryover_rotate.py
+++ b/scripts/tests/test_pi_carryover_rotate.py
@@ -1,0 +1,46 @@
+import sys
+import os
+import subprocess
+from unittest.mock import patch, MagicMock
+
+# Add scripts/bin to path so we can import the script
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../bin')))
+rotate_script = __import__("pi-carryover-rotate")
+
+@patch("time.sleep")
+@patch("subprocess.run")
+def test_rotation_sends_safe_keys_and_halts_agent(mock_run, mock_sleep, tmp_path):
+    # Setup dummy handoff environment
+    session_id = "test_session"
+    agent_id = "test_agent"
+    handoff_dir = f".pi/handoff/{session_id}/{agent_id}"
+    os.makedirs(handoff_dir, exist_ok=True)
+    
+    # Run the rotation with a dummy path containing an illegal character ('@')
+    rotate_script.run_rotation("pane_1", "tab_1", session_id, agent_id, "dummy@path.md")
+    
+    # 1. Verify the 2.0 second sleep occurred before typing
+    mock_sleep.assert_any_call(2.0)
+    
+    # 2. Verify the keys sent to herdr. 
+    # It should strip the '@' and append the STOP command.
+    expected_text = "resume context: dummypath.md STOP DO NOT EXECUTE TASKS WAIT FOR ME"
+    expected_keys = []
+    for c in expected_text:
+        if c == " ": expected_keys.append("Space")
+        else: expected_keys.append(c)
+        
+    # Find the send-keys call in the mocked subprocess calls
+    send_keys_call = None
+    for call in mock_run.call_args_list:
+        args = call[0][0]
+        if "send-keys" in args and expected_keys[0] in args:
+            send_keys_call = args
+            break
+            
+    assert send_keys_call is not None, "Did not find the herdr send-keys command"
+    
+    # Verify the exact array of keys passed to herdr matches what we expect
+    # args looks like: ['/usr/local/bin/herdr', 'pane', 'send-keys', 'pane_1', 'r', 'e', 's', 'u', 'm', 'e', 'Space', ...]
+    actual_keys_sent = send_keys_call[4:-1] # slice out the binary, pane args, and trailing 'Enter'
+    assert actual_keys_sent == expected_keys, f"Keys sent did not match expected whitelist translation.\nExpected: {expected_keys}\nGot: {actual_keys_sent}"


### PR DESCRIPTION
Restores carryover scripts, fixes the agent death-loop during carryover by appending STOP command, and adds pytest harnesses for the rotation logic.